### PR TITLE
[DH-496] Allow filtering by company name - sector - country - region.

### DIFF
--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -1,13 +1,13 @@
-from rest_framework.exceptions import ValidationError
-from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .models import Company
-from .. import elasticsearch
+from ..views import SearchWithFiltersAPIMixin
 
 
-class SearchCompanyAPIView(APIView):
+class SearchCompanyAPIView(SearchWithFiltersAPIMixin, APIView):
     """Filtered company search view."""
+
+    entity = Company
 
     SORT_BY_FIELDS = (
         'account_manager.name',
@@ -37,12 +37,12 @@ class SearchCompanyAPIView(APIView):
 
     FILTER_FIELDS = (
         'account_manager',
-        'alias',
-        'description',
         'export_to_country',
         'future_interest_country',
-        'name',
         'sector',
+        'registered_address_country',
+        'registered_address_postcode',
+        'registered_address_town',
         'trading_address_country',
         'trading_address_postcode',
         'trading_address_town',
@@ -50,36 +50,12 @@ class SearchCompanyAPIView(APIView):
         'uk_region'
     )
 
-    http_method_names = ('post',)
-
-    def post(self, request, format=None):
-        """Performs filtered company search."""
-        filters = {elasticsearch.remap_filter_id_field(field): request.data[field]
-                   for field in self.FILTER_FIELDS if field in request.data}
-
-        original_query = request.data.get('original_query', '')
-
-        sortby = request.data.get('sortby')
-        if sortby:
-            field = sortby.rsplit(':')[0]
-            if field not in self.SORT_BY_FIELDS:
-                raise ValidationError(f'"sortby" field is not one of {self.SORT_BY_FIELDS}.')
-
-        offset = int(request.query_params.get('offset', 0))
-        limit = int(request.query_params.get('limit', 100))
-
-        results = elasticsearch.get_search_by_entity_query(
-            entity=Company,
-            term=original_query,
-            filters=filters,
-            field_order=sortby,
-            offset=offset,
-            limit=limit,
-        ).execute()
-
-        response = {
-            'count': results.hits.total,
-            'results': [x.to_dict() for x in results.hits],
-        }
-
-        return Response(data=response)
+    REMAP_FIELDS = {
+        'account_manager': 'account_manager.id',
+        'export_to_country': 'export_to_countries.id',
+        'future_interest_country': 'future_interest_countries.id',
+        'sector': 'sector.id',
+        'registered_address_country': 'address_country.id',
+        'trading_address_country': 'trading_address_country.id',
+        'uk_region': 'uk_region.id',
+    }

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -44,6 +44,7 @@ class Contact(DocType, MapDBModelToDict):
     archived_by = dsl_utils.contact_mapping('archived_by')
     company = dsl_utils.id_name_partial_mapping('company')
     company_sector = dsl_utils.id_name_mapping()
+    company_uk_region = dsl_utils.id_name_mapping()
 
     MAPPINGS = {
         'id': str,
@@ -55,6 +56,7 @@ class Contact(DocType, MapDBModelToDict):
 
     COMPUTED_MAPPINGS = {
         'company_sector': dict_utils.computed_nested_id_name_dict('company.sector'),
+        'company_uk_region': dict_utils.computed_nested_id_name_dict('company.uk_region'),
         'address_1': contact_dict_utils.computed_address_field('address_1'),
         'address_2': contact_dict_utils.computed_address_field('address_2'),
         'address_town': contact_dict_utils.computed_address_field('address_town'),

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -23,7 +23,7 @@ def test_contact_dbmodel_to_dict():
             'address_country', 'address_postcode', 'telephone_alternative',
             'email_alternative', 'notes', 'contactable_by_dit',
             'contactable_by_dit_partners', 'contactable_by_email',
-            'contactable_by_phone', 'company_sector'}
+            'contactable_by_phone', 'company_sector', 'company_uk_region'}
 
     assert set(result.keys()) == keys
 

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -2,7 +2,7 @@ import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.company.test.factories import ContactFactory
+from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core.constants import Country, Sector, UKRegion
 from datahub.core.test_utils import APITestMixin
 
@@ -41,13 +41,16 @@ class TestSearch(APITestMixin):
 
     def test_filter_contact(self, setup_es, setup_data):
         """Tests matching contact using multiple filters."""
-        contact = ContactFactory(address_same_as_company=True)
-        company = contact.company
-        company.name = 'SlothsCats'
-        company.trading_address_country_id = Country.united_kingdom.value.id
-        company.uk_region_id = UKRegion.east_of_england.value.id
-        company.sector_id = Sector.renewable_energy_wind.value.id
-        company.save()
+        company = CompanyFactory(
+            name='SlothsCats',
+            trading_address_country_id=Country.united_kingdom.value.id,
+            uk_region_id=UKRegion.east_of_england.value.id,
+            sector_id=Sector.renewable_energy_wind.value.id
+        )
+        ContactFactory(
+            address_same_as_company=True,
+            company=company
+        )
 
         setup_es.indices.refresh()
 

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import ContactFactory
-from datahub.core.constants import Country, Sector
+from datahub.core.constants import Country, Sector, UKRegion
 from datahub.core.test_utils import APITestMixin
 
 pytestmark = pytest.mark.django_db
@@ -27,15 +27,49 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:contact')
 
+        united_kingdom_id = Country.united_kingdom.value.id
+
         response = self.api_client.post(url, {
             'original_query': term,
-            'last_name': 'defg',
+            'address_country': united_kingdom_id,
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] > 0
+        contact = response.data['results'][0]
+        assert contact['address_country']['id'] == united_kingdom_id
+
+    def test_filter_contact(self, setup_es, setup_data):
+        """Tests matching contact using multiple filters."""
+        contact = ContactFactory(address_same_as_company=True)
+        company = contact.company
+        company.name = 'SlothsCats'
+        company.trading_address_country_id = Country.united_kingdom.value.id
+        company.uk_region_id = UKRegion.east_of_england.value.id
+        company.sector_id = Sector.renewable_energy_wind.value.id
+        company.save()
+
+        setup_es.indices.refresh()
+
+        term = ''
+
+        url = reverse('api-v3:search:contact')
+
+        response = self.api_client.post(url, {
+            'original_query': term,
+            'company_name': company.name,
+            'company_sector': company.sector_id,
+            'company_uk_region': company.uk_region_id,
+            'address_country': company.trading_address_country_id,
         })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
-        assert len(response.data['results']) == 1
-        assert response.data['results'][0]['last_name'] == 'defg'
+        contact = response.data['results'][0]
+        assert contact['address_country']['id'] == company.trading_address_country_id
+        assert contact['company']['name'] == company.name
+        assert contact['company_uk_region']['id'] == company.uk_region_id
+        assert contact['company_sector']['id'] == company.sector_id
 
     def test_search_contact_by_partial_company_name(self, setup_es, setup_data):
         """Tests filtering by partially matching company name."""

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -37,12 +37,10 @@ class SearchContactAPIView(APIView):
     )
 
     FILTER_FIELDS = (
-        'adviser',
-        'company',
-        'first_name',
-        'job_title',
-        'last_name',
         'company_name',
+        'company_sector',
+        'company_uk_region',
+        'address_country',
     )
 
     http_method_names = ('post',)

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -1,13 +1,13 @@
-from rest_framework.exceptions import ValidationError
-from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from .models import Contact
-from .. import elasticsearch
+from ..views import SearchWithFiltersAPIMixin
 
 
-class SearchContactAPIView(APIView):
+class SearchContactAPIView(SearchWithFiltersAPIMixin, APIView):
     """Filtered contact search view."""
+
+    entity = Contact
 
     SORT_BY_FIELDS = (
         'address_country.name',
@@ -43,36 +43,9 @@ class SearchContactAPIView(APIView):
         'address_country',
     )
 
-    http_method_names = ('post',)
-
-    def post(self, request, format=None):
-        """Performs filtered contact search."""
-        filters = {elasticsearch.remap_filter_id_field(field): request.data[field]
-                   for field in self.FILTER_FIELDS if field in request.data}
-
-        original_query = request.data.get('original_query', '')
-
-        sortby = request.data.get('sortby')
-        if sortby:
-            field = sortby.rsplit(':')[0]
-            if field not in self.SORT_BY_FIELDS:
-                raise ValidationError(f'"sortby" field is not one of {self.SORT_BY_FIELDS}.')
-
-        offset = int(request.data.get('offset', 0))
-        limit = int(request.data.get('limit', 100))
-
-        results = elasticsearch.get_search_by_entity_query(
-            entity=Contact,
-            term=original_query,
-            filters=filters,
-            field_order=sortby,
-            offset=offset,
-            limit=limit,
-        ).execute()
-
-        response = {
-            'count': results.hits.total,
-            'results': [x.to_dict() for x in results.hits],
-        }
-
-        return Response(data=response)
+    REMAP_FIELDS = {
+        'company_name': 'company.name_trigram',
+        'company_sector': 'company_sector.id',
+        'company_uk_region': 'company_uk_region.id',
+        'address_country': 'address_country.id',
+    }

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -10,7 +10,6 @@ from elasticsearch_dsl.query import Match, MatchPhrase, Q
 
 from .apps import get_search_apps
 
-
 lowercase_keyword_analyzer = analysis.CustomAnalyzer(
     'lowercase_keyword_analyzer',
     tokenizer='keyword',
@@ -153,7 +152,6 @@ def apply_aggs_query(search, aggs):
         # skip range filters as we can't aggregate them
         if any(agg.endswith(x) for x in ('_before', '_after')):
             continue
-        agg = remap_filter_id_field(agg)
 
         search_aggs = search.aggs
         if '.' in agg:
@@ -212,30 +210,6 @@ def get_search_by_entity_query(term=None,
 def bulk(actions=None, chunk_size=None, **kwargs):
     """Send data in bulk to Elasticsearch."""
     return es_bulk(connections.get_connection(), actions=actions, chunk_size=chunk_size, **kwargs)
-
-
-FILTER_MAP = {
-    'sector': 'sector.id',
-    'account_manager': 'account_manager.id',
-    'export_to_country': 'export_to_countries.id',
-    'future_interest_country': 'future_interest_countries.id',
-    'uk_region': 'uk_region.id',
-    'trading_address_country': 'trading_address_country.id',
-    'address_country': 'address_country.id',
-    'adviser': 'adviser.id',
-    'client_relationship_manager': 'client_relationship_manager.id',
-    'investor_company': 'investor_company.id',
-    'investment_type': 'investment_type.id',
-    'stage': 'stage.id',
-    'company_name': 'company.name_trigram',
-    'company_sector': 'company_sector.id',
-    'company_uk_region': 'company_uk_region.id',
-}
-
-
-def remap_filter_id_field(field):
-    """Maps api field to elasticsearch field."""
-    return FILTER_MAP.get(field, field)
 
 
 def date_range_fields(fields):

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -228,6 +228,8 @@ FILTER_MAP = {
     'investment_type': 'investment_type.id',
     'stage': 'stage.id',
     'company_name': 'company.name_trigram',
+    'company_sector': 'company_sector.id',
+    'company_uk_region': 'company_uk_region.id',
 }
 
 

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -1,63 +1,17 @@
-from rest_framework.exceptions import ValidationError
-from rest_framework.pagination import _positive_int
-from rest_framework.response import Response
-from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from .models import Order
-from .. import elasticsearch
+from ..views import SearchWithFiltersAPIMixin
 
 
-class PaginatedAPIMixin:
-    """Mixin for paginated API Views."""
-
-    default_limit = api_settings.PAGE_SIZE
-    limit_query_param = 'limit'
-    offset_query_param = 'offset'
-    max_results = 10000
-
-    def get_limit(self, request):
-        """Return the limit specified by the user or the default one."""
-        if self.limit_query_param:
-            try:
-                return _positive_int(
-                    request.data[self.limit_query_param],
-                    strict=True
-                )
-            except (KeyError, ValueError):
-                pass
-
-        return self.default_limit
-
-    def get_offset(self, request):
-        """Return the offset specified by the user or the default one."""
-        try:
-            return _positive_int(
-                request.data[self.offset_query_param],
-            )
-        except (KeyError, ValueError):
-            return 0
-
-    def get_pagination_values(self, request):
-        """Return the pagination values (limit, offset) or raises ValidationError."""
-        limit = self.get_limit(request)
-        offset = self.get_offset(request)
-
-        if limit + offset > self.max_results:
-            raise ValidationError({
-                api_settings.NON_FIELD_ERRORS_KEY: (
-                    'Invalid offset/limit. '
-                    f'Result window cannot be greater than {self.max_results}'
-                )
-            })
-        return limit, offset
-
-
-class SearchOrderAPIView(PaginatedAPIMixin, APIView):
+class SearchOrderAPIView(SearchWithFiltersAPIMixin, APIView):
     """Filtered order search view."""
 
-    http_method_names = ('post',)
+    entity = Order
+
     DEFAULT_ORDERING = 'created_on:desc'
+
+    SORT_BY_FIELDS = ['created_on']
 
     FILTER_FIELDS = [
         'primary_market',
@@ -72,42 +26,3 @@ class SearchOrderAPIView(PaginatedAPIMixin, APIView):
         'assigned_to_adviser': 'assignees.id',
         'assigned_to_team': 'assignees.dit_team.id',
     }
-
-    def get_filtering_data(self, request):
-        """Return (filters, date ranges) to be used to query ES."""
-        filters = {
-            self.REMAP_FIELDS.get(field, field): request.data[field]
-            for field in self.FILTER_FIELDS
-            if field in request.data
-        }
-
-        try:
-            filters, ranges = elasticsearch.date_range_fields(filters)
-        except ValueError:
-            raise ValidationError({
-                api_settings.NON_FIELD_ERRORS_KEY: 'Date(s) in incorrect format.'
-            })
-
-        return filters, ranges
-
-    def post(self, request, format=None):
-        """Perform filtered order search."""
-        limit, offset = self.get_pagination_values(request)
-        filters, ranges = self.get_filtering_data(request)
-
-        results = elasticsearch.get_search_by_entity_query(
-            entity=Order,
-            term='',
-            filters=filters,
-            ranges=ranges,
-            field_order=self.DEFAULT_ORDERING,
-            offset=offset,
-            limit=limit,
-        ).execute()
-
-        response = {
-            'count': results.hits.total,
-            'results': [x.to_dict() for x in results.hits]
-        }
-
-        return Response(data=response)

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -55,37 +55,6 @@ def test_get_search_term_query():
     }
 
 
-def test_remap_fields():
-    """Tests fields remapping."""
-    fields = {
-        'sector': 'test',
-        'account_manager': 'test',
-        'export_to_country': 'test',
-        'future_interest_country': 'test',
-        'uk_region': 'test',
-        'trading_address_country': 'test',
-        'adviser': 'test',
-        'test': 'test',
-        'stage': ['a', 'b'],
-        'uk_based': [False]
-    }
-
-    remapped = {elasticsearch.remap_filter_id_field(field): value
-                for field, value in fields.items()}
-
-    assert 'sector.id' in remapped
-    assert 'account_manager.id' in remapped
-    assert 'export_to_countries.id' in remapped
-    assert 'future_interest_countries.id' in remapped
-    assert 'uk_region.id' in remapped
-    assert 'trading_address_country.id' in remapped
-    assert 'adviser.id' in remapped
-    assert 'test' in remapped
-    assert 'uk_based' in remapped
-    assert remapped['stage.id'] == ['a', 'b']
-    assert remapped['uk_based'] == [False]
-
-
 def test_remap_sort_field():
     """Test sort fields remapping."""
     fields = {

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -1,13 +1,16 @@
 import datetime
+from unittest import mock
 
 import pytest
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
 from datahub.core.test_utils import APITestMixin
 from datahub.investment.test.factories import InvestmentProjectFactory
+from ..views import PaginatedAPIMixin
 
 pytestmark = pytest.mark.django_db
 
@@ -382,3 +385,112 @@ class TestSearch(APITestMixin):
                         {'count': 1, 'entity': 'contact'},
                         {'count': 1, 'entity': 'investment_project'}]
         assert all(aggregation in response.data['aggregations'] for aggregation in aggregations)
+
+
+class TestPaginatedAPIMixin:
+    """Tests related to the paginated API mixin."""
+
+    def test_limit_as_valid_param(self):
+        """Test that get_limit returns the int value of the param if valid."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '3'
+            }
+        )
+
+        assert mixin.get_limit(request) == 3
+
+    def test_limit_as_non_int_defaults(self):
+        """Test that get_limit returns the default value if the param is not an int."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: 'non-int'
+            }
+        )
+
+        assert mixin.get_limit(request) == PaginatedAPIMixin.default_limit
+
+    def test_limit_as_negative_int_defaults(self):
+        """Test that get_limit returns the default value if param is a negative value."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '-1'
+            }
+        )
+
+        assert mixin.get_limit(request) == PaginatedAPIMixin.default_limit
+
+    def test_limit_as_zero_defaults(self):
+        """Test that get_limit returns the default value if param is 0."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '0'
+            }
+        )
+
+        assert mixin.get_limit(request) == PaginatedAPIMixin.default_limit
+
+    def test_offset_as_valid_param(self):
+        """Test that get_offset returns the int value if the param is valid."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.offset_query_param: '4'
+            }
+        )
+
+        assert mixin.get_offset(request) == 4
+
+    def test_offset_as_non_int_defaults(self):
+        """Test that get_offset returns the default value if the param is not an int."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.offset_query_param: 'non-int'
+            }
+        )
+
+        assert mixin.get_offset(request) == 0
+
+    def test_pagination_params_within_limit(self):
+        """Test that if the result window (offset + limit) is within limit, everything is OK."""
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '100',
+                PaginatedAPIMixin.offset_query_param: '9900',
+            }
+        )
+
+        limit, offset = mixin.get_pagination_values(request)
+
+        assert limit == 100
+        assert offset == 9900
+
+    def test_pagination_params_outside_limit(self):
+        """
+        Test that if the result window (offset + limit) is too large,
+        a validator error is returned.
+        """
+        mixin = PaginatedAPIMixin()
+
+        request = mock.MagicMock(
+            data={
+                PaginatedAPIMixin.limit_query_param: '100',
+                PaginatedAPIMixin.offset_query_param: '9901',
+            }
+        )
+
+        with pytest.raises(ValidationError):
+            mixin.get_pagination_values(request)

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -1,15 +1,166 @@
 """Search views."""
