### PR TITLE
Include adviser name in subscriber-list endpoint

### DIFF
--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -169,6 +169,7 @@ class SubscribedAdviserSerializer(serializers.Serializer):
     id = serializers.UUIDField(validators=[existing_adviser])
     first_name = serializers.CharField(read_only=True)
     last_name = serializers.CharField(read_only=True)
+    name = serializers.CharField(read_only=True)
     dit_team = NestedRelatedField(Team, read_only=True)
 
     class Meta:  # noqa: D101

--- a/datahub/omis/order/test/views/test_subscriber_list.py
+++ b/datahub/omis/order/test/views/test_subscriber_list.py
@@ -50,6 +50,7 @@ class TestGetSubscriberList(APITestMixin):
                 'id': str(adviser.id),
                 'first_name': adviser.first_name,
                 'last_name': adviser.last_name,
+                'name': adviser.name,
                 'dit_team': {
                     'id': str(adviser.dit_team.id),
                     'name': adviser.dit_team.name


### PR DESCRIPTION
This adds the `name` field to the response body of the subscriber-list endpoint.