### PR TITLE
Removed unnecessary type conversion.

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -90,7 +90,7 @@ def bulk(actions=None, chunk_size=None, **kwargs):
     return es_bulk(connections.get_connection(), actions=actions, chunk_size=chunk_size, **kwargs)
 
 
-def remap_fields(filter):
+def remap_fields(fields):
     """Replaces fields to match Elasticsearch data model."""
     name_map = {
         'sector': 'sector.id',
@@ -101,4 +101,4 @@ def remap_fields(filter):
         'trading_address_country': 'trading_address_country.id',
         'advisor': 'advisor.id',
     }
-    return {name_map.get(k, k): v for k, v in filter.items()}
+    return {name_map.get(k, k): v for k, v in fields.items()}

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -101,7 +101,4 @@ def remap_fields(filter):
         'trading_address_country': 'trading_address_country.id',
         'advisor': 'advisor.id',
     }
-    value_map = {
-        'uk_based': lambda x: x.lower() == 'true'
-    }
-    return {name_map.get(k, k): value_map.get(k, str)(v) for k, v in filter.items()}
+    return {name_map.get(k, k): v for k, v in filter.items()}

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -109,7 +109,7 @@ def test_remap_fields():
         'trading_address_country': 'test',
         'advisor': 'test',
         'test': 'test',
-        'uk_based': 'false'
+        'uk_based': False
     }
 
     remapped = elasticsearch.remap_fields(filters)

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -1,3 +1,4 @@
+import json
 from unittest import mock
 
 import pytest
@@ -114,13 +115,13 @@ class SearchTestCase(LeelooTestCase):
         assert response.data['results'][0]['trading_address_country']['id'] == constants.Country.united_states.value.id
 
     @mock.patch('datahub.search.views.elasticsearch.ES_INDEX', 'test')
-    def test_search_foreign_company(self):
+    def test_search_foreign_company_json(self):
         """Tests detailed company search."""
         url = f"{reverse('api-v3:search:company')}?offset=0&limit=100"
 
-        response = self.api_client.post(url, {
+        response = self.api_client.post(url, json.dumps({
             'uk_based': False,
-        })
+        }), content_type='application/json')
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -1,4 +1,3 @@
-import json
 from unittest import mock
 
 import pytest
@@ -119,9 +118,9 @@ class SearchTestCase(LeelooTestCase):
         """Tests detailed company search."""
         url = f"{reverse('api-v3:search:company')}?offset=0&limit=100"
 
-        response = self.api_client.post(url, json.dumps({
+        response = self.api_client.post(url, {
             'uk_based': False,
-        }), content_type='application/json')
+        }, format='json')
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1


### PR DESCRIPTION
Client sends POST data as JSON, so Booleans don't come as strings. 