### PR TITLE
Move API urls to its module

### DIFF
--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -1,0 +1,32 @@
+"""API URL config."""
+
+from django.conf.urls import include, url
+from rest_framework import routers
+
+from datahub.company import views as company_views
+from datahub.interaction import views as interaction_views
+from datahub.v2.urls import urlpatterns as v2_urlpatterns
+
+
+# API V1
+
+router_v1 = routers.SimpleRouter()
+router_v1.register(r'company', company_views.CompanyViewSetV1)
+router_v1.register(r'ch-company', company_views.CompaniesHouseCompanyReadOnlyViewSetV1)
+router_v1.register(r'contact', company_views.ContactViewSetV1)
+router_v1.register(r'interaction', interaction_views.InteractionViewSetV1)
+router_v1.register(r'advisor', company_views.AdvisorReadOnlyViewSetV1)
+
+v1_urls = router_v1.urls
+
+
+# API V2
+
+v2_urls = v2_urlpatterns
+
+
+# API V3
+
+v3_urls = [
+    url(r'^investment/', include(('datahub.investment.urls', 'investment'), namespace='investment'))
+]

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,22 +1,13 @@
 from django.conf import settings
-from django.conf.urls import url, include
+from django.conf.urls import include, url
 from django.contrib import admin
 from oauth2_provider.views import TokenView
-from rest_framework import routers
 
-from datahub.company import views as company_views
-from datahub.interaction import views as interaction_views
 from datahub.ping.views import ping
 from datahub.search.views import Search
 from datahub.user.views import who_am_i
-from datahub.v2.urls import urlpatterns as v2_urls
 
-router_v1 = routers.SimpleRouter()
-router_v1.register(r'company', company_views.CompanyViewSetV1)
-router_v1.register(r'ch-company', company_views.CompaniesHouseCompanyReadOnlyViewSetV1)
-router_v1.register(r'contact', company_views.ContactViewSetV1)
-router_v1.register(r'interaction', interaction_views.InteractionViewSetV1)
-router_v1.register(r'advisor', company_views.AdvisorReadOnlyViewSetV1)
+from . import api_urls
 
 
 unversioned_urls = [
@@ -26,13 +17,13 @@ unversioned_urls = [
     url(r'^metadata/', include('datahub.metadata.urls')),
     url(r'^token/$', TokenView.as_view(), name='token'),
     url(r'^whoami/$', who_am_i, name='who_am_i'),
-    url(r'^dashboard/', include('datahub.dashboard.urls', namespace='dashboard'))
+    url(r'^dashboard/', include(('datahub.dashboard.urls', 'dashboard'), namespace='dashboard'))
 ]
 
 urlpatterns = [
-    url(r'^', include(router_v1.urls, namespace='v1')),  # V1 has actually no version in the URL
-    url(r'^v2/', include(v2_urls, namespace='v2')),
-    url(r'^', include('datahub.investment.urls')),
+    url(r'^', include((api_urls.v1_urls, 'api'), namespace='api-v1')),  # V1 has actually no version in the URL
+    url(r'^v2/', include((api_urls.v2_urls, 'api'), namespace='api-v2')),
+    url(r'^v3/', include((api_urls.v3_urls, 'api'), namespace='api-v3')),
 ] + unversioned_urls
 
 if settings.DEBUG:

--- a/datahub/company/test/test_advisor_views.py
+++ b/datahub/company/test/test_advisor_views.py
@@ -11,14 +11,14 @@ class AdvisorTestCase(LeelooTestCase):
     def test_advisor_list_view(self):
         """Should return id and name."""
         AdvisorFactory()
-        url = reverse('v1:advisor-list')
+        url = reverse('api-v1:advisor-list')
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
     def test_advisor_filtered_view(self):
         """Test filtering."""
         AdvisorFactory(last_name='UNIQUE')
-        url = reverse('v1:advisor-list')
+        url = reverse('api-v1:advisor-list')
         response = self.api_client.get(url, data=dict(last_name__icontains='uniq'))
         assert response.status_code == status.HTTP_200_OK
         result = response.json()

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -15,7 +15,7 @@ class CompanyTestCase(LeelooTestCase):
         """List the companies."""
         CompanyFactory()
         CompanyFactory()
-        url = reverse('v1:company-list')
+        url = reverse('api-v1:company-list')
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -39,7 +39,7 @@ class CompanyTestCase(LeelooTestCase):
             alias='Xyz trading'
         )
 
