### PR TITLE
Remove dep from django.test.TestCase

### DIFF
--- a/datahub/company/test/test_advisor_views.py
+++ b/datahub/company/test/test_advisor_views.py
@@ -1,11 +1,11 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 from .factories import AdviserFactory
 
 
-class AdviserTestCase(LeelooTestCase):
+class TestAdviser(APITestMixin):
     """Adviser test case."""
 
     def test_adviser_list_view(self):

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -4,11 +4,11 @@ from rest_framework.reverse import reverse
 
 from datahub.company import models
 from datahub.core import constants
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 from .factories import CompaniesHouseCompanyFactory, CompanyFactory
 
 
-class CompanyTestCase(LeelooTestCase):
+class TestCompany(APITestMixin):
     """Company test case."""
 
     def test_list_companies(self):
@@ -279,7 +279,7 @@ class CompanyTestCase(LeelooTestCase):
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-class CHCompanyTestCase(LeelooTestCase):
+class TestCHCompany(APITestMixin):
     """Companies house company test case."""
 
     def test_list_ch_companies(self):

--- a/datahub/company/test/test_company_views_v3.py
+++ b/datahub/company/test/test_company_views_v3.py
@@ -11,11 +11,11 @@ from datahub.core.constants import (
     BusinessType, CompanyClassification, Country, HeadquarterType, Sector,
     UKRegion
 )
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 from datahub.investment.test.factories import InvestmentProjectFactory
 
 
-class CompanyTestCase(LeelooTestCase):
+class TestCompany(APITestMixin):
     """Company test case."""
 
     def test_list_companies(self):
@@ -346,7 +346,7 @@ class CompanyTestCase(LeelooTestCase):
         assert response.data['id'] == str(company.id)
 
 
-class CHCompanyTestCase(LeelooTestCase):
+class TestCHCompany(APITestMixin):
     """CH company tests."""
 
     def test_get_ch_company(self):

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -4,14 +4,14 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core import constants
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 from .factories import CompanyFactory, ContactFactory
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db
 
 
-class AddContactTestCase(LeelooTestCase):
+class TestAddContact(APITestMixin):
     """Add contact test case."""
 
     @freeze_time('2017-04-18 13:25:30.986208+00:00')
@@ -254,7 +254,7 @@ class AddContactTestCase(LeelooTestCase):
         }
 
 
-class EditContactTestCase(LeelooTestCase):
+class TestEditContact(APITestMixin):
     """Edit contact test case."""
 
     @freeze_time('2017-04-18 13:25:30.986208+00:00')
@@ -342,7 +342,7 @@ class EditContactTestCase(LeelooTestCase):
         }
 
 
-class ArchiveContactTestCase(LeelooTestCase):
+class TestArchiveContact(APITestMixin):
     """Archive/unarchive contact test case."""
 
     def test_archive_without_reason(self):
@@ -393,7 +393,7 @@ class ArchiveContactTestCase(LeelooTestCase):
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
-class ViewContactTestCase(LeelooTestCase):
+class TestViewContact(APITestMixin):
     """View contact test case."""
 
     @freeze_time('2017-04-18 13:25:30.986208+00:00')
@@ -478,7 +478,7 @@ class ViewContactTestCase(LeelooTestCase):
         }
 
 
-class ContactListTestCase(LeelooTestCase):
+class TestContactList(APITestMixin):
     """List/filter contacts test case."""
 
     def test_all(self):

--- a/datahub/dashboard/test/test_views.py
+++ b/datahub/dashboard/test/test_views.py
@@ -3,11 +3,11 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import CompanyFactory
 from datahub.core import constants
-from datahub.core.test_utils import get_test_user, LeelooTestCase
+from datahub.core.test_utils import APITestMixin, get_test_user
 from datahub.interaction.test.factories import InteractionFactory
 
 
