### PR TITLE
[DH-541] Support Elasticsearch 5.5.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     docker:
       - image: python:3.6
 
-      - image: elasticsearch:2.3
+      - image: elasticsearch:5.5
 
       - image: postgres:9.5
         environment:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       DJANGO_SECRET_KEY: changeme
       DJANGO_SETTINGS_MODULE: config.settings.local
       ES_INDEX: test_index
-      ES_URL: http://localhost:9200
+      ES5_URL: http://localhost:9200
       CDMS_AUTH_URL: http://example.com
       AWS_DEFAULT_REGION: eu-west-2
       AWS_ACCESS_KEY_ID: foo

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -180,7 +180,7 @@ REST_FRAMEWORK = {
 APPEND_SLASH = False
 
 # Leeloo stuff
-ES_URL = env('ES_URL')
+ES_URL = env('ES5_URL')
 ES_VERIFY_CERTS = env.bool('ES_VERIFY_CERTS', True)
 ES_INDEX = env('ES_INDEX')
 ES_INDEX_SETTINGS = {

--- a/config/settings/sample.env
+++ b/config/settings/sample.env
@@ -1,7 +1,7 @@
 DJANGO_SECRET_KEY=dev
 DEBUG=True
 DATABASE_URL=postgres://localhost/datahub
-ES_URL=http://localhost:9200
+ES5_URL=http://localhost:9200
 ES_INDEX=test
 DATAHUB_SECRET=secret
 CDMS_AUTH_URL=http://example.com

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -9,9 +9,9 @@ from ..models import MapDBModelToDict
 class Company(DocType, MapDBModelToDict):
     """Elasticsearch representation of Company model."""
 
-    id = String(index='not_analyzed')
+    id = dsl_utils.KeywordString()
     account_manager = dsl_utils.contact_or_adviser_mapping('account_manager')
-    alias = String()
+    alias = dsl_utils.SortableString()
     archived = Boolean()
     archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
     contacts = dsl_utils.contact_or_adviser_mapping('contacts')
@@ -26,7 +26,7 @@ class Company(DocType, MapDBModelToDict):
     employee_range = dsl_utils.id_name_mapping()
     headquarter_type = dsl_utils.id_name_mapping()
     modified_on = Date()
-    name = String(copy_to=['name_keyword', 'name_trigram'])
+    name = dsl_utils.SortableString(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = dsl_utils.CaseInsensitiveKeywordString()
     name_trigram = dsl_utils.TrigramString()
     one_list_account_owner = dsl_utils.contact_or_adviser_mapping('one_list_account_owner')

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch_dsl import Boolean, Date, DocType, String
+from elasticsearch_dsl import Boolean, Date, DocType, Keyword, String
 
 from .. import dict_utils
 from .. import dsl_utils
@@ -9,7 +9,7 @@ from ..models import MapDBModelToDict
 class Company(DocType, MapDBModelToDict):
     """Elasticsearch representation of Company model."""
 
-    id = dsl_utils.KeywordString()
+    id = Keyword()
     account_manager = dsl_utils.contact_or_adviser_mapping('account_manager')
     alias = dsl_utils.SortableString()
     archived = Boolean()
@@ -19,7 +19,7 @@ class Company(DocType, MapDBModelToDict):
     archived_reason = String()
     business_type = dsl_utils.id_name_mapping()
     classification = dsl_utils.id_name_mapping()
-    company_number = dsl_utils.CaseInsensitiveKeywordString()
+    company_number = dsl_utils.SortableCaseInsensitiveKeywordString()
     companies_house_data = dsl_utils.company_mapping()
     created_on = Date()
     description = dsl_utils.EnglishString()
@@ -27,7 +27,7 @@ class Company(DocType, MapDBModelToDict):
     headquarter_type = dsl_utils.id_name_mapping()
     modified_on = Date()
     name = dsl_utils.SortableString(copy_to=['name_keyword', 'name_trigram'])
-    name_keyword = dsl_utils.CaseInsensitiveKeywordString()
+    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordString()
     name_trigram = dsl_utils.TrigramString()
     one_list_account_owner = dsl_utils.contact_or_adviser_mapping('one_list_account_owner')
     parent = dsl_utils.id_name_mapping()
@@ -36,14 +36,14 @@ class Company(DocType, MapDBModelToDict):
     registered_address_country = dsl_utils.id_name_mapping()
     registered_address_county = String()
     registered_address_postcode = String()
-    registered_address_town = dsl_utils.CaseInsensitiveKeywordString()
+    registered_address_town = dsl_utils.SortableCaseInsensitiveKeywordString()
     sector = dsl_utils.id_name_mapping()
     trading_address_1 = String()
     trading_address_2 = String()
     trading_address_country = dsl_utils.id_name_mapping()
     trading_address_county = String()
     trading_address_postcode = String()
-    trading_address_town = dsl_utils.CaseInsensitiveKeywordString()
+    trading_address_town = dsl_utils.SortableCaseInsensitiveKeywordString()
     turnover_range = dsl_utils.id_name_mapping()
     uk_region = dsl_utils.id_name_mapping()
     uk_based = Boolean()

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -9,18 +9,18 @@ from ..models import MapDBModelToDict
 class Contact(DocType, MapDBModelToDict):
     """Elasticsearch representation of Contact model."""
 
-    id = String(index='not_analyzed')
+    id = dsl_utils.KeywordString()
     archived = Boolean()
     archived_on = Date()
     archived_reason = String()
     created_on = Date()
     modified_on = Date()
-    name = String()
+    name = dsl_utils.SortableString()
     name_keyword = dsl_utils.CaseInsensitiveKeywordString()
     name_trigram = dsl_utils.TrigramString()
     title = dsl_utils.id_name_mapping()
-    first_name = String(copy_to=['name', 'name_keyword', 'name_trigram'])
-    last_name = String(copy_to=['name', 'name_keyword', 'name_trigram'])
+    first_name = dsl_utils.SortableString(copy_to=['name', 'name_keyword', 'name_trigram'])
+    last_name = dsl_utils.SortableString(copy_to=['name', 'name_keyword', 'name_trigram'])
     primary = Boolean()
     telephone_countrycode = dsl_utils.KeywordString()
     telephone_number = dsl_utils.KeywordString()

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch_dsl import Boolean, Date, DocType, String
+from elasticsearch_dsl import Boolean, Date, DocType, Keyword, String
 from . import dict_utils as contact_dict_utils
 from .. import dict_utils
 from .. import dsl_utils
@@ -9,32 +9,32 @@ from ..models import MapDBModelToDict
 class Contact(DocType, MapDBModelToDict):
     """Elasticsearch representation of Contact model."""
 
-    id = dsl_utils.KeywordString()
+    id = Keyword()
     archived = Boolean()
     archived_on = Date()
     archived_reason = String()
     created_on = Date()
     modified_on = Date()
     name = dsl_utils.SortableString()
-    name_keyword = dsl_utils.CaseInsensitiveKeywordString()
+    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordString()
     name_trigram = dsl_utils.TrigramString()
     title = dsl_utils.id_name_mapping()
     first_name = dsl_utils.SortableString(copy_to=['name', 'name_keyword', 'name_trigram'])
     last_name = dsl_utils.SortableString(copy_to=['name', 'name_keyword', 'name_trigram'])
     primary = Boolean()
-    telephone_countrycode = dsl_utils.KeywordString()
-    telephone_number = dsl_utils.KeywordString()
-    email = dsl_utils.CaseInsensitiveKeywordString()
+    telephone_countrycode = Keyword()
+    telephone_number = Keyword()
+    email = dsl_utils.SortableCaseInsensitiveKeywordString()
     address_same_as_company = Boolean()
     address_1 = String()
     address_2 = String()
-    address_town = dsl_utils.CaseInsensitiveKeywordString()
-    address_county = dsl_utils.CaseInsensitiveKeywordString()
+    address_town = dsl_utils.SortableCaseInsensitiveKeywordString()
+    address_county = dsl_utils.SortableCaseInsensitiveKeywordString()
     address_postcode = String()
     telephone_alternative = String()
     email_alternative = String()
     notes = dsl_utils.EnglishString()
-    job_title = dsl_utils.CaseInsensitiveKeywordString()
+    job_title = dsl_utils.SortableCaseInsensitiveKeywordString()
     contactable_by_dit = Boolean()
     contactable_by_dit_partners = Boolean()
     contactable_by_email = Boolean()

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -17,6 +17,7 @@ class Contact(DocType, MapDBModelToDict):
     modified_on = Date()
     name = dsl_utils.SortableString()
     name_keyword = dsl_utils.SortableCaseInsensitiveKeywordString()
+    # field is being aggregated
     name_trigram = dsl_utils.TrigramString()
     title = dsl_utils.id_name_mapping()
     first_name = dsl_utils.SortableString(copy_to=['name', 'name_keyword', 'name_trigram'])

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -1,9 +1,7 @@
 from functools import partial
 from elasticsearch_dsl import Keyword, Nested, String
 
-
-KeywordString = Keyword
-CaseInsensitiveKeywordString = partial(
+SortableCaseInsensitiveKeywordString = partial(
     String,
     analyzer='lowercase_keyword_analyzer',
     fielddata=True
@@ -16,10 +14,10 @@ SortableString = partial(String, fielddata=True)
 def contact_or_adviser_mapping(field, include_dit_team=False):
     """Mapping for Adviser/Contact fields."""
     props = {
-        'id': KeywordString(),
-        'first_name': CaseInsensitiveKeywordString(),
-        'last_name': CaseInsensitiveKeywordString(),
-        'name': CaseInsensitiveKeywordString(),
+        'id': Keyword(),
+        'first_name': SortableCaseInsensitiveKeywordString(),
+        'last_name': SortableCaseInsensitiveKeywordString(),
+        'name': SortableCaseInsensitiveKeywordString(),
     }
 
     if include_dit_team:
@@ -30,10 +28,10 @@ def contact_or_adviser_mapping(field, include_dit_team=False):
 def contact_or_adviser_partial_mapping(field):
     """Mapping for Adviser/Contact fields that allows partial matching."""
     props = {
-        'id': KeywordString(),
-        'first_name': CaseInsensitiveKeywordString(),
-        'last_name': CaseInsensitiveKeywordString(),
-        'name': CaseInsensitiveKeywordString(copy_to=f'{field}.name_trigram'),
+        'id': Keyword(),
+        'first_name': SortableCaseInsensitiveKeywordString(),
+        'last_name': SortableCaseInsensitiveKeywordString(),
+        'name': SortableCaseInsensitiveKeywordString(copy_to=f'{field}.name_trigram'),
         'name_trigram': TrigramString(),
     }
     return Nested(properties=props)
@@ -42,16 +40,16 @@ def contact_or_adviser_partial_mapping(field):
 def id_name_mapping():
     """Mapping for id name fields."""
     return Nested(properties={
-        'id': KeywordString(),
-        'name': CaseInsensitiveKeywordString(),
+        'id': Keyword(),
+        'name': SortableCaseInsensitiveKeywordString(),
     })
 
 
 def id_name_partial_mapping(field):
     """Mapping for id name fields."""
     return Nested(properties={
-        'id': KeywordString(),
-        'name': CaseInsensitiveKeywordString(copy_to=f'{field}.name_trigram'),
+        'id': Keyword(),
+        'name': SortableCaseInsensitiveKeywordString(copy_to=f'{field}.name_trigram'),
         'name_trigram': TrigramString(),
     })
 
@@ -59,14 +57,14 @@ def id_name_partial_mapping(field):
 def id_uri_mapping():
     """Mapping for id uri fields."""
     return Nested(properties={
-        'id': KeywordString(),
-        'uri': CaseInsensitiveKeywordString()
+        'id': Keyword(),
+        'uri': SortableCaseInsensitiveKeywordString()
     })
 
 
 def company_mapping():
     """Mapping for id company_number fields."""
     return Nested(properties={
-        'id': KeywordString(),
-        'company_number': CaseInsensitiveKeywordString()
+        'id': Keyword(),
+        'company_number': SortableCaseInsensitiveKeywordString()
     })

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -1,11 +1,16 @@
 from functools import partial
-from elasticsearch_dsl import Nested, String
+from elasticsearch_dsl import Keyword, Nested, String
 
 
-KeywordString = partial(String, index='not_analyzed')
-CaseInsensitiveKeywordString = partial(String, analyzer='lowercase_keyword_analyzer')
+KeywordString = Keyword
+CaseInsensitiveKeywordString = partial(
+    String,
+    analyzer='lowercase_keyword_analyzer',
+    fielddata=True
+)
 TrigramString = partial(String, analyzer='trigram_analyzer')
 EnglishString = partial(String, analyzer='english_analyzer')
+SortableString = partial(String, fielddata=True)
 
 
 def contact_or_adviser_mapping(field, include_dit_team=False):

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -6,7 +6,7 @@ SortableCaseInsensitiveKeywordString = partial(
     analyzer='lowercase_keyword_analyzer',
     fielddata=True
 )
-TrigramString = partial(String, analyzer='trigram_analyzer')
+TrigramString = partial(String, analyzer='trigram_analyzer', fielddata=True)
 EnglishString = partial(String, analyzer='english_analyzer')
 SortableString = partial(String, fielddata=True)
 

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch_dsl import Date, DocType, String
+from elasticsearch_dsl import Date, DocType, Keyword, String
 
 from datahub.search import dict_utils, dsl_utils
 from datahub.search.models import MapDBModelToDict
@@ -8,9 +8,9 @@ from datahub.search.models import MapDBModelToDict
 class Event(DocType, MapDBModelToDict):
     """Elasticsearch representation of Event model."""
 
-    id = dsl_utils.KeywordString()
+    id = Keyword()
     name = dsl_utils.SortableString(copy_to=['name_keyword', 'name_trigram'])
-    name_keyword = dsl_utils.CaseInsensitiveKeywordString()
+    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordString()
     name_trigram = dsl_utils.TrigramString()
     event_type = dsl_utils.id_name_mapping()
     start_date = Date()
@@ -18,8 +18,8 @@ class Event(DocType, MapDBModelToDict):
     location_type = dsl_utils.id_name_mapping()
     address_1 = String()
     address_2 = String()
-    address_town = dsl_utils.CaseInsensitiveKeywordString()
-    address_county = dsl_utils.CaseInsensitiveKeywordString()
+    address_town = dsl_utils.SortableCaseInsensitiveKeywordString()
+    address_county = dsl_utils.SortableCaseInsensitiveKeywordString()
     address_postcode = String()
     address_country = dsl_utils.id_name_mapping()
     uk_region = dsl_utils.id_name_mapping()

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -9,7 +9,7 @@ class Event(DocType, MapDBModelToDict):
     """Elasticsearch representation of Event model."""
 
     id = dsl_utils.KeywordString()
-    name = String(copy_to=['name_keyword', 'name_trigram'])
+    name = dsl_utils.SortableString(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = dsl_utils.CaseInsensitiveKeywordString()
     name_trigram = dsl_utils.TrigramString()
     event_type = dsl_utils.id_name_mapping()

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch_dsl import Date, DocType
+from elasticsearch_dsl import Date, DocType, Keyword
 
 from datahub.search import dict_utils, dsl_utils
 from datahub.search.models import MapDBModelToDict
@@ -8,8 +8,8 @@ from datahub.search.models import MapDBModelToDict
 class Interaction(DocType, MapDBModelToDict):
     """Elasticsearch representation of Interaction model."""
 
-    id = dsl_utils.KeywordString()
-    kind = dsl_utils.KeywordString()
+    id = Keyword()
+    kind = Keyword()
     date = Date()
     company = dsl_utils.id_name_partial_mapping('company')
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -15,7 +15,7 @@ class Interaction(DocType, MapDBModelToDict):
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
     event = dsl_utils.id_name_partial_mapping('event')
     service = dsl_utils.id_name_mapping()
-    subject = dsl_utils.EnglishString()
+    subject = dsl_utils.EnglishString(fielddata=True)
     dit_adviser = dsl_utils.contact_or_adviser_partial_mapping('dit_adviser')
     notes = dsl_utils.EnglishString()
     dit_team = dsl_utils.id_name_mapping()

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -9,7 +9,7 @@ from ..models import MapDBModelToDict
 class InvestmentProject(DocType, MapDBModelToDict):
     """Elasticsearch representation of InvestmentProject."""
 
-    id = String(index='not_analyzed')
+    id = dsl_utils.KeywordString()
     approved_commitment_to_invest = Boolean()
     approved_fdi = Boolean()
     approved_good_value = Boolean()
@@ -38,7 +38,7 @@ class InvestmentProject(DocType, MapDBModelToDict):
     uk_company = dsl_utils.id_name_mapping()
     investor_company = dsl_utils.id_name_mapping()
     investment_type = dsl_utils.id_name_mapping()
-    name = String(copy_to=['name_keyword', 'name_trigram'])
+    name = dsl_utils.SortableString()
     name_keyword = dsl_utils.CaseInsensitiveKeywordString()
     name_trigram = dsl_utils.TrigramString()
     r_and_d_budget = Boolean()

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch_dsl import Boolean, Date, DocType, Double, Integer, String
+from elasticsearch_dsl import Boolean, Date, DocType, Double, Integer, Keyword, String
 
 from .. import dict_utils
 from .. import dsl_utils
@@ -9,7 +9,7 @@ from ..models import MapDBModelToDict
 class InvestmentProject(DocType, MapDBModelToDict):
     """Elasticsearch representation of InvestmentProject."""
 
-    id = dsl_utils.KeywordString()
+    id = Keyword()
     approved_commitment_to_invest = Boolean()
     approved_fdi = Boolean()
     approved_good_value = Boolean()
@@ -39,7 +39,7 @@ class InvestmentProject(DocType, MapDBModelToDict):
     investor_company = dsl_utils.id_name_mapping()
     investment_type = dsl_utils.id_name_mapping()
     name = dsl_utils.SortableString()
-    name_keyword = dsl_utils.CaseInsensitiveKeywordString()
+    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordString()
     name_trigram = dsl_utils.TrigramString()
     r_and_d_budget = Boolean()
     non_fdi_r_and_d_budget = Boolean()
@@ -56,12 +56,12 @@ class InvestmentProject(DocType, MapDBModelToDict):
     not_shareable_reason = String()
     operations_commenced_documents = dsl_utils.id_uri_mapping()
     stage = dsl_utils.id_name_mapping()
-    project_code = dsl_utils.CaseInsensitiveKeywordString()
+    project_code = dsl_utils.SortableCaseInsensitiveKeywordString()
     project_shareable = Boolean()
     referral_source_activity = dsl_utils.id_name_mapping()
     referral_source_activity_marketing = dsl_utils.id_name_mapping()
     referral_source_activity_website = dsl_utils.id_name_mapping()
-    referral_source_activity_event = dsl_utils.CaseInsensitiveKeywordString()
+    referral_source_activity_event = dsl_utils.SortableCaseInsensitiveKeywordString()
     referral_source_advisor = dsl_utils.contact_or_adviser_mapping('referral_source_advisor')
     sector = dsl_utils.id_name_mapping()
     average_salary = dsl_utils.id_name_mapping()

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from elasticsearch_dsl import Boolean, Date, DocType, Integer, String
+from elasticsearch_dsl import Boolean, Date, DocType, Integer, Keyword, String
 
 from .. import dict_utils
 from .. import dsl_utils
@@ -9,9 +9,9 @@ from ..models import MapDBModelToDict
 class Order(DocType, MapDBModelToDict):
     """Elasticsearch representation of Order model."""
 
-    id = dsl_utils.KeywordString()
-    reference = dsl_utils.CaseInsensitiveKeywordString()
-    status = dsl_utils.CaseInsensitiveKeywordString()
+    id = Keyword()
+    reference = dsl_utils.SortableCaseInsensitiveKeywordString()
+    status = dsl_utils.SortableCaseInsensitiveKeywordString()
     company = dsl_utils.id_name_mapping()
     contact = dsl_utils.contact_or_adviser_mapping('contact')
     created_by = dsl_utils.contact_or_adviser_mapping('created_by')
@@ -23,8 +23,8 @@ class Order(DocType, MapDBModelToDict):
     contacts_not_to_approach = String()
     delivery_date = Date()
     service_types = dsl_utils.id_name_mapping()
-    contact_email = dsl_utils.CaseInsensitiveKeywordString()
-    contact_phone = dsl_utils.KeywordString()
+    contact_email = dsl_utils.SortableCaseInsensitiveKeywordString()
+    contact_phone = Keyword()
     subscribers = dsl_utils.contact_or_adviser_mapping('subscribers', include_dit_team=True)
     assignees = dsl_utils.contact_or_adviser_mapping('assignees', include_dit_team=True)
     po_number = String(index='no')
@@ -38,12 +38,12 @@ class Order(DocType, MapDBModelToDict):
     total_cost = Integer()
 
     billing_contact_name = String()
-    billing_email = dsl_utils.CaseInsensitiveKeywordString()
-    billing_phone = dsl_utils.CaseInsensitiveKeywordString()
+    billing_email = dsl_utils.SortableCaseInsensitiveKeywordString()
+    billing_phone = dsl_utils.SortableCaseInsensitiveKeywordString()
     billing_address_1 = String()
     billing_address_2 = String()
-    billing_address_town = dsl_utils.CaseInsensitiveKeywordString()
-    billing_address_county = dsl_utils.CaseInsensitiveKeywordString()
+    billing_address_town = dsl_utils.SortableCaseInsensitiveKeywordString()
+    billing_address_county = dsl_utils.SortableCaseInsensitiveKeywordString()
     billing_address_postcode = String()
     billing_address_country = dsl_utils.id_name_mapping()
 

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -18,283 +18,293 @@ def test_mapping(setup_es):
     assert mapping.to_dict() == {
         'order': {
             'properties': {
-                'id': {
-                    'index': 'not_analyzed',
-                    'type': 'string'
+                'assignees': {
+                    'properties': {
+                        'dit_team': {
+                            'properties': {
+                                'id': {
+                                    'type': 'keyword'
+                                },
+                                'name': {
+                                    'analyzer': 'lowercase_keyword_analyzer',
+                                    'fielddata': True,
+                                    'type': 'text'
+                                }
+                            },
+                            'type': 'nested'
+                        },
+                        'first_name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        },
+                        'id': {
+                            'type': 'keyword'
+                        },
+                        'last_name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        }
+                    },
+                    'type': 'nested'
                 },
-                'reference': {
+                'billing_address_1': {
+                    'type': 'text'
+                },
+                'billing_address_2': {
+                    'type': 'text'
+                },
+                'billing_address_country': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        }
+                    },
+                    'type': 'nested'
+                },
+                'billing_address_county': {
                     'analyzer': 'lowercase_keyword_analyzer',
-                    'type': 'string'
+                    'fielddata': True,
+                    'type': 'text'
                 },
-                'status': {
+                'billing_address_postcode': {
+                    'type': 'text'
+                },
+                'billing_address_town': {
                     'analyzer': 'lowercase_keyword_analyzer',
-                    'type': 'string'
+                    'fielddata': True,
+                    'type': 'text'
                 },
-                'po_number': {
-                    'index': 'no',
-                    'type': 'string'
+                'billing_contact_name': {
+                    'type': 'text'
+                },
+                'billing_email': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'billing_phone': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
                 },
                 'company': {
                     'properties': {
                         'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
+                            'type': 'keyword'
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
+                            'fielddata': True,
+                            'type': 'text'
                         }
                     },
                     'type': 'nested'
                 },
                 'contact': {
                     'properties': {
-                        'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
-                        },
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
+                            'fielddata': True,
+                            'type': 'text'
+                        },
+                        'id': {
+                            'type': 'keyword'
                         },
                         'last_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
+                            'fielddata': True,
+                            'type': 'text'
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        }
-                    },
-                    'type': 'nested'
-                },
-                'created_by': {
-                    'properties': {
-                        'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
-                        },
-                        'first_name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        },
-                        'last_name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        },
-                        'name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        }
-                    },
-                    'type': 'nested'
-                },
-                'created_on': {
-                    'format': 'strict_date_optional_time||epoch_millis',
-                    'type': 'date'
-                },
-                'modified_on': {
-                    'format': 'strict_date_optional_time||epoch_millis',
-                    'type': 'date'
-                },
-                'primary_market': {
-                    'properties': {
-                        'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
-                        },
-                        'name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        }
-                    },
-                    'type': 'nested'
-                },
-                'sector': {
-                    'properties': {
-                        'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
-                        },
-                        'name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        }
-                    },
-                    'type': 'nested'
-                },
-                'description': {
-                    'analyzer': 'english_analyzer',
-                    'type': 'string'
-                },
-                'contacts_not_to_approach': {
-                    'type': 'string'
-                },
-                'delivery_date': {
-                    'format': 'strict_date_optional_time||epoch_millis',
-                    'type': 'date'
-                },
-                'service_types': {
-                    'properties': {
-                        'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
-                        },
-                        'name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
+                            'fielddata': True,
+                            'type': 'text'
                         }
                     },
                     'type': 'nested'
                 },
                 'contact_email': {
                     'analyzer': 'lowercase_keyword_analyzer',
-                    'type': 'string'
+                    'fielddata': True,
+                    'type': 'text'
                 },
                 'contact_phone': {
-                    'index': 'not_analyzed',
-                    'type': 'string'
+                    'type': 'keyword'
+                },
+                'contacts_not_to_approach': {
+                    'type': 'text'
+                },
+                'created_by': {
+                    'properties': {
+                        'first_name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        },
+                        'id': {
+                            'type': 'keyword'
+                        },
+                        'last_name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        }
+                    },
+                    'type': 'nested'
+                },
+                'created_on': {
+                    'type': 'date'
+                },
+                'delivery_date': {
+                    'type': 'date'
+                },
+                'description': {
+                    'analyzer': 'english_analyzer',
+                    'type': 'text'
+                },
+                'discount_value': {
+                    'index': False,
+                    'type': 'integer'
+                },
+                'id': {
+                    'type': 'keyword'
+                },
+                'modified_on': {
+                    'type': 'date'
+                },
+                'net_cost': {
+                    'index': False,
+                    'type': 'integer'
+                },
+                'po_number': {
+                    'index': False,
+                    'type': 'keyword'
+                },
+                'primary_market': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        }
+                    },
+                    'type': 'nested'
+                },
+                'reference': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'sector': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        }
+                    },
+                    'type': 'nested'
+                },
+                'service_types': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        }
+                    },
+                    'type': 'nested'
+                },
+                'status': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
                 },
                 'subscribers': {
                     'properties': {
-                        'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
-                        },
-                        'first_name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        },
-                        'last_name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        },
-                        'name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        },
                         'dit_team': {
                             'properties': {
                                 'id': {
-                                    'index': 'not_analyzed',
-                                    'type': 'string'
+                                    'type': 'keyword'
                                 },
                                 'name': {
                                     'analyzer': 'lowercase_keyword_analyzer',
-                                    'type': 'string'
+                                    'fielddata': True,
+                                    'type': 'text'
                                 }
                             },
                             'type': 'nested'
-                        }
-                    },
-                    'type': 'nested'
-                },
-                'assignees': {
-                    'properties': {
-                        'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
                         },
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
+                            'fielddata': True,
+                            'type': 'text'
+                        },
+                        'id': {
+                            'type': 'keyword'
                         },
                         'last_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