-        url = reverse('v1:company-detail', kwargs={'pk': company.id})
+        url = reverse('api-v1:company-detail', kwargs={'pk': company.id})
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -74,7 +74,7 @@ class CompanyTestCase(LeelooTestCase):
             classification_id=constants.CompanyClassification.tier_a.value.id,
         )
 
-        url = reverse('v1:company-detail', kwargs={'pk': company.id})
+        url = reverse('api-v1:company-detail', kwargs={'pk': company.id})
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -105,7 +105,7 @@ class CompanyTestCase(LeelooTestCase):
         )
 
         # now update it
-        url = reverse('v1:company-detail', kwargs={'pk': company.pk})
+        url = reverse('api-v1:company-detail', kwargs={'pk': company.pk})
         response = self.api_client.patch(url, {
             'name': 'Acme',
         })
@@ -123,7 +123,7 @@ class CompanyTestCase(LeelooTestCase):
             classification_id=constants.CompanyClassification.tier_a.value.id,
         )
 
-        url = reverse('v1:company-detail', kwargs={'pk': company.pk})
+        url = reverse('api-v1:company-detail', kwargs={'pk': company.pk})
         response = self.api_client.patch(url, {
             'classification': constants.CompanyClassification.tier_b.value.id,
         })
@@ -134,7 +134,7 @@ class CompanyTestCase(LeelooTestCase):
 
     def test_add_uk_company(self):
         """Test add new UK company."""
