### PR TITLE
Add created/modified on fields to OMIS endpoints

### DIFF
--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -4,10 +4,10 @@ from django.db import models
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now
 
-from datahub.company.models import Company, Contact
+from datahub.company.models import Advisor, Company, Contact
 from datahub.core.models import BaseModel
 
-from datahub.metadata.models import Country
+from datahub.metadata.models import Country, Sector
 
 
 class Order(BaseModel):
@@ -36,7 +36,7 @@ class Order(BaseModel):
         on_delete=models.SET_NULL
     )
     sector = models.ForeignKey(
-        'metadata.Sector',
+        Sector,
         related_name='+',
         null=True, blank=True,
         on_delete=models.SET_NULL
@@ -90,7 +90,7 @@ class OrderSubscriber(BaseModel):
         Order, on_delete=models.CASCADE, related_name='subscribers'
     )
     adviser = models.ForeignKey(
-        'company.Advisor', on_delete=models.CASCADE, related_name='+'
+        Advisor, on_delete=models.CASCADE, related_name='+'
     )
 
     def __str__(self):

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -13,6 +13,10 @@ class OrderSerializer(serializers.ModelSerializer):
 
     id = serializers.UUIDField(read_only=True)
     reference = serializers.CharField(read_only=True)
+
+    created_on = serializers.DateTimeField(read_only=True)
+    modified_on = serializers.DateTimeField(read_only=True)
+
     company = NestedRelatedField(Company)
     contact = NestedRelatedField(Contact)
     primary_market = NestedRelatedField(Country)
@@ -23,6 +27,8 @@ class OrderSerializer(serializers.ModelSerializer):
         fields = [
             'id',
             'reference',
+            'created_on',
+            'modified_on',
             'company',
             'contact',
             'primary_market',

--- a/datahub/omis/order/test/test_views.py
+++ b/datahub/omis/order/test/test_views.py
@@ -48,6 +48,8 @@ class TestAddOrderDetails(APITestMixin):
         assert response.json() == {
             'id': response.json()['id'],
             'reference': response.json()['reference'],
+            'created_on': '2017-04-18T13:00:00',
+            'modified_on': '2017-04-18T13:00:00',
             'company': {
                 'id': company.pk,
                 'name': company.name
@@ -112,6 +114,7 @@ class TestAddOrderDetails(APITestMixin):
 class TestChangeOrderDetails(APITestMixin):
     """Change Order details test case."""
 
+    @freeze_time('2017-04-18 13:00:00.000000+00:00')
     def test_success(self):
         """Test changing an existing order."""
         order = OrderFactory()
@@ -136,6 +139,8 @@ class TestChangeOrderDetails(APITestMixin):
         assert response.json() == {
             'id': order.id,
             'reference': order.reference,
+            'created_on': '2017-04-18T13:00:00',
+            'modified_on': '2017-04-18T13:00:00',
             'company': {
                 'id': str(order.company.id),
                 'name': order.company.name
@@ -259,6 +264,8 @@ class TestViewOrderDetails(APITestMixin):
         assert response.json() == {
             'id': order.id,
             'reference': order.reference,
+            'created_on': order.created_on.isoformat(),
+            'modified_on': order.modified_on.isoformat(),
             'company': {
                 'id': str(order.company.id),
                 'name': order.company.name


### PR DESCRIPTION
This adds the `created_on` and `modified_on` fields to the order endpoints.

The #348 might get bigger so I'm isolating part of it here which should be self contained and easier to review.