+import uuid
 from collections import namedtuple
 
 from rest_framework.exceptions import ValidationError
+from rest_framework.pagination import _positive_int
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from . import elasticsearch
 from .apps import get_search_apps
 
-
 EntitySearch = namedtuple('EntitySearch', ['model', 'name', 'plural_name'])
+
+
+class PaginatedAPIMixin:
+    """Mixin for paginated API Views."""
+
+    default_limit = api_settings.PAGE_SIZE
+    limit_query_param = 'limit'
+    offset_query_param = 'offset'
+    max_results = 10000
+
+    def get_limit(self, request):
+        """Return the limit specified by the user or the default one."""
+        if self.limit_query_param:
+            try:
+                return _positive_int(
+                    request.data[self.limit_query_param],
+                    strict=True
+                )
+            except (KeyError, ValueError):
+                pass
+
+        return self.default_limit
+
+    def get_offset(self, request):
+        """Return the offset specified by the user or the default one."""
+        try:
+            return _positive_int(
+                request.data[self.offset_query_param],
+            )
+        except (KeyError, ValueError):
+            return 0
+
+    def get_pagination_values(self, request):
+        """Return the pagination values (limit, offset) or raises ValidationError."""
+        limit = self.get_limit(request)
+        offset = self.get_offset(request)
+
+        if limit + offset > self.max_results:
+            raise ValidationError({
+                api_settings.NON_FIELD_ERRORS_KEY: (
+                    'Invalid offset/limit. '
+                    f'Result window cannot be greater than {self.max_results}'
+                )
+            })
+        return limit, offset
+
+
+class SearchWithFiltersAPIMixin(PaginatedAPIMixin):
+    """Mixin for Search with filters views."""
+
+    DEFAULT_ORDERING = None
+    SORT_BY_FIELDS = {}
+    FILTER_FIELDS = {}
+    REMAP_FIELDS = {}
+
+    # Specify entity you want to search in (eg. Company, Contact, InvestmentProject and so on...)
+    entity = None
+    with_aggregations = False
+
+    http_method_names = ('post',)
+
+    def validate_filter_value(self, field, value):
+        """Checks if supplied value for given field is valid."""
+        es_field = self.REMAP_FIELDS.get(field, field)
+        if isinstance(value, list):
+            if not all(isinstance(item, (int, str,)) for item in value):
+                raise ValueError({field: 'Contains invalid values in the list.'})
+        elif es_field.endswith('.id'):
+            try:
+                uuid.UUID(value)
+            except ValueError:
+                raise ValueError({field: 'Contains invalid id.'})
+        elif isinstance(value, dict):
+            raise ValueError({field: 'Contains invalid value.'})
+
+        return value
+
+    def get_filtering_data(self, request):
+        """Return (filters, date ranges) to be used to query ES."""
+        try:
+            filters = {
+                self.REMAP_FIELDS.get(field, field):
+                    self.validate_filter_value(field, request.data[field])
+                for field in self.FILTER_FIELDS
+                if field in request.data
+            }
+        except ValueError as e:
+            raise ValidationError(e)
+
+        try:
+            filters, ranges = elasticsearch.date_range_fields(filters)
+        except ValueError:
+            raise ValidationError({
+                api_settings.NON_FIELD_ERRORS_KEY: 'Date(s) in incorrect format.'
+            })
+
+        return filters, ranges
+
+    def extract_aggregates(self, results):
+        """Extracts aggregates from results."""
+        aggregations = {}
+        for field in self.FILTER_FIELDS:
+            es_field = self.REMAP_FIELDS.get(field, field)
+            if es_field in results.aggregations:
+                aggregation = results.aggregations[es_field]
+                if '.' in es_field:
+                    aggregation = aggregation[es_field]
+
+                aggregations[field] = [bucket.to_dict() for bucket in aggregation['buckets']]
+        return aggregations
+
+    def post(self, request, format=None):
+        """Performs filtered contact search."""
+        limit, offset = self.get_pagination_values(request)
+        filters, ranges = self.get_filtering_data(request)
+
+        original_query = request.data.get('original_query', '')
+
+        sortby = request.data.get('sortby', self.DEFAULT_ORDERING)
+        if sortby:
+            field = sortby.rsplit(':')[0]
+            if field not in self.SORT_BY_FIELDS:
+                raise ValidationError(f'"sortby" field is not one of {self.SORT_BY_FIELDS}.')
+
+        options = {
+            'entity': self.entity,
+            'term': original_query,
+            'filters': filters,
+            'ranges': ranges,
+            'field_order': sortby,
+            'offset': offset,
+            'limit': limit,
+        }
+        if self.with_aggregations:
+            options['aggs'] = [self.REMAP_FIELDS.get(field, field) for field in self.FILTER_FIELDS]
+
+        results = elasticsearch.get_search_by_entity_query(
+            **options
+        ).execute()
+
+        response = {
+            'count': results.hits.total,
+            'results': [x.to_dict() for x in results.hits],
+        }
+
+        if self.with_aggregations:
+            response['aggregations'] = self.extract_aggregates(results)
+
+        return Response(data=response)
 
 
 class SearchBasicAPIView(APIView):


### PR DESCRIPTION
This brings `Contact` filters in line with requirements, which state we need 4 filters:

- Company Name (with partial matching)
- Sector
- Country
- UK Region