+                            'fielddata': True,
+                            'type': 'text'
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        },
-                        'dit_team': {
-                            'properties': {
-                                'id': {
-                                    'index': 'not_analyzed',
-                                    'type': 'string'
-                                },
-                                'name': {
-                                    'analyzer': 'lowercase_keyword_analyzer',
-                                    'type': 'string'
-                                }
-                            },
-                            'type': 'nested'
+                            'fielddata': True,
+                            'type': 'text'
                         }
                     },
                     'type': 'nested'
-                },
-                'discount_value': {
-                    'index': 'no',
-                    'type': 'integer'
-                },
-                'vat_status': {
-                    'index': 'no',
-                    'type': 'string'
-                },
-                'vat_number': {
-                    'index': 'no',
-                    'type': 'string'
-                },
-                'vat_verified': {
-                    'index': 'no',
-                    'type': 'boolean'
-                },
-                'net_cost': {
-                    'index': 'no',
-                    'type': 'integer'
                 },
                 'subtotal_cost': {
-                    'index': 'no',
-                    'type': 'integer'
-                },
-                'vat_cost': {
-                    'index': 'no',
+                    'index': False,
                     'type': 'integer'
                 },
                 'total_cost': {
                     'type': 'integer'
                 },
-                'billing_contact_name': {
-                    'type': 'string'
+                'vat_cost': {
+                    'index': False,
+                    'type': 'integer'
                 },
-                'billing_email': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'type': 'string'
+                'vat_number': {
+                    'index': False,
+                    'type': 'keyword'
                 },
-                'billing_phone': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'type': 'string'
+                'vat_status': {
+                    'index': False,
+                    'type': 'keyword'
                 },
-                'billing_address_1': {
-                    'type': 'string'
-                },
-                'billing_address_2': {
-                    'type': 'string'
-                },
-                'billing_address_county': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'type': 'string'
-                },
-                'billing_address_town': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'type': 'string'
-                },
-                'billing_address_postcode': {
-                    'type': 'string'
-                },
-                'billing_address_country': {
-                    'properties': {
-                        'id': {
-                            'index': 'not_analyzed',
-                            'type': 'string'
-                        },
-                        'name': {
-                            'analyzer': 'lowercase_keyword_analyzer',
-                            'type': 'string'
-                        }
-                    },
-                    'type': 'nested'
-                },
+                'vat_verified': {
+                    'index': False,
+                    'type': 'boolean'
+                }
             }
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - POSTGRES_DB=datahub
 
   es:
