### PR TITLE
Remove hard-coded absolute fixture paths in test suite config

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import PurePath
+
 import pytest
 
 from django.core.management import call_command
@@ -6,10 +8,11 @@ from pytest_django.lazy_django import skip_if_no_django
 
 @pytest.fixture(scope='session')
 def django_db_setup(django_db_setup, django_db_blocker):
+    fixtures_dir = PurePath(__file__).parent / 'fixtures'
     with django_db_blocker.unblock():
-        call_command('loaddata', '/app/fixtures/metadata.yaml')
-        call_command('loaddata', '/app/fixtures/undefined.yaml')
-        call_command('loaddata', '/app/fixtures/datahub_businesstypes.yaml')
+        call_command('loaddata', fixtures_dir / 'metadata.yaml')
+        call_command('loaddata', fixtures_dir / 'undefined.yaml')
+        call_command('loaddata', fixtures_dir / 'datahub_businesstypes.yaml')
 
 
 @pytest.fixture


### PR DESCRIPTION
This makes it possible to run the test suite outside of Docker.