### PR TITLE
Abstract out paginated logic in search API views

### DIFF
--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -1,11 +1,15 @@
+from unittest import mock
 import pytest
 
 from freezegun import freeze_time
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin
 from datahub.omis.order.test.factories import OrderFactory
+
+from ..views import PaginatedAPIMixin
 
 
 pytestmark = pytest.mark.django_db
@@ -56,3 +60,112 @@ class TestSearchOrder(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == 1
         assert response.json()['results'][0]['reference'] == 'ref1'
+
+
+class TestPaginatedAPIMixin:
+    """Tests related to the paginated API mixin."""
+
+    def test_limit_as_valid_param(self):
+        """Test that get_limit returns the int value of the param if valid."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '3'
+            }
+        )
+
+        assert mixin.get_limit(request) == 3
+
+    def test_limit_as_non_int_defaults(self):
+        """Test that get_limit returns the default value if the param is not an int."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: 'non-int'
+            }
+        )
+
+        assert mixin.get_limit(request) == PaginatedAPIMixin.default_limit
+
+    def test_limit_as_negative_int_defaults(self):
+        """Test that get_limit returns the default value if param is a negative value."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '-1'
+            }
+        )
+
+        assert mixin.get_limit(request) == PaginatedAPIMixin.default_limit
+
+    def test_limit_as_zero_defaults(self):
+        """Test that get_limit returns the default value if param is 0."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '0'
+            }
+        )
+
+        assert mixin.get_limit(request) == PaginatedAPIMixin.default_limit
+
+    def test_offset_as_valid_param(self):
+        """Test that get_offset returns the int value if the param is valid."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.offset_query_param: '4'
+            }
+        )
+
+        assert mixin.get_offset(request) == 4
+
+    def test_offset_as_non_int_defaults(self):
+        """Test that get_offset returns the default value if the param is not an int."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.offset_query_param: 'non-int'
+            }
+        )
+
+        assert mixin.get_offset(request) == 0
+
+    def test_pagination_params_within_limit(self):
+        """Test that if the result window (offset + limit) is within limit, everything is OK."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '100',
+                PaginatedAPIMixin.offset_query_param: '9900',
+            }
+        )
+
+        limit, offset = mixin.get_pagination_values(request)
+
+        assert limit == 100
+        assert offset == 9900
+
+    def test_pagination_params_outside_limit(self):
+        """
+        Test that if the result window (offset + limit) is too large,
+        a validator error is returned.
+        """
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '100',
+                PaginatedAPIMixin.offset_query_param: '9901',
+            }
+        )
+
+        with pytest.raises(ValidationError):
+            mixin.get_pagination_values(request)

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -1,3 +1,7 @@
+from django.conf import settings
+
+from rest_framework.exceptions import ValidationError
+from rest_framework.pagination import _positive_int
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -5,7 +9,49 @@ from .models import Order
 from .. import elasticsearch
 
 
-class SearchOrderAPIView(APIView):
+class PaginatedAPIMixin:
+    """Mixin for paginated API Views."""
+
+    default_limit = settings.REST_FRAMEWORK['PAGE_SIZE']
+    limit_query_param = 'limit'
+    offset_query_param = 'offset'
+    max_results = 10000
+
+    def get_limit(self, request):
+        """Return the limit specified by the user or the default one."""
+        if self.limit_query_param:
+            try:
+                return _positive_int(
+                    request.data[self.limit_query_param],
+                    strict=True
+                )
+            except (KeyError, ValueError):
+                pass
+
+        return self.default_limit
+
+    def get_offset(self, request):
+        """Return the offset specified by the user or the default one."""
+        try:
+            return _positive_int(
+                request.data[self.offset_query_param],
+            )
+        except (KeyError, ValueError):
+            return 0
+
+    def get_pagination_values(self, request):
+        """Return the pagination values (limit, offset) or raises ValidationError."""
+        limit = self.get_limit(request)
+        offset = self.get_offset(request)
+
+        if limit + offset > self.max_results:
+            raise ValidationError(
+                f'Invalid offset/limit. Result window cannot be greater than {self.max_results}'
+            )
+        return limit, offset
+
+
+class SearchOrderAPIView(PaginatedAPIMixin, APIView):
     """Filtered order search view."""
 
     http_method_names = ('post',)
@@ -13,8 +59,7 @@ class SearchOrderAPIView(APIView):
 
     def post(self, request, format=None):
         """Perform filtered order search."""
-        offset = int(request.data.get('offset', 0))
-        limit = int(request.data.get('limit', 100))
+        limit, offset = self.get_pagination_values(request)
 
         results = elasticsearch.get_search_by_entity_query(
             entity=Order,


### PR DESCRIPTION
@reupen @elcct what do you think about abstracting out the pagination logic?

I've added it just to the OMIS search API View but could be applied to the other ones as well if you want.

This also catches the 500 error about the result window being too big that we are getting from sentry recently.