### PR TITLE
Switch to new-style Django middleware and update django-reversion

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -60,7 +60,7 @@ LOCAL_APPS = (
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -66,7 +66,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'reversion.middleware.RevisionMiddleware',

--- a/config/settings/heroku.py
+++ b/config/settings/heroku.py
@@ -2,7 +2,7 @@ import socket
 
 from .production import *
 
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INSTALLED_APPS += ('debug_toolbar',)
 
 INTERNAL_IPS = ['127.0.0.1', '10.0.2.2', ]

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -8,7 +8,7 @@ from .common import *
 
 # DRF
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += ['rest_framework.authentication.SessionAuthentication']
-MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
+MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INSTALLED_APPS += ('debug_toolbar',)
 
 INTERNAL_IPS = ['127.0.0.1', '10.0.2.2', ]

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,6 +1,6 @@
 from .common import *
 
-MIDDLEWARE_CLASSES += ('raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',)
+MIDDLEWARE += ('raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware',)
 INSTALLED_APPS += ('raven.contrib.django.raven_compat',)
 
 # Logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ Django==1.11.1
 djangorestframework==3.6.3
 django-environ==0.4.3
 django-extensions==1.7.9
-django-filter==1.0.3
-django-reversion==2.0.7
+django-filter==1.0.4
+django-reversion==2.0.8
 django-pglocks==1.0.2
 django-crispy-forms==1.6.1
 


### PR DESCRIPTION
This switches from the deprecated old-style middleware to the [new-style Django 1.10+ middleware](https://docs.djangoproject.com/en/1.11/topics/http/middleware/). All the middleware we are using is supposed to be compatible with `MIDDLEWARE` (as opposed to `MIDDLEWARE_CLASSES`).

`SessionAuthenticationMiddleware` is no longer needed – see https://docs.djangoproject.com/en/1.11/releases/1.10/#features-removed-in-1-10

Switching to new-style middleware also fixed the problem with django-reversion and the metadata views.