### PR TITLE
Basic search query fields across all entities.

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -10,6 +10,12 @@ from elasticsearch_dsl.query import Match, MatchPhrase, Q
 
 from .models import Company, Contact, InvestmentProject
 
+ALL_MODELS = (
+    Company,
+    Contact,
+    InvestmentProject,
+)
+
 lowercase_keyword_analyzer = analysis.CustomAnalyzer(
     'lowercase_keyword_analyzer',
     tokenizer='keyword',
@@ -109,11 +115,7 @@ def get_basic_search_query(term, entities=None, field_order=None, offset=0, limi
 
     Also returns number of results in other entities.
     """
-    fields = set(chain.from_iterable(entity.SEARCH_FIELDS for entity in (
-        Company,
-        Contact,
-        InvestmentProject,
-    )))
+    fields = set(chain.from_iterable(entity.SEARCH_FIELDS for entity in ALL_MODELS))
     # Sort the fields so that this function is deterministic
     # and the same query is always generated with the same inputs
     fields = sorted(fields)

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -8,6 +8,8 @@ from elasticsearch_dsl import analysis, Index, Search
 from elasticsearch_dsl.connections import connections
 from elasticsearch_dsl.query import Match, MatchPhrase, Q
 
+from .models import Company, Contact, InvestmentProject
+
 lowercase_keyword_analyzer = analysis.CustomAnalyzer(
     'lowercase_keyword_analyzer',
     tokenizer='keyword',
@@ -107,7 +109,11 @@ def get_basic_search_query(term, entities=None, field_order=None, offset=0, limi
 
     Also returns number of results in other entities.
     """
-    fields = set(chain.from_iterable(entity.SEARCH_FIELDS for entity in entities))
+    fields = set(chain.from_iterable(entity.SEARCH_FIELDS for entity in (
+        Company,
+        Contact,
+        InvestmentProject,
+    )))
     # Sort the fields so that this function is deterministic
     # and the same query is always generated with the same inputs
     fields = sorted(fields)

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -128,6 +128,36 @@ def test_get_basic_search_query():
                         }
                     }, {
                         'nested': {
+                            'path': 'business_activities',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'business_activities.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'classification',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'classification.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
                             'path': 'company',
                             'query': {
                                 'bool': {
@@ -146,8 +176,155 @@ def test_get_basic_search_query():
                             'email': 'test'
                         }
                     }, {
+                        'nested': {
+                            'path': 'export_to_countries',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'export_to_countries.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'future_interest_countries',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'future_interest_countries.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'intermediate_company',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'intermediate_company.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'investor_company',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'investor_company.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
                         'match': {
                             'notes': 'test'
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'registered_address_country',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'registered_address_country.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'match': {
+                            'registered_address_town': 'test'
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'sector',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'sector.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'trading_address_country',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'trading_address_country.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'match': {
+                            'trading_address_town': 'test'
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'uk_company',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'uk_company.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'uk_region',
+                            'query': {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'match': {
+                                                'uk_region.name': 'test'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }, {
+                        'match': {
+                            'website': 'test'
                         }
                     }
                 ]


### PR DESCRIPTION
Basic search needs to look across all entities for aggregation to work correctly. This change includes all `SEARCH_FIELDS` from all entities in the basic search.