-class DashboardTestCase(LeelooTestCase):
+class TestDashboard(APITestMixin):
     """Dashboard test case."""
 
     def test_intelligent_homepage(self):

--- a/datahub/interaction/test/test_interaction_views.py
+++ b/datahub/interaction/test/test_interaction_views.py
@@ -5,12 +5,12 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 from datahub.interaction.test.factories import InteractionFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
 
 
-class InteractionTestCase(LeelooTestCase):
+class TestInteraction(APITestMixin):
     """Interaction test case."""
 
     def test_interaction_detail_view(self):

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -13,7 +13,7 @@ from rest_framework.reverse import reverse
 from datahub.company.test.factories import (AdviserFactory, CompanyFactory,
                                             ContactFactory)
 from datahub.core import constants
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 from datahub.core.utils import executor
 from datahub.documents.av_scan import virus_scan_document
 from datahub.investment import views
@@ -23,7 +23,7 @@ from datahub.investment.test.factories import (
 )
 
 
-class InvestmentViewsTestCase(LeelooTestCase):
+class TestInvestmentViews(APITestMixin):
     """Tests for the deprecated project, value, team and requirements views."""
 
     def test_list_projects_success(self):
@@ -586,7 +586,7 @@ class InvestmentViewsTestCase(LeelooTestCase):
         }
 
 
-class UnifiedViewsTestCase(LeelooTestCase):
+class TestUnifiedViews(APITestMixin):
     """Tests for the unified investment views."""
 
     def test_list_projects_success(self):
@@ -1316,7 +1316,7 @@ class UnifiedViewsTestCase(LeelooTestCase):
         assert response_data['phase'] == response_data['stage']
 
 
-class TeamMemberViewsTestCase(LeelooTestCase):
+class TestTeamMemberViews(APITestMixin):
     """Tests for the team member views."""
 
     def test_add_team_member_nonexistent_project(self):
@@ -1499,13 +1499,11 @@ class TeamMemberViewsTestCase(LeelooTestCase):
         assert str(new_team_members[0].adviser.pk) == team_members[1].adviser.pk
 
 
-class AuditLogViewTestCase(LeelooTestCase):
+class TestAuditLogView(APITestMixin):
     """Tests for the audit log view."""
 
     def test_audit_log_view(self):
         """Test retrieval of audit log."""
