### PR TITLE
Add ability to filter orders by assigned advisers

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -164,6 +164,9 @@ APPEND_SLASH = False
 # Leeloo stuff
 ES_URL = env('ES_URL')
 ES_INDEX = env('ES_INDEX')
+ES_INDEX_SETTINGS = {
+    'index.mapping.nested_fields.limit': 100
+}
 DATAHUB_SECRET = env('DATAHUB_SECRET')
 CDMS_AUTH_URL = env('CDMS_AUTH_URL')
 CDMS_TEXT_MAX_LENGTH = 4000

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -13,5 +13,10 @@ INSTALLED_APPS += [
 ]
 
 ES_INDEX = 'test'
+ES_INDEX_SETTINGS = {
+    'index.mapping.nested_fields.limit': 100,
+    'number_of_shards': 1,
+    'number_of_replicas': 0,
+}
 DOCUMENT_BUCKET='test-bucket'
 AV_SERVICE_URL='http://av-service/'

--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -438,12 +438,13 @@ class Service(Enum):
 class Team(Enum):
     """Team."""
 
-    healthcare_uk = Constant(
-        'Healthcare UK', '3ff47a07-002c-e311-a78e-e4115bead28a'
+    healthcare_uk = Constant('Healthcare UK', '3ff47a07-002c-e311-a78e-e4115bead28a')
+    tees_valley_lep = Constant('Tees Valley LEP', 'a889ef76-8925-e511-b6bc-e4115bead28a')
+    td_events_healthcare = Constant(
+        'TD - Events - Healthcare', 'daf924aa-9698-e211-a939-e4115bead28a'
     )
-    crm = Constant(
-        'crm', 'a7f924aa-9698-e211-a939-e4115bead28a'
-    )
+    food_from_britain = Constant('Food From Britain', '8cf924aa-9698-e211-a939-e4115bead28a')
+    crm = Constant('crm', 'a7f924aa-9698-e211-a939-e4115bead28a')
 
 
 class ServiceDeliveryStatus(Enum):

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -91,7 +91,7 @@ class SearchConfig(AppConfig):
         from datahub.search import elasticsearch
 
         elasticsearch.configure_connection()
-        elasticsearch.configure_index(settings.ES_INDEX)
+        elasticsearch.configure_index(settings.ES_INDEX, settings.ES_INDEX_SETTINGS)
 
         for search_app in get_search_apps():
             search_app.init_all()

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -45,7 +45,4 @@ def create_test_index(client, index):
     if client.indices.exists(index=index):
         client.indices.delete(index)
 
-    elasticsearch.configure_index(index, {
-        'number_of_shards': 1,
-        'number_of_replicas': 0,
-    })
+    elasticsearch.configure_index(index, settings.ES_INDEX_SETTINGS)

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -32,7 +32,10 @@ def _contact_dict(obj, include_dit_team=False):
     }
 
     if include_dit_team:
-        data['dit_team'] = _id_name_dict(obj.dit_team)
+        if obj.dit_team:
+            data['dit_team'] = _id_name_dict(obj.dit_team)
+        else:
+            data['dit_team'] = {}
     return data
 
 

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -22,14 +22,18 @@ def _id_uri_dict(obj):
     }
 
 
-def _contact_dict(obj):
+def _contact_dict(obj, include_dit_team=False):
     """Creates dictionary with selected field from supplied object."""
