### PR TITLE
Support of partial matching, remove _all query, hyphens.

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -64,10 +64,7 @@ def get_search_term_query(term, fields=None):
     ]
 
     if fields:
-        for field in fields:
-            should_query.append(
-                get_match_query(field, term)
-            )
+        should_query.extend([get_match_query(field, term) for field in fields])
 
     return Q('bool', should=should_query)
 
@@ -192,10 +189,7 @@ def get_search_by_entity_query(term=None,
                 must_filter.append(get_term_query(k, v))
 
     if ranges:
-        for k, v in ranges.items():
-            must_filter.append(
-                Q('range', **{k: v})
-            )
+        must_filter.extend([Q('range', **{k: v}) for k, v in ranges.items()])
 
     s = Search(index=settings.ES_INDEX).query('bool', must=query)
     s = get_sort_query(s, field_order=field_order)

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -46,8 +46,8 @@ def _company_dict(obj):
 def _contact_mapping(field):
     """Mapping for Adviser/Contact fields."""
     return Nested(properties={'id': String(index='not_analyzed'),
-                              'first_name': String(copy_to=[f'{field}.name', '_combined_fields']),
-                              'last_name': String(copy_to=[f'{field}.name', '_combined_fields']),
+                              'first_name': String(copy_to=f'{field}.name'),
+                              'last_name': String(copy_to=f'{field}.name'),
                               'name': String(index='not_analyzed'),
                               })
 
@@ -56,7 +56,7 @@ def _id_name_mapping():
     """Mapping for id name fields."""
     return Nested(properties={
         'id': String(index='not_analyzed'),
-        'name': String(index='not_analyzed', copy_to='_combined_fields')
+        'name': String(index='not_analyzed')
     })
 
 
@@ -64,7 +64,7 @@ def _id_uri_mapping():
     """Mapping for id uri fields."""
     return Nested(properties={
         'id': String(index='not_analyzed'),
-        'uri': String(index='not_analyzed', copy_to='_combined_fields')
+        'uri': String(index='not_analyzed')
     })
 
 
@@ -72,7 +72,7 @@ def _company_mapping():
     """Mapping for id company_number fields."""
     return Nested(properties={
         'id': String(index='not_analyzed'),
-        'company_number': String(copy_to='_combined_fields')
+        'company_number': String()
     })
 
 
@@ -82,6 +82,8 @@ class MapDBModelToDict:
     IGNORED_FIELDS = ()
 
     MAPPINGS = {}
+
+    SEARCH_FIELDS = ()
 
     @classmethod
     def es_document(cls, dbmodel):
@@ -191,6 +193,10 @@ class Company(DocType, MapDBModelToDict):
         'orders', 'created_by', 'modified_by'
     )
 
+    SEARCH_FIELDS = (
+        'trading_address_country.name', 'uk_region.name', 'website',
+    )
+
     class Meta:
         """Default document meta data."""
 
@@ -248,6 +254,10 @@ class Contact(DocType, MapDBModelToDict):
     IGNORED_FIELDS = (
         'interactions', 'servicedeliverys', 'investment_projects', 'orders',
         'created_by', 'modified_by'
+    )
+
+    SEARCH_FIELDS = (
+        'address_country.name', 'email', 'notes',
     )
 
     class Meta:
@@ -353,6 +363,11 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'uk_region_locations', 'strategic_drivers',
         'client_considering_other_countries', 'cdms_project_code',
         'interactions', 'documents', 'created_by', 'modified_by'
+    )
+
+    SEARCH_FIELDS = (
+        'investor_company.name', 'business_activities.name', 'sector.name',
+        'intermediate_company.name', 'sector.name',
     )
 
     class Meta:

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -46,8 +46,8 @@ def _company_dict(obj):
 def _contact_mapping(field):
     """Mapping for Adviser/Contact fields."""
     return Nested(properties={'id': String(index='not_analyzed'),
-                              'first_name': String(copy_to=f'{field}.name'),
-                              'last_name': String(copy_to=f'{field}.name'),
+                              'first_name': String(copy_to=[f'{field}.name', '_combined_fields']),
+                              'last_name': String(copy_to=[f'{field}.name', '_combined_fields']),
                               'name': String(index='not_analyzed'),
                               })
 
@@ -56,7 +56,7 @@ def _id_name_mapping():
     """Mapping for id name fields."""
     return Nested(properties={
         'id': String(index='not_analyzed'),
-        'name': String(index='not_analyzed')
+        'name': String(index='not_analyzed', copy_to='_combined_fields')
     })
 
 