-        user = self.get_user()
-
         initial_datetime = datetime.utcnow()
         with reversion.create_revision():
             iproject = InvestmentProjectFactory(
@@ -1514,7 +1512,7 @@ class AuditLogViewTestCase(LeelooTestCase):
 
             reversion.set_comment('Initial')
             reversion.set_date_created(initial_datetime)
-            reversion.set_user(user)
+            reversion.set_user(self.user)
 
         changed_datetime = datetime.utcnow()
         with reversion.create_revision():
@@ -1523,7 +1521,7 @@ class AuditLogViewTestCase(LeelooTestCase):
 
             reversion.set_comment('Changed')
             reversion.set_date_created(changed_datetime)
-            reversion.set_user(user)
+            reversion.set_user(self.user)
 
         url = reverse('api-v3:investment:audit-item',
                       kwargs={'pk': iproject.pk})
@@ -1535,13 +1533,13 @@ class AuditLogViewTestCase(LeelooTestCase):
         assert len(response_data) == 1, 'Only one entry in audit log'
         entry = response_data[0]
 
-        assert entry['user']['name'] == user.name, 'Valid user captured'
+        assert entry['user']['name'] == self.user.name, 'Valid user captured'
         assert entry['comment'] == 'Changed', 'Comments can be set manually'
         assert entry['timestamp'] == changed_datetime.isoformat(), 'TS can be set manually'
         assert entry['changes']['description'] == ['Initial desc', 'New desc'], 'Changes are reflected'
 
 
-class ArchiveViewsTestCase(LeelooTestCase):
+class TestArchiveViews(APITestMixin):
     """Tests for the archive and unarchive views."""
 
     def test_archive_project_success(self):
@@ -1615,7 +1613,7 @@ class ArchiveViewsTestCase(LeelooTestCase):
         assert response_data['archived_reason'] == ''
 
 
-class DocumentViewsTestCase(LeelooTestCase):
+class TestDocumentViews(APITestMixin):
     """Tests for the document views."""
 
     def test_documents_list_is_filtered_by_project(self):

--- a/datahub/leads/test/test_views.py
+++ b/datahub/leads/test/test_views.py
@@ -6,13 +6,13 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 from datahub.leads.test.factories import BusinessLeadFactory
 
 FROZEN_TIME = '2017-04-18T13:25:30.986208'
 
 
-class BusinessLeadViewsTestCase(LeelooTestCase):
+class TestBusinessLeadViews(APITestMixin):
     """Business lead views test case."""
 
     def test_list_leads_success(self):

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -9,14 +9,14 @@ from rest_framework.reverse import reverse
 from datahub.company.test.factories import CompanyFactory
 from datahub.core import constants
 from datahub.core.test_utils import (
-    LeelooTestCase, synchronous_executor_submit, synchronous_transaction_on_commit,
+    APITestMixin, synchronous_executor_submit, synchronous_transaction_on_commit,
 )
 
 pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.usefixtures('setup_data', 'post_save_handlers')
-class SearchTestCase(LeelooTestCase):
+class TestSearch(APITestMixin):
     """Tests search views."""
 
     def test_basic_search_all_companies(self):

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -1,10 +1,10 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import get_test_user, LeelooTestCase
+from datahub.core.test_utils import APITestMixin, get_test_user
 
 
-class UserViewTestCase(LeelooTestCase):
+class TestUserView(APITestMixin):
     """User view test case."""
 
     def test_who_am_i_authenticated(self):

--- a/datahub/v2/tests/repos/test_service_deliveries_repo.py
+++ b/datahub/v2/tests/repos/test_service_deliveries_repo.py
@@ -1,7 +1,6 @@
 import uuid
 
 import pytest
-from django.test import TestCase
 from django.utils.timezone import now
 from freezegun import freeze_time
 
@@ -18,7 +17,7 @@ pytestmark = pytest.mark.django_db
 DUMMY_CONFIG = config = {'url_builder': lambda kwargs: None}
 
 
-class ServiceDeliveriesRepoTestCase(TestCase):
+class TestServiceDeliveriesRepo:
     """Service delivery repo test case."""
 
     def test_get(self):

--- a/datahub/v2/tests/views/test_parsers.py
+++ b/datahub/v2/tests/views/test_parsers.py
@@ -2,10 +2,10 @@ import json
 
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 
 
-class JSONParserTestCase(LeelooTestCase):
+class TestJSONParser(APITestMixin):
     """Test generic parser error through a v2 view."""
 
     def test_data_key_not_in_post_body(self):

--- a/datahub/v2/tests/views/test_service_delivery.py
+++ b/datahub/v2/tests/views/test_service_delivery.py
@@ -7,13 +7,13 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core import constants
-from datahub.core.test_utils import LeelooTestCase
+from datahub.core.test_utils import APITestMixin
 
 from datahub.interaction.test.factories import ServiceDeliveryFactory, ServiceOfferFactory
 from datahub.metadata.test.factories import EventFactory
 
 
-class ServiceDeliveryViewTestCase(LeelooTestCase):
+class TestServiceDeliveryView(APITestMixin):
     """Service Delivery view test case."""
 
     def test_service_delivery_detail_view(self):


### PR DESCRIPTION
We are using pytest but in some cases we were still subclassing `django.test.TestCase`

This:
- removes the dep from `django.test.TestCase`
- replaces the login in `setUp` with python properties
- renames `LeelooTestCase` to `APITestMixin`

Overall, the tests run faster now as we have less overhead.