-    image: elasticsearch:2.3
+    image: elasticsearch:5.5
     restart: always
     ports:
       - "9200:9200"

--- a/requirements.in
+++ b/requirements.in
@@ -28,8 +28,8 @@ boto3==1.4.7
 notifications-python-client==4.4.0
 
 # ES
-elasticsearch==2.4.1
-elasticsearch-dsl==2.2.0
+elasticsearch==5.4.0
+elasticsearch-dsl==5.3.0
 
 # Testing and dev
 pytest==3.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,12 +22,12 @@ django-mptt==0.8.7
 django-oauth-toolkit==1.0.0
 django-pglocks==1.0.2
 django-reversion==2.0.10
-django==1.11.5            # via django-debug-toolbar, django-environ, django-model-utils, django-oauth-toolkit, django-reversion
+django==1.11.5
 djangorestframework==3.6.4
 docopt==0.6.2             # via notifications-python-client
 docutils==0.14            # via botocore
-elasticsearch-dsl==2.2.0
-elasticsearch==2.4.1
+elasticsearch-dsl==5.3.0
+elasticsearch==5.4.0
 factory-boy==2.9.2
 faker==0.8.4              # via factory-boy
 first==2.0.1              # via pip-tools


### PR DESCRIPTION
Biggest difference is that Elasticsearch 5 has `fielddata` set to `False` by default. It means that we have to set it to `True` for the string fields we want to sort by.