### PR TITLE
Removed 'description' from filter and aggregates.

### DIFF
--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -197,13 +197,13 @@ class TestSearch(APITestMixin):
         url = reverse('api-v3:search:investment_project')
 
         response = self.api_client.post(url, {
-            'description': 'investmentproject1',
+            'original_query': 'abc defg',
         }, format='json')
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         assert len(response.data['results']) == 1
-        assert response.data['results'][0]['description'] == 'investmentproject1'
+        assert response.data['results'][0]['name'] == 'abc defg'
 
     def test_search_investment_project_date_json(self):
         """Tests detailed investment project search."""

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -191,7 +191,7 @@ class SearchInvestmentProjectAPIView(APIView):
     )
 
     FILTER_FIELDS = (
-        'client_relationship_manager', 'description', 'estimated_land_date_after',
+        'client_relationship_manager', 'estimated_land_date_after',
         'estimated_land_date_before', 'investor_company', 'investment_type',
         'stage', 'sector'
     )


### PR DESCRIPTION
It makes no sense to `filter` and `aggregate` by this field, as it is too unique.