### PR TITLE
Refactor quote creation

### DIFF
--- a/datahub/omis/quote/manager.py
+++ b/datahub/omis/quote/manager.py
@@ -1,0 +1,26 @@
+from django.db import models
+
+from .utils import generate_quote_content, generate_quote_reference
+
+
+class QuoteManager(models.Manager):
+    """Custom Quote Manager."""
+
+    def create_from_order(self, order, by, commit=True):
+        """
+        :param order: Order instance for this quote
+        :param by: who made the action
+        :param commit: True if the changes have to be committed
+
+        :returns: Quote object generated from the order
+        """
+        quote = self.model(
+            created_by=by,
+            reference=generate_quote_reference(order),
+            content=generate_quote_content(order),
+        )
+
+        if commit:
+            quote.save()
+
+        return quote

--- a/datahub/omis/quote/models.py
+++ b/datahub/omis/quote/models.py
@@ -1,18 +1,12 @@
 import uuid
-from pathlib import PurePath
 
 from django.conf import settings
 from django.db import models
-from django.template.loader import render_to_string
-from django.utils.crypto import get_random_string
 from django.utils.timezone import now
 
 from datahub.core.models import BaseModel
 
-from datahub.omis.core.utils import generate_reference
-
-
-QUOTE_TEMPLATE = PurePath(__file__).parent / 'templates/content.md'
+from .manager import QuoteManager
 
 
 class Quote(BaseModel):
@@ -30,29 +24,7 @@ class Quote(BaseModel):
         related_name='+'
     )
 
-    @classmethod
-    def generate_reference(cls, order):
-        """
-        :returns: a random unused reference of form:
-                <order.reference>/Q-<(2) lettes>/<(1) number> e.g. GEA962/16/Q-AB1
-        :raises RuntimeError: if no reference can be generated.
-        """
-        def gen():
-            return '{letters}{numbers}'.format(
-                letters=get_random_string(length=2, allowed_chars='ACEFHJKMNPRTUVWXY'),
-                numbers=get_random_string(length=1, allowed_chars='123456789')
-            )
-        return generate_reference(model=cls, gen=gen, prefix=f'{order.reference}/Q-')
-
-    @classmethod
-    def generate_content(cls, order):
-        """
-        :returns: the quote populated with the given order details.
-        """
-        return render_to_string(
-            QUOTE_TEMPLATE,
-            {'order': order}
-        )
+    objects = QuoteManager()
 
     def cancel(self, by):
         """Cancel the current quote."""

--- a/datahub/omis/quote/serializers.py
+++ b/datahub/omis/quote/serializers.py
@@ -40,8 +40,9 @@ class BasicQuoteSerializer(serializers.ModelSerializer):
     def create(self, validated_data, commit=True):
         """Call `order.generate_quote` instead of creating the object directly."""
         order = self.context['order']
+        current_user = self.context['current_user']
 
-        order.generate_quote(validated_data, commit=commit)
+        order.generate_quote(by=current_user, commit=commit)
         return order.quote
 
     class Meta:  # noqa: D101

