### PR TITLE
Adds verify_certs parameter to Elasticsearch connection.

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -168,6 +168,7 @@ APPEND_SLASH = False
 
 # Leeloo stuff
 ES_URL = env('ES_URL')
+ES_VERIFY_CERTS = env.bool('ES_VERIFY_CERTS', True)
 ES_INDEX = env('ES_INDEX')
 ES_INDEX_SETTINGS = {
     'index.mapping.nested_fields.limit': 100

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -64,7 +64,8 @@ def configure_connection():
     """Configure Elasticsearch default connection."""
     connections.configure(
         default={
-            'hosts': [settings.ES_URL]
+            'hosts': [settings.ES_URL],
+            'verify_certs': settings.ES_VERIFY_CERTS
         }
     )
 

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -162,5 +162,6 @@ def test_configure_connection(connections, settings):
     elasticsearch.configure_connection()
 
     connections.configure.assert_called_with(default={
-        'hosts': [settings.ES_URL]
+        'hosts': [settings.ES_URL],
+        'verify_certs': settings.ES_VERIFY_CERTS
     })


### PR DESCRIPTION
This is to fix the warning when connecting to Elasticsearch via SSL.

```
(...) using SSL with verify_certs=False is insecure.
```