### PR TITLE
[DH-496] Contact filters

### DIFF
--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -44,6 +44,7 @@ class Contact(DocType, MapDBModelToDict):
     archived_by = dsl_utils.contact_mapping('archived_by')
     company = dsl_utils.id_name_partial_mapping('company')
     company_sector = dsl_utils.id_name_mapping()
+    company_uk_region = dsl_utils.id_name_mapping()
 
     MAPPINGS = {
         'id': str,
@@ -55,6 +56,7 @@ class Contact(DocType, MapDBModelToDict):
 
     COMPUTED_MAPPINGS = {
         'company_sector': dict_utils.computed_nested_id_name_dict('company.sector'),
+        'company_uk_region': dict_utils.computed_nested_id_name_dict('company.uk_region'),
         'address_1': contact_dict_utils.computed_address_field('address_1'),
         'address_2': contact_dict_utils.computed_address_field('address_2'),
         'address_town': contact_dict_utils.computed_address_field('address_town'),

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -23,7 +23,7 @@ def test_contact_dbmodel_to_dict():
             'address_country', 'address_postcode', 'telephone_alternative',
             'email_alternative', 'notes', 'contactable_by_dit',
             'contactable_by_dit_partners', 'contactable_by_email',
-            'contactable_by_phone', 'company_sector'}
+            'contactable_by_phone', 'company_sector', 'company_uk_region'}
 
     assert set(result.keys()) == keys
 

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -3,7 +3,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import ContactFactory
-from datahub.core.constants import Country, Sector
+from datahub.core.constants import Country, Sector, UKRegion
 from datahub.core.test_utils import APITestMixin
 
 pytestmark = pytest.mark.django_db
@@ -27,15 +27,49 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:contact')
 
+        united_kingdom_id = Country.united_kingdom.value.id
+
         response = self.api_client.post(url, {
             'original_query': term,
-            'last_name': 'defg',
+            'address_country': united_kingdom_id,
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] > 0
+        contact = response.data['results'][0]
+        assert contact['address_country']['id'] == united_kingdom_id
+
+    def test_filter_contact(self, setup_es, setup_data):
+        """Tests matching contact using multiple filters."""
+        contact = ContactFactory(address_same_as_company=True)
+        company = contact.company
+        company.name = 'SlothsCats'
+        company.trading_address_country_id = Country.united_kingdom.value.id
+        company.uk_region_id = UKRegion.east_of_england.value.id
+        company.sector_id = Sector.renewable_energy_wind.value.id
+        company.save()
+
+        setup_es.indices.refresh()
+
+        term = ''
+
+        url = reverse('api-v3:search:contact')
+
+        response = self.api_client.post(url, {
+            'original_query': term,
+            'company_name': company.name,
+            'company_sector': company.sector_id,
+            'company_uk_region': company.uk_region_id,
+            'address_country': company.trading_address_country_id,
         })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
-        assert len(response.data['results']) == 1
-        assert response.data['results'][0]['last_name'] == 'defg'
+        contact = response.data['results'][0]
+        assert contact['address_country']['id'] == company.trading_address_country_id
+        assert contact['company']['name'] == company.name
+        assert contact['company_uk_region']['id'] == company.uk_region_id
+        assert contact['company_sector']['id'] == company.sector_id
 
     def test_search_contact_by_partial_company_name(self, setup_es, setup_data):
         """Tests filtering by partially matching company name."""

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -2,7 +2,7 @@ import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.company.test.factories import ContactFactory
+from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core.constants import Country, Sector, UKRegion
 from datahub.core.test_utils import APITestMixin
 
@@ -69,6 +69,40 @@ class TestSearch(APITestMixin):
         assert contact['address_country']['id'] == company.trading_address_country_id
         assert contact['company']['name'] == company.name
         assert contact['company_uk_region']['id'] == company.uk_region_id
+        assert contact['company_sector']['id'] == company.sector_id
+
+    def test_filter_without_uk_region(self, setup_es, setup_data):
+        """Tests matching contact without uk_region using multiple filters."""
+        company = CompanyFactory(
+            registered_address_country_id=Country.united_states.value.id,
+            trading_address_country_id=Country.united_states.value.id,
+            uk_region_id=None,
+            sector_id=Sector.renewable_energy_wind.value.id
+        )
+        ContactFactory(
+            address_same_as_company=True,
+            company=company
+        )
+
+        setup_es.indices.refresh()
+
+        term = ''
+
+        url = reverse('api-v3:search:contact')
+
+        response = self.api_client.post(url, {
+            'original_query': term,
+            'company_name': company.name,
+            'company_sector': company.sector_id,
+            'address_country': company.trading_address_country_id,
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1
+        contact = response.data['results'][0]
+        assert contact['address_country']['id'] == company.trading_address_country_id
+        assert contact['company']['name'] == company.name
+        assert contact['company_uk_region'] is None
         assert contact['company_sector']['id'] == company.sector_id
 
     def test_search_contact_by_partial_company_name(self, setup_es, setup_data):

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -37,12 +37,10 @@ class SearchContactAPIView(APIView):
     )
 
     FILTER_FIELDS = (
-        'adviser',
-        'company',
-        'first_name',
-        'job_title',
-        'last_name',
         'company_name',
+        'company_sector',
+        'company_uk_region',
+        'address_country',
     )
 
     http_method_names = ('post',)

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -228,6 +228,8 @@ FILTER_MAP = {
     'investment_type': 'investment_type.id',
     'stage': 'stage.id',
     'company_name': 'company.name_trigram',
+    'company_sector': 'company_sector.id',
+    'company_uk_region': 'company_uk_region.id',
 }
 
 


### PR DESCRIPTION
This brings `Contact` filters in line with requirements, which state we need 4 filters:

- Company Name (with partial matching)
- Sector
- Country
- UK Region