@@ -64,7 +64,7 @@ def _id_uri_mapping():
     """Mapping for id uri fields."""
     return Nested(properties={
         'id': String(index='not_analyzed'),
-        'uri': String(index='not_analyzed')
+        'uri': String(index='not_analyzed', copy_to='_combined_fields')
     })
 
 
@@ -72,7 +72,7 @@ def _company_mapping():
     """Mapping for id company_number fields."""
     return Nested(properties={
         'id': String(index='not_analyzed'),
-        'company_number': String()
+        'company_number': String(copy_to='_combined_fields')
     })
 
 
@@ -136,8 +136,9 @@ class Company(DocType, MapDBModelToDict):
     headquarter_type = _id_name_mapping()
     id = String(index='not_analyzed')
     modified_on = Date()
-    name = String(copy_to='name_keyword')
+    name = String(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = String(analyzer='lowercase_keyword_analyzer')
+    name_trigram = String(analyzer='trigram_analyzer')
     one_list_account_owner = _contact_mapping('one_list_account_owner')
     parent = _id_name_mapping()
     registered_address_1 = String()
@@ -206,8 +207,9 @@ class Contact(DocType, MapDBModelToDict):
     created_on = Date()
     modified_on = Date()
     id = String(index='not_analyzed')
-    name = String(copy_to='name_keyword')
+    name = String(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = String(analyzer='lowercase_keyword_analyzer')
+    name_trigram = String(analyzer='trigram_analyzer')
     title = _id_name_mapping()
     first_name = String(copy_to='name')
     last_name = String(copy_to='name')
@@ -287,8 +289,9 @@ class InvestmentProject(DocType, MapDBModelToDict):
     uk_company = _id_name_mapping()
     investor_company = _id_name_mapping()
     investment_type = _id_name_mapping()
-    name = String(copy_to='name_keyword')
+    name = String(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = String(analyzer='lowercase_keyword_analyzer')
+    name_trigram = String(analyzer='trigram_analyzer')
     r_and_d_budget = Boolean()
     non_fdi_r_and_d_budget = Boolean()
     new_tech_to_uk = Boolean()

--- a/datahub/search/test/conftest.py
+++ b/datahub/search/test/conftest.py
@@ -42,13 +42,13 @@ def setup_data(client):
         name='abc defg',
         description='investmentproject1',
         estimated_land_date=datetime.datetime(2011, 6, 13, 9, 44, 31, 62870)
-    ).save()
+    )
     InvestmentProjectFactory(
         description='investmentproject2',
         estimated_land_date=datetime.datetime(2057, 6, 13, 9, 44, 31, 62870),
         project_manager=AdviserFactory(),
         project_assurance_adviser=AdviserFactory(),
-    ).save()
+    )
 
     country_uk = constants.Country.united_kingdom.value.id
     country_us = constants.Country.united_states.value.id
@@ -57,14 +57,14 @@ def setup_data(client):
         trading_address_1='1 Fake Lane',
         trading_address_town='Downtown',
         trading_address_country_id=country_uk
