### PR TITLE
Add X-Forwarded-For to Gunicorn access log format

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python manage.py distributed_migrate --noinput && gunicorn config.wsgi --access-logfile -
+web: python manage.py distributed_migrate --noinput && gunicorn config.wsgi --config config/gunicorn.py
 init_rev: python manage.py createinitialrevisions

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,0 +1,2 @@
+accesslog = '-'
+access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({X-Forwarded-For}i)s'

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,2 +1,8 @@
-accesslog = '-'
-access_log_format = '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({X-Forwarded-For}i)s'
+import os
+
+accesslog = os.environ.get('GUNICORN_ACCESSLOG', '-')
+access_log_format = os.environ.get(
+    'GUNICORN_ACCESS_LOG_FORMAT',
+    '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" '
+    '%({X-Forwarded-For}i)s'
+)


### PR DESCRIPTION
Stuck it at the end of the log format so that the beginning is still in the standard log format. Could move it if we want to though.