### PR TITLE
[DH-335] Make default search type whole string.

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -33,17 +33,22 @@ def configure_connection():
         )
 
 
-def get_basic_search_query(term, entities=('company',), offset=0, limit=100):
-    """Performs basic search looking for name and then _all in entity.
-
-    Also returns number of results in other entities.
-    """
-    query = Q('bool', should=[
+def get_search_term_query(term):
+    """Returns search term query."""
+    return Q('bool', should=[
         MatchPhrase(name={'query': term, 'boost': 2}),
         MatchPhrase(_all={'query': term, 'boost': 1.5}),
         Match(name={'query': term, 'boost': 1.0}),
         Match(_all={'query': term, 'boost': 0.5}),
     ])
+
+
+def get_basic_search_query(term, entities=('company',), offset=0, limit=100):
+    """Performs basic search looking for name and then _all in entity.
+
+    Also returns number of results in other entities.
+    """
+    query = get_search_term_query(term)
     s = Search(index=settings.ES_INDEX).query(query)
     s = s.post_filter(
         Q('bool', should=[Q('term', _type=entity) for entity in entities])
@@ -60,7 +65,7 @@ def get_search_by_entity_query(term=None, filters=None, entity=None, ranges=None
     """Perform filtered search for given terms in given entity."""
     query = [Q('term', _type=entity)]
     if term != '':
-        query.append(Q('multi_match', query=term, fields=['name', '_all']))
+        query.append(get_search_term_query(term))
 
     query_filter = []
 

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -10,21 +10,56 @@ def test_get_basic_search_query():
 
     assert query.to_dict() == {
         'query': {
-            'multi_match': {
-                'query': 'test',
-                'fields': ['name', '_all']
+            'bool': {
+                'should': [
+                    {
+                        'match_phrase': {
+                            'name': {
+                                'query': 'test',
+                                'boost': 2
+                            }
+                        }
+                    }, {
+                        'match_phrase': {
+                            '_all': {
+                                'query': 'test',
+                                'boost': 1.5
+                            }
+                        }
+                    }, {
+                        'match': {
+                            'name': {
+                                'query': 'test',
+                                'boost': 1.0
+                            }
+                        }
+                    }, {
+                        'match': {
+                            '_all': {
+                                'query': 'test',
+                                'boost': 0.5
+                            }
+                        }
+                    }
+                ]
             }
         },
         'post_filter': {
             'bool': {
                 'should': [
-                    {'term': {'_type': 'contact'}}
+                    {
+                        'term': {
+                            '_type': 'contact'
+                        }
+                    }
                 ]
             }
         },
         'aggs': {
             'count_by_type': {
-                'terms': {'field': '_type'}
+                'terms': {
+                    'field': '_type'
+                }
             }
         },
         'from': 5,

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -4,6 +4,47 @@ from unittest import mock
 from datahub.search import elasticsearch
 
 
+def test_get_search_term_query():
+    """Tests search term query."""
+    query = elasticsearch.get_search_term_query('hello')
+
+    assert query.to_dict() == {
+        'bool': {
+            'should': [
+                {
+                    'match_phrase': {
+                        'name': {
+                            'query': 'hello',
+                            'boost': 2
+                        }
+                    }
+                }, {
+                    'match_phrase': {
+                        '_all': {
+                            'query': 'hello',
+                            'boost': 1.5
+                        }
+                    }
+                }, {
+                    'match': {
+                        'name': {
+                            'query': 'hello',
+                            'boost': 1.0
+                        }
+                    }
+                }, {
+                    'match': {
+                        '_all': {
+                            'query': 'hello',
+                            'boost': 0.5
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+
 def test_get_basic_search_query():
     """Tests basic search query."""
     query = elasticsearch.get_basic_search_query('test', entities=('contact',), offset=5, limit=5)
@@ -92,37 +133,73 @@ def test_search_by_entity_query():
     assert query.to_dict() == {
         'query': {
             'bool': {
-                'must': [{
-                    'term': {
-                        '_type': 'company'
-                    }}, {
-                    'multi_match': {
-                        'query': 'test',
-                        'fields': ['name', '_all']
-                    }}]
+                'must': [
+                    {
+                        'term': {
+                            '_type': 'company'
+                        }
+                    }, {
+                        'bool': {
+                            'should': [
+                                {
+                                    'match_phrase': {
+                                        'name': {
+                                            'query': 'test',
+                                            'boost': 2
+                                        }
+                                    }
+                                }, {
+                                    'match_phrase': {
+                                        '_all': {
+                                            'query': 'test',
+                                            'boost': 1.5
+                                        }
+                                    }
+                                }, {
+                                    'match': {
+                                        'name': {
+                                            'query': 'test',
+                                            'boost': 1.0
+                                        }
+                                    }
+                                }, {
+                                    'match': {
+                                        '_all': {
+                                            'query': 'test',
+                                            'boost': 0.5
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
             }
         },
         'post_filter': {
             'bool': {
-                'must': [{
-                    'term': {
-                        'address_town': 'Woodside'
-                    }}, {
-                    'nested': {
-                        'path': 'trading_address_country',
-                        'query': {
-                            'term': {
-                                'trading_address_country.id':
-                                    '80756b9a-5d95-e211-a939-e4115bead28a'
+                'must': [
+                    {
+                        'term': {
+                            'address_town': 'Woodside'
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'trading_address_country',
+                            'query': {
+                                'term': {
+                                    'trading_address_country.id': '80756b9a-5d95-e211-a939-e4115bead28a'
+                                }
                             }
                         }
-                    }}, {
-                    'range': {
-                        'estimated_land_date': {
-                            'gte': '2017-06-13T09:44:31.062870',
-                            'lte': '2017-06-13T09:44:31.062870'
+                    }, {
+                        'range': {
+                            'estimated_land_date': {
+                                'gte': '2017-06-13T09:44:31.062870',
+                                'lte': '2017-06-13T09:44:31.062870'
+                            }
                         }
-                    }}
+                    }
                 ]
             }
         },


### PR DESCRIPTION
It changes the query to look for exact phrases first and is giving lower priority to incomplete matches.
