### PR TITLE
Update various dependencies

### DIFF
--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -321,7 +321,7 @@ class Sector(Enum):
 
 
 class Title(Enum):
-    """"Titles."""
+    """Titles."""
 
     admiral = Constant('Admiral', 'c1d9b924-6095-e211-a939-e4115bead28a')
     admiral_of_the_fleet = Constant('Admiral of the Fleet', 'c2d9b924-6095-e211-a939-e4115bead28a')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,15 @@ cssselect==1.0.1
 
 # Django and django related
 Django==1.10.7
-djangorestframework==3.6.2
+djangorestframework==3.6.3
 django-environ==0.4.3
-django-extensions==1.7.8
-django-filter==1.0.2
+django-extensions==1.7.9
+django-filter==1.0.3
 django-reversion==2.0.7
 django-pglocks==1.0.2
 django-crispy-forms==1.6.1
 
-django-oauth-toolkit==0.11.0
+django-oauth-toolkit==0.12.0
 whitenoise==3.3.0
 pyyaml==3.12
 python-dateutil==2.6.0
@@ -33,13 +33,13 @@ elasticsearch-dsl==2.2.0
 # Testing
 pytest-django==3.1.2
 pytest-sugar==0.8.0
-pytest-cov==2.4.0
-Werkzeug==0.12.1
+pytest-cov==2.5.1
+Werkzeug==0.12.2
 ipython==6.0.0
 ipdb==0.10.3
 factory-boy==2.8.1
-freezegun==0.3.8
-django-debug-toolbar==1.7
+freezegun==0.3.9
+django-debug-toolbar==1.8
 
 # Code static analysis
 pep8==1.7.0
@@ -47,14 +47,14 @@ flake8==3.3.0
 flake8-blind-except==0.1.1
 flake8-debugger==1.4.0
 flake8-import-order==0.12
-flake8-docstrings==1.0.3
+flake8-docstrings==1.1.0
 flake8-print==2.0.2
 flake8-quotes==0.9.0
 flake8-string-format==0.2.3
 pep8-naming==0.4.1
-pydocstyle==1.1.1  # pydocstyle 2.0.0 doesn't work with flake8-docstrings 1.0.3
+pydocstyle==2.0.0
 
 gunicorn==19.7.1
 raven==6.0.0
 MarkupSafe==1.0
-requests==2.13.0
+requests==2.14.2


### PR DESCRIPTION
These are the change logs:

http://www.django-rest-framework.org/topics/release-notes/
https://github.com/django-extensions/django-extensions/blob/master/CHANGELOG.md
https://github.com/carltongibson/django-filter/blob/develop/CHANGES.rst
https://github.com/evonove/django-oauth-toolkit/blob/master/CHANGELOG.md
https://github.com/spulec/freezegun/blob/master/CHANGELOG
https://github.com/pallets/werkzeug/blob/master/CHANGES
http://django-debug-toolbar.readthedocs.io/en/stable/changes.html
https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst
https://github.com/kennethreitz/requests/blob/master/HISTORY.rst
https://gitlab.com/pycqa/flake8-docstrings/blob/master/HISTORY.rst
https://github.com/PyCQA/pydocstyle/releases

We aren't compatible with the latest Django and django-reversion at present so those remain at the previous versions.