### PR TITLE
Libraries upgraded to latest versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 
 RUN mkdir -p /shared
 RUN mkdir -p /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,45 +1,45 @@
 pip==9.0.1
 
 # For CH Sync
-lxml==3.6.4
+lxml==3.7.3
 cssselect==1.0.1
 
 # Django and django related
 Django==1.10.7
-djangorestframework==3.5.4
-django-environ==0.4.1
-django-extensions==1.7.6
-django-filter==1.0.1
-django-reversion==2.0.6
+djangorestframework==3.6.2
+django-environ==0.4.3
+django-extensions==1.7.8
+django-filter==1.0.2
+django-reversion==2.0.7
 django-pglocks==1.0.2
 django-crispy-forms==1.6.1
 
 django-oauth-toolkit==0.11.0
 whitenoise==3.3.0
 pyyaml==3.12
-python-dateutil==2.5.3
-colander==1.3.2
+python-dateutil==2.6.0
+colander==1.3.3
 pyquery==1.2.17
 
 # Persistency layer
-psycopg2==2.6.2
+psycopg2==2.7.1
 
 boto3==1.4.4
 
 # ES
-elasticsearch==2.4.0
-elasticsearch-dsl==2.1.0
+elasticsearch==5.3.0
+elasticsearch-dsl==5.2.0
 
 # Testing
 pytest-django==3.1.2
 pytest-sugar==0.8.0
 pytest-cov==2.4.0
-Werkzeug==0.11.15
-ipython==5.2.2
-ipdb==0.10.2
+Werkzeug==0.12.1
+ipython==6.0.0
+ipdb==0.10.3
 factory-boy==2.8.1
 freezegun==0.3.8
-django-debug-toolbar==1.6
+django-debug-toolbar==1.7
 
 # Code static analysis
 pep8==1.7.0
@@ -54,7 +54,7 @@ flake8-string-format==0.2.3
 pep8-naming==0.4.1
 pydocstyle==1.1.1  # pydocstyle 2.0.0 doesn't work with flake8-docstrings 1.0.3
 
-gunicorn==19.6.0
+gunicorn==19.7.1
 raven==6.0.0
-MarkupSafe==0.23
+MarkupSafe==1.0
 requests==2.13.0

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.1


### PR DESCRIPTION
I was unable to upgrade `Django` and there was problem upgrading `django-reversion` to 2.0.8 - could only upgrade to 2.0.7

### Django==1.11 

Official www.django-rest-framework.org doesn't list Django 1.11 as supported version of Django.

Failed tests:

```
         - datahub\company\test/test_admin.py:13 test_enable_users_action
         - datahub\company\test/test_admin.py:35 test_disable_users_action
         - datahub\company\test/test_contact_views.py:17 ContactTestCase.test_add_contact_address_same_as_company
         - datahub\company\test/test_contact_views.py:72 ContactTestCase.test_add_contact_invalid_email_address
         - datahub\company\test/test_contact_views.py:134 ContactTestCase.test_add_contact_manual_address
         - datahub\company\test/test_contact_views.py:91 ContactTestCase.test_add_contact_no_address
         - datahub\company\test/test_contact_views.py:111 ContactTestCase.test_add_contact_partial_manual_address
         - datahub\company\test/test_contact_views.py:155 ContactTestCase.test_add_contact_with_contact_preferences_not_set
         - datahub\company\test/test_contact_views.py:179 ContactTestCase.test_add_contact_with_contact_preferences_set_to_false
         - datahub\dashboard\test/test_views.py:13 DashboardTestCase.test_intelligent_homepage
         - datahub\interaction\test/test_interaction_views.py:23 InteractionTestCase.test_add_interaction
```

```
         - datahub\core\test/test_auth.py:80 test_invalid_cdms_credentials
         - datahub\core\test/test_auth.py:103 test_cdms_returns_500
         - datahub\core\test/test_auth.py:188 test_valid_cdms_credentials_and_cdms_communication_fails
         - datahub\core\test/test_auth.py:217 test_password_changed_in_cdms
         - datahub\core\test/test_auth.py:246 test_valid_cdms_credentials_user_not_whitelisted
         - datahub\core\test/test_auth.py:271 test_valid_django_user
```

### django-reversion==2.08

Upgrade to 2.07 was possible

Tests failed:

```
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[business types view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[countries view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[employee ranges view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[interaction types view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[sector view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[service view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[roles view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[titles view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[turnover view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[UK regions view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[teams view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[service delivery status view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[event view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[headquarter type view]
         - datahub\metadata\test/test_views.py:62 test_metadata_view_post[company classification view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[business types view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[countries view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[employee ranges view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[interaction types view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[sector view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[service view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[roles view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[titles view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[turnover view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[UK regions view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[teams view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[service delivery status view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[event view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[headquarter type view]
         - datahub\metadata\test/test_views.py:72 test_metadata_view_put[company classification view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[business types view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[countries view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[employee ranges view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[interaction types view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[sector view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[service view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[roles view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[titles view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[turnover view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[UK regions view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[teams view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[service delivery status view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[event view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[headquarter type view]
         - datahub\metadata\test/test_views.py:83 test_metadata_view_patch[company classification view]
         - datahub\user\test/test_views.py:10 UserViewTestCase.test_who_am_i_authenticated
         - datahub\v2\tests\repos/test_service_deliveries_repo.py:175 ServiceDeliveriesRepoTestCase.test_filter_by_company_id
         - datahub\v2\tests\repos/test_service_deliveries_repo.py:213 ServiceDeliveriesRepoTestCase.test_filter_by_contact_and_company_ids
         - datahub\v2\tests\repos/test_service_deliveries_repo.py:194 ServiceDeliveriesRepoTestCase.test_filter_by_contact_id
         - datahub\v2\tests\repos/test_service_deliveries_repo.py:161 ServiceDeliveriesRepoTestCase.test_filter_with_pagination
         - datahub\v2\tests\repos/test_service_deliveries_repo.py:24 ServiceDeliveriesRepoTestCase.test_get
         - datahub\v2\tests\repos/test_service_deliveries_repo.py:49 ServiceDeliveriesRepoTestCase.test_get_does_not_exist
         - datahub\v2\tests\repos/test_service_deliveries_repo.py:54 ServiceDeliveriesRepoTestCase.test_insert
         - datahub\v2\tests\repos/test_service_deliveries_repo.py:131 ServiceDeliveriesRepoTestCase.test_update
         - datahub\v2\tests\schemas/test_service_deliveries_schema.py:149 test_service_deliveries_valid_schema
         - datahub\v2\tests\views/test_parsers.py:42 JSONParserTestCase.test_data_contains_incorrect_entity_name
         - datahub\v2\tests\views/test_parsers.py:11 JSONParserTestCase.test_data_key_not_in_post_body
```

Run tests with:

```
pytest --cov -k "not liveserver" -s
pytest -k liveserver
```
