### PR TITLE
Update requirements

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -149,7 +149,7 @@ REST_FRAMEWORK = {
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.NamespaceVersioning',
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 100,
-    'DEFAULT_AUTHENTICATION_CLASSES': ['oauth2_provider.ext.rest_framework.OAuth2Authentication'],
+    'DEFAULT_AUTHENTICATION_CLASSES': ['oauth2_provider.contrib.rest_framework.OAuth2Authentication'],
     'DEFAULT_PERMISSION_CLASSES': ['rest_framework.permissions.IsAuthenticated'],
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 pip==9.0.1
 
 # For CH Sync
-lxml==3.7.3
+lxml==3.8.0
 cssselect==1.0.1
 
 # Django and django related
-Django==1.11.1
+Django==1.11.2
 djangorestframework==3.6.3
 django-environ==0.4.3
 django-extensions==1.7.9
@@ -14,7 +14,7 @@ django-reversion==2.0.8
 django-pglocks==1.0.2
 django-mptt==0.8.7
 
-django-oauth-toolkit==0.12.0
+django-oauth-toolkit==1.0.0
 whitenoise==3.3.0
 pyyaml==3.12
 colander==1.3.3
@@ -34,7 +34,7 @@ elasticsearch-dsl==2.2.0
 pytest-django==3.1.2
 pytest-sugar==0.8.0
 pytest-cov==2.5.1
-ipython==6.0.0
+ipython==6.1.0
 ipdb==0.10.3
 factory-boy==2.8.1
 freezegun==0.3.9
@@ -49,11 +49,11 @@ flake8-debugger==1.4.0
 flake8-import-order==0.12
 flake8-docstrings==1.1.0
 flake8-print==2.0.2
-flake8-quotes==0.9.0
+flake8-quotes==0.11.0
 flake8-string-format==0.2.3
 pep8-naming==0.4.1
 pydocstyle==2.0.0
 
 gunicorn==19.7.1
-raven==6.0.0
-requests==2.14.2
+raven==6.1.0
+requests==2.17.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ flake8-debugger==1.4.0
 flake8-import-order==0.12
 flake8-docstrings==1.1.0
 flake8-print==2.0.2
-flake8-quotes==0.11.0
+flake8-quotes==0.9.0
 flake8-string-format==0.2.3
 pep8-naming==0.4.1
 pydocstyle==2.0.0


### PR DESCRIPTION
Note: The OAuth2 update includes a migration.

Change logs:
https://docs.djangoproject.com/en/1.11/releases/1.11.2/
https://github.com/evonove/django-oauth-toolkit/blob/master/CHANGELOG.md
https://github.com/requests/requests/blob/master/HISTORY.rst
https://github.com/getsentry/raven-python/blob/master/CHANGES
https://github.com/lxml/lxml/blob/master/CHANGES.txt
http://ipython.readthedocs.io/en/stable/whatsnew/version6.html#ipython-6-1
