### PR TITLE
Add interactions search endpoint

### DIFF
--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -11,6 +11,7 @@ SEARCH_APPS = [
     'datahub.search.company.CompanySearchApp',
     'datahub.search.contact.ContactSearchApp',
     'datahub.search.investment.InvestmentSearchApp',
+    'datahub.search.interaction.InteractionSearchApp',
     'datahub.search.omis.OrderSearchApp',
 ]
 

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -101,6 +101,26 @@ def test_get_basic_search_query():
                         }
                     },
                     {
+                        'nested': {
+                            'path': 'contact',
+                            'query': {
+                                'match': {
+                                    'contact.name': 'test'
+                                }
+                            }
+                        }
+                    },
+                    {
+                        'nested': {
+                            'path': 'dit_team',
+                            'query': {
+                                'match': {
+                                    'dit_team.name': 'test'
+                                }
+                            }
+                        }
+                    },
+                    {
                         'match': {
                             'email': 'test'
                         }
@@ -173,6 +193,11 @@ def test_get_basic_search_query():
                                     'sector.name': 'test'
                                 }
                             }
+                        }
+                    },
+                    {
+                        'match': {
+                            'subject': 'test'
                         }
                     },
                     {

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -101,6 +101,26 @@ def test_get_basic_search_query():
                         }
                     },
                     {
+                        'nested': {
+                            'path': 'contact',
+                            'query': {
+                                'match': {
+                                    'contact.name': 'test'
+                                }
+                            }
+                        }
+                    },
+                    {
+                        'nested': {
+                            'path': 'dit_team',
+                            'query': {
+                                'match': {
+                                    'dit_team.name': 'test'
+                                }
+                            }
+                        }
+                    },
+                    {
                         'match': {
                             'email': 'test'
                         }
@@ -173,6 +193,11 @@ def test_get_basic_search_query():
                                     'sector.name': 'test'
                                 }
                             }
