### PR TITLE
Pin pydocstyle to 1.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ flake8-print==2.0.2
 flake8-quotes==0.9.0
 flake8-string-format==0.2.3
 pep8-naming==0.4.1
+pydocstyle==1.1.1  # pydocstyle 2.0.0 doesn't work with flake8-docstrings 1.0.3
 
 gunicorn==19.6.0
 raven==6.0.0


### PR DESCRIPTION
The newly released pydocstyle 2.0.0 doesn't work with flake8-docstrings 1.0.3