### PR TITLE
Move search apps from __init__.py to separate modules

### DIFF
--- a/datahub/search/company/__init__.py
+++ b/datahub/search/company/__init__.py
@@ -1,30 +1,3 @@
-from datahub.company.models import Company as DBCompany
+from .apps import CompanySearchApp
 
-from .models import Company
-from .views import SearchCompanyAPIView
-
-from ..apps import SearchApp
-from ..models import DataSet
-
-
-class CompanySearchApp(SearchApp):
-    """SearchApp for company"""
-
-    name = 'company'
-    plural_name = 'companies'
-    ESModel = Company
-    DBModel = DBCompany
-    view = SearchCompanyAPIView
-
-    def get_dataset(self):
-        """Returns dataset that will be synchronised with Elasticsearch."""
-        prefetch_fields = (
-            'registered_address_country', 'business_type', 'sector', 'employee_range',
-            'turnover_range', 'account_manager', 'export_to_countries',
-            'future_interest_countries', 'trading_address_country', 'headquarter_type',
-            'classification', 'one_list_account_owner',
-        )
-
-        qs = self.DBModel.objects.prefetch_related(*prefetch_fields).all().order_by('pk')
-
-        return DataSet(qs, self.ESModel)
+__all__ = ('CompanySearchApp',)

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -1,0 +1,30 @@
+from datahub.company.models import Company as DBCompany
+
+from .models import Company
+from .views import SearchCompanyAPIView
+
+from ..apps import SearchApp
+from ..models import DataSet
+
+
+class CompanySearchApp(SearchApp):
+    """SearchApp for company"""
+
+    name = 'company'
+    plural_name = 'companies'
+    ESModel = Company
+    DBModel = DBCompany
+    view = SearchCompanyAPIView
+
+    def get_dataset(self):
+        """Returns dataset that will be synchronised with Elasticsearch."""
+        prefetch_fields = (
+            'registered_address_country', 'business_type', 'sector', 'employee_range',
+            'turnover_range', 'account_manager', 'export_to_countries',
+            'future_interest_countries', 'trading_address_country', 'headquarter_type',
+            'classification', 'one_list_account_owner',
+        )
+
+        qs = self.DBModel.objects.prefetch_related(*prefetch_fields).all().order_by('pk')
+
+        return DataSet(qs, self.ESModel)

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -19,10 +19,18 @@ class CompanySearchApp(SearchApp):
     def get_dataset(self):
         """Returns dataset that will be synchronised with Elasticsearch."""
         prefetch_fields = (
-            'registered_address_country', 'business_type', 'sector', 'employee_range',
-            'turnover_range', 'account_manager', 'export_to_countries',
-            'future_interest_countries', 'trading_address_country', 'headquarter_type',
-            'classification', 'one_list_account_owner',
+            'registered_address_country',
+            'business_type',
+            'sector',
+            'employee_range',
+            'turnover_range',
+            'account_manager',
+            'export_to_countries',
+            'future_interest_countries',
+            'trading_address_country',
+            'headquarter_type',
+            'classification',
+            'one_list_account_owner',
         )
 
         qs = self.DBModel.objects.prefetch_related(*prefetch_fields).all().order_by('pk')

--- a/datahub/search/contact/__init__.py
+++ b/datahub/search/contact/__init__.py
@@ -1,16 +1,3 @@
-from datahub.company.models import Contact as DBContact
+from .apps import ContactSearchApp
 
-from .models import Contact
-from .views import SearchContactAPIView
-
-from ..apps import SearchApp
-
-
-class ContactSearchApp(SearchApp):
-    """SearchApp for contacts"""
-
-    name = 'contact'
-    plural_name = 'contacts'
-    ESModel = Contact
-    DBModel = DBContact
-    view = SearchContactAPIView
+__all__ = ('ContactSearchApp',)

--- a/datahub/search/contact/apps.py
+++ b/datahub/search/contact/apps.py
@@ -1,0 +1,16 @@
+from datahub.company.models import Contact as DBContact
+
+from .models import Contact
+from .views import SearchContactAPIView
+
+from ..apps import SearchApp
+
+
+class ContactSearchApp(SearchApp):
+    """SearchApp for contacts"""
+
+    name = 'contact'
+    plural_name = 'contacts'
+    ESModel = Contact
+    DBModel = DBContact
+    view = SearchContactAPIView

--- a/datahub/search/investment/__init__.py
+++ b/datahub/search/investment/__init__.py
@@ -1,16 +1,3 @@
-from datahub.investment.models import InvestmentProject as DBInvestmentProject
+from .apps import InvestmentSearchApp
 
-from .models import InvestmentProject
-from .views import SearchInvestmentProjectAPIView
-
-from ..apps import SearchApp
-
-
-class InvestmentSearchApp(SearchApp):
-    """SearchApp for investment"""
-
-    name = 'investment_project'
-    plural_name = 'investment_projects'
-    ESModel = InvestmentProject
-    DBModel = DBInvestmentProject
-    view = SearchInvestmentProjectAPIView
+__all__ = ('InvestmentSearchApp',)

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -1,0 +1,16 @@
+from datahub.investment.models import InvestmentProject as DBInvestmentProject
+
+from .models import InvestmentProject
+from .views import SearchInvestmentProjectAPIView
+
+from ..apps import SearchApp
+
+
+class InvestmentSearchApp(SearchApp):
+    """SearchApp for investment"""
+
+    name = 'investment_project'
+    plural_name = 'investment_projects'
+    ESModel = InvestmentProject
+    DBModel = DBInvestmentProject
+    view = SearchInvestmentProjectAPIView

--- a/datahub/search/omis/__init__.py
+++ b/datahub/search/omis/__init__.py
@@ -1,16 +1,3 @@
-from datahub.omis.order.models import Order as DBOrder
+from .apps import OrderSearchApp
 
-from .models import Order
-from .views import SearchOrderAPIView
-
-from ..apps import SearchApp
-
-
-class OrderSearchApp(SearchApp):
-    """SearchApp for order"""
-
-    name = 'order'
-    plural_name = 'orders'
-    ESModel = Order
-    DBModel = DBOrder
-    view = SearchOrderAPIView
+__all__ = ('OrderSearchApp',)

--- a/datahub/search/omis/apps.py
+++ b/datahub/search/omis/apps.py
@@ -1,0 +1,16 @@
+from datahub.omis.order.models import Order as DBOrder
+
+from .models import Order
+from .views import SearchOrderAPIView
+
+from ..apps import SearchApp
+
+
+class OrderSearchApp(SearchApp):
+    """SearchApp for order"""
+
+    name = 'order'
+    plural_name = 'orders'
+    ESModel = Order
+    DBModel = DBOrder
+    view = SearchOrderAPIView


### PR DESCRIPTION
Better not to define classes etc. in `__init__.py` as it's not particularly discoverable and will probably get added to over time.