+                        }
+                    },
+                    {
+                        'match': {
+                            'subject': 'test'
                         }
                     },
                     {

--- a/datahub/search/interaction/__init__.py
+++ b/datahub/search/interaction/__init__.py
@@ -1,0 +1,3 @@
+from datahub.search.interaction.apps import InteractionSearchApp
+
+__all__ = ('InteractionSearchApp',)

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -1,8 +1,10 @@
 from datahub.interaction.models import Interaction as DBInteraction
+from datahub.interaction.queryset import get_interaction_queryset_v3
 
 from datahub.search.apps import SearchApp
 from datahub.search.interaction.models import Interaction
 from datahub.search.interaction.views import SearchInteractionAPIView
+from datahub.search.models import DataSet
 
 
 class InteractionSearchApp(SearchApp):
@@ -13,3 +15,9 @@ class InteractionSearchApp(SearchApp):
     ESModel = Interaction
     DBModel = DBInteraction
     view = SearchInteractionAPIView
+
+    def get_dataset(self):
+        """Returns dataset that will be synchronised with Elasticsearch."""
+        queryset = get_interaction_queryset_v3().order_by('pk')
+
+        return DataSet(queryset, self.ESModel)

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -1,0 +1,15 @@
+from datahub.interaction.models import Interaction as DBInteraction
+
+from datahub.search.apps import SearchApp
+from datahub.search.interaction.models import Interaction
+from datahub.search.interaction.views import SearchInteractionAPIView
+
+
+class InteractionSearchApp(SearchApp):
+    """SearchApp for interactions."""
+
+    name = 'interaction'
+    plural_name = 'interactions'
+    ESModel = Interaction
+    DBModel = DBInteraction
+    view = SearchInteractionAPIView

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -1,0 +1,55 @@
+from django.conf import settings
+from elasticsearch_dsl import Date, DocType, String
+
+from datahub.search import dict_utils, dsl_utils
+from datahub.search.models import MapDBModelToDict
+
+
+class Interaction(DocType, MapDBModelToDict):
+    """Elasticsearch representation of Interaction model."""
+
+    id = dsl_utils.KeywordString()
+    date = Date()
+    company = dsl_utils.id_name_partial_mapping('company')
+    contact = dsl_utils.contact_mapping('contact')
+    service = dsl_utils.id_name_mapping()
+    subject = String()
+    dit_adviser = dsl_utils.contact_mapping('dit_adviser')
+    notes = String()
+    dit_team = dsl_utils.id_name_mapping()
+    interaction_type = dsl_utils.id_name_mapping()
+    investment_project = dsl_utils.id_name_mapping()
+    created_on = Date()
+    modified_on = Date()
+
+    MAPPINGS = {
+        'id': str,
+        'company': dict_utils.id_name_dict,
+        'contact': dict_utils.contact_or_adviser_dict,
+        'service': dict_utils.id_name_dict,
+        'dit_adviser': dict_utils.contact_or_adviser_dict,
+        'dit_team': dict_utils.id_name_dict,
+        'interaction_type': dict_utils.id_name_dict,
+        'investment_project': dict_utils.id_name_dict,
+    }
+
+    COMPUTED_MAPPINGS = {}
+
+    IGNORED_FIELDS = (
+        'created_by',
+        'modified_by',
+    )
+
+    SEARCH_FIELDS = [
+        'subject',
+        'company.name',
+        'contact.name',
+        'dit_team.name',
+        'notes'
+    ]
+
+    class Meta:
+        """Default document meta data."""
+
+        index = settings.ES_INDEX
+        doc_type = 'interaction'

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -1,11 +1,11 @@
 from rest_framework import serializers
 from rest_framework.settings import api_settings
 
+from datahub.search.elasticsearch import MAX_RESULTS
+
 
 class LimitOffsetSerializer(serializers.Serializer):
     """Serialiser used to validate limit/offset values in POST bodies."""
-
-    MAX_RESULTS = 10000
 
     offset = serializers.IntegerField(default=0, min_value=0, max_value=MAX_RESULTS - 1)
     limit = serializers.IntegerField(default=api_settings.PAGE_SIZE, min_value=1)

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -1,0 +1,57 @@
+from rest_framework import serializers
+from rest_framework.settings import api_settings
+
+
+class LimitOffsetSerializer(serializers.Serializer):
+    """Serialiser used to validate limit/offset values in POST bodies."""
+
+    MAX_RESULTS = 10000
+
+    offset = serializers.IntegerField(default=0, min_value=0, max_value=MAX_RESULTS - 1)
+    limit = serializers.IntegerField(default=api_settings.PAGE_SIZE, min_value=1)
+
+
+class SearchSerializer(LimitOffsetSerializer):
+    """Serialiser used to validate interaction search POST bodies."""
+
+    SORT_BY_FIELDS = (
+        'company.name',
+        'contact.name',
+        'date',
+        'dit_adviser.name',
+        'dit_team.name',
+        'id',
+        'subject',
+    )
+
+    SORT_DIRECTIONS = (
+        'asc',
+        'desc'
+    )
+
+    original_query = serializers.CharField(default='', allow_blank=True)
+    sortby = serializers.CharField(default=None)
+
+    def validate_sortby(self, val):
+        """
+        Validates the sortby field.
+
+        Called by DRF.
+        """
+        if val is None:
+            return None
+
+        errors = []
+
+        field, sep, order = val.partition(':')
+        if field not in self.SORT_BY_FIELDS:
+            errors.append(f"'sortby' field is not one of {self.SORT_BY_FIELDS}.")
+
+        if sep and order not in self.SORT_DIRECTIONS:
+            errors.append(f"Invalid sort direction '{order}', must be one of "
+                          f'{self.SORT_DIRECTIONS}')
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return val

--- a/datahub/search/interaction/signals.py
+++ b/datahub/search/interaction/signals.py
@@ -1,0 +1,76 @@
+from django.db import transaction
+from django.db.models.signals import post_save
+
+from datahub.company.models import Company as DBCompany, Contact as DBContact
+from datahub.interaction.models import Interaction as DBInteraction
+from datahub.investment.models import InvestmentProject as DBInvestmentProject
+
+from datahub.search.signals import sync_es
+from .models import Interaction as ESInteraction
+
+
+def sync_interaction_to_es(sender, instance, **kwargs):
+    """Sync contact to the Elasticsearch."""
+    transaction.on_commit(
+        lambda: sync_es(ESInteraction, DBInteraction, str(instance.pk))
+    )
+
+
+def sync_related_interactions_to_es(sender, instance, **kwargs):
+    """Sync related interactions."""
+    for contact in instance.interactions.all():
+        sync_interaction_to_es(sender, contact, **kwargs)
+
+
+def connect_signals():
+    """Connect signals for ES sync."""
+    post_save.connect(
+        sync_interaction_to_es,
+        sender=DBInteraction,
+        dispatch_uid='sync_interaction_to_es'
+    )
+
+    post_save.connect(
+        sync_related_interactions_to_es,
+        sender=DBCompany,
+        dispatch_uid='company_sync_related_interactions_to_es'
+    )
+
+    post_save.connect(
+        sync_related_interactions_to_es,
+        sender=DBContact,
+        dispatch_uid='contact_sync_related_interactions_to_es'
+    )
+
+    post_save.connect(
+        sync_related_interactions_to_es,
+        sender=DBInvestmentProject,
+        dispatch_uid='iproject_sync_related_interactions_to_es'
+    )
+
+
+def disconnect_signals():
+    """Disconnect signals from ES sync."""
+    post_save.disconnect(
+        sync_interaction_to_es,
+        sender=DBInteraction,
+        dispatch_uid='sync_interaction_to_es'
+    )
+
+    post_save.disconnect(
+        sync_related_interactions_to_es,
+        sender=DBCompany,
+        dispatch_uid='company_sync_related_interactions_to_es'
+    )
+
+    post_save.disconnect(
+        sync_related_interactions_to_es,
+        sender=DBContact,
+        dispatch_uid='contact_sync_related_interactions_to_es'
+    )
+
+    post_save.disconnect(
+        sync_related_interactions_to_es,
+        sender=DBInvestmentProject,
+        dispatch_uid='iproject_sync_related_interactions_to_es'
+    )

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -1,0 +1,66 @@
+import pytest
+
+from datahub.interaction.test.factories import InteractionFactory
+from datahub.investment.test.factories import InvestmentProjectFactory
+from datahub.search.interaction.models import Interaction
+
+pytestmark = pytest.mark.django_db
+
+
+def test_interaction_to_dict():
+    """Test converting an interaction to a dict."""
+    interaction = InteractionFactory(
+        investment_project=InvestmentProjectFactory()
+    )
+
+    result = Interaction.dbmodel_to_dict(interaction)
+
+    assert result == {
+        'id': str(interaction.pk),
+        'date': interaction.date,
+        'company': {
+            'id': str(interaction.company.pk),
+            'name': interaction.company.name,
+        },
+        'contact': {
+            'id': str(interaction.contact.pk),
+            'first_name': interaction.contact.first_name,
+            'name': interaction.contact.name,
+            'last_name': interaction.contact.last_name,
+        },
+        'service': {
+            'id': str(interaction.service.pk),
+            'name': interaction.service.name,
+        },
+        'subject': interaction.subject,
+        'dit_adviser': {
+            'id': str(interaction.dit_adviser.pk),
+            'first_name': interaction.dit_adviser.first_name,
+            'name': interaction.dit_adviser.name,
+            'last_name': interaction.dit_adviser.last_name,
+        },
+        'notes': interaction.notes,
+        'dit_team': {
+            'id': str(interaction.dit_team.pk),
+            'name': interaction.dit_team.name,
+        },
+        'interaction_type': {
+            'id': str(interaction.interaction_type.pk),
+            'name': interaction.interaction_type.name,
+        },
+        'investment_project': {
+            'id': str(interaction.investment_project.pk),
+            'name': interaction.investment_project.name,
+        },
+        'created_on': interaction.created_on,
+        'modified_on': interaction.modified_on,
+    }
+
+
+def test_interactions_to_es_documents():
+    """Test converting 2 orders to Elasticsearch documents."""
+    interactions = InteractionFactory.create_batch(2)
+
+    result = Interaction.dbmodels_to_es_documents(interactions)
+
+    assert {item['_id'] for item in result} == {str(item.pk) for item in interactions}

--- a/datahub/search/interaction/tests/test_signals.py
+++ b/datahub/search/interaction/tests/test_signals.py
@@ -1,0 +1,98 @@
+import pytest
+
+from django.conf import settings
+
+from datahub.interaction.test.factories import InteractionFactory
+from datahub.investment.test.factories import InvestmentProjectFactory
+from datahub.search.interaction.apps import InteractionSearchApp
+
+pytestmark = pytest.mark.django_db
+
+
+def test_new_interaction_synced(setup_es):
+    """Test that new interactions are synced to ES."""
+    interaction = InteractionFactory()
+    setup_es.indices.refresh()
+
+    assert setup_es.get(
+        index=settings.ES_INDEX,
+        doc_type=InteractionSearchApp.name,
+        id=interaction.pk
+    )
+
+
+def test_updated_interaction_synced(setup_es):
+    """Test that when an interaction is updated it is synced to ES."""
+    interaction = InteractionFactory()
+    new_subject = 'pluto'
+    interaction.subject = new_subject
+    interaction.save()
+    setup_es.indices.refresh()
+
+    result = setup_es.get(
+        index=settings.ES_INDEX,
+        doc_type=InteractionSearchApp.name,
+        id=interaction.pk
+    )
+    assert result['_source']['subject'] == new_subject
+
+
+def test_updating_company_name_updates_interaction(setup_es):
+    """Test that when a company name is updated, the company's interactions are synced to ES."""
+    interaction = InteractionFactory()
+    new_company_name = 'exogenous'
+    interaction.company.name = new_company_name
+    interaction.company.save()
+    setup_es.indices.refresh()
+
+    result = setup_es.get(
+        index=settings.ES_INDEX,
+        doc_type=InteractionSearchApp.name,
+        id=interaction.pk
+    )
+    assert result['_source']['company']['name'] == new_company_name
+
+
+def test_updating_contact_name_updates_interaction(setup_es):
+    """Test that when a contact's name is updated, the contact's interactions are synced to ES."""
+    interaction = InteractionFactory()
+    new_first_name = 'Jamie'
+    new_last_name = 'Bloggs'
+    interaction.contact.first_name = new_first_name
+    interaction.contact.last_name = new_last_name
+    interaction.contact.save()
+    setup_es.indices.refresh()
+
+    result = setup_es.get(
+        index=settings.ES_INDEX,
+        doc_type=InteractionSearchApp.name,
+        id=interaction.pk
+    )
+    assert result['_source']['contact'] == {
+        'id': str(interaction.contact.id),
+        'first_name': new_first_name,
+        'last_name': new_last_name,
+        'name': f'{new_first_name} {new_last_name}',
+    }
+
+
+def test_updating_project_name_updates_interaction(setup_es):
+    """
+    Test that when an investment project's name is updated, the project's interactions are
+    synced to ES.
+    """
+    project = InvestmentProjectFactory()
+    interaction = InteractionFactory(
+        investment_project=project
+    )
+    new_project_name = 'helios'
+    project.name = new_project_name
+    project.save()
+    setup_es.indices.refresh()
+
+    result = setup_es.get(
+        index=settings.ES_INDEX,
+        doc_type=InteractionSearchApp.name,
+        id=interaction.pk
+    )
+    assert result['_source']['investment_project']['name'] == new_project_name

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -1,0 +1,176 @@
+from collections import Counter
+
+import pytest
+
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.core.test_utils import APITestMixin
+from datahub.interaction.test.factories import InteractionFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def interactions(setup_es):
+    """Sets up data for the tests."""
+    data = []
+    with freeze_time('2017-01-01 13:00:00'):
+        data.extend([
+            InteractionFactory(subject='Exports meeting'),
+            InteractionFactory(subject='Email about exhibition'),
+            InteractionFactory(subject='Event at HQ'),
+        ])
+
+    setup_es.indices.refresh()
+
+    yield data
+
+
+@pytest.mark.usefixtures('interactions')
+class TestViews(APITestMixin):
+    """Tests interaction search views."""
+
+    def test_get_all(self, interactions):
+        """
+        Tests that all interactions are returned with an empty POST body.
+        """
+        url = reverse('api-v3:search:interaction')
+
+        response = self.api_client.post(url, {}, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(interactions)
+        expected_ids = Counter(str(interaction.id) for interaction in interactions)
+        assert Counter([item['id'] for item in response_data['results']]) == expected_ids
+
+    def test_limit(self):
+        """Tests that results can be limited."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'limit': 1
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert len(response_data['results']) == 1
+
+    def test_offset(self):
+        """Tests that results can be offset."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'offset': 1
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert len(response_data['results']) == 2
+
+    def test_sort_by_subject_asc(self, interactions):
+        """Tests sorting of results by subject (ascending)."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'sortby': 'subject:asc'
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(interactions)
+        expected_subjects = list(sorted(interaction.subject for interaction in interactions))
+        assert [item['subject'] for item in response_data['results']] == expected_subjects
+
+    def test_sort_by_subject_desc(self, interactions):
+        """Tests sorting of results by subject (ascending)."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'sortby': 'subject:desc'
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(interactions)
+        expected_subjects = list(sorted((interaction.subject for interaction in interactions),
+                                        reverse=True))
+        assert [item['subject'] for item in response_data['results']] == expected_subjects
+
+    def test_sort_by_invalid_field(self):
+        """Tests attempting to sort by an invalid field and direction."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'sortby': 'gyratory:backwards'
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data == {
+            'sortby': [
+                "'sortby' field is not one of ('company.name', 'contact.name', 'date'"
+                ", 'dit_adviser.name', 'dit_team.name', 'id', 'subject').",
+                "Invalid sort direction 'backwards', must be one of ('asc', 'desc')",
+            ]
+        }
+
+    @pytest.mark.parametrize('term', ('exports', 'meeting', 'exports meeting'))
+    def test_search_original_query(self, interactions, term):
+        """Tests searching across fields for a particular interaction."""
+        url = reverse('api-v3:search:interaction')
+
+        request_data = {
+            'original_query': term
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        interaction = interactions[0]
+        assert response_data['count'] == 1
+        assert response_data['results'] == [{
+            'id': str(interaction.pk),
+            'date': interaction.date.isoformat(),
+            'company': {
+                'id': str(interaction.company.pk),
+                'name': interaction.company.name,
+            },
+            'contact': {
+                'id': str(interaction.contact.pk),
+                'first_name': interaction.contact.first_name,
+                'name': interaction.contact.name,
+                'last_name': interaction.contact.last_name,
+            },
+            'service': {
+                'id': str(interaction.service.pk),
+                'name': interaction.service.name,
+            },
+            'subject': interaction.subject,
+            'dit_adviser': {
+                'id': str(interaction.dit_adviser.pk),
+                'first_name': interaction.dit_adviser.first_name,
+                'name': interaction.dit_adviser.name,
+                'last_name': interaction.dit_adviser.last_name,
+            },
+            'notes': interaction.notes,
+            'dit_team': {
+                'id': str(interaction.dit_team.pk),
+                'name': interaction.dit_team.name,
+            },
+            'interaction_type': {
+                'id': str(interaction.interaction_type.pk),
+                'name': interaction.interaction_type.name,
+            },
+            'investment_project': None,
+            'created_on': interaction.created_on.isoformat(),
+            'modified_on': interaction.modified_on.isoformat(),
+        }]

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -1,0 +1,36 @@
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from datahub.search import elasticsearch
+from .models import Interaction
+from .serializers import SearchSerializer
+
+
+class SearchInteractionAPIView(APIView):
+    """Filtered interaction search view."""
+
+    http_method_names = ('post',)
+
+    def post(self, request, format=None):
+        """Performs filtered interaction search."""
+        serializer = SearchSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated_data = serializer.validated_data
+
+        query = elasticsearch.get_search_by_entity_query(
+            entity=Interaction,
+            term=validated_data['original_query'],
+            filters={},
+            field_order=validated_data['sortby'],
+            offset=validated_data['offset'],
+            limit=validated_data['limit'],
+        )
+
+        results = query.execute()
+
+        response = {
+            'count': results.hits.total,
+            'results': [x.to_dict() for x in results.hits],
+        }
+
+        return Response(data=response)

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -103,6 +103,26 @@ def test_get_basic_search_query():
                         }
                     },
                     {
+                        'nested': {
+                            'path': 'contact',
+                            'query': {
+                                'match': {
+                                    'contact.name': 'test'
+                                }
+                            }
+                        }
+                    },
+                    {
+                        'nested': {
+                            'path': 'dit_team',
+                            'query': {
+                                'match': {
+                                    'dit_team.name': 'test'
+                                }
+                            }
+                        }
+                    },
+                    {
                         'match': {
                             'email': 'test'
                         }
@@ -175,6 +195,11 @@ def test_get_basic_search_query():
                                     'sector.name': 'test'
                                 }
                             }
+                        }
+                    },
+                    {
+                        'match': {
+                            'subject': 'test'
                         }
                     },
                     {

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -14,7 +14,6 @@ class PaginatedAPIMixin:
     default_limit = api_settings.PAGE_SIZE
     limit_query_param = 'limit'
     offset_query_param = 'offset'
-    max_results = 10000
 
     def get_limit(self, request):
         """Return the limit specified by the user or the default one."""
@@ -43,11 +42,11 @@ class PaginatedAPIMixin:
         limit = self.get_limit(request)
         offset = self.get_offset(request)
 
-        if limit + offset > self.max_results:
+        if limit + offset > elasticsearch.MAX_RESULTS:
             raise ValidationError({
                 api_settings.NON_FIELD_ERRORS_KEY: (
                     'Invalid offset/limit. '
-                    f'Result window cannot be greater than {self.max_results}'
+                    f'Result window cannot be greater than {elasticsearch.MAX_RESULTS}'
                 )
             })
         return limit, offset

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -1,6 +1,8 @@
 import datetime
 from unittest import mock
 
+import pytest
+
 from .. import elasticsearch
 
 
@@ -53,6 +55,24 @@ def test_get_search_term_query():
             ]
         }
     }
+
+
+@pytest.mark.parametrize(
+    'offset,limit,expected_size', (
+        (8950, 1000, 1000),
+        (9950, 1000, 50),
+        (10000, 1000, 0),
+    )
+)
+def test_offset_near_max_results(offset, limit, expected_size):
+    """Tests limit clipping when near max_results."""
+    query = elasticsearch.get_basic_search_query(
+        'test', entities=(mock.Mock(),), offset=offset, limit=limit
+    )
+
+    query_dict = query.to_dict()
+    assert query_dict['from'] == offset
+    assert query_dict['size'] == expected_size
 
 
 def test_remap_fields():


### PR DESCRIPTION
It was a bit unfortunate that I had to modify those query tests in the other search apps – I think we could probably move those up a level and maybe consolidate them?

I've also used a DRF serialiser here to validate the POST body. I think we can look at doing this across the search apps. I've seen a few other things that we could probably tidy up as well.