-    return {
+    data = {
         'id': str(obj.id),
         'first_name': obj.first_name,
         'last_name': obj.last_name,
         'name': obj.name,
     }
+
+    if include_dit_team:
+        data['dit_team'] = _id_name_dict(obj.dit_team)
+    return data
 
 
 def _company_dict(obj):

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -7,13 +7,18 @@ CaseInsensitiveKeywordString = partial(String, analyzer='lowercase_keyword_analy
 TrigramString = partial(String, analyzer='trigram_analyzer')
 
 
-def _contact_mapping(field):
+def _contact_mapping(field, include_dit_team=False):
     """Mapping for Adviser/Contact fields."""
-    return Nested(properties={'id': KeywordString(),
-                              'first_name': CaseInsensitiveKeywordString(),
-                              'last_name': CaseInsensitiveKeywordString(),
-                              'name': CaseInsensitiveKeywordString(),
-                              })
+    props = {
+        'id': KeywordString(),
+        'first_name': CaseInsensitiveKeywordString(),
+        'last_name': CaseInsensitiveKeywordString(),
+        'name': CaseInsensitiveKeywordString(),
+    }
+
+    if include_dit_team:
+        props['dit_team'] = _id_name_mapping()
+    return Nested(properties=props)
 
 
 def _id_name_mapping():

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -137,7 +137,7 @@ def get_term_query(field, value):
     if '.' not in field:
         return term
 
-    return Q('nested', path=field.split('.', maxsplit=1)[0], query=term)
+    return Q('nested', path=field.rsplit('.', maxsplit=1)[0], query=term)
 
 
 def get_match_query(field, value):

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -23,6 +23,8 @@ class Order(DocType, MapDBModelToDict):
     service_types = dsl_utils._id_name_mapping()
     contact_email = dsl_utils.CaseInsensitiveKeywordString()
     contact_phone = dsl_utils.KeywordString()
+    subscribers = dsl_utils._contact_mapping('subscribers', include_dit_team=True)
+    assignees = dsl_utils._contact_mapping('assignees', include_dit_team=True)
 
     MAPPINGS = {
         'id': str,
@@ -32,12 +34,16 @@ class Order(DocType, MapDBModelToDict):
         'primary_market': dict_utils._id_name_dict,
         'sector': dict_utils._id_name_dict,
         'service_types': lambda col: [dict_utils._id_name_dict(c) for c in col.all()],
+        'subscribers': lambda col: [
+            dict_utils._contact_dict(c.adviser, include_dit_team=True) for c in col.all()
+        ],
+        'assignees': lambda col: [
+            dict_utils._contact_dict(c.adviser, include_dit_team=True) for c in col.all()
+        ],
     }
 
     IGNORED_FIELDS = (
         'modified_by',
-        'subscribers',
-        'assignees',
         'modified_on',
         'product_info',
         'further_info',

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -142,6 +142,74 @@ def test_mapping(setup_es):
                     'index': 'not_analyzed',
                     'type': 'string'
                 },
+                'subscribers': {
+                    'properties': {
+                        'id': {
+                            'index': 'not_analyzed',
+                            'type': 'string'
+                        },
+                        'first_name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'type': 'string'
+                        },
+                        'last_name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'type': 'string'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'type': 'string'
+                        },
+                        'dit_team': {
+                            'properties': {
+                                'id': {
+                                    'index': 'not_analyzed',
+                                    'type': 'string'
+                                },
+                                'name': {
+                                    'analyzer': 'lowercase_keyword_analyzer',
+                                    'type': 'string'
+                                }
+                            },
+                            'type': 'nested'
+                        }
+                    },
+                    'type': 'nested'
+                },
+                'assignees': {
+                    'properties': {
+                        'id': {
+                            'index': 'not_analyzed',
+                            'type': 'string'
+                        },
+                        'first_name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'type': 'string'
+                        },
+                        'last_name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'type': 'string'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'type': 'string'
+                        },
+                        'dit_team': {
+                            'properties': {
+                                'id': {
+                                    'index': 'not_analyzed',
+                                    'type': 'string'
+                                },
+                                'name': {
+                                    'analyzer': 'lowercase_keyword_analyzer',
+                                    'type': 'string'
+                                }
+                            },
+                            'type': 'nested'
+                        }
+                    },
+                    'type': 'nested'
+                },
             }
         }
     }
@@ -208,5 +276,19 @@ def test_indexed_doc(setup_es):
             'delivery_date': order.delivery_date.isoformat(),
             'contact_email': order.contact_email,
             'contact_phone': order.contact_phone,
+            'subscribers': [
+                {
+                    'id': str(subscriber.adviser.pk),
+                    'name': str(subscriber.adviser.name),
+                }
+                for subscriber in order.subscribers.all()
+            ],
+            'assignees': [
+                {
+                    'id': str(subscriber.adviser.pk),
+                    'name': str(subscriber.adviser.name),
+                }
+                for subscriber in order.assignees.all()
+            ],
         }
     }

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -1,7 +1,8 @@
 import pytest
 
-from datahub.omis.order.test.factories import OrderAssigneeFactory, OrderFactory, \
-    OrderSubscriberFactory
+from datahub.omis.order.test.factories import (
+    OrderAssigneeFactory, OrderFactory, OrderSubscriberFactory
+)
 
 from ..models import Order as ESOrder
 

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 
-from datahub.omis.order.test.factories import OrderFactory
+from datahub.omis.order.test.factories import OrderAssigneeFactory, OrderFactory, \
+    OrderSubscriberFactory
 
 from ..models import Order as ESOrder
 
