### PR TITLE
[DH-491] Add pagination to audit log views

### DIFF
--- a/datahub/company/urls.py
+++ b/datahub/company/urls.py
@@ -28,7 +28,7 @@ contact_unarchive = ContactViewSet.as_view({
 })
 
 contact_audit = ContactAuditViewSet.as_view({
-    'get': 'retrieve',
+    'get': 'list',
 })
 
 contact_urls = [
@@ -55,7 +55,7 @@ company_item = CompanyViewSetV3.as_view({
 })
 
 company_audit = CompanyAuditViewSet.as_view({
-    'get': 'retrieve',
+    'get': 'list',
 })
 
 company_archive = CompanyViewSetV3.as_view({

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -5,7 +5,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
 from rest_framework.filters import OrderingFilter
 
-from datahub.core.audit import AuditSerializer
+from datahub.core.audit import AuditViewSet
 from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.viewsets import CoreViewSetV1, CoreViewSetV3
 from datahub.investment.queryset import get_slim_investment_project_queryset
@@ -67,10 +67,9 @@ class CompanyViewSetV3(ArchivableViewSetMixin, CoreViewSetV3):
     )
 
 
-class CompanyAuditViewSet(CoreViewSetV3):
+class CompanyAuditViewSet(AuditViewSet):
     """Company audit views."""
 
-    serializer_class = AuditSerializer
     queryset = Company.objects.all()
 
 
@@ -101,10 +100,9 @@ class ContactViewSet(ArchivableViewSetMixin, CoreViewSetV3):
         return data
 
 
-class ContactAuditViewSet(CoreViewSetV3):
+class ContactAuditViewSet(AuditViewSet):
     """Contact audit views."""
 
-    serializer_class = AuditSerializer
     queryset = Contact.objects.all()
 
 

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -5,8 +5,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
 from rest_framework.filters import OrderingFilter
 
+from datahub.core.audit import AuditSerializer
 from datahub.core.mixins import ArchivableViewSetMixin
-from datahub.core.serializers import AuditSerializer
 from datahub.core.viewsets import CoreViewSetV1, CoreViewSetV3
 from datahub.investment.queryset import get_slim_investment_project_queryset
 from .models import Advisor, CompaniesHouseCompany, Company, Contact

--- a/datahub/core/audit.py
+++ b/datahub/core/audit.py
@@ -86,7 +86,7 @@ class _VersionQuerySetProxy:
         self.queryset = queryset
 
     def __getitem__(self, item):
-        """Handles instance[item], forwards calls to underlying query set.
+        """Handles self[item], forwarding calls to underlying query set.
 
         Where item is a slice, 1 is added to item.stop.
         """

--- a/datahub/core/audit.py
+++ b/datahub/core/audit.py
@@ -1,0 +1,101 @@
+from rest_framework import serializers
+from rest_framework.pagination import LimitOffsetPagination
+from reversion.models import Version
+
+
+class VersionQuerySetProxy:
+    """
+    Proxies a VersionQuerySet, modifying slicing behaviour to return an extra item.
+
+    This is allow the AuditSerializer to use the LimitOffsetPagination class
+    as N+1 versions are required to produce N audit log entries.
+    """
+
+    def __init__(self, queryset):
+        """Initialises the instance, saving a reference to the underlying query set."""
+        self.queryset = queryset
+
+    def __getitem__(self, item):
+        """Handles instance[item], forwards calls to underlying query set.
+
+        Where item is a slice, 1 is added to item.stop.
+        """
+        if isinstance(item, slice):
+            if item.step is not None:
+                raise TypeError('Slicing with step not supported')
+
+            stop = item.stop + 1 if item.stop is not None else None
+            return self.queryset[item.start:stop]
+
+        return self.queryset[item]
+
+    def count(self):
+        """
+        Gets the count of the query set, minus 1. This is due to N audit log entries
+        being generated from N+1 query set results.
+
+        The return value is always non-negative.
+        """
+        return max(self.queryset.count() - 1, 0)
+
+
+class AuditSerializer(serializers.Serializer):
+    """Generic serializer for audit logs."""
+
+    def to_representation(self, instance):
+        """Override serialization process completely to get the Versions."""
+        request = self.context['request']
+        paginator = LimitOffsetPagination()
+
+        versions = Version.objects.get_for_object(instance)
+        versions_subset = paginator.paginate_queryset(VersionQuerySetProxy(versions), request)
+
+        version_pairs = (
+            (versions_subset[n], versions_subset[n + 1]) for n in range(len(versions_subset) - 1)
+        )
+        return {
+            'results': self._construct_changelog(version_pairs),
+            'count': paginator.count,
+            'next': paginator.get_next_link(),
+            'previous': paginator.get_previous_link()
+        }
+
+    def _construct_changelog(self, version_pairs):
+        changelog = []
+        for v_new, v_old in version_pairs:
+            version_creator = v_new.revision.user
+            creator_repr = None
+            if version_creator:
+                creator_repr = {
+                    'id': str(version_creator.pk),
+                    'first_name': version_creator.first_name,
+                    'last_name': version_creator.last_name,
+                    'name': version_creator.name,
+                    'email': version_creator.email,
+                }
+
+            changelog.append({
+                'id': v_new.id,
+                'user': creator_repr,
+                'timestamp': v_new.revision.date_created,
+                'comment': v_new.revision.comment or '',
+                'changes': self._diff_versions(
+                    v_old.field_dict, v_new.field_dict
+                ),
+            })
+
+        return changelog
+
+    @staticmethod
+    def _diff_versions(old_version, new_version):
+        changes = {}
+
+        for field_name, new_value in new_version.items():
+            if field_name not in old_version:
+                changes[field_name] = [None, new_value]
+            else:
+                old_value = old_version[field_name]
+                if old_value != new_value:
+                    changes[field_name] = [old_value, new_value]
+
+        return changes

--- a/datahub/core/serializers.py
+++ b/datahub/core/serializers.py
@@ -4,8 +4,6 @@ from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 from rest_framework.fields import UUIDField
-from rest_framework.pagination import LimitOffsetPagination
-from reversion.models import Version
 
 
 class ConstantModelSerializer(serializers.Serializer):
@@ -16,104 +14,6 @@ class ConstantModelSerializer(serializers.Serializer):
 
     class Meta:  # noqa: D101
         fields = '__all__'
-
-
-class VersionQuerySetProxy:
-    """
-    Proxies a VersionQuerySet, modifying slicing behaviour to return an extra item.
-
-    This is allow the AuditSerializer to use the LimitOffsetPagination class
-    as N+1 versions are required to produce N audit log entries.
-    """
-
-    def __init__(self, queryset):
-        """Initialises the instance, saving a reference to the underlying query set."""
-        self.queryset = queryset
-
-    def __getitem__(self, item):
-        """Handles instance[item], forwards calls to underlying query set.
-
-        Where item is a slice, 1 is added to item.stop.
-        """
-        if isinstance(item, slice):
-            if item.step is not None:
-                raise TypeError('Slicing with step not supported')
-
-            stop = item.stop + 1 if item.stop is not None else None
-            return self.queryset[item.start:stop]
-
-        return self.queryset[item]
-
-    def count(self):
-        """
-        Gets the count of the query set, minus 1. This is due to N audit log entries
-        being generated from N+1 query set results.
-
-        The return value is always non-negative.
-        """
-        return max(self.queryset.count() - 1, 0)
-
-
-class AuditSerializer(serializers.Serializer):
-    """Generic serializer for audit logs."""
-
-    def to_representation(self, instance):
-        """Override serialization process completely to get the Versions."""
-        request = self.context['request']
-        paginator = LimitOffsetPagination()
-
-        versions = Version.objects.get_for_object(instance)
-        versions_subset = paginator.paginate_queryset(VersionQuerySetProxy(versions), request)
-
-        version_pairs = (
-            (versions_subset[n], versions_subset[n + 1]) for n in range(len(versions_subset) - 1)
-        )
-        return {
-            'results': self._construct_changelog(version_pairs),
-            'count': paginator.count,
-            'next': paginator.get_next_link(),
-            'previous': paginator.get_previous_link()
-        }
-
-    def _construct_changelog(self, version_pairs):
-        changelog = []
-        for v_new, v_old in version_pairs:
-            version_creator = v_new.revision.user
-            creator_repr = None
-            if version_creator:
-                creator_repr = {
-                    'id': str(version_creator.pk),
-                    'first_name': version_creator.first_name,
-                    'last_name': version_creator.last_name,
-                    'name': version_creator.name,
-                    'email': version_creator.email,
-                }
-
-            changelog.append({
-                'id': v_new.id,
-                'user': creator_repr,
-                'timestamp': v_new.revision.date_created,
-                'comment': v_new.revision.comment or '',
-                'changes': self._diff_versions(
-                    v_old.field_dict, v_new.field_dict
-                ),
-            })
-
-        return changelog
-
-    @staticmethod
-    def _diff_versions(old_version, new_version):
-        changes = {}
-
-        for field_name, new_value in new_version.items():
-            if field_name not in old_version:
-                changes[field_name] = [None, new_value]
-            else:
-                old_value = old_version[field_name]
-                if old_value != new_value:
-                    changes[field_name] = [old_value, new_value]
-
-        return changes
 
 
 class NestedRelatedField(serializers.RelatedField):

--- a/datahub/core/serializers.py
+++ b/datahub/core/serializers.py
@@ -4,6 +4,7 @@ from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 from rest_framework.fields import UUIDField
+from rest_framework.pagination import LimitOffsetPagination
 from reversion.models import Version
 
 
@@ -17,23 +18,65 @@ class ConstantModelSerializer(serializers.Serializer):
         fields = '__all__'
 
 
+class VersionQuerySetProxy:
+    """
+    Proxies a VersionQuerySet, modifying slicing behaviour to return an extra item.
+
+    This is allow the AuditSerializer to use the LimitOffsetPagination class
+    as N+1 versions are required to produce N audit log entries.
+    """
+
+    def __init__(self, queryset):
+        """Initialises the instance, saving a reference to the underlying query set."""
+        self.queryset = queryset
+
+    def __getitem__(self, item):
+        """Handles instance[item], forwards calls to underlying query set.
+
+        Where item is a slice, 1 is added to item.stop.
+        """
+        if isinstance(item, slice):
+            if item.step is not None:
+                raise TypeError('Slicing with step not supported')
+
+            stop = item.stop + 1 if item.stop is not None else None
+            return self.queryset[item.start:stop]
+
+        return self.queryset[item]
+
+    def count(self):
+        """
+        Gets the count of the query set, minus 1. This is due to N audit log entries
+        being generated from N+1 query set results.
+
+        The return value is always non-negative.
+        """
+        return max(self.queryset.count() - 1, 0)
+
+
 class AuditSerializer(serializers.Serializer):
     """Generic serializer for audit logs."""
 
     def to_representation(self, instance):
         """Override serialization process completely to get the Versions."""
-        versions = Version.objects.get_for_object(instance)
-        version_pairs = (
-            (versions[n], versions[n + 1]) for n in range(len(versions) - 1)
-        )
+        request = self.context['request']
+        paginator = LimitOffsetPagination()
 
+        versions = Version.objects.get_for_object(instance)
+        versions_subset = paginator.paginate_queryset(VersionQuerySetProxy(versions), request)
+
+        version_pairs = (
+            (versions_subset[n], versions_subset[n + 1]) for n in range(len(versions_subset) - 1)
+        )
         return {
             'results': self._construct_changelog(version_pairs),
+            'count': paginator.count,
+            'next': paginator.get_next_link(),
+            'previous': paginator.get_previous_link()
         }
 
     def _construct_changelog(self, version_pairs):
         changelog = []
-
         for v_new, v_old in version_pairs:
             version_creator = v_new.revision.user
             creator_repr = None

--- a/datahub/core/test/test_audit.py
+++ b/datahub/core/test/test_audit.py
@@ -30,6 +30,9 @@ def test_audit_log_diff_algo():
 
 
 @pytest.mark.parametrize('num_versions,offset,limit,exp_results,exp_next,exp_previous', (
+    (0, '', '', [], None, None),
+    (1, '', '', [], None, None),
+    (2, '', '', [0], None, None),
     (26, '', '', range(0, 25), None, None),
     (26, '10', '10', range(10, 20), 'http://test/audit?offset=20&limit=10',
      'http://test/audit?limit=10'),

--- a/datahub/core/test/test_audit.py
+++ b/datahub/core/test/test_audit.py
@@ -1,0 +1,101 @@
+from unittest.mock import MagicMock, Mock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from reversion.models import Version
+
+from datahub.core.audit import AuditSerializer
+
+
+def test_audit_log_diff_algo():
+    """Test simple diff algorithm."""
+    given = {
+        'old': {
+            'field1': 'val1',
+            'field2': 'val2',
+        },
+        'new': {
+            'field1': 'val1',
+            'field2': 'new-val',
+            'field3': 'added',
+        },
+    }
+
+    expected = {
+        'field2': ['val2', 'new-val'],
+        'field3': [None, 'added'],
+    }
+
+    assert AuditSerializer._diff_versions(given['old'], given['new']) == expected
+
+
+@pytest.mark.parametrize('num_versions,offset,limit,exp_results,exp_next,exp_previous', (
+    (26, '', '', range(0, 25), None, None),
+    (26, '10', '10', range(10, 20), 'http://test/audit?offset=20&limit=10',
+     'http://test/audit?limit=10'),
+    (26, '20', '10', range(20, 25), None, 'http://test/audit?offset=10&limit=10'),
+))
+def test_audit_log_pagination(num_versions, offset, limit, exp_results, exp_next, exp_previous,
+                              monkeypatch):
+    """Test the audit log pagination."""
+    monkeypatch.setattr(
+        Version.objects, 'get_for_object', _create_get_for_object_stub(num_versions)
+    )
+    instance = Mock()
+    request = Mock(
+        build_absolute_uri=lambda: 'http://test/audit',
+        query_params={
+            'offset': offset,
+            'limit': limit
+        })
+    context = {
+        'request': request
+    }
+    serializer = AuditSerializer(context=context)
+    response_data = serializer.to_representation(instance)
+    results = response_data['results']
+
+    assert response_data['count'] == max(num_versions - 1, 0)
+    assert _create_canonical_url_object(response_data['next']) == _create_canonical_url_object(
+        exp_next)
+    assert _create_canonical_url_object(response_data['previous']) == _create_canonical_url_object(
+        exp_previous)
+    assert [result['id'] for result in results] == list(exp_results)
+
+
+class _VersionQuerySetStub:
+    """VersionQuerySet stub."""
+
+    def __init__(self, count):
+        """Initialises the instance, creating some stub version instances to return as results."""
+        self.items = [MagicMock(id=n) for n in range(count)]
+
+    def __getitem__(self, item):
+        """Returns items from the fake data generated."""
+        return self.items[item]
+
+    def __len__(self):
+        """Returns the number of items generated."""
+        return len(self.items)
+
+    def count(self):
+        """Returns the number of items generated."""
+        return len(self.items)
+
+
+def _create_get_for_object_stub(num_versions):
+    """Creates a stub replacement for Version.objects.get_for_object."""
+    def mock_versions(obj, model_db=None):
+        return _VersionQuerySetStub(num_versions)
+
+    return mock_versions
+
+
+def _create_canonical_url_object(url):
+    """Turns a URL into an object in a canonical form that can be used for comparisons."""
+    if url is None:
+        return None
+    parse_results = urlparse(url)
+    parsed_dict = parse_results._asdict()
+    parsed_dict['query'] = parse_qs(parse_results.query)
+    return parsed_dict

--- a/datahub/core/test/test_audit.py
+++ b/datahub/core/test/test_audit.py
@@ -4,7 +4,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from reversion.models import Version
 
-from datahub.core.audit import AuditSerializer
+from datahub.core.audit import AuditViewSet
 
 
 def test_audit_log_diff_algo():
@@ -26,7 +26,7 @@ def test_audit_log_diff_algo():
         'field3': [None, 'added'],
     }
 
-    assert AuditSerializer._diff_versions(given['old'], given['new']) == expected
+    assert AuditViewSet._diff_versions(given['old'], given['new']) == expected
 
 
 @pytest.mark.parametrize('num_versions,offset,limit,exp_results,exp_next,exp_previous', (
@@ -48,17 +48,14 @@ def test_audit_log_pagination(num_versions, offset, limit, exp_results, exp_next
             'offset': offset,
             'limit': limit
         })
-    context = {
-        'request': request
-    }
-    serializer = AuditSerializer(context=context)
-    response_data = serializer.to_representation(instance)
-    results = response_data['results']
+    serializer = AuditViewSet(request=request)
+    response = serializer.create_response(instance)
+    results = response.data['results']
 
-    assert response_data['count'] == max(num_versions - 1, 0)
-    assert _create_canonical_url_object(response_data['next']) == _create_canonical_url_object(
+    assert response.data['count'] == max(num_versions - 1, 0)
+    assert _create_canonical_url_object(response.data['next']) == _create_canonical_url_object(
         exp_next)
-    assert _create_canonical_url_object(response_data['previous']) == _create_canonical_url_object(
+    assert _create_canonical_url_object(response.data['previous']) == _create_canonical_url_object(
         exp_previous)
     assert [result['id'] for result in results] == list(exp_results)
 

--- a/datahub/core/test/test_serializers.py
+++ b/datahub/core/test/test_serializers.py
@@ -1,107 +1,11 @@
 from unittest.mock import call, MagicMock, Mock
-from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.exceptions import ValidationError
-from reversion.models import Version
 
-from datahub.core.serializers import AuditSerializer, NestedRelatedField
-
-
-def test_audit_log_diff_algo():
-    """Test simple diff algorithm."""
-    given = {
-        'old': {
-            'field1': 'val1',
-            'field2': 'val2',
-        },
-        'new': {
-            'field1': 'val1',
-            'field2': 'new-val',
-            'field3': 'added',
-        },
-    }
-
-    expected = {
-        'field2': ['val2', 'new-val'],
-        'field3': [None, 'added'],
-    }
-
-    assert AuditSerializer._diff_versions(given['old'], given['new']) == expected
-
-
-@pytest.mark.parametrize('num_versions,offset,limit,exp_results,exp_next,exp_previous', (
-    (26, '', '', range(0, 25), None, None),
-    (26, '10', '10', range(10, 20), 'http://test/audit?offset=20&limit=10',
-     'http://test/audit?limit=10'),
-    (26, '20', '10', range(20, 25), None, 'http://test/audit?offset=10&limit=10'),
-))
-def test_audit_log_pagination(num_versions, offset, limit, exp_results, exp_next, exp_previous,
-                              monkeypatch):
-    """Test the audit log pagination."""
-    monkeypatch.setattr(
-        Version.objects, 'get_for_object', _create_get_for_object_stub(num_versions)
-    )
-    instance = Mock()
-    request = Mock(
-        build_absolute_uri=lambda: 'http://test/audit',
-        query_params={
-            'offset': offset,
-            'limit': limit
-        })
-    context = {
-        'request': request
-    }
-    serializer = AuditSerializer(context=context)
-    response_data = serializer.to_representation(instance)
-    results = response_data['results']
-
-    assert response_data['count'] == max(num_versions - 1, 0)
-    assert _create_canonical_url_object(response_data['next']) == _create_canonical_url_object(
-        exp_next)
-    assert _create_canonical_url_object(response_data['previous']) == _create_canonical_url_object(
-        exp_previous)
-    assert [result['id'] for result in results] == list(exp_results)
-
-
-class _VersionQuerySetStub:
-    """VersionQuerySet stub."""
-
-    def __init__(self, count):
-        """Initialises the instance, creating some stub version instances to return as results."""
-        self.items = [MagicMock(id=n) for n in range(count)]
-
-    def __getitem__(self, item):
-        """Returns items from the fake data generated."""
-        return self.items[item]
-
-    def __len__(self):
-        """Returns the number of items generated."""
-        return len(self.items)
-
-    def count(self):
-        """Returns the number of items generated."""
-        return len(self.items)
-
-
-def _create_get_for_object_stub(num_versions):
-    """Creates a stub replacement for Version.objects.get_for_object."""
-    def mock_versions(obj, model_db=None):
-        return _VersionQuerySetStub(num_versions)
-
-    return mock_versions
-
-
-def _create_canonical_url_object(url):
-    """Turns a URL into an object in a canonical form that can be used for comparisons."""
-    if url is None:
-        return None
-    parse_results = urlparse(url)
-    parsed_dict = parse_results._asdict()
-    parsed_dict['query'] = parse_qs(parse_results.query)
-    return parsed_dict
+from datahub.core.serializers import NestedRelatedField
 
 
 def test_nested_rel_field_to_internal_dict():

--- a/datahub/core/test/test_serializers.py
+++ b/datahub/core/test/test_serializers.py
@@ -1,9 +1,11 @@
 from unittest.mock import call, MagicMock, Mock
+from urllib.parse import parse_qs, urlparse
 from uuid import uuid4
 
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.exceptions import ValidationError
+from reversion.models import Version
 
 from datahub.core.serializers import AuditSerializer, NestedRelatedField
 
@@ -28,6 +30,78 @@ def test_audit_log_diff_algo():
     }
 
     assert AuditSerializer._diff_versions(given['old'], given['new']) == expected
+
+
+@pytest.mark.parametrize('num_versions,offset,limit,exp_results,exp_next,exp_previous', (
+    (26, '', '', range(0, 25), None, None),
+    (26, '10', '10', range(10, 20), 'http://test/audit?offset=20&limit=10',
+     'http://test/audit?limit=10'),
+    (26, '20', '10', range(20, 25), None, 'http://test/audit?offset=10&limit=10'),
+))
+def test_audit_log_pagination(num_versions, offset, limit, exp_results, exp_next, exp_previous,
+                              monkeypatch):
+    """Test the audit log pagination."""
+    monkeypatch.setattr(
+        Version.objects, 'get_for_object', _create_get_for_object_stub(num_versions)
+    )
+    instance = Mock()
+    request = Mock(
+        build_absolute_uri=lambda: 'http://test/audit',
+        query_params={
+            'offset': offset,
+            'limit': limit
+        })
+    context = {
+        'request': request
+    }
+    serializer = AuditSerializer(context=context)
+    response_data = serializer.to_representation(instance)
+    results = response_data['results']
+
+    assert response_data['count'] == max(num_versions - 1, 0)
+    assert _create_canonical_url_object(response_data['next']) == _create_canonical_url_object(
+        exp_next)
+    assert _create_canonical_url_object(response_data['previous']) == _create_canonical_url_object(
+        exp_previous)
+    assert [result['id'] for result in results] == list(exp_results)
+
+
+class _VersionQuerySetStub:
+    """VersionQuerySet stub."""
+
+    def __init__(self, count):
+        """Initialises the instance, creating some stub version instances to return as results."""
+        self.items = [MagicMock(id=n) for n in range(count)]
+
+    def __getitem__(self, item):
+        """Returns items from the fake data generated."""
+        return self.items[item]
+
+    def __len__(self):
+        """Returns the number of items generated."""
+        return len(self.items)
+
+    def count(self):
+        """Returns the number of items generated."""
+        return len(self.items)
+
+
+def _create_get_for_object_stub(num_versions):
+    """Creates a stub replacement for Version.objects.get_for_object."""
+    def mock_versions(obj, model_db=None):
+        return _VersionQuerySetStub(num_versions)
+
+    return mock_versions
+
+
+def _create_canonical_url_object(url):
+    """Turns a URL into an object in a canonical form that can be used for comparisons."""
+    if url is None:
+        return None
+    parse_results = urlparse(url)
+    parsed_dict = parse_results._asdict()
+    parsed_dict['query'] = parse_qs(parse_results.query)
+    return parsed_dict
 
 
 def test_nested_rel_field_to_internal_dict():

--- a/datahub/investment/urls.py
+++ b/datahub/investment/urls.py
@@ -29,7 +29,7 @@ project_team_member_item = IProjectTeamMembersViewSet.as_view({
 })
 
 audit_item = IProjectAuditViewSet.as_view({
-    'get': 'retrieve',
+    'get': 'list',
 })
 
 archive_item = IProjectViewSet.as_view({

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -7,8 +7,8 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.response import Response
 
+from datahub.core.audit import AuditSerializer
 from datahub.core.mixins import ArchivableViewSetMixin
-from datahub.core.serializers import AuditSerializer
 from datahub.core.utils import executor
 from datahub.core.viewsets import CoreViewSetV3
 from datahub.documents.av_scan import virus_scan_document

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -7,7 +7,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import status
 from rest_framework.response import Response
 
-from datahub.core.audit import AuditSerializer
+from datahub.core.audit import AuditViewSet
 from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.utils import executor
 from datahub.core.viewsets import CoreViewSetV3
@@ -24,10 +24,9 @@ from datahub.investment.serializers import (
 _team_member_queryset = InvestmentProjectTeamMember.objects.select_related('adviser')
 
 
-class IProjectAuditViewSet(CoreViewSetV3):
+class IProjectAuditViewSet(AuditViewSet):
     """Investment Project audit views."""
 
-    serializer_class = AuditSerializer
     queryset = InvestmentProject.objects.all()
 
     def get_view_name(self):


### PR DESCRIPTION
With a bit of pain, this gets pagination working with the audit log views. This includes refactoring the audit serialiser to be a view set instead, as it makes more sense and works better with the paginators.