### PR TITLE
Add get order by id endpoint

### DIFF
--- a/datahub/omis/order/urls.py
+++ b/datahub/omis/order/urls.py
@@ -9,6 +9,11 @@ order_collection = OrderViewSet.as_view({
     'post': 'create'
 })
 
+order_item = OrderViewSet.as_view({
+    'get': 'retrieve'
+})
+
 urlpatterns = [
     url(r'^order$', order_collection, name='list'),
+    url(r'^order/(?P<pk>[0-9a-z-]{36})$', order_item, name='detail'),
 ]


### PR DESCRIPTION
This adds a GET `/v3/omis/order/<order-id>` endpoint returning
the order details, e.g.

```
{
    'id': 'aa6998d6-ab5a-4ba8-8090-9b663813d0d2',
    'reference': 'TTU169/17',
    'company': {
        'name': 'My Corp',
        'id': 'd98da59a-84fd-4e08-8ffb-c702d4706548'
    },
    'contact': {
        'name': 'John Doe',
        'id': 'f56b4017-2132-4c98-9356-b3859f409490'
    },
    'primary_market': {
        'name': 'France',
        'id': '82756b9a-5d95-e211-a939-e4115bead28a'
    }
}
```