### PR TITLE
Update dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,12 +3,12 @@ lxml==3.8.0
 cssselect==1.0.1
 
 # Django and django related
-Django==1.11.4
-djangorestframework==3.6.3
-django-environ==0.4.3
-django-extensions==1.8.1
+Django==1.11.5
+djangorestframework==3.6.4
+django-environ==0.4.4
+django-extensions==1.9.0
 django-filter==1.0.4
-django-reversion==2.0.9
+django-reversion==2.0.10
 django-pglocks==1.0.2
 django-model-utils==3.0.0
 django-mptt==0.8.7  # Remove after squashing migrations
@@ -21,9 +21,9 @@ pyquery==1.2.17
 python-dateutil==2.6.1
 
 # Persistency layer
-psycopg2==2.7.3
+psycopg2==2.7.3.1
 
-boto3==1.4.6
+boto3==1.4.7
 
 notifications-python-client==4.3.1
 
@@ -60,5 +60,5 @@ pydocstyle==2.0.0
 
 gunicorn==19.7.1
 raven==6.1.0
-requests==2.18.3
+requests==2.18.4
 requests_toolbelt==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,8 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-appnope==0.1.0            # via ipython
-boto3==1.4.6
-botocore==1.6.0           # via boto3, s3transfer
+boto3==1.4.7
+botocore==1.7.4           # via boto3, s3transfer
 certifi==2017.7.27.1      # via requests
 chardet==3.0.4            # via requests
 click==6.7                # via pip-tools
@@ -16,22 +15,24 @@ coverage==4.4.1           # via pytest-cov
 cssselect==1.0.1
 decorator==4.1.2          # via ipython, traitlets
 django-debug-toolbar==1.8
-django-environ==0.4.3
-django-extensions==1.8.1
+django-environ==0.4.4
+django-extensions==1.9.0
 django-filter==1.0.4
 django-model-utils==3.0.0
 django-mptt==0.8.7
 django-oauth-toolkit==1.0.0
 django-pglocks==1.0.2
-django-reversion==2.0.9
-django==1.11.4
-djangorestframework==3.6.3
+django-reversion==2.0.10
+django==1.11.5            # via django-debug-toolbar, django-environ, django-model-utils, django-oauth-toolkit, django-reversion
+djangorestframework==3.6.4
+dnspython==1.15.0         # via email-validator
 docopt==0.6.2             # via notifications-python-client
-docutils==0.13.1          # via botocore
+docutils==0.14            # via botocore
 elasticsearch-dsl==2.2.0
 elasticsearch==2.4.1
+email-validator==1.0.2    # via faker
 factory-boy==2.9.2
-faker==0.7.18             # via factory-boy
+faker==0.8.3              # via factory-boy
 first==2.0.1              # via pip-tools
 flake8-blind-except==0.1.1
 flake8-debugger==1.4.0
@@ -45,11 +46,11 @@ flake8==3.4.1
 freezegun==0.3.9
 future==0.16.0            # via notifications-python-client
 gunicorn==19.7.1
-idna==2.5                 # via requests
+idna==2.6                 # via email-validator, requests
 ipdb==0.10.3
 ipython-genutils==0.2.0   # via traitlets
 ipython==6.1.0
-iso8601==0.1.11           # via colander
+iso8601==0.1.12           # via colander
 jedi==0.10.2              # via ipython
 jmespath==0.9.3           # via boto3, botocore
 lxml==3.8.0
@@ -63,14 +64,14 @@ pexpect==4.2.1            # via ipython
 pickleshare==0.7.4        # via ipython
 pip-tools==1.9.0
 prompt-toolkit==1.0.15    # via ipython
-psycopg2==2.7.3
+psycopg2==2.7.3.1
 ptyprocess==0.5.2         # via pexpect
 py==1.4.34                # via pytest
 pycodestyle==2.3.1        # via flake8, flake8-import-order
 pydocstyle==2.0.0
 pyflakes==1.5.0           # via flake8
 pygments==2.2.0           # via ipython
-pyjwt==1.5.2              # via notifications-python-client
+pyjwt==1.5.3              # via notifications-python-client
 pyquery==1.2.17
 pytest-cov==2.5.1
 pytest-django==3.1.2
@@ -81,9 +82,9 @@ pytz==2017.2              # via django
 pyyaml==3.12
 raven==6.1.0
 requests-mock==1.3.0
-requests==2.18.3
+requests==2.18.4
 requests_toolbelt==0.8.0
-s3transfer==0.1.10        # via boto3
+s3transfer==0.1.11        # via boto3
 simplegeneric==0.8.1      # via ipython
 six==1.10.0               # via django-environ, django-extensions, elasticsearch-dsl, faker, freezegun, pip-tools, prompt-toolkit, pydocstyle, python-dateutil, requests-mock, traitlets
 snowballstemmer==1.2.1    # via pydocstyle


### PR DESCRIPTION
https://docs.djangoproject.com/en/1.11/releases/1.11.5/
http://www.django-rest-framework.org/topics/release-notes/#36x-series
https://github.com/requests/requests/blob/master/HISTORY.rst
https://github.com/Frozenball/pytest-sugar/blob/master/CHANGES.rst
https://github.com/etianen/django-reversion/blob/master/CHANGELOG.rst
https://github.com/joke2k/django-environ#changelog
https://github.com/boto/boto3/blob/develop/CHANGELOG.rst
http://initd.org/psycopg/docs/news.html

We don't seem to be compatible with the latest pytest, so have left that out for now.