### PR TITLE
Add ability to get the content of a quote

### DIFF
--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -148,11 +148,13 @@ class Order(BaseModel):
             validator.set_instance(self)
             validator()
 
-        quote = Quote.objects.create(
+        quote = Quote(
             **quote_data,
             reference=Quote.generate_reference(self),
             content=Quote.generate_content(self)
         )
+        quote.save()
+
         self.quote = quote
         self.save()
 

--- a/datahub/omis/quote/serializers.py
+++ b/datahub/omis/quote/serializers.py
@@ -5,8 +5,18 @@ from datahub.company.serializers import NestedAdviserField
 from .models import Quote
 
 
-class QuoteSerializer(serializers.ModelSerializer):
-    """Quote DRF serializer."""
+class ExpandParamSerializer(serializers.Serializer):
+    """Holds the `expand` param for getting the complete details of an object."""
+
+    expand = serializers.BooleanField(default=False)
+
+
+class BasicQuoteSerializer(serializers.ModelSerializer):
+    """
+    Basic Quote DRF serializer.
+
+    It does not include the content of a quote which is usually long.
+    """
 
     created_on = serializers.DateTimeField(read_only=True)
     created_by = NestedAdviserField(read_only=True)
@@ -23,4 +33,19 @@ class QuoteSerializer(serializers.ModelSerializer):
         fields = [
             'created_on',
             'created_by',
+        ]
+
+
+class ExpandedQuoteSerializer(BasicQuoteSerializer):
+    """
+    Expanded Quote DRF serializer.
+
+    It includes the content of a quote which is usually long.
+    """
+
+    content = serializers.CharField(read_only=True)
+
+    class Meta(BasicQuoteSerializer.Meta):  # noqa: D101
+        fields = BasicQuoteSerializer.Meta.fields + [
+            'content',
         ]


### PR DESCRIPTION
The endpoint `/v3/omis/order/<order-id>/quote` now accepts ~~`full=1`~~ `expand=1` to indicate that the response body has to include the content of the quote as well.

By default we want to return a lighter version.