### PR TITLE
Stop converting uuids to str in factories

### DIFF
--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -9,7 +9,7 @@ from datahub.core import constants
 class AdviserFactory(factory.django.DjangoModelFactory):
     """Adviser factory."""
 
-    id = factory.Sequence(lambda _: str(uuid.uuid4()))
+    id = factory.LazyFunction(uuid.uuid4)
     first_name = factory.Sequence(lambda n: f'name {n}')
     last_name = factory.Sequence(lambda n: f'surname {n}')
     dit_team_id = constants.Team.healthcare_uk.value.id
@@ -24,7 +24,7 @@ class AdviserFactory(factory.django.DjangoModelFactory):
 class CompanyFactory(factory.django.DjangoModelFactory):
     """Company factory."""
 
-    id = factory.Sequence(lambda _: str(uuid.uuid4()))
+    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     name = factory.Sequence(lambda n: f'name{n}')
@@ -62,7 +62,7 @@ class CompaniesHouseCompanyFactory(factory.django.DjangoModelFactory):
 class ContactFactory(factory.django.DjangoModelFactory):
     """Contact factory"""
 
-    id = factory.Sequence(lambda _: str(uuid.uuid4()))
+    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     title_id = constants.Title.wing_commander.value.id

--- a/datahub/company/test/test_company_views_v3.py
+++ b/datahub/company/test/test_company_views_v3.py
@@ -157,15 +157,15 @@ class TestCompany(APITestMixin):
             key=itemgetter('id')
         )
         expected_projects = sorted(({
-            'id': projects[0].id,
+            'id': str(projects[0].id),
             'name': projects[0].name,
             'project_code': projects[0].project_code
         }, {
-            'id': projects[1].id,
+            'id': str(projects[1].id),
             'name': projects[1].name,
             'project_code': projects[1].project_code
         }, {
-            'id': projects[2].id,
+            'id': str(projects[2].id),
             'name': projects[2].name,
             'project_code': projects[2].project_code
         }), key=itemgetter('id'))

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -30,7 +30,7 @@ class TestAddContact(APITestMixin):
             'last_name': 'Nelson',
             'job_title': constants.Role.owner.value.name,
             'company': {
-                'id': company.pk
+                'id': str(company.pk)
             },
             'email': 'foo@bar.com',
             'email_alternative': 'foo2@bar.com',
@@ -65,7 +65,7 @@ class TestAddContact(APITestMixin):
             'last_name': 'Nelson',
             'job_title': constants.Role.owner.value.name,
             'company': {
-                'id': company.pk,
+                'id': str(company.pk),
                 'name': company.name
             },
             'adviser': {
@@ -329,7 +329,7 @@ class TestEditContact(APITestMixin):
             'last_name': 'Nelson',
             'job_title': constants.Role.owner.value.name,
             'company': {
-                'id': company.pk,
+                'id': str(company.pk),
                 'name': company.name
             },
             'email': 'foo@bar.com',
@@ -394,7 +394,7 @@ class TestArchiveContact(APITestMixin):
             'last_name': self.user.last_name
         }
         assert response.data['archived_reason'] == 'foo'
-        assert response.data['id'] == contact.pk
+        assert response.data['id'] == str(contact.pk)
 
     def test_unarchive(self):
         """Test unarchiving a contact."""
@@ -406,7 +406,7 @@ class TestArchiveContact(APITestMixin):
         assert not response.data['archived']
         assert not response.data['archived_by']
         assert response.data['archived_reason'] == ''
-        assert response.data['id'] == contact.pk
+        assert response.data['id'] == str(contact.pk)
 
     def test_unarchive_wrong_method(self):
         """Tests that GET requests to the unarchive endpoint fail."""
