### PR TITLE
Change error key when validating assignees

### DIFF
--- a/datahub/omis/order/test/test_validators.py
+++ b/datahub/omis/order/test/test_validators.py
@@ -182,7 +182,7 @@ class TestAssigneesFilledInValidator:
             validator()
 
         assert exc.value.detail == {
-            'assignees': ['The total estimated time cannot be zero.']
+            'assignee_time': ['The total estimated time cannot be zero.']
         }
 
     def test_non_zero_estimated_time_succeeds(self):

--- a/datahub/omis/order/validators.py
+++ b/datahub/omis/order/validators.py
@@ -141,7 +141,7 @@ class AssigneesFilledInValidator:
 
         if not self.instance.assignees.aggregate(sum=models.Sum('estimated_time'))['sum']:
             raise ValidationError({
-                'assignees': [self.no_estimated_time_message]
+                'assignee_time': [self.no_estimated_time_message]
             })
 
 


### PR DESCRIPTION
This changes the error key to assignee_time when validating if the overall time is > 0.