### PR TITLE
Amend investment project endpoint filter fields

### DIFF
--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -38,8 +38,7 @@ class IProjectViewSet(CoreViewSetV3):
         'business_activities'
     )
     filter_backends = (DjangoFilterBackend,)
-    filter_fields = ('investor_company_id', 'intermediate_company_id',
-                     'investment_recipient_company')
+    filter_fields = ('investor_company_id',)
 
     def get_view_name(self):
         """Returns the view set name for the DRF UI."""


### PR DESCRIPTION
Remove intermediate_company_id and investment_recipient_company as filter fields for listing projects as they aren't needed.