### PR TITLE
Add endpoint to update order details

### DIFF
--- a/datahub/core/test/test_validate_utils.py
+++ b/datahub/core/test/test_validate_utils.py
@@ -32,53 +32,51 @@ def test_any_of_all():
     validator({'field_a': Mock(), 'field_b': Mock()})
 
 
-def test_get_value_instance():
-    """Tests getting a simple value from an instance."""
-    instance = Mock(field1=1, field2=2)
-    data = {'field2': 456}
-    data_combiner = DataCombiner(instance, data)
-    assert data_combiner.get_value('field1') == 1
+class TestDataCombiner:
+    """Data Combiner tests."""
 
+    def test_get_value_instance(self):
+        """Tests getting a simple value from an instance."""
+        instance = Mock(field1=1, field2=2)
+        data = {'field2': 456}
+        data_combiner = DataCombiner(instance, data)
+        assert data_combiner.get_value('field1') == 1
 
-def test_get_value_data():
-    """Tests getting a simple value from update data."""
-    instance = Mock(field1=1, field2=2)
-    data = {'field2': 456}
-    data_combiner = DataCombiner(instance, data)
-    assert data_combiner.get_value('field2') == 456
+    def test_get_value_data(self):
+        """Tests getting a simple value from update data."""
+        instance = Mock(field1=1, field2=2)
+        data = {'field2': 456}
+        data_combiner = DataCombiner(instance, data)
+        assert data_combiner.get_value('field2') == 456
 
+    def test_get_value_to_many_instance(self):
+        """Tests getting a to-many value from an instance."""
+        instance = Mock(field1=MagicMock())
+        instance.field1.all.return_value = [123]
+        data_combiner = DataCombiner(instance, None)
+        assert data_combiner.get_value_to_many('field1') == [123]
 
-def test_get_value_to_many_instance():
-    """Tests getting a to-many value from an instance."""
-    instance = Mock(field1=MagicMock())
-    instance.field1.all.return_value = [123]
-    data_combiner = DataCombiner(instance, None)
-    assert data_combiner.get_value_to_many('field1') == [123]
+    def test_get_value_to_many_data(self):
+        """Tests getting a to-many value from update data."""
+        instance = Mock(field1=MagicMock())
+        data = {'field1': [123]}
+        data_combiner = DataCombiner(instance, data)
+        assert data_combiner.get_value_to_many('field1') == data['field1']
 
+    def test_get_value_id_instance(self):
+        """Tests getting a foreign key from an instance."""
+        subinstance = Mock()
+        subinstance.id = 1234
+        instance = Mock(field1=subinstance)
+        data_combiner = DataCombiner(instance, None)
+        assert data_combiner.get_value_id('field1') == str(subinstance.id)
 
-def test_get_value_to_many_data():
-    """Tests getting a to-many value from update data."""
-    instance = Mock(field1=MagicMock())
-    data = {'field1': [123]}
-    data_combiner = DataCombiner(instance, data)
-    assert data_combiner.get_value_to_many('field1') == data['field1']
-
-
-def test_get_value_id_instance():
-    """Tests getting a foreign key from an instance."""
-    subinstance = Mock()
-    subinstance.id = 1234
-    instance = Mock(field1=subinstance)
-    data_combiner = DataCombiner(instance, None)
-    assert data_combiner.get_value_id('field1') == str(subinstance.id)
-
-
-def test_get_value_id_value():
-    """Tests getting a foreign key from update data."""
-    subinstance = Mock()
-    subinstance.id = 1234
-    new_subinstance = Mock()
-    new_subinstance.id = 456
-    instance = Mock(field1=subinstance)
-    data_combiner = DataCombiner(instance, {'field1': new_subinstance})
-    assert data_combiner.get_value_id('field1') == str(new_subinstance.id)
+    def test_get_value_id_value(self):
+        """Tests getting a foreign key from update data."""
+        subinstance = Mock()
+        subinstance.id = 1234
+        new_subinstance = Mock()
+        new_subinstance.id = 456
+        instance = Mock(field1=subinstance)
+        data_combiner = DataCombiner(instance, {'field1': new_subinstance})
+        assert data_combiner.get_value_id('field1') == str(new_subinstance.id)

--- a/datahub/core/test/test_validate_utils.py
+++ b/datahub/core/test/test_validate_utils.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, Mock
 import pytest
 from rest_framework.exceptions import ValidationError
 
-from datahub.core.validate_utils import AnyOfValidator, UpdatedDataView
+from datahub.core.validate_utils import AnyOfValidator, DataCombiner
 
 
 def test_any_of_none():
@@ -36,32 +36,32 @@ def test_get_value_instance():
     """Tests getting a simple value from an instance."""
     instance = Mock(field1=1, field2=2)
     data = {'field2': 456}
