### PR TITLE
Add D200 and D205 to Flake8 ignored-rules list

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,11 +14,13 @@ max-line-length = 119
 # D203: 1 blank line required before class docstring
 # D100: Missing docstring in public module
 # D104 Missing docstring in public package
+# D200 One-line docstring should fit on one line with quotes
+# D205 1 blank line required between summary line and description
 # D400 First line should end with a period
 # D401 First line should be in imperative mood
 # P101: format string does contain unindexed parameters
 exclude = */migrations/*,__pycache__,manage.py,config/*,conftest.py,factories.py,datahub/korben/test/*,env/*
-ignore = D203, D100, D104, D400, D401, P101
+ignore = D203, D100, D104, D200, D205, D400, D401, P101
 max-line-length = 119
 max-complexity = 10
 application-import-names = datahub,loading_scripts


### PR DESCRIPTION
Those rules are:

- D200 One-line docstring should fit on one line with quotes
- D205 1 blank line required between summary line and description

When enabled, these rules force you to have a summary line that fits on one line. I don't see the benefit of strictly enforcing that; it encourages you to use long lines and with indentation the usable length of a line isn't even consistent.