### PR TITLE
Adds aggregates of available filters.

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -202,13 +202,6 @@ FILTER_NAME_MAP = {
     'stage': 'stage.id',
 }
 
-REVERSE_FILTER_NAME_MAP = {y: x for x, y in FILTER_NAME_MAP.items()}
-
-
-def reverse_remap_field(field):
-    """Maps elasticsearch field to api field."""
-    return REVERSE_FILTER_NAME_MAP.get(field, field)
-
 
 def remap_field(field):
     """Maps api field to elasticsearch field."""

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -109,22 +109,20 @@ def get_term_query(field, value):
 def apply_aggs_query(search, aggs):
     """Applies aggregates query to the search."""
     for agg in aggs:
-        if any([x in agg for x in ('_before', '_after')]):
+        # skip range filters as we can't aggregate them
+        if any(agg.endswith(x) for x in ('_before', '_after')):
             continue
-
         agg = remap_field(agg)
+
+        search_aggs = search.aggs
         if '.' in agg:
-            search.aggs.bucket(
+            search_aggs = search_aggs.bucket(
                 agg,
                 'nested',
                 path=agg.split('.', 1)[0]
-            ).bucket(
-                agg,
-                'terms',
-                field=agg
             )
-        else:
-            search.aggs.bucket(agg, 'terms', field=agg)
+
+        search_aggs.bucket(agg, 'terms', field=agg)
 
 
 def get_search_by_entity_query(term=None,

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -207,11 +207,6 @@ FILTER_NAME_MAP = {
 REVERSE_FILTER_NAME_MAP = {y: x for x, y in FILTER_NAME_MAP.items()}
 
 
-def remap_fields(fields):
-    """Replaces fields to match Elasticsearch data model."""
-    return {remap_field(k): v for k, v in fields.items()}
-
-
 def reverse_remap_field(field):
     """Maps elasticsearch field to api field."""
     return REVERSE_FILTER_NAME_MAP.get(field, field)

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -231,7 +231,7 @@ def test_remap_fields():
         'uk_based': [False]
     }
 
-    remapped = elasticsearch.remap_fields(fields)
+    remapped = {elasticsearch.remap_field(field): value for field, value in fields.items()}
 
     assert 'sector.id' in remapped
     assert 'account_manager.id' in remapped

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -471,3 +471,46 @@ class TestSearch(APITestMixin):
         assert constants.InvestmentProjectStage.active.value.id in stages
         assert constants.InvestmentProjectStage.prospect.value.id not in stages
         assert constants.InvestmentProjectStage.won.value.id not in stages
+
+    @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+    @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+    def test_search_investment_project_aggregates(self):
+        """Tests aggregates in investment project search."""
+        url = reverse('api-v3:search:investment_project')
+
+        InvestmentProjectFactory(
+            name='Pear 1',
+            stage_id=constants.InvestmentProjectStage.active.value.id
+        )
+        InvestmentProjectFactory(
+            name='Pear 2',
+            stage_id=constants.InvestmentProjectStage.prospect.value.id,
+        )
+        InvestmentProjectFactory(
+            name='Pear 3',
+            stage_id=constants.InvestmentProjectStage.prospect.value.id
+        )
+        InvestmentProjectFactory(
+            name='Pear 4',
+            stage_id=constants.InvestmentProjectStage.won.value.id
+        )
+
+        connections.get_connection().indices.refresh()
+
+        response = self.api_client.post(url, {
+            'original_query': 'Pear',
+            'stage': [
+                constants.InvestmentProjectStage.prospect.value.id,
+                constants.InvestmentProjectStage.active.value.id,
+            ],
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 3
+        assert len(response.data['results']) == 3
+        assert 'aggregations' in response.data
+
+        stages = [{'key': constants.InvestmentProjectStage.prospect.value.id, 'doc_count': 2},
+                  {'key': constants.InvestmentProjectStage.active.value.id, 'doc_count': 1},
+                  {'key': constants.InvestmentProjectStage.won.value.id, 'doc_count': 1}]
+        assert all([stage in response.data['aggregations']['stage'] for stage in stages])

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -513,4 +513,4 @@ class TestSearch(APITestMixin):
         stages = [{'key': constants.InvestmentProjectStage.prospect.value.id, 'doc_count': 2},
                   {'key': constants.InvestmentProjectStage.active.value.id, 'doc_count': 1},
                   {'key': constants.InvestmentProjectStage.won.value.id, 'doc_count': 1}]
-        assert all([stage in response.data['aggregations']['stage'] for stage in stages])
+        assert all(stage in response.data['aggregations']['stage'] for stage in stages)

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -85,9 +85,8 @@ class SearchCompanyAPIView(APIView):
 
     def post(self, request, format=None):
         """Performs filtered company search."""
-        filters = {field: request.data[field]
+        filters = {elasticsearch.remap_field(field): request.data[field]
                    for field in self.FILTER_FIELDS if field in request.data}
-        filters = elasticsearch.remap_fields(filters)
 
         original_query = request.data.get('original_query', '')
 
@@ -137,10 +136,8 @@ class SearchContactAPIView(APIView):
 
     def post(self, request, format=None):
         """Performs filtered contact search."""
-        filters = {field: request.data[field]
+        filters = {elasticsearch.remap_field(field): request.data[field]
                    for field in self.FILTER_FIELDS if field in request.data}
-
-        filters = elasticsearch.remap_fields(filters)
 
         original_query = request.data.get('original_query', '')
 
@@ -203,10 +200,8 @@ class SearchInvestmentProjectAPIView(APIView):
 
     def post(self, request, format=None):
         """Performs filtered contact search."""
-        filters = {field: request.data[field]
+        filters = {elasticsearch.remap_field(field): request.data[field]
                    for field in self.FILTER_FIELDS if field in request.data}
-        filters = elasticsearch.remap_fields(filters)
-
         try:
             filters, ranges = elasticsearch.date_range_fields(filters)
         except ValueError:
@@ -235,15 +230,13 @@ class SearchInvestmentProjectAPIView(APIView):
 
         aggregations = {}
         for field in self.FILTER_FIELDS:
-            r_field = elasticsearch.remap_field(field)
+            es_field = elasticsearch.remap_field(field)
+            if es_field in results.aggregations:
+                aggregation = results.aggregations[es_field]
+                if '.' in es_field:
+                    aggregation = aggregation[es_field]
 
-            if r_field in results.aggregations:
-                if '.' in r_field:
-                    buckets = results.aggregations[r_field][r_field]['buckets']
-                else:
-                    buckets = results.aggregations[r_field]['buckets']
-
-                aggregations[field] = [bucket.to_dict() for bucket in buckets]
+                aggregations[field] = [bucket.to_dict() for bucket in aggregation['buckets']]
 
         response = {
             'count': results.hits.total,


### PR DESCRIPTION
It adds `aggregates` to the detailed search response that contains number of documents available for given filter.

For example:

```
{
  ...
  "aggregates": {
    "client_relationship_manager": [
      {
        "key": "24b48db0-df99-4794-8efb-8d9263bd74cb",
        "doc_count": 1
      },
      {
        "key": "a1608e86-5250-4ac4-a497-9a8171d6e663",
        "doc_count": 1
      },
      {
        "key": "adbc7a08-21c7-4628-9485-e6772660f6a0",
        "doc_count": 1
      },
      {
        "key": "df991b62-a0b2-4ddf-b70c-e277007de7ba",
        "doc_count": 1
      }
    ],
    "description": [
      {
        "key": "desc",
        "doc_count": 4
      },
      {
        "key": "105",
        "doc_count": 1
      },
      {
        "key": "106",
        "doc_count": 1
      },
      {
        "key": "107",
        "doc_count": 1
      },
      {
        "key": "108",
        "doc_count": 1
      }
    ],
    "investor_company": [
      {
        "key": "2ea09770-b07a-4974-92b7-c8027a21df9b",
        "doc_count": 1
      },
      {
        "key": "74fd0499-6d89-478b-8c4b-8fe5ecd0e905",
        "doc_count": 1
      },
      {
        "key": "8b0e55ae-e83a-4ff9-bcfe-246203a00d5a",
        "doc_count": 1
      },
      {
        "key": "a8de575f-0fe6-48a5-a0df-b35706f01dd5",
        "doc_count": 1
      }
    ],
    "investment_type": [
      {
        "key": "031269ab-b7ec-40e9-8a4e-7371404f0622",
        "doc_count": 4
      }
    ],
    "stage": [
      {
        "key": "8a320cc9-ae2e-443e-9d26-2f36452c2ced",
        "doc_count": 2
      },
      {
        "key": "7606cc19-20da-4b74-aba1-2cec0d753ad8",
        "doc_count": 1
      },
      {
        "key": "945ea6d1-eee3-4f5b-9144-84a75b71b8e6",
        "doc_count": 1
      }
    ],
    "sector": [
      {
        "key": "b422c9d2-5f95-e211-a939-e4115bead28a",
        "doc_count": 4
      }
    ]
  }
}
```