-    data_view = UpdatedDataView(instance, data)
-    assert data_view.get_value('field1') == 1
+    data_combiner = DataCombiner(instance, data)
+    assert data_combiner.get_value('field1') == 1
 
 
 def test_get_value_data():
     """Tests getting a simple value from update data."""
     instance = Mock(field1=1, field2=2)
     data = {'field2': 456}
-    data_view = UpdatedDataView(instance, data)
-    assert data_view.get_value('field2') == 456
+    data_combiner = DataCombiner(instance, data)
+    assert data_combiner.get_value('field2') == 456
 
 
 def test_get_value_to_many_instance():
     """Tests getting a to-many value from an instance."""
     instance = Mock(field1=MagicMock())
     instance.field1.all.return_value = [123]
-    data_view = UpdatedDataView(instance, None)
-    assert data_view.get_value_to_many('field1') == [123]
+    data_combiner = DataCombiner(instance, None)
+    assert data_combiner.get_value_to_many('field1') == [123]
 
 
 def test_get_value_to_many_data():
     """Tests getting a to-many value from update data."""
     instance = Mock(field1=MagicMock())
     data = {'field1': [123]}
-    data_view = UpdatedDataView(instance, data)
-    assert data_view.get_value_to_many('field1') == data['field1']
+    data_combiner = DataCombiner(instance, data)
+    assert data_combiner.get_value_to_many('field1') == data['field1']
 
 
 def test_get_value_id_instance():
@@ -69,8 +69,8 @@ def test_get_value_id_instance():
     subinstance = Mock()
     subinstance.id = 1234
     instance = Mock(field1=subinstance)
-    data_view = UpdatedDataView(instance, None)
-    assert data_view.get_value_id('field1') == str(subinstance.id)
+    data_combiner = DataCombiner(instance, None)
+    assert data_combiner.get_value_id('field1') == str(subinstance.id)
 
 
 def test_get_value_id_value():
@@ -80,5 +80,5 @@ def test_get_value_id_value():
     new_subinstance = Mock()
     new_subinstance.id = 456
     instance = Mock(field1=subinstance)
-    data_view = UpdatedDataView(instance, {'field1': new_subinstance})
-    assert data_view.get_value_id('field1') == str(new_subinstance.id)
+    data_combiner = DataCombiner(instance, {'field1': new_subinstance})
+    assert data_combiner.get_value_id('field1') == str(new_subinstance.id)

--- a/datahub/core/validate_utils.py
+++ b/datahub/core/validate_utils.py
@@ -39,8 +39,8 @@ class AnyOfValidator:
 
         :param attrs:   Serializer data (post-field-validation/processing)
         """
-        data_view = UpdatedDataView(self.serializer.instance, attrs)
-        values = (data_view.get_value(field) for field in self.fields)
+        data_combiner = DataCombiner(self.serializer.instance, attrs)
+        values = (data_combiner.get_value(field) for field in self.fields)
         value_present = any(value for value in values if value is not None)
         if not value_present:
             field_names = ', '.join(self.fields)
@@ -52,16 +52,17 @@ class AnyOfValidator:
         return f'{self.__class__.__name__}(fields={self.fields!r})'
 
 
-class UpdatedDataView:
+class DataCombiner:
     """
-    Provides a view of a model instance and dict of new data.
+    Combines values from the dict of updated data and the model instance fields.
+    Its methods return the first value found in the chain (update_data, instance).
 
     Used for cross-field validation of v3 endpoints (because PATCH requests
     will only contain data for fields being updated).
     """
 
     def __init__(self, instance, update_data):
-        """Initialises the view."""
+        """Initialises the combiner."""
         if instance is None and update_data is None:
             raise TypeError('One of instance and update_data must be provided '
                             'and not None')

--- a/datahub/investment/validate.py
+++ b/datahub/investment/validate.py
@@ -8,7 +8,7 @@ from datahub.core.constants import (
     InvestmentProjectStage as Stage, InvestmentType,
     ReferralSourceActivity as Activity
 )
-from datahub.core.validate_utils import UpdatedDataView
+from datahub.core.validate_utils import DataCombiner
 from datahub.investment.models import InvestmentProject
 
 
@@ -70,7 +70,7 @@ def validate(instance=None, update_data=None, fields=None, next_stage=False):
     :param next_stage:  Perform validation for the next stage (rather than the current stage)
     :return:            dict containing errors for incomplete fields
     """
-    data = UpdatedDataView(instance, update_data)
+    data = DataCombiner(instance, update_data)
     info = model_meta.get_field_info(InvestmentProject)
     desired_stage = data.get_value('stage') or Stage.prospect.value
     desired_stage_order = desired_stage.order

--- a/datahub/leads/serializers.py
+++ b/datahub/leads/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 
 from datahub.company.models import Advisor, Company
 from datahub.core.serializers import NestedRelatedField