@@ -465,7 +465,7 @@ class TestViewContact(APITestMixin):
             'last_name': 'Nelson',
             'job_title': constants.Role.owner.value.name,
             'company': {
-                'id': company.pk,
+                'id': str(company.pk),
                 'name': company.name
             },
             'adviser': {
@@ -528,7 +528,7 @@ class TestContactList(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
-        expected_contacts = {contact.id for contact in contacts}
+        expected_contacts = {str(contact.id) for contact in contacts}
         assert {contact['id'] for contact in response.data['results']} == expected_contacts
 
 

--- a/datahub/company/test/test_models.py
+++ b/datahub/company/test/test_models.py
@@ -20,7 +20,7 @@ def test_company_can_have_one_list_owner_assigned():
     # re-fetch object for completeness
     company_refetch = Company.objects.get(pk=str(company.pk))
 
-    assert str(company_refetch.one_list_account_owner_id) == str(adviser.pk)
+    assert company_refetch.one_list_account_owner_id == adviser.pk
 
 
 def test_company_can_have_hierarchy():

--- a/datahub/documents/test/factories.py
+++ b/datahub/documents/test/factories.py
@@ -9,7 +9,7 @@ from datahub.company.test.factories import AdviserFactory
 class DocumentFactory(factory.django.DjangoModelFactory):
     """Document factory."""
 
-    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     path = factory.Sequence(lambda n: f'projects/doc{n}.txt')

--- a/datahub/investment/test/factories.py
+++ b/datahub/investment/test/factories.py
@@ -16,7 +16,7 @@ from datahub.core.test.factories import to_many_field
 class InvestmentProjectFactory(factory.django.DjangoModelFactory):
     """Investment project factory."""
 
-    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     name = factory.Sequence(lambda n: f'name {n}')

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -136,7 +136,7 @@ class TestUnifiedViews(APITestMixin):
         assert response_data['stage']['id'] == request_data['stage']['id']
         assert len(response_data['client_contacts']) == 2
         assert Counter(contact['id'] for contact in response_data[
-            'client_contacts']) == Counter(contact.id for contact in contacts)
+            'client_contacts']) == Counter(str(contact.id) for contact in contacts)
         assert Counter(activity['id'] for activity in response_data[
             'business_activities']) == Counter(activity['id'] for activity in activities)
         assert response_data['other_business_activity'] == request_data['other_business_activity']
@@ -219,7 +219,7 @@ class TestUnifiedViews(APITestMixin):
 
     def test_get_project_success(self):
         """Test successfully getting a project."""
-        contacts = [ContactFactory().id, ContactFactory().id]
+        contacts = [str(ContactFactory().id), str(ContactFactory().id)]
         project = InvestmentProjectFactory(client_contacts=contacts)
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
         response = self.api_client.get(url)
@@ -994,7 +994,7 @@ class TestTeamMemberViews(APITestMixin):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         new_team_members = InvestmentProjectTeamMember.objects.filter(investment_project=project)
         assert new_team_members.count() == 1
-        assert str(new_team_members[0].adviser.pk) == team_members[1].adviser.pk
+        assert new_team_members[0].adviser.pk == team_members[1].adviser.pk
 
 
 class TestAuditLogView(APITestMixin):
@@ -1158,7 +1158,7 @@ class TestDocumentViews(APITestMixin):
         doc = IProjectDocument.objects.get(pk=response_data['id'])
         assert doc.filename == 'test.txt'
         assert doc.doc_type == 'total_investment'
-        assert str(doc.project.pk) == str(project.pk)
+        assert doc.project.pk == project.pk
         assert 'signed_upload_url' in response.data
 
     def test_document_retrieval(self):

