### PR TITLE
Turn off W503 Flake8/pycodestyle rule

### DIFF
--- a/datahub/investment/serializers.py
+++ b/datahub/investment/serializers.py
@@ -279,10 +279,10 @@ class IProjectSerializer(IProjectSummarySerializer, IProjectValueSerializer,
     class Meta:  # noqa: D101
         model = InvestmentProject
         fields = (
-            IProjectSummarySerializer.Meta.fields +
-            IProjectValueSerializer.Meta.fields +
-            IProjectRequirementsSerializer.Meta.fields +
-            IProjectTeamSerializer.Meta.fields
+            IProjectSummarySerializer.Meta.fields
+            + IProjectValueSerializer.Meta.fields
+            + IProjectRequirementsSerializer.Meta.fields
+            + IProjectTeamSerializer.Meta.fields
         )
         extra_kwargs = IProjectSummarySerializer.Meta.extra_kwargs
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,8 +5,9 @@
 # D203: 1 blank line required before class docstring
 # D100: Missing docstring in public module
 # D104: Missing docstring in public package
+# W503: line break occurred before a binary operator (not recommended in PEP 8)
 exclude = */migrations/*,__pycache__,manage.py,config/*,
-ignore = D203, D100, D104
+ignore = D100,D104,D203,W503
 max-line-length = 99
 
 
@@ -19,8 +20,9 @@ max-line-length = 99
 # D400 First line should end with a period
 # D401 First line should be in imperative mood
 # P101: format string does contain unindexed parameters
+# W503: line break occurred before a binary operator (not recommended in PEP 8)
 exclude = */migrations/*,__pycache__,manage.py,config/*,env/*
-ignore = D203, D100, D104, D200, D205, D400, D401, P101
+ignore = D100,D104,D200,D203,D205,D400,D401,P101,W503
 max-line-length = 99
 max-complexity = 10
 application-import-names = datahub,loading_scripts


### PR DESCRIPTION
It's in the default pycodestyle ignore list^, and is not the style recommended by PEP 8^^. 

Because we were overriding the ignore list, we were re-enabling all the checks ignored by default.

Unfortunately, there is no corresponding check for the inverse style.

^ https://pycodestyle.readthedocs.io/en/latest/intro.html#error-codes
^^ https://www.python.org/dev/peps/pep-0008/#should-a-line-break-before-or-after-a-binary-operator