### PR TITLE
Remove validation of site_decided for investment projects

### DIFF
--- a/datahub/investment/models.py
+++ b/datahub/investment/models.py
@@ -160,6 +160,7 @@ class IProjectRequirementsAbstract(models.Model):
         abstract = True
 
     client_requirements = models.TextField(blank=True, null=True)
+    # site_decided is deprecated; will be removed
     site_decided = models.NullBooleanField()
     address_line_1 = models.CharField(blank=True, null=True,
                                       max_length=MAX_LENGTH)

--- a/datahub/investment/serializers.py
+++ b/datahub/investment/serializers.py
@@ -196,7 +196,7 @@ class IProjectRequirementsSerializer(serializers.ModelSerializer):
         model = InvestmentProject
         fields = (
             'client_requirements',
-            'site_decided',
+            'site_decided',  # deprecated; will be removed
             'address_line_1',
             'address_line_2',
             'address_line_3',

--- a/datahub/investment/test/test_validate.py
+++ b/datahub/investment/test/test_validate.py
@@ -142,7 +142,6 @@ def test_validate_reqs_fail():
     assert errors == {
         'client_considering_other_countries': 'This field is required.',
         'client_requirements': 'This field is required.',
-        'site_decided': 'This field is required.',
         'strategic_drivers': 'This field is required.',
         'uk_region_locations': 'This field is required.'
     }

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -389,7 +389,6 @@ class TestUnifiedViews(APITestMixin):
             'total_investment',
             'client_considering_other_countries',
             'client_requirements',
-            'site_decided',
             'strategic_drivers',
             'uk_region_locations',
         ))
@@ -413,7 +412,6 @@ class TestUnifiedViews(APITestMixin):
             'total_investment': ['This field is required.'],
             'client_considering_other_countries': ['This field is required.'],
             'client_requirements': ['This field is required.'],
-            'site_decided': ['This field is required.'],
             'strategic_drivers': ['This field is required.'],
             'uk_region_locations': ['This field is required.'],
         }
@@ -464,7 +462,6 @@ class TestUnifiedViews(APITestMixin):
             'total_investment': ['This field is required.'],
             'client_considering_other_countries': ['This field is required.'],
             'client_requirements': ['This field is required.'],
-            'site_decided': ['This field is required.'],
             'strategic_drivers': ['This field is required.'],
             'uk_region_locations': ['This field is required.'],
             'project_assurance_adviser': ['This field is required.'],

--- a/datahub/investment/validate.py
+++ b/datahub/investment/validate.py
@@ -22,7 +22,6 @@ VALIDATION_MAPPING = {
     'uk_region_locations': Stage.assign_pm.value,
     'client_requirements': Stage.assign_pm.value,
     'client_considering_other_countries': Stage.assign_pm.value,
-    'site_decided': Stage.assign_pm.value,
     'project_manager': Stage.active.value,
     'project_assurance_adviser': Stage.active.value,
     'client_cannot_provide_foreign_investment': Stage.verify_win.value,


### PR DESCRIPTION
`site_decided` is being removed from the forms in the front end so this removes it from the list of required fields.