--- a/datahub/omis/quote/test/test_managers.py
+++ b/datahub/omis/quote/test/test_managers.py
@@ -1,0 +1,68 @@
+from unittest import mock
+import pytest
+
+from datahub.company.test.factories import AdviserFactory
+
+from ..models import Quote
+
+
+# mark the whole module for db use
+pytestmark = pytest.mark.django_db
+
+
+class TestQuoteManager:
+    """Tests for the Quote Manager."""
+
+    @mock.patch('datahub.omis.quote.manager.generate_quote_reference')
+    @mock.patch('datahub.omis.quote.manager.generate_quote_content')
+    def test_create_from_order_commit_true(
+        self,
+        mocked_generate_quote_content,
+        mocked_generate_quote_reference
+    ):
+        """
+        Test that Quote.objects.create_from_order creates a quote
+        and commits the changes.
+        """
+        mocked_generate_quote_content.return_value = 'Quote content'
+        mocked_generate_quote_reference.return_value = 'ABC123'
+
+        by = AdviserFactory()
+        quote = Quote.objects.create_from_order(
+            order=mock.MagicMock(),
+            by=by,
+            commit=True
+        )
+
+        quote.refresh_from_db()
+        assert quote.reference == 'ABC123'
+        assert quote.content == 'Quote content'
+        assert quote.created_by == by
+
+    @mock.patch('datahub.omis.quote.manager.generate_quote_reference')
+    @mock.patch('datahub.omis.quote.manager.generate_quote_content')
+    def test_create_from_order_commit_false(
+        self,
+        mocked_generate_quote_content,
+        mocked_generate_quote_reference
+    ):
+        """
+        Test that Quote.objects.create_from_order with commit=False builds a quote
+        but doesn't commit the changes.
+        """
+        mocked_generate_quote_content.return_value = 'Quote content'
+        mocked_generate_quote_reference.return_value = 'ABC123'
+
+        by = AdviserFactory()
+        quote = Quote.objects.create_from_order(
+            order=mock.MagicMock(),
+            by=by,
+            commit=False
+        )
+
+        assert quote.reference == 'ABC123'
+        assert quote.content == 'Quote content'
+        assert quote.created_by == by
+
+        with pytest.raises(Quote.DoesNotExist):
+            quote.refresh_from_db()

--- a/datahub/omis/quote/test/test_models.py
+++ b/datahub/omis/quote/test/test_models.py
@@ -1,66 +1,16 @@
-from pathlib import PurePath
-from unittest import mock
 import pytest
-from dateutil.parser import parse as dateutil_parse
 from django.utils.timezone import now
 from freezegun import freeze_time
 
-from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
-from datahub.core.constants import Country
-from datahub.omis.order.test.factories import CancelledQuoteFactory, OrderFactory
+from datahub.company.test.factories import AdviserFactory
+from datahub.omis.order.test.factories import CancelledQuoteFactory
 
 from .factories import QuoteFactory
 from ..models import Quote
 
-COMPILED_QUOTE_TEMPLATE = PurePath(__file__).parent / 'support/compiled_content.md'
-
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db
-
-
-class TestGenerateReference:
-    """Tests for the generate_reference logic."""
-
-    @mock.patch('datahub.omis.quote.models.get_random_string')
-    def test_reference(self, get_random_string):
-        """Test that the quote reference is generated as expected."""
-        get_random_string.side_effect = ['DE', 4]
-
-        order = mock.Mock(
-            reference='ABC123'
-        )
-
-        reference = Quote.generate_reference(order)
-        assert reference == 'ABC123/Q-DE4'
-
-
-class TestGenerateContent:
-    """Tests for the generate_content logic."""
-
-    @freeze_time('2017-04-18 13:00:00.000000+00:00')
-    def test_content(self):
-        """Test that the quote content is populated as expected."""
-        company = CompanyFactory(name='My Coorp')
-        contact = ContactFactory(
-            company=company,
-            first_name='John',
-            last_name='Doe'
-        )
-        order = OrderFactory(
-            delivery_date=dateutil_parse('2017-06-20'),
-            company=company,
-            contact=contact,
-            reference='ABC123',
-            primary_market_id=Country.france.value.id,
-            description='lorem ipsum',
-        )
-
-        content = Quote.generate_content(order)
-        with open(COMPILED_QUOTE_TEMPLATE, 'r') as f:
-            expected_content = f.read()
-
-        assert content == expected_content
 
 
 class TestCancelQuote:

--- a/datahub/omis/quote/test/test_utils.py
+++ b/datahub/omis/quote/test/test_utils.py
@@ -1,0 +1,62 @@
+from pathlib import PurePath
+from unittest import mock
+import pytest
+from dateutil.parser import parse as dateutil_parse
+from freezegun import freeze_time
+
+from datahub.company.test.factories import CompanyFactory, ContactFactory
+from datahub.core.constants import Country
+from datahub.omis.order.test.factories import OrderFactory
+
+from ..utils import generate_quote_content, generate_quote_reference
+
+
+COMPILED_QUOTE_TEMPLATE = PurePath(__file__).parent / 'support/compiled_content.md'
+
+
+# mark the whole module for db use
+pytestmark = pytest.mark.django_db
+
+
+class TestGenerateQuoteReference:
+    """Tests for the generate_quote_reference logic."""
+
+    @mock.patch('datahub.omis.quote.utils.get_random_string')
+    def test_reference(self, get_random_string):
+        """Test that the quote reference is generated as expected."""
+        get_random_string.side_effect = ['DE', 4]
+
+        order = mock.Mock(
+            reference='ABC123'
+        )
+
+        reference = generate_quote_reference(order)
+        assert reference == 'ABC123/Q-DE4'
+
+
+class TestGenerateQuoteContent:
+    """Tests for the generate_quote_content logic."""
+
+    @freeze_time('2017-04-18 13:00:00.000000+00:00')
+    def test_content(self):
+        """Test that the quote content is populated as expected."""
+        company = CompanyFactory(name='My Coorp')
+        contact = ContactFactory(
+            company=company,
+            first_name='John',
+            last_name='Doe'
+        )
+        order = OrderFactory(
+            delivery_date=dateutil_parse('2017-06-20'),
+            company=company,
+            contact=contact,
+            reference='ABC123',
+            primary_market_id=Country.france.value.id,
+            description='lorem ipsum',
+        )
+
+        content = generate_quote_content(order)
+        with open(COMPILED_QUOTE_TEMPLATE, 'r') as f:
+            expected_content = f.read()
+
+        assert content == expected_content

--- a/datahub/omis/quote/test/test_views.py
+++ b/datahub/omis/quote/test/test_views.py
@@ -141,7 +141,12 @@ class TestCreatePreviewOrder(APITestMixin):
         assert response.json() == {
             'content': response.json()['content'],
             'created_on': None,
-            'created_by': None,
+            'created_by': {
+                'id': str(self.user.pk),
+                'first_name': self.user.first_name,
+                'last_name': self.user.last_name,
+                'name': self.user.name
+            },
             'cancelled_on': None,
             'cancelled_by': None,
         }

--- a/datahub/omis/quote/utils.py
+++ b/datahub/omis/quote/utils.py
@@ -1,0 +1,35 @@
+from pathlib import PurePath
+
+from django.template.loader import render_to_string
+from django.utils.crypto import get_random_string
+
+from datahub.omis.core.utils import generate_reference
+
+
+QUOTE_TEMPLATE = PurePath(__file__).parent / 'templates/content.md'
+
+
+def generate_quote_reference(order):
+    """
+    :returns: a random unused reference of form:
+            <order.reference>/Q-<(2) lettes>/<(1) number> e.g. GEA962/16/Q-AB1
+    :raises RuntimeError: if no reference can be generated.
+    """
+    from .models import Quote
+
+    def gen():
+        return '{letters}{numbers}'.format(
+            letters=get_random_string(length=2, allowed_chars='ACEFHJKMNPRTUVWXY'),
+            numbers=get_random_string(length=1, allowed_chars='123456789')
+        )
+    return generate_reference(model=Quote, gen=gen, prefix=f'{order.reference}/Q-')
+
+
+def generate_quote_content(order):
+    """
+    :returns: the content of the quote populated with the given order details.
+    """
+    return render_to_string(
+        QUOTE_TEMPLATE,
+        {'order': order}
+    )


### PR DESCRIPTION
This refactors the quote creation logic to make it more obvious and consistent:
- a quote gets created by the `QuoteManager`
- the classmethods to populate the quote have been moved to `utils.py`
- `order.generate_quote` has now the same signature as `order.reopen`