### PR TITLE
Improve search query.

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -21,10 +21,10 @@ def configure_connection():
 def get_search_term_query(term):
     """Returns search term query."""
     return Q('bool', should=[
-        MatchPhrase(name={'query': term, 'boost': 2}),
-        MatchPhrase(_all={'query': term, 'boost': 1.5}),
-        Match(name={'query': term, 'boost': 1.0}),
-        Match(_all={'query': term, 'boost': 0.5}),
+        MatchPhrase(name={'query': term, 'slop': 200}),
+        Match(name={'query': term}),
+        MatchPhrase(_all={'query': term}),
+        Match(_all={'query': term}),
     ])
 
 

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -15,28 +15,25 @@ def test_get_search_term_query():
                     'match_phrase': {
                         'name': {
                             'query': 'hello',
-                            'boost': 2
-                        }
-                    }
-                }, {
-                    'match_phrase': {
-                        '_all': {
-                            'query': 'hello',
-                            'boost': 1.5
+                            'slop': 200
                         }
                     }
                 }, {
                     'match': {
                         'name': {
                             'query': 'hello',
-                            'boost': 1.0
+                        }
+                    }
+                }, {
+                    'match_phrase': {
+                        '_all': {
+                            'query': 'hello',
                         }
                     }
                 }, {
                     'match': {
                         '_all': {
                             'query': 'hello',
-                            'boost': 0.5
                         }
                     }
                 }
@@ -57,28 +54,25 @@ def test_get_basic_search_query():
                         'match_phrase': {
                             'name': {
                                 'query': 'test',
-                                'boost': 2
-                            }
-                        }
-                    }, {
-                        'match_phrase': {
-                            '_all': {
-                                'query': 'test',
-                                'boost': 1.5
+                                'slop': 200
                             }
                         }
                     }, {
                         'match': {
                             'name': {
                                 'query': 'test',
-                                'boost': 1.0
+                            }
+                        }
+                    }, {
+                        'match_phrase': {
+                            '_all': {
+                                'query': 'test',
                             }
                         }
                     }, {
                         'match': {
                             '_all': {
                                 'query': 'test',
-                                'boost': 0.5
                             }
                         }
                     }
@@ -145,28 +139,25 @@ def test_search_by_entity_query():
                                     'match_phrase': {
                                         'name': {
                                             'query': 'test',
-                                            'boost': 2
-                                        }
-                                    }
-                                }, {
-                                    'match_phrase': {
-                                        '_all': {
-                                            'query': 'test',
-                                            'boost': 1.5
+                                            'slop': 200
                                         }
                                     }
                                 }, {
                                     'match': {
                                         'name': {
                                             'query': 'test',
-                                            'boost': 1.0
+                                        }
+                                    }
+                                }, {
+                                    'match_phrase': {
+                                        '_all': {
+                                            'query': 'test',
                                         }
                                     }
                                 }, {
                                     'match': {
                                         '_all': {
                                             'query': 'test',
-                                            'boost': 0.5
                                         }
                                     }
                                 }


### PR DESCRIPTION
In the previous query, results had too narrow difference in the score that resulted sometimes in having order that is not desired. Proposed query sets the scores further apart by favouring matches that have matching words closer to each other (using `slop`). This should fix tests failing at random.