### PR TITLE
Use RequiredUnlessAlreadyBlank for a few more fields

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -133,7 +133,7 @@ class CompanySerializerWriteV1(serializers.ModelSerializer):
         extra_kwargs = {
             'registered_address_country': {'required': True, 'allow_null': False},
         }
-        validators = [RequiredUnlessAlreadyBlank('sector')]
+        validators = [RequiredUnlessAlreadyBlank('sector', 'business_type')]
 
 
 NestedAdviserField = partial(
@@ -377,4 +377,4 @@ class CompanySerializerV3(serializers.ModelSerializer):
             'archived_on': {'read_only': True},
             'archived_reason': {'read_only': True}
         }
-        validators = [RequiredUnlessAlreadyBlank('sector')]
+        validators = [RequiredUnlessAlreadyBlank('sector', 'business_type')]

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -357,7 +357,7 @@ class TestCompany(APITestMixin):
     @pytest.mark.parametrize('field', ('sector', 'business_type'))
     def test_update_null_field_to_null(self, field):
         """
-        Tests setting fields to null that are current null, and are allowed to be null
+        Tests setting fields to null that are currently null, and are allowed to be null
         when already null.
         """
         creation_data = {

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -307,7 +307,7 @@ class TestCompany(APITestMixin):
             'registered_address_country': ['This field may not be null.']
         }
 
-    @pytest.mark.parametrize('field', ('sector',))
+    @pytest.mark.parametrize('field', ('sector', 'business_type'))
     def test_add_company_without_required_field(self, field):
         """
         Tests adding a company without required fields that are allowed to be null (during
@@ -317,7 +317,6 @@ class TestCompany(APITestMixin):
         response = self.api_client.post(url, {
             'name': 'Acme',
             'alias': None,
-            'business_type': BusinessType.company.value.id,
             'registered_address_1': '75 Stramford Road',
             'registered_address_town': 'London',
             'registered_address_country': Country.united_kingdom.value.id,
@@ -329,6 +328,7 @@ class TestCompany(APITestMixin):
 
     @pytest.mark.parametrize('field,value', (
         ('sector', Sector.aerospace_assembly_aircraft.value.id),
+        ('business_type', BusinessType.government_dept.value.id),
     ))
     def test_update_non_null_field_to_null(self, field, value):
         """
@@ -354,7 +354,7 @@ class TestCompany(APITestMixin):
             field: ['This field is required.'],
         }
 
-    @pytest.mark.parametrize('field', ('sector',))
+    @pytest.mark.parametrize('field', ('sector', 'business_type'))
     def test_update_null_field_to_null(self, field):
         """
         Tests setting fields to null that are current null, and are allowed to be null

--- a/datahub/company/test/test_company_views_v3.py
+++ b/datahub/company/test/test_company_views_v3.py
@@ -397,7 +397,7 @@ class TestCompany(APITestMixin):
     @pytest.mark.parametrize('field', ('sector',))
     def test_update_null_field_to_null(self, field):
         """
-        Tests setting fields to null that are current null, and are allowed to be null
+        Tests setting fields to null that are currently null, and are allowed to be null
         when already null.
         """
         creation_data = {

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from datahub.company.serializers import AdviserSerializer
-from datahub.core.validate_utils import AnyOfValidator
+from datahub.core.validate_utils import AnyOfValidator, RequiredUnlessAlreadyBlank
 from .models import Interaction
 
 
@@ -22,4 +22,7 @@ class InteractionSerializerWrite(serializers.ModelSerializer):
     class Meta:  # noqa: D101
         model = Interaction
         fields = '__all__'
-        validators = [AnyOfValidator('company', 'investment_project')]
+        validators = [
+            AnyOfValidator('company', 'investment_project'),
+            RequiredUnlessAlreadyBlank('dit_team', 'interaction_type', 'service')
+        ]


### PR DESCRIPTION
Use it for a few more fields that were made nullable in https://github.com/uktrade/data-hub-leeloo/pull/196:

* Company.business_type
* Interaction.dit_team
* Interaction.interaction_type
* Interaction.service