--- a/datahub/leads/test/factories.py
+++ b/datahub/leads/test/factories.py
@@ -12,7 +12,7 @@ from datahub.company.test.factories import (
 class BusinessLeadFactory(factory.django.DjangoModelFactory):
     """Business lead factory."""
 
-    id = factory.Sequence(lambda _: str(uuid.uuid4()))
+    id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     first_name = factory.Sequence(lambda n: 'name {n}')

--- a/datahub/leads/test/test_views.py
+++ b/datahub/leads/test/test_views.py
@@ -61,7 +61,7 @@ class TestBusinessLeadViews(APITestMixin):
             'archived_reason': None,
             'company': {
                 'id': str(lead.company.pk),
-                'name': str(lead.company.name)
+                'name': lead.company.name
             },
             'company_name': lead.company_name,
             'contactable_by_dit': False,

--- a/datahub/metadata/test/factories.py
+++ b/datahub/metadata/test/factories.py
@@ -8,7 +8,7 @@ from datahub.core import constants
 class EventFactory(factory.django.DjangoModelFactory):
     """Event factory."""
 
-    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    id = factory.LazyFunction(uuid.uuid4)
     name = factory.Sequence(lambda n: f'name {n}')
 
     class Meta:  # noqa: D101
@@ -18,7 +18,7 @@ class EventFactory(factory.django.DjangoModelFactory):
 class ServiceFactory(factory.django.DjangoModelFactory):
     """Service factory."""
 
-    id = factory.LazyFunction(lambda: str(uuid.uuid4()))
+    id = factory.LazyFunction(uuid.uuid4)
     name = factory.Sequence(lambda n: f'name {n}')
 
     class Meta:  # noqa: D101

--- a/datahub/omis/order/test/views/test_order_assignees.py
+++ b/datahub/omis/order/test/views/test_order_assignees.py
@@ -51,7 +51,7 @@ class TestGetOrderAssignees(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
             {
-                'adviser_id': adviser.id,
+                'adviser_id': str(adviser.id),
                 'first_name': adviser.first_name,
                 'last_name': adviser.last_name,
                 'estimated_time': (120 * i),
@@ -145,21 +145,21 @@ class TestChangeOrderAssignees(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
             {
-                'adviser_id': adviser1.id,
+                'adviser_id': str(adviser1.id),
                 'first_name': adviser1.first_name,
                 'last_name': adviser1.last_name,
                 'estimated_time': 200,
                 'is_lead': False
             },
             {
-                'adviser_id': adviser2.id,
+                'adviser_id': str(adviser2.id),
                 'first_name': adviser2.first_name,
                 'last_name': adviser2.last_name,
                 'estimated_time': assignee2.estimated_time,
                 'is_lead': False
             },
             {
-                'adviser_id': adviser3.id,
+                'adviser_id': str(adviser3.id),
                 'first_name': adviser3.first_name,
                 'last_name': adviser3.last_name,
                 'estimated_time': 250,
@@ -168,7 +168,6 @@ class TestChangeOrderAssignees(APITestMixin):
         ]
 
         # check created_by / modified_by
-        created_by.refresh_from_db()
         assignee1.refresh_from_db()
         assignee2.refresh_from_db()
         assignee3 = OrderAssignee.objects.get(order=order, adviser=adviser3)
@@ -316,7 +315,6 @@ class TestChangeOrderAssignees(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_200_OK
-        created_by.refresh_from_db()
         assignee1.refresh_from_db()
 
         assert assignee1.created_by == created_by

--- a/datahub/omis/order/test/views/test_order_details.py
+++ b/datahub/omis/order/test/views/test_order_details.py
@@ -59,15 +59,15 @@ class TestAddOrderDetails(APITestMixin):
                 'name': self.user.name
             },
             'company': {
-                'id': company.pk,
+                'id': str(company.pk),
                 'name': company.name
             },
             'contact': {
-                'id': contact.pk,
+                'id': str(contact.pk),
                 'name': contact.name
             },
             'primary_market': {
-                'id': country.id,
+                'id': str(country.id),
                 'name': country.name
             },
             'sector': {

--- a/datahub/omis/order/test/views/test_subscriber_list.py
+++ b/datahub/omis/order/test/views/test_subscriber_list.py
@@ -47,7 +47,7 @@ class TestGetSubscriberList(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
             {
-                'id': adviser.id,
+                'id': str(adviser.id),
                 'first_name': adviser.first_name,
                 'last_name': adviser.last_name,
                 'dit_team': {
@@ -81,7 +81,7 @@ class TestChangeSubscriberList(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert {adv['id'] for adv in response.json()} == {adv.id for adv in advisers}
+        assert {adv['id'] for adv in response.json()} == {str(adv.id) for adv in advisers}
 
     def test_change_existing_list(self):
         """
@@ -114,7 +114,7 @@ class TestChangeSubscriberList(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert {adv['id'] for adv in response.json()} == {adv.id for adv in final_advisers}
+        assert {adv['id'] for adv in response.json()} == {str(adv.id) for adv in final_advisers}
 
         # check that the id of the existing subscription didn't change
         assert order.subscribers.filter(id=subscriptions[1].id).exists()

--- a/datahub/search/test/test_signals.py
+++ b/datahub/search/test/test_signals.py
@@ -46,7 +46,7 @@ def test_company_auto_updates_to_es(setup_data, post_save_handlers):
     result = elasticsearch.get_basic_search_query(new_test_name, entities=('company',)).execute()
 
     assert result.hits.total == 1
-    assert result.hits[0].id == company.id
+    assert result.hits[0].id == str(company.id)
 
 
 @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
@@ -83,7 +83,7 @@ def test_contact_auto_updates_to_es(setup_data, post_save_handlers):
     result = elasticsearch.get_basic_search_query(new_test_name, entities=('contact',)).execute()
 
     assert result.hits.total == 1
-    assert result.hits[0].id == contact.id
+    assert result.hits[0].id == str(contact.id)
 
 
 @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)

--- a/datahub/v2/tests/repos/test_service_deliveries_repo.py
+++ b/datahub/v2/tests/repos/test_service_deliveries_repo.py
@@ -151,7 +151,7 @@ class TestServiceDeliveriesRepo:
                 'contact': {
                     'data': {
                         'type': 'Contact',
-                        'id': contact.pk
+                        'id': str(contact.pk)
                     }
                 }
             }

--- a/datahub/v2/tests/views/test_service_delivery.py
+++ b/datahub/v2/tests/views/test_service_delivery.py
@@ -88,19 +88,19 @@ class TestServiceDeliveryView(APITestMixin):
                 'company': {
                     'data': {
                         'type': 'Company',
-                        'id': CompanyFactory().pk
+                        'id': str(CompanyFactory().pk)
                     }
                 },
                 'contact': {
                     'data': {
                         'type': 'Contact',
-                        'id': ContactFactory().pk
+                        'id': str(ContactFactory().pk)
                     }
                 },
                 'service': {
                     'data': {
                         'type': 'Service',
-                        'id': service_offer.service.id
+                        'id': str(service_offer.service.id)
                     }
                 },
                 'dit_team': {
@@ -145,19 +145,19 @@ class TestServiceDeliveryView(APITestMixin):
                 'company': {
                     'data': {
                         'type': 'Company',
-                        'id': CompanyFactory().pk
+                        'id': str(CompanyFactory().pk)
                     }
                 },
                 'contact': {
                     'data': {
                         'type': 'Contact',
-                        'id': ContactFactory().pk
+                        'id': str(ContactFactory().pk)
                     }
                 },
                 'service': {
                     'data': {
                         'type': 'Service',
-                        'id': service_offer.service.id
+                        'id': str(service_offer.service.id)
                     }
                 },
                 'dit_team': {
@@ -195,13 +195,13 @@ class TestServiceDeliveryView(APITestMixin):
                 'company': {
                     'data': {
                         'type': 'Company',
-                        'id': CompanyFactory().pk
+                        'id': str(CompanyFactory().pk)
                     }
                 },
                 'contact': {
                     'data': {
                         'type': 'Contact',
-                        'id': ContactFactory().pk
+                        'id': str(ContactFactory().pk)
                     }
                 },
                 'service': {
@@ -337,13 +337,13 @@ class TestServiceDeliveryView(APITestMixin):
                 'company': {
                     'data': {
                         'type': 'Company',
-                        'id': CompanyFactory().pk
+                        'id': str(CompanyFactory().pk)
                     }
                 },
                 'contact': {
                     'data': {
                         'type': 'Contact',
-                        'id': ContactFactory().pk
+                        'id': str(ContactFactory().pk)
                     }
                 },
                 'service': {


### PR DESCRIPTION
Factories are used to quickly create /  set up objects during tests.
The django UUIDField returns UUID objects so it's wrong to cast those factory fields to str.

This fixes factories everywhere and casts UUID values to str when comparing to the API response values instead.