### PR TITLE
Simplify search app queryset logic

### DIFF
--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -23,6 +23,7 @@ class SearchApp:
     plural_name = None
     ESModel = None
     view = None
+    queryset = None
 
     def __init__(self, mod):
         """Create this search app without initialising any ES config."""
@@ -53,11 +54,16 @@ class SearchApp:
         signals_mod = import_module(self.mod_signals)
         getattr(signals_mod, 'disconnect_signals')()
 
+    def get_queryset(self):
+        """Gets the queryset that will be synced with Elasticsearch."""
+        queryset = self.queryset or self.DBModel.objects.all()
+        return queryset.order_by('pk')
+
     def get_dataset(self):
         """Returns dataset that will be synchronised with Elasticsearch."""
-        qs = self.DBModel.objects.all().order_by('pk')
+        queryset = self.get_queryset()
 
-        return DataSet(qs, self.ESModel)
+        return DataSet(queryset, self.ESModel)
 
 
 @lru_cache(maxsize=None)

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -56,8 +56,7 @@ class SearchApp:
 
     def get_queryset(self):
         """Gets the queryset that will be synced with Elasticsearch."""
-        queryset = self.queryset or self.DBModel.objects.all()
-        return queryset.order_by('pk')
+        return self.queryset.order_by('pk')
 
     def get_dataset(self):
         """Returns dataset that will be synchronised with Elasticsearch."""

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -4,35 +4,27 @@ from .models import Company
 from .views import SearchCompanyAPIView
 
 from ..apps import SearchApp
-from ..models import DataSet
 
 
 class CompanySearchApp(SearchApp):
-    """SearchApp for company"""
+    """SearchApp for company."""
 
     name = 'company'
     plural_name = 'companies'
     ESModel = Company
     DBModel = DBCompany
     view = SearchCompanyAPIView
-
-    def get_dataset(self):
-        """Returns dataset that will be synchronised with Elasticsearch."""
-        prefetch_fields = (
-            'registered_address_country',
-            'business_type',
-            'sector',
-            'employee_range',
-            'turnover_range',
-            'account_manager',
-            'export_to_countries',
-            'future_interest_countries',
-            'trading_address_country',
-            'headquarter_type',
-            'classification',
-            'one_list_account_owner',
-        )
-
-        qs = self.DBModel.objects.prefetch_related(*prefetch_fields).all().order_by('pk')
-
-        return DataSet(qs, self.ESModel)
+    queryset = DBCompany.objects.prefetch_related(
+        'registered_address_country',
+        'business_type',
+        'sector',
+        'employee_range',
+        'turnover_range',
+        'account_manager',
+        'export_to_countries',
+        'future_interest_countries',
+        'trading_address_country',
+        'headquarter_type',
+        'classification',
+        'one_list_account_owner',
+    )

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -12,7 +12,6 @@ class CompanySearchApp(SearchApp):
     name = 'company'
     plural_name = 'companies'
     ESModel = Company
-    DBModel = DBCompany
     view = SearchCompanyAPIView
     queryset = DBCompany.objects.prefetch_related(
         'registered_address_country',

--- a/datahub/search/contact/apps.py
+++ b/datahub/search/contact/apps.py
@@ -12,5 +12,5 @@ class ContactSearchApp(SearchApp):
     name = 'contact'
     plural_name = 'contacts'
     ESModel = Contact
-    DBModel = DBContact
     view = SearchContactAPIView
+    queryset = DBContact.objects.all()

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -4,7 +4,6 @@ from datahub.interaction.queryset import get_interaction_queryset_v3
 from datahub.search.apps import SearchApp
 from datahub.search.interaction.models import Interaction
 from datahub.search.interaction.views import SearchInteractionAPIView
-from datahub.search.models import DataSet
 
 
 class InteractionSearchApp(SearchApp):
@@ -15,9 +14,4 @@ class InteractionSearchApp(SearchApp):
     ESModel = Interaction
     DBModel = DBInteraction
     view = SearchInteractionAPIView
-
-    def get_dataset(self):
-        """Returns dataset that will be synchronised with Elasticsearch."""
-        queryset = get_interaction_queryset_v3().order_by('pk')
-
-        return DataSet(queryset, self.ESModel)
+    queryset = get_interaction_queryset_v3()

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -1,4 +1,3 @@
-from datahub.interaction.models import Interaction as DBInteraction
 from datahub.interaction.queryset import get_interaction_queryset_v3
 
 from datahub.search.apps import SearchApp
@@ -12,6 +11,5 @@ class InteractionSearchApp(SearchApp):
     name = 'interaction'
     plural_name = 'interactions'
     ESModel = Interaction
-    DBModel = DBInteraction
     view = SearchInteractionAPIView
     queryset = get_interaction_queryset_v3()

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -12,5 +12,5 @@ class InvestmentSearchApp(SearchApp):
     name = 'investment_project'
     plural_name = 'investment_projects'
     ESModel = InvestmentProject
-    DBModel = DBInvestmentProject
     view = SearchInvestmentProjectAPIView
+    queryset = DBInvestmentProject.objects.all()

--- a/datahub/search/omis/apps.py
+++ b/datahub/search/omis/apps.py
@@ -12,5 +12,5 @@ class OrderSearchApp(SearchApp):
     name = 'order'
     plural_name = 'orders'
     ESModel = Order
-    DBModel = DBOrder
     view = SearchOrderAPIView
+    queryset = DBOrder.objects.all()


### PR DESCRIPTION
This replaces the DBModel class attribute in the search apps with a queryset class attribute (similar to the DRF API views) so that apps don't need to override get_dataset() to modify the queryset.