### PR TITLE
Downgrade Elasticsearch client to 2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,8 @@ psycopg2==2.7.1
 boto3==1.4.4
 
 # ES
-elasticsearch==5.3.0
-elasticsearch-dsl==5.2.0
+elasticsearch==2.4.1
+elasticsearch-dsl==2.2.0
 
 # Testing
 pytest-django==3.1.2


### PR DESCRIPTION
While we are still using Elasticsearch 2.x