### PR TITLE
Explicitly set Sentry app packages

### DIFF
--- a/config/settings/common_sentry.py
+++ b/config/settings/common_sentry.py
@@ -3,8 +3,6 @@ from config.settings.common import *
 MIDDLEWARE.append('raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware')
 INSTALLED_APPS.append('raven.contrib.django.raven_compat')
 
-SENTRY_DSN = env('DJANGO_SENTRY_DSN')
-
 # Logging
 LOGGING = {
     'version': 1,
@@ -48,7 +46,7 @@ LOGGING = {
     },
 }
 
-
 RAVEN_CONFIG = {
-    'DSN': SENTRY_DSN,
+    'dsn': env('DJANGO_SENTRY_DSN'),
+    'include_paths': ['datahub']
 }


### PR DESCRIPTION
These are what Sentry considers as the app in the 'App only' view of the stack trace.

It defaults to INSTALLED_APPS, but this was excluding the search app because the entry for it is pointing at the AppConfig class.