### PR TITLE
Turn off D400 (first line must end with full stop) rule in Flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+# Codeclimate is using pycodestyle and still requires the section
+# to be named pep8
+# See https://docs.codeclimate.com/v1.0/docs/pep8
 [pep8]
 # D203: 1 blank line required before class docstring
 # D100: Missing docstring in public module
@@ -11,10 +14,11 @@ max-line-length = 119
 # D203: 1 blank line required before class docstring
 # D100: Missing docstring in public module
 # D104 Missing docstring in public package
+# D400 First line should end with a period
 # D401 First line should be in imperative mood
 # P101: format string does contain unindexed parameters
 exclude = */migrations/*,__pycache__,manage.py,config/*,conftest.py,factories.py
-ignore = D203, D100, D104, D401, P101
+ignore = D203, D100, D104, D400, D401, P101
 max-line-length = 119
 max-complexity = 10
 application-import-names = datahub,loading_scripts


### PR DESCRIPTION
The rule is counter-productive and doesn't need to be strictly enforced.