### PR TITLE
Add ability to preview an order

### DIFF
--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -131,9 +131,13 @@ class Order(BaseModel):
         return f'{settings.DATAHUB_FRONTEND_BASE_URL}/omis/{self.pk}'
 
     @transaction.atomic
-    def generate_quote(self, quote_data):
+    def generate_quote(self, quote_data, commit=True):
         """
-        Generate a quote for this order if possible or raise
+        :returns: a quote for this order
+
+        :param quote_data: extra quote data e.g. created_by etc.
+            This should not include content or reference which are generated on the fly
+        :param commit: if False, the changes will not be saved. Useful for previewing a quote
 
         :raises rest_framework.exceptions.ValidationError: in case of validation error
         :raises datahub.omis.core.exceptions.Conflict: in case of errors with the state of the
@@ -153,10 +157,14 @@ class Order(BaseModel):
             reference=Quote.generate_reference(self),
             content=Quote.generate_content(self)
         )
-        quote.save()
+
+        if commit:
+            quote.save()
 
         self.quote = quote
-        self.save()
+
+        if commit:
+            self.save()
 
 
 class OrderSubscriber(BaseModel):

--- a/datahub/omis/order/test/test_models.py
+++ b/datahub/omis/order/test/test_models.py
@@ -115,6 +115,18 @@ class TestGenerateQuote:
         assert order.quote.reference
         assert order.quote.content
 
+    def test_without_committing(self):
+        """Test that a quote can be generated without saving its changes."""
+        order = OrderFactory()
+        order.generate_quote({}, commit=False)
+
+        assert order.quote.reference
+        assert order.quote.content
+
+        order.refresh_from_db()
+        assert not order.quote
+        assert not Quote.objects.count()
+
 
 class TestOrderAssignee:
     """Tests for the OrderAssignee model."""

--- a/datahub/omis/quote/serializers.py
+++ b/datahub/omis/quote/serializers.py
@@ -21,11 +21,16 @@ class BasicQuoteSerializer(serializers.ModelSerializer):
     created_on = serializers.DateTimeField(read_only=True)
     created_by = NestedAdviserField(read_only=True)
 
-    def create(self, validated_data):
+    def preview(self):
+        """Same as create but without saving the changes."""
+        self.instance = self.create(self.validated_data, commit=False)
+        return self.instance
+
+    def create(self, validated_data, commit=True):
         """Call `order.generate_quote` instead of creating the object directly."""
         order = self.context['order']
-        order.generate_quote(validated_data)
 
+        order.generate_quote(validated_data, commit=commit)
         return order.quote
 
     class Meta:  # noqa: D101

--- a/datahub/omis/quote/urls.py
+++ b/datahub/omis/quote/urls.py
@@ -12,4 +12,9 @@ urlpatterns = [
         }),
         name='item'
     ),
+    url(
+        r'^order/(?P<order_pk>[0-9a-z-]{36})/quote/preview$',
+        QuoteViewSet.as_view({'post': 'preview'}),
+        name='preview'
+    ),
 ]

--- a/datahub/omis/quote/views.py
+++ b/datahub/omis/quote/views.py
@@ -1,5 +1,8 @@
 from django.http import Http404
 
+from rest_framework import status
+from rest_framework.response import Response
+
 from datahub.core.viewsets import CoreViewSetV3
 
 from datahub.omis.order.models import Order
@@ -16,6 +19,15 @@ class QuoteViewSet(CoreViewSetV3):
     expanded_serializer_class = ExpandedQuoteSerializer
 
     order_lookup_url_kwarg = 'order_pk'
+
+    def preview(self, request, *args, **kwargs):
+        """
+        Same as `create` but without actually saving the changes.
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        serializer.preview()
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     def get_order(self):
         """
@@ -47,7 +59,7 @@ class QuoteViewSet(CoreViewSetV3):
         This can be implicit from the action or explicitly requested with the
         `expand` query param.
         """
-        if self.action == 'create':
+        if self.action in ('create', 'preview'):
             return True
 
         param_serializer = ExpandParamSerializer(data=self.request.GET)


### PR DESCRIPTION
This adds a new endpoint `v3/order/<order-id>/quote/preview` which acts exactly like the create but without actually saving the changes.
The endpoint is used to preview the content before creating a quote.