### PR TITLE
Add django_filters to INSTALLED_APPS

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -44,6 +44,7 @@ THIRD_PARTY_APPS = (
     'django_extensions',
     'reversion',
     'oauth2_provider',
+    'django_filters',
 )
 
 LOCAL_APPS = (


### PR DESCRIPTION
Required by django-filters 1.0.2, otherwise it breaks the DRF browseable API (see https://github.com/carltongibson/django-filter/issues/562)