### PR TITLE
Add ability to filter interactions by contact

### DIFF
--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -789,11 +789,8 @@ class ContactListV3TestCase(LeelooTestCase):
         ContactFactory.create_batch(3, company=company1)
         contacts = ContactFactory.create_batch(2, company=company2)
 
-        url = '{}?company_id={}'.format(
-            reverse('api-v3:contact:list'),
-            company2.id
-        )
-        response = self.api_client.get(url)
+        url = reverse('api-v3:contact:list')
+        response = self.api_client.get(url, {'company_id': company2.id})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2

--- a/datahub/interaction/test/test_interaction_views.py
+++ b/datahub/interaction/test/test_interaction_views.py
@@ -63,11 +63,8 @@ class InteractionTestCase(LeelooTestCase):
         InteractionFactory.create_batch(3, contact=contact1)
         interactions = InteractionFactory.create_batch(2, contact=contact2)
 
-        url = '{}?contact_id={}'.format(
-            reverse('api-v1:interaction-list'),
-            contact2.id
-        )
-        response = self.api_client.get(url)
+        url = reverse('api-v1:interaction-list')
+        response = self.api_client.get(url, {'contact_id': contact2.id})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2

--- a/datahub/interaction/test/test_interaction_views.py
+++ b/datahub/interaction/test/test_interaction_views.py
@@ -54,3 +54,21 @@ class InteractionTestCase(LeelooTestCase):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['subject'] == 'I am another subject'
+
+    def test_list_filtered(self):
+        """List of interactions filtered by contact"""
+        contact1 = ContactFactory()
+        contact2 = ContactFactory()
+
+        InteractionFactory.create_batch(3, contact=contact1)
+        interactions = InteractionFactory.create_batch(2, contact=contact2)
+
+        url = '{}?contact_id={}'.format(
+            reverse('api-v1:interaction-list'),
+            contact2.id
+        )
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+        assert {i['id'] for i in response.data['results']} == {str(i.id) for i in interactions}

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -1,3 +1,5 @@
+from django_filters.rest_framework import DjangoFilterBackend
+
 from datahub.core.viewsets import CoreViewSetV1
 from datahub.interaction.models import Interaction
 from datahub.interaction.serializers import (
@@ -17,6 +19,10 @@ class InteractionViewSetV1(CoreViewSetV1):
         'company',
         'contact'
     ).all()
+    filter_backends = (
+        DjangoFilterBackend,
+    )
+    filter_fields = ['contact_id']
 
     def get_additional_data(self, create):
         """Set dit_advisor to the user on model instance creation."""


### PR DESCRIPTION
This adds the `?contact_id=...` filter to the interaction API v1.

The reason behind it is that at the moment the frontend is getting the interactions by using the contact endpoint v1 and looping over the `contact.interactions` field.
By adding this, we can refactor the frontend and then get rid of the contact API v1.

I would consider this just as a temporary solution and we should really convert the interaction endpoints to v3 as well.