### PR TITLE
Stop overriding dit_adviser for new interactions

### DIFF
--- a/datahub/interaction/test/test_interaction_views.py
+++ b/datahub/interaction/test/test_interaction_views.py
@@ -25,12 +25,13 @@ class InteractionTestCase(LeelooTestCase):
     @freeze_time('2017-04-18 13:25:30.986208+00:00')
     def test_add_interaction(self):
         """Test add new interaction."""
+        adviser = AdviserFactory()
         url = reverse('api-v1:interaction-list')
         response = self.api_client.post(url, {
             'interaction_type': constants.InteractionType.business_card.value.id,
             'subject': 'whatever',
             'date': now().isoformat(),
-            'dit_adviser': AdviserFactory().pk,
+            'dit_adviser': adviser.pk,
             'notes': 'hello',
             'company': CompanyFactory().pk,
             'contact': ContactFactory().pk,
@@ -40,7 +41,7 @@ class InteractionTestCase(LeelooTestCase):
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
-        assert response_data['dit_adviser'] == str(self.user.pk)
+        assert response_data['dit_adviser'] == str(adviser.pk)
         assert response_data['modified_on'] == '2017-04-18T13:25:30.986208'
         assert response_data['created_on'] == '2017-04-18T13:25:30.986208'
 
@@ -48,12 +49,13 @@ class InteractionTestCase(LeelooTestCase):
     def test_add_interaction_project(self):
         """Test add new interaction for an investment project."""
         project = InvestmentProjectFactory()
+        adviser = AdviserFactory()
         url = reverse('api-v1:interaction-list')
         response = self.api_client.post(url, {
             'interaction_type': constants.InteractionType.business_card.value.id,
             'subject': 'whatever',
             'date': now().isoformat(),
-            'dit_adviser': AdviserFactory().pk,
+            'dit_adviser': adviser.pk,
             'notes': 'hello',
             'investment_project': project.pk,
             'service': constants.Service.trade_enquiry.value.id,
@@ -62,7 +64,7 @@ class InteractionTestCase(LeelooTestCase):
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
-        assert response_data['dit_adviser'] == str(self.user.pk)
+        assert response_data['dit_adviser'] == str(adviser.pk)
         assert response_data['investment_project'] == str(project.pk)
         assert response_data['modified_on'] == '2017-04-18T13:25:30.986208'
         assert response_data['created_on'] == '2017-04-18T13:25:30.986208'

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -23,10 +23,3 @@ class InteractionViewSetV1(CoreViewSetV1):
         DjangoFilterBackend,
     )
     filter_fields = ['contact_id', 'investment_project_id']
-
-    def get_additional_data(self, create):
-        """Set dit_adviser to the user on model instance creation."""
-        data = {}
-        if create:
-            data['dit_adviser'] = self.request.user
-        return data


### PR DESCRIPTION
As discussed with @jim68000, this stops the overriding of the `dit_adviser` that the front end was sending when creating interactions.

The front end will be amended to default to the current user when creating an interaction.

This change will also alter the behaviour of the home-page endpoint an interaction will show up on the home page of the user entered as the adviser for that interaction, which was discussed as more desirable.