### PR TITLE
Correct metadata URL path regex

### DIFF
--- a/datahub/metadata/views.py
+++ b/datahub/metadata/views.py
@@ -49,5 +49,5 @@ urls_args = []
 # programmatically generate metadata views
 for name, model in METADATA_MAPPING.items():
     fn = partial(metadata_view, model=model)
-    path = fr'{name}/$'
+    path = fr'^{name}/$'
     urls_args.append(((path, fn), {'name': name}))


### PR DESCRIPTION
Fixes problem with `/metadata/non-fdi-type/` endpoint returning the wrong data.