-        url = reverse('v1:company-list')
+        url = reverse('api-v1:company-list')
         response = self.api_client.post(url, {
             'name': 'Acme',
             'alias': None,
@@ -153,7 +153,7 @@ class CompanyTestCase(LeelooTestCase):
 
     def test_add_uk_company_without_uk_region(self):
         """Test add new UK without UK region company."""
-        url = reverse('v1:company-list')
+        url = reverse('api-v1:company-list')
         response = self.api_client.post(url, {
             'name': 'Acme',
             'alias': None,
@@ -169,7 +169,7 @@ class CompanyTestCase(LeelooTestCase):
 
     def test_add_not_uk_company(self):
         """Test add new not UK company."""
-        url = reverse('v1:company-list')
+        url = reverse('api-v1:company-list')
         response = self.api_client.post(url, {
             'name': 'Acme',
             'alias': None,
@@ -185,7 +185,7 @@ class CompanyTestCase(LeelooTestCase):
 
     def test_add_company_partial_trading_address(self):
         """Test add new company with partial trading address."""
-        url = reverse('v1:company-list')
+        url = reverse('api-v1:company-list')
         response = self.api_client.post(url, {
             'name': 'Acme',
             'business_type': constants.BusinessType.company.value.id,
@@ -205,7 +205,7 @@ class CompanyTestCase(LeelooTestCase):
 
     def test_add_company_with_trading_address(self):
         """Test add new company with trading_address."""
-        url = reverse('v1:company-list')
+        url = reverse('api-v1:company-list')
         response = self.api_client.post(url, {
             'name': 'Acme',
             'business_type': constants.BusinessType.company.value.id,
@@ -223,7 +223,7 @@ class CompanyTestCase(LeelooTestCase):
 
     def test_add_company_with_website_without_scheme(self):
         """Test add new company with trading_address."""
-        url = reverse('v1:company-list')
+        url = reverse('api-v1:company-list')
         response = self.api_client.post(url, {
             'name': 'Acme',
             'business_type': constants.BusinessType.company.value.id,
@@ -244,7 +244,7 @@ class CompanyTestCase(LeelooTestCase):
     def test_archive_company_no_reason(self):
         """Test company archive."""
         company = CompanyFactory()
-        url = reverse('v1:company-archive', kwargs={'pk': company.id})
+        url = reverse('api-v1:company-archive', kwargs={'pk': company.id})
         response = self.api_client.post(url, format='json')
 
         assert response.data['archived']
@@ -254,7 +254,7 @@ class CompanyTestCase(LeelooTestCase):
     def test_archive_company_reason(self):
         """Test company archive."""
         company = CompanyFactory()
-        url = reverse('v1:company-archive', kwargs={'pk': company.id})
+        url = reverse('api-v1:company-archive', kwargs={'pk': company.id})
         response = self.api_client.post(url, {'reason': 'foo'}, format='json')
 
         assert response.data['archived']
@@ -264,7 +264,7 @@ class CompanyTestCase(LeelooTestCase):
     def test_unarchive_company(self):
         """Unarchive a company."""
         company = CompanyFactory(archived=True, archived_on=now(), archived_reason='foo')
-        url = reverse('v1:company-unarchive', kwargs={'pk': company.id})
+        url = reverse('api-v1:company-unarchive', kwargs={'pk': company.id})
         response = self.api_client.get(url)
 
         assert not response.data['archived']
@@ -280,7 +280,7 @@ class CHCompanyTestCase(LeelooTestCase):
         CompaniesHouseCompanyFactory()
         CompaniesHouseCompanyFactory()
 
-        url = reverse('v1:companieshousecompany-list')
+        url = reverse('api-v1:companieshousecompany-list')
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -290,7 +290,7 @@ class CHCompanyTestCase(LeelooTestCase):
         """Test companies house company detail."""
         ch_company = CompaniesHouseCompanyFactory(company_number=123)
 
-        url = reverse('v1:companieshousecompany-detail', kwargs={'company_number': ch_company.company_number})
+        url = reverse('api-v1:companieshousecompany-detail', kwargs={'company_number': ch_company.company_number})
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -298,7 +298,7 @@ class CHCompanyTestCase(LeelooTestCase):
 
     def test_ch_company_cannot_be_written(self):
         """Test CH company POST is not allowed."""
-        url = reverse('v1:companieshousecompany-list')
+        url = reverse('api-v1:companieshousecompany-list')
         response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
@@ -308,7 +308,7 @@ class CHCompanyTestCase(LeelooTestCase):
         CompaniesHouseCompanyFactory(company_number=1234567890)
 
         # promote a company to ch
-        url = reverse('v1:company-list')
+        url = reverse('api-v1:company-list')
         response = self.api_client.post(url, {
             'name': 'Acme',
             'company_number': 1234567890,

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -17,7 +17,7 @@ class ContactTestCase(LeelooTestCase):
     @freeze_time('2017-04-18 13:25:30.986208+00:00')
     def test_add_contact_address_same_as_company(self):
         """Test add new contact."""
-        url = reverse('v1:contact-list')
+        url = reverse('api-v1:contact-list')
         company = CompanyFactory()
         response = self.api_client.post(url, {
             'first_name': 'Oratio',
@@ -71,7 +71,7 @@ class ContactTestCase(LeelooTestCase):
 
     def test_add_contact_invalid_email_address(self):
         """Test add new contact."""
-        url = reverse('v1:contact-list')
+        url = reverse('api-v1:contact-list')
         response = self.api_client.post(url, {
             'first_name': 'Oratio',
             'last_name': 'Nelson',
@@ -90,7 +90,7 @@ class ContactTestCase(LeelooTestCase):
 
     def test_add_contact_no_address(self):
         """Test add new contact without any address."""
-        url = reverse('v1:contact-list')
+        url = reverse('api-v1:contact-list')
         response = self.api_client.post(url, {
             'first_name': 'Oratio',
             'last_name': 'Nelson',
@@ -110,7 +110,7 @@ class ContactTestCase(LeelooTestCase):
 
     def test_add_contact_partial_manual_address(self):
         """Test add new contact with a partial manual address."""
-        url = reverse('v1:contact-list')
+        url = reverse('api-v1:contact-list')
 
         response = self.api_client.post(url, {
             'first_name': 'Oratio',
@@ -133,7 +133,7 @@ class ContactTestCase(LeelooTestCase):
 
     def test_add_contact_manual_address(self):
         """Test add new contact manual address."""
-        url = reverse('v1:contact-list')
+        url = reverse('api-v1:contact-list')
         response = self.api_client.post(url, {
             'first_name': 'Oratio',
             'last_name': 'Nelson',
@@ -154,7 +154,7 @@ class ContactTestCase(LeelooTestCase):
 
     def test_add_contact_with_contact_preferences_not_set(self):
         """Don't set any contact preference."""
-        url = reverse('v1:contact-list')
+        url = reverse('api-v1:contact-list')
         response = self.api_client.post(url, {
             'first_name': 'Oratio',
             'last_name': 'Nelson',
@@ -178,7 +178,7 @@ class ContactTestCase(LeelooTestCase):
 
     def test_add_contact_with_contact_preferences_set_to_false(self):
         """Contact preference both set to false."""
-        url = reverse('v1:contact-list')
+        url = reverse('api-v1:contact-list')
         response = self.api_client.post(url, {
             'first_name': 'Oratio',
             'last_name': 'Nelson',
@@ -205,7 +205,7 @@ class ContactTestCase(LeelooTestCase):
     def test_modify_contact(self):
         """Modify an existing contact."""
         contact = ContactFactory(first_name='Foo')
-        url = reverse('v1:contact-detail', kwargs={'pk': contact.pk})
+        url = reverse('api-v1:contact-detail', kwargs={'pk': contact.pk})
         response = self.api_client.patch(url, {
             'first_name': 'bar',
         })
@@ -216,7 +216,7 @@ class ContactTestCase(LeelooTestCase):
     def test_archive_contact_no_reason(self):
         """Test archive contact without providing a reason."""
         contact = ContactFactory()
-        url = reverse('v1:contact-archive', kwargs={'pk': contact.pk})
+        url = reverse('api-v1:contact-archive', kwargs={'pk': contact.pk})
         response = self.api_client.post(url)
 
         assert response.data['archived']
@@ -226,7 +226,7 @@ class ContactTestCase(LeelooTestCase):
     def test_archive_contact_reason(self):
         """Test archive contact providing a reason."""
         contact = ContactFactory()
-        url = reverse('v1:contact-archive', kwargs={'pk': contact.pk})
+        url = reverse('api-v1:contact-archive', kwargs={'pk': contact.pk})
         response = self.api_client.post(url, {'reason': 'foo'})
 
         assert response.data['archived']
@@ -236,7 +236,7 @@ class ContactTestCase(LeelooTestCase):
     def test_unarchive_contact(self):
         """Test unarchive contact."""
         contact = ContactFactory(archived=True, archived_reason='foo')
-        url = reverse('v1:contact-unarchive', kwargs={'pk': contact.pk})
+        url = reverse('api-v1:contact-unarchive', kwargs={'pk': contact.pk})
         response = self.api_client.get(url)
 
         assert not response.data['archived']
@@ -246,7 +246,7 @@ class ContactTestCase(LeelooTestCase):
     def test_contact_detail_view(self):
         """Contact detail view."""
         contact = ContactFactory()
-        url = reverse('v1:contact-detail', kwargs={'pk': contact.pk})
+        url = reverse('api-v1:contact-detail', kwargs={'pk': contact.pk})
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK

--- a/datahub/dashboard/test/test_views.py
+++ b/datahub/dashboard/test/test_views.py
@@ -15,7 +15,7 @@ class DashboardTestCase(LeelooTestCase):
         user = get_test_user()
 
         # add contact using the API to save the user from the session
-        url = reverse('v1:contact-list')
+        url = reverse('api-v1:contact-list')
         api_response = self.api_client.post(url, {
             'first_name': 'Oratio',
             'last_name': 'Nelson',

--- a/datahub/interaction/test/test_interaction_views.py
+++ b/datahub/interaction/test/test_interaction_views.py
@@ -14,7 +14,7 @@ class InteractionTestCase(LeelooTestCase):
     def test_interaction_detail_view(self):
         """Interaction detail view."""
         interaction = InteractionFactory()
-        url = reverse('v1:interaction-detail', kwargs={'pk': interaction.pk})
+        url = reverse('api-v1:interaction-detail', kwargs={'pk': interaction.pk})
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -22,7 +22,7 @@ class InteractionTestCase(LeelooTestCase):
 
     def test_add_interaction(self):
         """Test add new interaction."""
-        url = reverse('v1:interaction-list')
+        url = reverse('api-v1:interaction-list')
         response = self.api_client.post(url, {
             'interaction_type': constants.InteractionType.business_card.value.id,
             'subject': 'whatever',
@@ -41,7 +41,7 @@ class InteractionTestCase(LeelooTestCase):
         """Modify an existing interaction."""
         interaction = InteractionFactory(subject='I am a subject')
 
-        url = reverse('v1:interaction-detail', kwargs={'pk': interaction.pk})
+        url = reverse('api-v1:interaction-detail', kwargs={'pk': interaction.pk})
         response = self.api_client.patch(url, {
             'subject': 'I am another subject',
         })

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -20,7 +20,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
     def test_list_projects_success(self):
         """Test successfully listing projects."""
         project = InvestmentProjectFactory()
-        url = reverse('investment:v3:project')
+        url = reverse('api-v3:investment:project')
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -33,7 +33,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         company = CompanyFactory()
         project = InvestmentProjectFactory(investor_company_id=company.id)
         InvestmentProjectFactory()
-        url = reverse('investment:v3:project')
+        url = reverse('api-v3:investment:project')
         response = self.api_client.get(url, {
             'investor_company_id': str(company.id)
         })
@@ -50,7 +50,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         recipient_company = CompanyFactory()
         intermediate_company = CompanyFactory()
         advisor = AdvisorFactory()
-        url = reverse('investment:v3:project')
+        url = reverse('api-v3:investment:project')
         aerospace_id = constants.Sector.aerospace_assembly_aircraft.value.id
         new_site_id = (constants.FDIType.creation_of_new_site_or_activity
                        .value.id)
@@ -131,7 +131,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
 
     def test_create_project_fail(self):
         """Test creating a project with missing required values."""
-        url = reverse('investment:v3:project')
+        url = reverse('api-v3:investment:project')
         request_data = {}
         response = self.api_client.post(url, data=request_data, format='json')
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -154,7 +154,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
 
     def test_create_project_fail_none(self):
         """Test creating a project with None for required values."""
-        url = reverse('investment:v3:project')
+        url = reverse('api-v3:investment:project')
         request_data = {
             'business_activities': None,
             'client_contacts': None,
@@ -191,7 +191,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
 
     def test_create_project_fail_empty_to_many(self):
         """Test creating a project with empty to-many field values."""
-        url = reverse('investment:v3:project')
+        url = reverse('api-v3:investment:project')
         request_data = {
             'business_activities': [],
             'client_contacts': []
@@ -211,7 +211,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         """Test successfully getting a project."""
         contacts = [ContactFactory().id, ContactFactory().id]
         project = InvestmentProjectFactory(client_contacts=contacts)
-        url = reverse('investment:v3:project-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:project-item', kwargs={'pk': project.pk})
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -233,7 +233,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         project = InvestmentProjectFactory(
             client_contacts=[ContactFactory().id, ContactFactory().id]
         )
-        url = reverse('investment:v3:project-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:project-item', kwargs={'pk': project.pk})
         request_data = {
             'investment_type': {
                 'id': str(constants.InvestmentType.fdi.value.id)
@@ -251,7 +251,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         project = InvestmentProjectFactory(
             client_contacts=[ContactFactory().id, ContactFactory().id]
         )
-        url = reverse('investment:v3:project-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:project-item', kwargs={'pk': project.pk})
         new_contact = ContactFactory()
         request_data = {
             'name': 'new name',
@@ -271,7 +271,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
     def test_change_phase_assign_pm_failure(self):
         """Tests moving an incomplete project to the Assign PM phase."""
         project = InvestmentProjectFactory()
-        url = reverse('investment:v3:project-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:project-item', kwargs={'pk': project.pk})
         request_data = {
             'phase': {
                 'id': constants.InvestmentProjectPhase.assign_pm.value.id
@@ -308,7 +308,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
             strategic_drivers=strategic_drivers,
             uk_region_locations=[constants.UKRegion.england.value.id]
         )
-        url = reverse('investment:v3:project-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:project-item', kwargs={'pk': project.pk})
         request_data = {
             'phase': {
                 'id': constants.InvestmentProjectPhase.assign_pm.value.id
@@ -322,7 +322,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         project = InvestmentProjectFactory(
             client_contacts=[ContactFactory().id, ContactFactory().id]
         )
-        url = reverse('investment:v3:project-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:project-item', kwargs={'pk': project.pk})
         request_data = {
             'phase': {
                 'id': constants.InvestmentProjectPhase.active.value.id
@@ -364,7 +364,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
             project_assurance_advisor=advisor,
             project_manager=advisor
         )
-        url = reverse('investment:v3:project-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:project-item', kwargs={'pk': project.pk})
         request_data = {
             'phase': {
                 'id': constants.InvestmentProjectPhase.active.value.id
@@ -388,7 +388,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
             new_tech_to_uk=False,
             export_revenue=True
         )
-        url = reverse('investment:v3:value-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:value-item', kwargs={'pk': project.pk})
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -413,7 +413,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         salary_id = constants.SalaryRange.below_25000.value.id
         project = InvestmentProjectFactory(total_investment=999,
                                            number_new_jobs=100)
-        url = reverse('investment:v3:value-item', kwargs={'pk': project.pk})
+        url = reverse('api-v3:investment:value-item', kwargs={'pk': project.pk})
         request_data = {
             'number_new_jobs': 555,
             'average_salary': {'id': salary_id},
@@ -447,7 +447,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
             strategic_drivers=strategic_drivers,
             uk_region_locations=uk_region_locations
         )
-        url = reverse('investment:v3:requirements-item',
+        url = reverse('api-v3:investment:requirements-item',
                       kwargs={'pk': project.pk})
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
@@ -467,7 +467,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         project = InvestmentProjectFactory(client_requirements='client reqs',
                                            site_decided=True,
                                            address_line_1='address 1')
-        url = reverse('investment:v3:requirements-item',
+        url = reverse('api-v3:investment:requirements-item',
                       kwargs={'pk': project.pk})
         request_data = {
             'address_line_1': 'address 1 new',
@@ -492,7 +492,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
             project_manager_id=pm_advisor.id,
             project_assurance_advisor_id=pa_advisor.id
         )
-        url = reverse('investment:v3:team-item',
+        url = reverse('api-v3:investment:team-item',
                       kwargs={'pk': project.pk})
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
@@ -522,7 +522,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
     def test_get_team_empty(self):
         """Test successfully getting an empty project requirements object."""
         project = InvestmentProjectFactory()
-        url = reverse('investment:v3:team-item',
+        url = reverse('api-v3:investment:team-item',
                       kwargs={'pk': project.pk})
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
@@ -545,7 +545,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
             project_manager_id=advisor_1.id,
             project_assurance_advisor_id=advisor_2.id
         )
-        url = reverse('investment:v3:team-item',
+        url = reverse('api-v3:investment:team-item',
                       kwargs={'pk': project.pk})
         request_data = {
             'project_manager': {

--- a/datahub/investment/urls.py
+++ b/datahub/investment/urls.py
@@ -1,13 +1,11 @@
 """Investment views URL config."""
 
-from django.conf.urls import include, url
+from django.conf.urls import url
 
 from datahub.investment.views import (
     IProjectRequirementsViewSet, IProjectTeamViewSet, IProjectValueViewSet,
     IProjectViewSet
 )
-
-app_name = 'investment'
 
 project_collection = IProjectViewSet.as_view({
     'get': 'list',
@@ -34,18 +32,10 @@ team_item = IProjectTeamViewSet.as_view({
     'patch': 'partial_update'
 })
 
-urlpatterns_v3 = [
-    url(r'^investment/project$', project_collection, name='project'),
-    url(r'^investment/(?P<pk>[0-9a-z-]{36})/project$', project_item,
-        name='project-item'),
-    url(r'^investment/(?P<pk>[0-9a-z-]{36})/value$', value_item,
-        name='value-item'),
-    url(r'^investment/(?P<pk>[0-9a-z-]{36})/requirements$', requirements_item,
-        name='requirements-item'),
-    url(r'^investment/(?P<pk>[0-9a-z-]{36})/team', team_item,
-        name='team-item')
-]
-
 urlpatterns = [
-    url('^v3/', include(urlpatterns_v3, namespace='v3'))
+    url(r'^project$', project_collection, name='project'),
+    url(r'^(?P<pk>[0-9a-z-]{36})/project$', project_item, name='project-item'),
+    url(r'^(?P<pk>[0-9a-z-]{36})/value$', value_item, name='value-item'),
+    url(r'^(?P<pk>[0-9a-z-]{36})/requirements$', requirements_item, name='requirements-item'),
+    url(r'^(?P<pk>[0-9a-z-]{36})/team', team_item, name='team-item')
 ]

--- a/datahub/v2/tests/views/test_parsers.py
+++ b/datahub/v2/tests/views/test_parsers.py
@@ -10,7 +10,7 @@ class JSONParserTestCase(LeelooTestCase):
 
     def test_data_key_not_in_post_body(self):
         """Test data key is missing from post body."""
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         data = {
             'type': 'ServiceDelivery',
             'attributes': {
@@ -41,7 +41,7 @@ class JSONParserTestCase(LeelooTestCase):
 
     def test_data_contains_incorrect_entity_name(self):
         """Test add new service delivery with incorrect format."""
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         data = {
             'type': 'whatever',
             'attributes': {

--- a/datahub/v2/tests/views/test_service_delivery.py
+++ b/datahub/v2/tests/views/test_service_delivery.py
@@ -23,7 +23,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
             service=service_offer.service,
             dit_team=service_offer.dit_team,
         )
-        url = reverse('v2:servicedelivery-detail', kwargs={'object_id': servicedelivery.pk})
+        url = reverse('api-v2:servicedelivery-detail', kwargs={'object_id': servicedelivery.pk})
         response = self.api_client.get(url)
         content = json.loads(response.content.decode('utf-8'))
         assert response.status_code == status.HTTP_200_OK
@@ -33,7 +33,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
 
     def test_service_delivery_detail_view_not_found(self):
         """Service Delivery detail view not found."""
-        url = reverse('v2:servicedelivery-detail', kwargs={'object_id': uuid.uuid4()})
+        url = reverse('api-v2:servicedelivery-detail', kwargs={'object_id': uuid.uuid4()})
         response = self.api_client.get(url)
         content = json.loads(response.content.decode('utf-8'))
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -53,7 +53,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
                 event=service_offer.event
             )
             for i in range(6)]
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         response = self.api_client.get(url)
         content = json.loads(response.content.decode('utf-8'))
         assert response.status_code == status.HTTP_200_OK
@@ -65,7 +65,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
     def test_add_service_delivery_incorrect_format(self):
         """Test add new service delivery with incorrect format."""
         service_offer = ServiceOfferFactory()
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         data = {
             'type': 'ServiceDelivery',
             'attributes': {
@@ -122,7 +122,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
     def test_add_service_delivery(self):
         """Test add new service delivery."""
         service_offer = ServiceOfferFactory()
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         data = {
             'type': 'ServiceDelivery',
             'attributes': {
@@ -172,7 +172,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
 
     def test_add_service_delivery_incorrect_accept_header_format(self):
         """Test add new service delivery incorrect accept header format."""
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         data = {
             'type': 'ServiceDelivery',
             'attributes': {
@@ -238,7 +238,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
             uk_region_id=constants.UKRegion.east_midlands.value.id
         )
 
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         data = {
             'type': 'ServiceDelivery',
             'attributes': {
@@ -280,7 +280,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
             service=service_offer.service,
             dit_team=service_offer.dit_team
         )
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         response = self.api_client.get(url, data={'company_id': company.pk})
         content = json.loads(response.content.decode('utf-8'))
         assert response.status_code == status.HTTP_200_OK
@@ -304,7 +304,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
             service=service_offer.service,
             dit_team=service_offer.dit_team
         )
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         response = self.api_client.get(url, data={'contact_id': contact.pk})
         content = json.loads(response.content.decode('utf-8'))
         assert response.status_code == status.HTTP_200_OK
@@ -312,7 +312,7 @@ class ServiceDeliveryViewTestCase(LeelooTestCase):
 
     def test_add_service_delivery_incorrect_service_team_event_combination(self):
         """Test add new service delivery with invalid service/team/even combination."""
-        url = reverse('v2:servicedelivery-list')
+        url = reverse('api-v2:servicedelivery-list')
         data = {
             'type': 'ServiceDelivery',
             'attributes': {

--- a/datahub/v2/views/service_deliveries.py
+++ b/datahub/v2/views/service_deliveries.py
@@ -19,7 +19,7 @@ class ServiceDeliveryListViewV2(APIView):
     param_keys = frozenset({'company_id', 'contact_id', 'offset', 'limit'})
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
     parser_classes = (JSONParser, parsers.FormParser, parsers.MultiPartParser)
-    detail_view_name = 'v2:servicedelivery-detail'
+    detail_view_name = 'api-v2:servicedelivery-detail'
     entity_name = 'ServiceDelivery'
 
     def get(self, request):
@@ -63,7 +63,7 @@ class ServiceDeliveryDetailViewV2(APIView):
     repo_class = service_deliveries_repos.ServiceDeliveryDatabaseRepo
     renderer_classes = (JSONRenderer, BrowsableAPIRenderer)
     parser_classes = (JSONParser, parsers.FormParser, parsers.MultiPartParser)
-    detail_view_name = 'v2:servicedelivery-detail'
+    detail_view_name = 'api-v2:servicedelivery-detail'
     entity_name = 'ServiceDelivery'
 
     def get(self, request, object_id):


### PR DESCRIPTION
This refactors the API urls so that:
- all the urls are defined in `config.api_urls`
- all the namespaces are consistent and start with the namespace `api-v(x)`
- the v3 namespace is not tight to the investment module only and can include others