### PR TITLE
[DH-482] Exclude BaseModel fields from django-reversion versions

### DIFF
--- a/datahub/company/admin.py
+++ b/datahub/company/admin.py
@@ -1,13 +1,12 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 
-from reversion.admin import VersionAdmin
-
+from datahub.core.admin import BaseModelVersionAdmin
 from .models import Advisor, CompaniesHouseCompany, Company, Contact
 
 
 @admin.register(Company)
-class CompanyAdmin(VersionAdmin):
+class CompanyAdmin(BaseModelVersionAdmin):
     """Company admin."""
 
     search_fields = ['name', 'id', 'company_number']
@@ -15,7 +14,7 @@ class CompanyAdmin(VersionAdmin):
 
 
 @admin.register(Contact)
-class ContactAdmin(VersionAdmin):
+class ContactAdmin(BaseModelVersionAdmin):
     """Contact admin."""
 
     search_fields = ['first_name', 'last_name', 'company__name']
@@ -40,7 +39,7 @@ class CHCompany(admin.ModelAdmin):
 
 
 @admin.register(Advisor)
-class AdviserAdmin(VersionAdmin, UserAdmin):
+class AdviserAdmin(BaseModelVersionAdmin, UserAdmin):
     """Adviser admin."""
 
     fieldsets = (

--- a/datahub/company/test/test_company_views_v3.py
+++ b/datahub/company/test/test_company_views_v3.py
@@ -512,6 +512,8 @@ class TestAuditLogView(APITestMixin):
         assert entry['comment'] == 'Changed'
         assert entry['timestamp'] == changed_datetime.isoformat()
         assert entry['changes']['description'] == ['Initial desc', 'New desc']
+        assert not {'created_on', 'created_by', 'modified_on', 'modified_by'} & entry[
+            'changes'].keys()
 
 
 class TestCHCompany(APITestMixin):

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -573,3 +573,5 @@ class TestAuditLogView(APITestMixin):
         assert entry['comment'] == 'Changed'
         assert entry['timestamp'] == changed_datetime.isoformat()
         assert entry['changes']['notes'] == ['Initial notes', 'New notes']
+        assert not {'created_on', 'created_by', 'modified_on', 'modified_by'} & entry[
+            'changes'].keys()

--- a/datahub/core/admin.py
+++ b/datahub/core/admin.py
@@ -1,0 +1,36 @@
+from reversion.admin import VersionAdmin
+
+
+class ConfigurableVersionAdmin(VersionAdmin):
+    """
+    Subclass of VersionAdmin that allows the excluded model fields for django-reversion
+    to be easily set.
+
+    This is in line with the example on:
+    https://django-reversion.readthedocs.io/en/stable/admin.html#reversion-admin-versionadmin
+
+    Excluded fields are not saved in django-reversion versions.
+
+    This is set in the admin class because we're using django-reversion auto-registration
+    via VersionAdmin.
+    """
+
+    reversion_excluded_fields = None
+
+    def reversion_register(self, model, **options):
+        """Used the the django-reversion model auto-registration mechanism."""
+        if self.reversion_excluded_fields:
+            options['exclude'] = self.reversion_excluded_fields
+        super().reversion_register(model, **options)
+
+
+class BaseModelVersionAdmin(ConfigurableVersionAdmin):
+    """
+    VersionAdmin subclass that excludes fields defined on BaseModel.
+
+    These aren't particularly useful to save in django-reversion versions because
+    created_by/created_on will not change between versions, and modified_on/modified_by
+    is tracked by django-reversion separately in revisions.
+    """
+
+    reversion_excluded_fields = ('created_on', 'created_by', 'modified_on', 'modified_by')

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -1,12 +1,11 @@
 from django.contrib import admin
 
-from reversion.admin import VersionAdmin
-
+from datahub.core.admin import BaseModelVersionAdmin
 from .models import Interaction, ServiceDelivery, ServiceOffer
 
 
 @admin.register(Interaction)
-class InteractionAdmin(VersionAdmin):
+class InteractionAdmin(BaseModelVersionAdmin):
     """Interaction admin."""
 
     search_fields = ['id', 'company__company_number', 'company__company_name', 'contact_email']
@@ -14,7 +13,7 @@ class InteractionAdmin(VersionAdmin):
 
 
 @admin.register(ServiceDelivery)
-class ServiceDeliveryAdmin(VersionAdmin):
+class ServiceDeliveryAdmin(BaseModelVersionAdmin):
     """Service Delivery admin."""
 
     search_fields = ['id', 'company__company_number', 'company__company_name', 'contact_email']
@@ -22,7 +21,7 @@ class ServiceDeliveryAdmin(VersionAdmin):
 
 
 @admin.register(ServiceOffer)
-class ServiceOfferAdmin(VersionAdmin):
+class ServiceOfferAdmin(BaseModelVersionAdmin):
     """Service Offer admin."""
 
     raw_id_fields = ('event',)

--- a/datahub/investment/admin.py
+++ b/datahub/investment/admin.py
@@ -2,14 +2,13 @@
 
 from django.contrib import admin
 
-from reversion.admin import VersionAdmin
-
+from datahub.core.admin import BaseModelVersionAdmin
 from datahub.investment.models import (InvestmentProject, InvestmentProjectTeamMember,
                                        IProjectDocument)
 
 
 @admin.register(InvestmentProject)
-class InvestmentProjectAdmin(VersionAdmin):
+class InvestmentProjectAdmin(BaseModelVersionAdmin):
     """Investment project admin."""
 
     search_fields = ['name']
@@ -27,7 +26,7 @@ class InvestmentProjectAdmin(VersionAdmin):
 
 
 @admin.register(InvestmentProjectTeamMember)
-class InvestmentProjectTeamMemberAdmin(VersionAdmin):
+class InvestmentProjectTeamMemberAdmin(BaseModelVersionAdmin):
     """Investment project team member admin."""
 
     raw_id_fields = (

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -1069,6 +1069,8 @@ class TestAuditLogView(APITestMixin):
         assert entry['timestamp'] == changed_datetime.isoformat(), 'TS can be set manually'
         assert entry['changes']['description'] == ['Initial desc', 'New desc'], \
             'Changes are reflected'
+        assert not {'created_on', 'created_by', 'modified_on', 'modified_by'} & entry[
+            'changes'].keys()
 
 
 class TestArchiveViews(APITestMixin):


### PR DESCRIPTION
These aren't particularly useful to save in django-reversion versions because  created_by/created_on will not change between versions, and modified_on/modified_by is tracked by django-reversion separately in revisions.

Excluding them also means they won't be included in responses from the audit endpoints.