### PR TITLE
[DH-327] Allow simple strings for relationship fields in v3 API

### DIFF
--- a/datahub/core/serializers.py
+++ b/datahub/core/serializers.py
@@ -54,7 +54,11 @@ class NestedRelatedField(serializers.RelatedField):
     def to_internal_value(self, data):
         """Converts a user-provided value to a model instance."""
         try:
-            data = self.pk_field.to_internal_value(data['id'])
+            if isinstance(data, str):
+                id_repr = data
+            else:
+                id_repr = data['id']
+            data = self.pk_field.to_internal_value(id_repr)
             return self.get_queryset().get(pk=data)
         except ObjectDoesNotExist:
             self.fail('does_not_exist', pk_value=data)
@@ -87,7 +91,7 @@ class NestedRelatedField(serializers.RelatedField):
 
         return _Choices(
             (
-                self.to_representation(item),
+                self.pk_field.to_representation(item.pk),
                 self.display_value(item)
             )
             for item in queryset

--- a/datahub/core/test/test_serializers.py
+++ b/datahub/core/test/test_serializers.py
@@ -8,12 +8,21 @@ from rest_framework.exceptions import ValidationError
 from datahub.core.serializers import NestedRelatedField
 
 
-def test_nested_rel_field_to_internal():
+def test_nested_rel_field_to_internal_dict():
     """Tests that model instances are returned for a dict with an 'id' key."""
     model = MagicMock()
     field = NestedRelatedField(model)
     uuid_ = uuid4()
-    assert field.to_internal_value({'id': uuid_})
+    assert field.to_internal_value({'id': str(uuid_)})
+    assert model.objects.all().get.call_args_list == [call(pk=uuid_)]
+
+
+def test_nested_rel_field_to_internal_str():
+    """Tests that model instances are returned for a dict with an 'id' key."""
+    model = MagicMock()
+    field = NestedRelatedField(model)
+    uuid_ = uuid4()
+    assert field.to_internal_value(str(uuid_))
     assert model.objects.all().get.call_args_list == [call(pk=uuid_)]
 
 
@@ -85,10 +94,8 @@ def test_nested_rel_field_to_choices():
     instance.name = 'instance name'
     model.objects.all.return_value = [instance] * 2
     field = NestedRelatedField(model)
-    assert list(field.get_choices().items()) == [({
-        'id': str(instance.id),
-        'name': instance.name
-    }, str(instance))] * 2
+    assert (list(field.get_choices().items()) == [(str(instance.id),
+                                                   str(instance))] * 2)
 
 
 def test_nested_rel_field_to_choices_limit():
@@ -99,7 +106,5 @@ def test_nested_rel_field_to_choices_limit():
     instance.name = 'instance name'
     model.objects.all.return_value = [instance] * 2
     field = NestedRelatedField(model)
-    assert list(field.get_choices(1).items()) == [({
-        'id': str(instance.id),
-        'name': instance.name
-    }, str(instance))]
+    assert (list(field.get_choices(1).items()) == [(str(instance.id),
+                                                    str(instance))])


### PR DESCRIPTION
Amends NestedRelatedField so that both objects and strings are accepted as input values.

This also made it possible to fix the DRF browseable API for v3 endpoints.