### PR TITLE
Fixes grouping of multiple filters.

### DIFF
--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -126,8 +126,7 @@ def test_search_by_entity_query():
                                 {
                                     'match_phrase': {
                                         'name_keyword': {
-                                            'query': 'test',
-                                            'boost': 2
+                                            'query': 'test', 'boost': 2
                                         }
                                     }
                                 }, {
@@ -148,11 +147,38 @@ def test_search_by_entity_query():
                     }
                 ]
             }
-        },
-        'post_filter': {
+        }, 'post_filter': {
             'bool': {
                 'must': [
                     {
+                        'bool': {
+                            'should': [
+                                {
+                                    'term': {
+                                        'address_town': 'Woodside'
+                                    }
+                                }
+                            ],
+                            'minimum_should_match': 1
+                        }
+                    }, {
+                        'bool': {
+                            'should': [
+                                {
+                                    'nested': {
+                                        'path': 'trading_address_country',
+                                        'query': {
+                                            'term': {
+                                                'trading_address_country.id':
+                                                    '80756b9a-5d95-e211-a939-e4115bead28a'
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            'minimum_should_match': 1
+                        }
+                    }, {
                         'range': {
                             'estimated_land_date': {
                                 'gte': '2017-06-13T09:44:31.062870',
@@ -160,25 +186,7 @@ def test_search_by_entity_query():
                             }
                         }
                     }
-                ],
-                'should': [
-                    {
-                        'term': {
-                            'address_town': 'Woodside'
-                        }
-                    }, {
-                        'nested': {
-                            'path': 'trading_address_country',
-                            'query': {
-                                'term': {
-                                    'trading_address_country.id':
-                                        '80756b9a-5d95-e211-a939-e4115bead28a'
-                                }
-                            }
-                        }
-                    }
-                ],
-                'minimum_should_match': 1
+                ]
             }
         },
         'from': 5,

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -485,8 +485,8 @@ class TestSearch(APITestMixin):
 
         # checks if we only have investment projects with investor companies we filtered
         assert {
-            investment_project1.investor_company.pk,
-            investment_project2.investor_company.pk
+            str(investment_project1.investor_company.pk),
+            str(investment_project2.investor_company.pk)
         } == {
             investment_project['investor_company']['id']
             for investment_project in response.data['results']

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -447,6 +447,10 @@ class TestSearch(APITestMixin):
             stage_id=constants.InvestmentProjectStage.prospect.value.id,
         )
         InvestmentProjectFactory(
+            investor_company=CompanyFactory(),
+            stage_id=constants.InvestmentProjectStage.won.value.id,
+        )
+        InvestmentProjectFactory(
             stage_id=constants.InvestmentProjectStage.won.value.id
         )
 

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -426,32 +426,28 @@ class TestSearch(APITestMixin):
     @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
     @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
     def test_search_investment_project_multiple_filters(self):
-        """Tests detailed investment project search."""
+        """Tests multiple filters in investment project search.
+
+        We make sure that out of provided investment projects, we will
+        receive only those that match our filter.
+        """
         url = reverse('api-v3:search:investment_project')
 
-        company_a = CompanyFactory(
-            name='companyA'
+        investment_project1 = InvestmentProjectFactory(
+            investment_type_id=constants.InvestmentType.fdi.value.id,
+            stage_id=constants.InvestmentProjectStage.active.value.id
         )
-        company_b = CompanyFactory(
-            name='companyB'
+        investment_project2 = InvestmentProjectFactory(
+            investment_type_id=constants.InvestmentType.fdi.value.id,
+            stage_id=constants.InvestmentProjectStage.won.value.id,
         )
 
         InvestmentProjectFactory(
-            investment_type_id=constants.InvestmentType.fdi.value.id,
-            investor_company=company_a,
-            sector_id=constants.Sector.aerospace_assembly_aircraft.value.id,
-            stage_id=constants.InvestmentProjectStage.active.value.id
-        )
-        InvestmentProjectFactory(
-            investor_company=company_b,
-            stage_id=constants.InvestmentProjectStage.prospect.value.id,
-        )
-        InvestmentProjectFactory(
-            investor_company=CompanyFactory(),
-            stage_id=constants.InvestmentProjectStage.won.value.id,
-        )
-        InvestmentProjectFactory(
             stage_id=constants.InvestmentProjectStage.won.value.id
+        )
+        InvestmentProjectFactory(
+            investment_type_id=constants.InvestmentType.fdi.value.id,
+            stage_id=constants.InvestmentProjectStage.prospect.value.id,
         )
 
         connections.get_connection().indices.refresh()
@@ -459,8 +455,8 @@ class TestSearch(APITestMixin):
         response = self.api_client.post(url, {
             'investment_type': constants.InvestmentType.fdi.value.id,
             'investor_company': [
-                company_a.pk,
-                company_b.pk,
+                investment_project1.investor_company.pk,
+                investment_project2.investor_company.pk,
             ],
             'stage': [
                 constants.InvestmentProjectStage.won.value.id,
@@ -469,15 +465,16 @@ class TestSearch(APITestMixin):
         }, format='json')
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 1
-        assert len(response.data['results']) == 1
+        assert response.data['count'] == 2
+        assert len(response.data['results']) == 2
 
+        # checks if we only have investment projects with stages we filtered
         stages = set([investment_project['stage']['id']
                       for investment_project in response.data['results']])
 
         assert constants.InvestmentProjectStage.active.value.id in stages
         assert constants.InvestmentProjectStage.prospect.value.id not in stages
-        assert constants.InvestmentProjectStage.won.value.id not in stages
+        assert constants.InvestmentProjectStage.won.value.id in stages
 
     @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
     @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)


### PR DESCRIPTION
For query `a.x, a.y, b.x, b.y, c.x` we created filter like `c.x and (a.x or a.y or b.x or b.y)` which is not what we want. This changes it so the filter query becomes `(a.x or a.y) and (b.x or b.y) and c.x`
