### PR TITLE
Add get an OMIS quote endpoint

### DIFF
--- a/datahub/omis/quote/serializers.py
+++ b/datahub/omis/quote/serializers.py
@@ -1,7 +1,6 @@
 from rest_framework import serializers
 
-from datahub.company.models import Advisor
-from datahub.core.serializers import NestedRelatedField
+from datahub.company.serializers import NestedAdviserField
 
 from .models import Quote
 
@@ -10,7 +9,7 @@ class QuoteSerializer(serializers.ModelSerializer):
     """Quote DRF serializer."""
 
     created_on = serializers.DateTimeField(read_only=True)
-    created_by = NestedRelatedField(Advisor, read_only=True)
+    created_by = NestedAdviserField(read_only=True)
 
     def create(self, validated_data):
         """Call `order.generate_quote` instead of creating the object directly."""

--- a/datahub/omis/quote/test/factories.py
+++ b/datahub/omis/quote/test/factories.py
@@ -1,11 +1,15 @@
 import uuid
 import factory
 
+from datahub.company.test.factories import AdviserFactory
+
 
 class QuoteFactory(factory.django.DjangoModelFactory):
     """Order factory."""
 
     id = factory.LazyFunction(uuid.uuid4)
+    created_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SubFactory(AdviserFactory)
     reference = factory.Faker('text', max_nb_chars=10)
     content = factory.Faker('text')
 

--- a/datahub/omis/quote/urls.py
+++ b/datahub/omis/quote/urls.py
@@ -7,7 +7,8 @@ urlpatterns = [
     url(
         r'^order/(?P<order_pk>[0-9a-z-]{36})/quote$',
         QuoteViewSet.as_view({
-            'post': 'create'
+            'post': 'create',
+            'get': 'retrieve',
         }),
         name='item'
     ),

--- a/datahub/omis/quote/views.py
+++ b/datahub/omis/quote/views.py
@@ -17,12 +17,27 @@ class QuoteViewSet(CoreViewSetV3):
     order_lookup_url_kwarg = 'order_pk'
 
     def get_order(self):
-        """Get main order from url kwargs."""
+        """
+        :returns: the main order from url kwargs.
+
+        :raises Http404: if the order doesn't exist
+        """
         try:
             order = Order.objects.get(pk=self.kwargs[self.order_lookup_url_kwarg])
         except Order.DoesNotExist:
             raise Http404('The specified order does not exist.')
         return order
+
+    def get_object(self):
+        """
+        :returns: the quote related to the order.
+
+        :raises Http404: if the quote doesn't exist
+        """
+        quote = self.get_order().quote
+        if not quote:
+            raise Http404('The specified quote does not exist.')
+        return quote
 
     def get_serializer_context(self):
         """Extra context provided to the serializer class."""


### PR DESCRIPTION
This adds a new enpoint `/v3/omis/order/<order-id>/quote` which returns the details of a quote.

The content of the quote is not included in the response and will be returned by a different endpoint to keep the response body small.