-from datahub.core.validate_utils import UpdatedDataView
+from datahub.core.validate_utils import DataCombiner
 from datahub.leads.models import BusinessLead
 from datahub.metadata import models as meta_models
 
@@ -41,14 +41,14 @@ class BusinessLeadSerializer(serializers.ModelSerializer):
         as well as an email address or phone number.
         """
         errors = {}
-        data_view = UpdatedDataView(self.instance, data)
-        company_name = data_view.get_value('company_name')
-        trading_name = data_view.get_value('trading_name')
-        company = data_view.get_value('company')
-        first_name = data_view.get_value('first_name')
-        last_name = data_view.get_value('last_name')
-        telephone_number = data_view.get_value('telephone_number')
-        email = data_view.get_value('email')
+        data_combiner = DataCombiner(self.instance, data)
+        company_name = data_combiner.get_value('company_name')
+        trading_name = data_combiner.get_value('trading_name')
+        company = data_combiner.get_value('company')
+        first_name = data_combiner.get_value('first_name')
+        last_name = data_combiner.get_value('last_name')
+        telephone_number = data_combiner.get_value('telephone_number')
+        email = data_combiner.get_value('email')
 
         has_company_name = any((company_name, company, trading_name))
         has_contact_name = first_name and last_name

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -30,10 +30,29 @@ class OrderSerializer(serializers.ModelSerializer):
         """
         Extra check that a contact works at the given company.
         """
-        if data['contact'].company != data['company']:
+        # get the data from `data` or fallback to the instance data in case of PATCH
+        data_to_validate = dict(data)
+        if self.partial:
+            for field in self.get_fields().keys() - data.keys():
+                data_to_validate[field] = getattr(self.instance, field)
+
+        # check that contact works at company
+        if data_to_validate['contact'].company != data_to_validate['company']:
             raise serializers.ValidationError({
                 'contact': 'The contact does not work at the given company.'
             })
+
+        # company and primary_market cannot be changed after creation
+        if self.instance:
+            if data_to_validate['company'] != self.instance.company:
+                raise serializers.ValidationError({
+                    'company': 'The company cannot be changed after creation.'
+                })
+
+            if data_to_validate['primary_market'] != self.instance.primary_market:
+                raise serializers.ValidationError({
+                    'primary_market': 'The primary market cannot be changed after creation.'
+                })
 
         return data
 

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from datahub.company.models import Advisor, Company, Contact
 from datahub.core.serializers import NestedRelatedField
-from datahub.core.validate_utils import UpdatedDataView
+from datahub.core.validate_utils import DataCombiner
 from datahub.metadata.models import Country, Team
 
 from .models import Order
@@ -29,9 +29,9 @@ class OrderSerializer(serializers.ModelSerializer):
 
     def validate(self, data):
         """Extra checks."""
-        data_view = UpdatedDataView(self.instance, data)
-        company = data_view.get_value('company')
-        contact = data_view.get_value('contact')
+        data_combiner = DataCombiner(self.instance, data)
+        company = data_combiner.get_value('company')
+        contact = data_combiner.get_value('contact')
 
         # check that contact works at company
         if contact.company != company:
@@ -46,7 +46,7 @@ class OrderSerializer(serializers.ModelSerializer):
                     'company': 'The company cannot be changed after creation.'
                 })
 
-            if data_view.get_value('primary_market') != self.instance.primary_market:
+            if data_combiner.get_value('primary_market') != self.instance.primary_market:
                 raise serializers.ValidationError({
                     'primary_market': 'The primary market cannot be changed after creation.'
                 })

--- a/datahub/omis/order/test/factories.py
+++ b/datahub/omis/order/test/factories.py
@@ -13,7 +13,7 @@ class OrderFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyFunction(lambda: str(uuid.uuid4()))
     company = factory.SubFactory(CompanyFactory)
-    contact = factory.SubFactory(ContactFactory)
+    contact = factory.LazyAttribute(lambda o: ContactFactory(company=o.company))
     primary_market_id = Country.france.value.id
 
     class Meta:  # noqa: D101

--- a/datahub/omis/order/urls.py
+++ b/datahub/omis/order/urls.py
@@ -10,7 +10,8 @@ order_collection = OrderViewSet.as_view({
 })
 
 order_item = OrderViewSet.as_view({
-    'get': 'retrieve'
+    'get': 'retrieve',
+    'patch': 'partial_update'
 })
 
 


### PR DESCRIPTION
This allows clients to PATCH the contact field of existing orders.
Company and primary market cannot be changed after creation.

PATCH `v3/omis/order/<order-id>` - [docs](https://documenter.getpostman.com/view/2403194/omis/6fZxPC3#63fb90aa-6499-6eaf-7e88-a8350216d4ed).