-    ).save()
+    )
     CompanyFactory(
         name='abc defg us ltd',
         trading_address_1='1 Fake Lane',
         trading_address_town='Downtown',
         trading_address_country_id=country_us,
         registered_address_country_id=country_us
-    ).save()
+    )
 
     management.call_command(sync_es.Command())
     client.indices.refresh()

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -19,15 +19,27 @@ def test_get_search_term_query():
                         }
                     }
                 }, {
-                    'match': {
-                        'name': {
-                            'query': 'hello',
+                    'match_phrase': {
+                        'id': {
+                            'query': 'hello'
                         }
                     }
                 }, {
                     'match': {
-                        '_all': {
-                            'query': 'hello',
+                        'name': {
+                            'query': 'hello'
+                        }
+                    }
+                }, {
+                    'match_phrase': {
+                        'name_trigram': {
+                            'query': 'hello'
+                        }
+                    }
+                }, {
+                    'match': {
+                        '_combined_fields': {
+                            'query': 'hello'
                         }
                     }
                 }
@@ -52,22 +64,33 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
-                        'match': {
-                            'name': {
-                                'query': 'test',
+                        'match_phrase': {
+                            'id': {
+                                'query': 'test'
                             }
                         }
                     }, {
                         'match': {
-                            '_all': {
-                                'query': 'test',
+                            'name': {
+                                'query': 'test'
+                            }
+                        }
+                    }, {
+                        'match_phrase': {
+                            'name_trigram': {
+                                'query': 'test'
+                            }
+                        }
+                    }, {
+                        'match': {
+                            '_combined_fields': {
+                                'query': 'test'
                             }
                         }
                     }
                 ]
             }
-        },
-        'post_filter': {
+        }, 'post_filter': {
             'bool': {
                 'should': [
                     {
@@ -77,8 +100,7 @@ def test_get_basic_search_query():
                     }
                 ]
             }
-        },
-        'aggs': {
+        }, 'aggs': {
             'count_by_type': {
                 'terms': {
                     'field': '_type'
@@ -130,14 +152,26 @@ def test_search_by_entity_query():
                                         }
                                     }
                                 }, {
+                                    'match_phrase': {
+                                        'id': {
+                                            'query': 'test'
+                                        }
+                                    }
+                                }, {
                                     'match': {
                                         'name': {
                                             'query': 'test'
                                         }
                                     }
                                 }, {
+                                    'match_phrase': {
+                                        'name_trigram': {
+                                            'query': 'test'
+                                        }
+                                    }
+                                }, {
                                     'match': {
-                                        '_all': {
+                                        '_combined_fields': {
                                             'query': 'test'
                                         }
                                     }
@@ -186,7 +220,24 @@ def test_search_by_entity_query():
                             }
                         }
                     }
-                ]
+                ], 'should': [
+                    {
+                        'term': {
+                            'address_town': 'Woodside'
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'trading_address_country',
+                            'query': {
+                                'term': {
+                                    'trading_address_country.id':
+                                        '80756b9a-5d95-e211-a939-e4115bead28a'
+                                }
+                            }
+                        }
+                    }
+                ],
+                'minimum_should_match': 1
             }
         },
         'from': 5,

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -268,7 +268,7 @@ class TestSearch(APITestMixin):
     @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
     @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
     def test_search_partial_match(self):
-        """Tests quality of results."""
+        """Tests partial matching."""
         CompanyFactory(name='Veryuniquename1')
         CompanyFactory(name='Veryuniquename2')
         CompanyFactory(name='Veryuniquename3')
@@ -298,7 +298,7 @@ class TestSearch(APITestMixin):
     @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
     @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
     def test_search_hyphen_match(self):
-        """Tests quality of results."""
+        """Tests hyphen query."""
         CompanyFactory(name='t-shirt')
         CompanyFactory(name='tshirt')
         CompanyFactory(name='electronic shirt')
@@ -328,7 +328,7 @@ class TestSearch(APITestMixin):
     @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
     @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
     def test_search_id_match(self):
-        """Tests quality of results."""
+        """Tests exact id matching."""
         CompanyFactory(id='0fb3379c-341c-4dc4-b125-bf8d47b26baa')
         CompanyFactory(id='0fb2379c-341c-4dc4-b225-bf8d47b26baa')
         CompanyFactory(id='0fb4379c-341c-4dc4-b325-bf8d47b26baa')

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -44,9 +44,9 @@ class TestSearch(APITestMixin):
         })
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 3
+        assert response.data['count'] == 2
         assert response.data['companies'][0]['name'].startswith(term)
-        assert [{'count': 3, 'entity': 'company'},
+        assert [{'count': 2, 'entity': 'company'},
                 {'count': 1, 'entity': 'contact'},
                 {'count': 1, 'entity': 'investment_project'}] == response.data['aggregations']
 
@@ -64,7 +64,7 @@ class TestSearch(APITestMixin):
         assert response.data['count'] == 1
         assert response.data['contacts'][0]['first_name'] in term
         assert response.data['contacts'][0]['last_name'] in term
-        assert [{'count': 3, 'entity': 'company'},
+        assert [{'count': 2, 'entity': 'company'},
                 {'count': 1, 'entity': 'contact'},
                 {'count': 1, 'entity': 'investment_project'}] == response.data['aggregations']
 
@@ -81,7 +81,7 @@ class TestSearch(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         assert response.data['investment_projects'][0]['name'] == term
-        assert [{'count': 3, 'entity': 'company'},
+        assert [{'count': 2, 'entity': 'company'},
                 {'count': 1, 'entity': 'contact'},
                 {'count': 1, 'entity': 'investment_project'}] == response.data['aggregations']
 
@@ -127,7 +127,7 @@ class TestSearch(APITestMixin):
         })
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 3
+        assert response.data['count'] == 2
         assert len(response.data['companies']) == 1
 
     def test_search_company(self):


### PR DESCRIPTION
It adds partial matching using trigrams, filters "-" to be able to match t-shirt and tshirt, removes _all field and uses _combined_fields instead, where we can include fields we want to search by. It also does exact matching of ids. It doesn't change existing tests.