### PR TITLE
Move OMIS validation logic to own validators

### DIFF
--- a/datahub/omis/order/test/test_validators.py
+++ b/datahub/omis/order/test/test_validators.py
@@ -1,0 +1,130 @@
+from unittest import mock
+import pytest
+
+from rest_framework.exceptions import ValidationError
+
+from ..validators import ContactWorksAtCompanyValidator, ReadonlyAfterCreationValidator
+
+
+class TestContactWorksAtCompanyValidator:
+    """Tests for ContactWorksAtCompanyValidator."""
+
+    def test_contact_from_company(self):
+        """
+        Test that if the contact specified in data works
+        at the company specified in data, the validation passes.
+        """
+        serializer = mock.Mock()
+        company = serializer.instance.company
+        new_contact = mock.Mock(company=company)
+
+        validator = ContactWorksAtCompanyValidator()
+        validator.set_context(serializer)
+
+        try:
+            validator({
+                'contact': new_contact,
+                'company': company
+            })
+        except Exception:
+            pytest.fail('Should not raise a validator error')
+
+    def test_contact_not_from_company(self):
+        """
+        Test that if the contact specified in data doesn't works
+        at the company specified in data, the validation fails.
+        """
+        serializer = mock.Mock()
+        company = serializer.instance.company
+        new_contact = mock.Mock()  # doesn't work at `company`
+
+        validator = ContactWorksAtCompanyValidator()
+        validator.set_context(serializer)
+
+        with pytest.raises(ValidationError):
+            validator({
+                'contact': new_contact,
+                'company': company
+            })
+
+    def test_with_different_field_names(self):
+        """
+        Test that the validation passes when using different field names.
+        """
+        serializer = mock.Mock()
+        company = serializer.instance.company
+        new_main_contact = mock.Mock(company=company)
+
+        validator = ContactWorksAtCompanyValidator(
+            contact_field='main_contact',
+            company_field='main_company'
+        )
+        validator.set_context(serializer)
+
+        try:
+            validator({
+                'main_contact': new_main_contact,
+                'main_company': company
+            })
+        except Exception:
+            pytest.fail('Should not raise a validator error')
+
+
+class TestReadonlyAfterCreationValidator:
+    """Tests for ReadonlyAfterCreationValidator."""
+
+    def test_can_change_when_creating(self):
+        """Test that if we are creating the instance, the validation passes."""
+        serializer = mock.Mock(instance=None)
+
+        validator = ReadonlyAfterCreationValidator(
+            fields=('field1', 'field2')
+        )
+        validator.set_context(serializer)
+
+        try:
+            validator({
+                'field1': 'some value',
+                'field2': 'some value',
+            })
+        except Exception:
+            pytest.fail('Should not raise a validator error')
+
+    def test_cannot_change_after_creation(self):
+        """
+        Test that if we are updating the instance and we try to update the fields,
+        the validation fails.
+        """
+        serializer = mock.Mock()  # serializer.instance is != None
+
+        validator = ReadonlyAfterCreationValidator(
+            fields=('field1', 'field2')
+        )
+        validator.set_context(serializer)
+
+        with pytest.raises(ValidationError):
+            validator({
+                'field1': 'some value',
+                'field2': 'some value',
+            })
+
+    def test_ok_if_the_values_dont_change_after_creation(self):
+        """
+        Test that if we are updating the instance and we don't update the fields,
+        the validation passes.
+        """
+        serializer = mock.Mock()
+        instance = serializer.instance
+
+        validator = ReadonlyAfterCreationValidator(
+            fields=('field1', 'field2')
+        )
+        validator.set_context(serializer)
+
+        try:
+            validator({
+                'field1': instance.field1,
+                'field2': instance.field2,
+            })
+        except Exception:
+            pytest.fail('Should not raise a validator error')

--- a/datahub/omis/order/validators.py
+++ b/datahub/omis/order/validators.py
@@ -1,0 +1,66 @@
+from rest_framework import serializers
+
+from datahub.core.validate_utils import DataCombiner
+
+
+class ContactWorksAtCompanyValidator:
+    """Validator which checks if contact works at the specified company."""
+
+    message = 'The contact does not work at the given company.'
+
+    def __init__(self, contact_field='contact', company_field='company'):
+        """Set the fields."""
+        self.contact_field = contact_field
+        self.company_field = company_field
+
+    def set_context(self, serializer):
+        """
+        This hook is called by the serializer instance,
+        prior to the validation call being made.
+        """
+        self.instance = getattr(serializer, 'instance', None)
+
+    def __call__(self, data):
+        """Validate that contact works at company."""
+        data_combiner = DataCombiner(self.instance, data)
+        company = data_combiner.get_value(self.company_field)
+        contact = data_combiner.get_value(self.contact_field)
+
+        if contact.company != company:
+            raise serializers.ValidationError({
+                self.contact_field: self.message
+            })
+
+
+class ReadonlyAfterCreationValidator:
+    """
+    Validator which checks that the specified fields become readonly
+    after creation.
+    """
+
+    message = 'The {0} cannot be changed after creation.'
+
+    def __init__(self, fields):
+        """Set the fields."""
+        self.fields = fields
+
+    def set_context(self, serializer):
+        """
+        This hook is called by the serializer instance,
+        prior to the validation call being made.
+        """
+        self.instance = getattr(serializer, 'instance', None)
+
+    def __call__(self, data):
+        """Validate readonly fields after creation."""
+        data_combiner = DataCombiner(self.instance, data)
+
+        if self.instance:
+            for field in self.fields:
+                value = data_combiner.get_value(field)
+
+                if value != getattr(self.instance, field):
+                    field_name = self.instance._meta.get_field(field).verbose_name
+                    raise serializers.ValidationError({
+                        field: self.message.format(field_name)
+                    })


### PR DESCRIPTION
This moves some of the validation logic to DRF validators so that it's clearer what happens and we can easily add extra ones.