@@ -10,6 +11,9 @@ pytestmark = pytest.mark.django_db
 def test_order_to_dict():
     """Test converting an order to dict."""
     order = OrderFactory()
+    OrderSubscriberFactory.create_batch(2, order=order)
+    OrderAssigneeFactory.create_batch(2, order=order)
+
     result = ESOrder.dbmodel_to_dict(order)
 
     assert result == {
@@ -52,6 +56,32 @@ def test_order_to_dict():
         'delivery_date': order.delivery_date,
         'contact_email': order.contact_email,
         'contact_phone': order.contact_phone,
+        'subscribers': [
+            {
+                'id': str(subscriber.adviser.pk),
+                'first_name': subscriber.adviser.first_name,
+                'last_name': subscriber.adviser.last_name,
+                'name': str(subscriber.adviser.name),
+                'dit_team': {
+                    'id': str(subscriber.adviser.dit_team.pk),
+                    'name': str(subscriber.adviser.dit_team.name),
+                }
+            }
+            for subscriber in order.subscribers.all()
+        ],
+        'assignees': [
+            {
+                'id': str(assignee.adviser.pk),
+                'first_name': assignee.adviser.first_name,
+                'last_name': assignee.adviser.last_name,
+                'name': str(assignee.adviser.name),
+                'dit_team': {
+                    'id': str(assignee.adviser.dit_team.pk),
+                    'name': str(assignee.adviser.dit_team.name),
+                }
+            }
+            for assignee in order.assignees.all()
+        ],
     }
 
 

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -62,11 +62,15 @@ class SearchOrderAPIView(PaginatedAPIMixin, APIView):
     FILTER_FIELDS = [
         'primary_market',
         'created_on_before',
-        'created_on_after'
+        'created_on_after',
+        'assigned_to_adviser',
+        'assigned_to_team',
     ]
 
     REMAP_FIELDS = {
-        'primary_market': 'primary_market.id'
+        'primary_market': 'primary_market.id',
+        'assigned_to_adviser': 'assignees.id',
+        'assigned_to_team': 'assignees.dit_team.id',
     }
 
     def get_filtering_data(self, request):

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -63,6 +63,30 @@ def test_contact_dict():
     }
 
 
+def test_contact_dict_include_dit_team():
+    """Tests contact_dict including its team."""
+    obj = mock.Mock()
+    obj.id = 123
+    obj.first_name = 'First'
+    obj.last_name = 'Last'
+    obj.name = 'First Last'
+    obj.dit_team.id = 321
+    obj.dit_team.name = 'team name'
+
+    res = dict_utils._contact_dict(obj, include_dit_team=True)
+
+    assert res == {
+        'id': str(obj.id),
+        'first_name': obj.first_name,
+        'last_name': obj.last_name,
+        'name': obj.name,
+        'dit_team': {
+            'id': '321',
+            'name': 'team name'
+        }
+    }
+
+
 def test_company_dict():
     """Tests company_dict."""
     obj = mock.Mock()

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -87,6 +87,26 @@ def test_contact_dict_include_dit_team():
     }
 
 
+def test_contact_dict_none_dit_team():
+    """Tests contact_dict including its team when dit_team is None."""
+    obj = mock.Mock()
+    obj.id = 123
+    obj.first_name = 'First'
+    obj.last_name = 'Last'
+    obj.name = 'First Last'
+    obj.dit_team = None
+
+    res = dict_utils._contact_dict(obj, include_dit_team=True)
+
+    assert res == {
+        'id': str(obj.id),
+        'first_name': obj.first_name,
+        'last_name': obj.last_name,
+        'name': obj.name,
+        'dit_team': {}
+    }
+
+
 def test_company_dict():
     """Tests company_dict."""
     obj = mock.Mock()


### PR DESCRIPTION
This:
- adds subscribers and assignees to the indexed order
- adds two filters to the search view:
	- assigned_to_adviser: filters by assignee adviser id
	- assigned_to_team: filters by assignee adviser team id

When creating or deleting an OrderAssignee or an OrderSubscriber, we need to update the order as well as it normalises those values in nested lists.
This means that if I create n assignees or n subscribers, at approx the same time, it triggers n equal commands to sync the related order.
It doesn't seem easy to group those ES syncs and only sync once per order.