### PR TITLE
Add OMIS order get endpoint for public facing app

### DIFF
--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -40,5 +40,9 @@ v3_urls = [
     url(r'^', include((investment_urls, 'investment'), namespace='investment')),
     url(r'^', include((leads_urls, 'business-leads'), namespace='business-leads')),
     url(r'^', include((search_urls, 'search'), namespace='search')),
-    url(r'^omis/', include((omis_urls, 'omis'), namespace='omis'))
+    url(r'^omis/', include((omis_urls.internal_frontend_urls, 'omis'), namespace='omis')),
+    url(
+        r'^omis/public/',
+        include((omis_urls.public_urls, 'omis-public'), namespace='omis-public')
+    ),
 ]

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -185,6 +185,65 @@ class OrderSerializer(serializers.ModelSerializer):
         return data
 
 
+class CompanyWithAddressSerializer(serializers.ModelSerializer):
+    """
+    Read-only DRF Serializer for Company with id, name an registered address.
+    """
+
+    registered_address_country = NestedRelatedField(Country)
+
+    class Meta:  # noqa: D101
+        model = Company
+        fields = (
+            'id',
+            'name',
+            'registered_address_1',
+            'registered_address_2',
+            'registered_address_county',
+            'registered_address_postcode',
+            'registered_address_town',
+            'registered_address_country',
+        )
+        read_only_fields = fields
+
+
+class PublicOrderSerializer(serializers.ModelSerializer):
+    """DRF serializer for public facing API."""
+
+    company = CompanyWithAddressSerializer()
+    contact = NestedRelatedField(Contact)
+    billing_address_country = NestedRelatedField(Country)
+
+    class Meta:  # noqa: D101
+        model = Order
+        fields = (
+            'public_token',
+            'reference',
+            'status',
+            'created_on',
+            'company',
+            'contact',
+            'contact_email',
+            'contact_phone',
+            'po_number',
+            'discount_value',
+            'net_cost',
+            'subtotal_cost',
+            'vat_cost',
+            'total_cost',
+            'billing_contact_name',
+            'billing_email',
+            'billing_phone',
+            'billing_address_1',
+            'billing_address_2',
+            'billing_address_town',
+            'billing_address_county',
+            'billing_address_postcode',
+            'billing_address_country',
+        )
+        read_only_fields = fields
+
+
 def existing_adviser(adviser_id):
     """
     DRF Validator. It raises a ValidationError if adviser_id is not a valid adviser id.

--- a/datahub/omis/order/test/views/test_public_order_details.py
+++ b/datahub/omis/order/test/views/test_public_order_details.py
@@ -1,0 +1,166 @@
+import pytest
+
+from oauth2_provider.models import Application
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.core.test_utils import APITestMixin
+from datahub.oauth.scopes import Scope
+from datahub.omis.quote.test.factories import QuoteFactory
+
+from ..factories import OrderFactory
+from ...constants import OrderStatus
+
+
+# mark the whole module for db use
+pytestmark = pytest.mark.django_db
+
+
+class TestViewPublicOrderDetails(APITestMixin):
+    """Tests for the pubic facing order endpoints."""
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (
+            OrderStatus.quote_awaiting_acceptance,
+            OrderStatus.quote_accepted,
+            OrderStatus.paid,
+            OrderStatus.complete
+        )
+    )
+    def test_get(self, order_status):
+        """Test getting an existing order by `public_token`."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=order_status
+        )
+
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'public_token': order.public_token,
+            'reference': order.reference,
+            'status': order.status,
+            'created_on': order.created_on.isoformat(),
+            'company': {
+                'id': str(order.company.pk),
+                'name': order.company.name,
+                'registered_address_1': order.company.registered_address_1,
+                'registered_address_2': order.company.registered_address_2,
+                'registered_address_county': order.company.registered_address_county,
+                'registered_address_postcode': order.company.registered_address_postcode,
+                'registered_address_town': order.company.registered_address_town,
+                'registered_address_country': {
+                    'id': str(order.company.registered_address_country.pk),
+                    'name': order.company.registered_address_country.name
+                },
+            },
+            'contact': {
+                'id': str(order.contact.pk),
+                'name': order.contact.name
+            },
+            'contact_email': order.contact_email,
+            'contact_phone': order.contact_phone,
+            'po_number': order.po_number,
+            'discount_value': order.discount_value,
+            'net_cost': order.net_cost,
+            'subtotal_cost': order.subtotal_cost,
+            'vat_cost': order.vat_cost,
+            'total_cost': order.total_cost,
+            'billing_contact_name': order.billing_contact_name,
+            'billing_email': order.billing_email,
+            'billing_phone': order.billing_phone,
+            'billing_address_1': order.billing_address_1,
+            'billing_address_2': order.billing_address_2,
+            'billing_address_town': order.billing_address_town,
+            'billing_address_county': order.billing_address_county,
+            'billing_address_postcode': order.billing_address_postcode,
+            'billing_address_country': {
+                'id': str(order.billing_address_country.pk),
+                'name': order.billing_address_country.name
+            },
+        }
+
+    def test_not_found_with_invalid_public_token(self):
+        """Test 404 when getting a non-existent order."""
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': ('1234-abcd-' * 5)}  # len(token) == 50
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (OrderStatus.draft, OrderStatus.cancelled)
+    )
+    def test_not_found_if_in_disallowed_status(self, order_status):
+        """Test 404 when the order is not in an allowed state."""
+        order = OrderFactory(status=order_status)
+
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, verb):
+        """Test that makes sure the other verbs are not allowed."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=OrderStatus.quote_awaiting_acceptance
+        )
+
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = getattr(client, verb)(url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    @pytest.mark.parametrize(
+        'scope',
+        (s.value for s in Scope if s != Scope.public_omis_front_end.value)
+    )
+    def test_other_scopes_not_allowed(self, scope):
+        """Test that other oauth2 scopes are not allowed."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=OrderStatus.quote_awaiting_acceptance
+        )
+
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=scope,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/omis/order/urls.py
+++ b/datahub/omis/order/urls.py
@@ -2,9 +2,9 @@
 
 from django.conf.urls import url
 
-from .views import AssigneeView, OrderViewSet, SubscriberListView
+from .views import AssigneeView, OrderViewSet, PublicOrderViewSet, SubscriberListView
 
-
+# internal frontend API
 order_collection = OrderViewSet.as_view({
     'post': 'create'
 })
@@ -15,7 +15,7 @@ order_item = OrderViewSet.as_view({
 })
 
 
-urlpatterns = [
+internal_frontend_urls = [
     url(r'^order$', order_collection, name='list'),
     url(r'^order/(?P<pk>[0-9a-z-]{36})$', order_item, name='detail'),
 
@@ -30,4 +30,14 @@ urlpatterns = [
         AssigneeView.as_view(),
         name='assignee'
     ),
+]
+
+
+# public facing API
+public_order_item = PublicOrderViewSet.as_view({
+    'get': 'retrieve'
+})
+
+public_urls = [
+    url(r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})$', public_order_item, name='detail'),
 ]

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -6,8 +6,14 @@ from rest_framework.views import APIView
 from datahub.core.viewsets import CoreViewSetV3
 from datahub.oauth.scopes import Scope
 
+from .constants import OrderStatus
 from .models import Order
-from .serializers import OrderAssigneeSerializer, OrderSerializer, SubscribedAdviserSerializer
+from .serializers import (
+    OrderAssigneeSerializer,
+    OrderSerializer,
+    PublicOrderSerializer,
+    SubscribedAdviserSerializer
+)
 
 
 class OrderViewSet(CoreViewSetV3):
@@ -19,6 +25,26 @@ class OrderViewSet(CoreViewSetV3):
         'company',
         'contact',
         'primary_market',
+    )
+
+
+class PublicOrderViewSet(CoreViewSetV3):
+    """ViewSet for public facing order endpoint."""
+
+    lookup_field = 'public_token'
+
+    required_scopes = (Scope.public_omis_front_end,)
+    serializer_class = PublicOrderSerializer
+    queryset = Order.objects.filter(
+        status__in=(
+            OrderStatus.quote_awaiting_acceptance,
+            OrderStatus.quote_accepted,
+            OrderStatus.paid,
+            OrderStatus.complete,
+        )
+    ).select_related(
+        'company',
+        'contact'
     )
 
 

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -3,7 +3,11 @@ from django.conf.urls import include, url
 from .order import urls as order_urls
 from .quote import urls as quote_urls
 
-urlpatterns = [
-    url(r'^', include((order_urls, 'order'), namespace='order')),
+internal_frontend_urls = [
+    url(r'^', include((order_urls.internal_frontend_urls, 'order'), namespace='order')),
     url(r'^', include((quote_urls, 'quote'), namespace='quote')),
+]
+
+public_urls = [
+    url(r'^', include((order_urls.public_urls, 'order'), namespace='order')),
 ]


### PR DESCRIPTION
This adds `GET /v3/omis/public/order/<public-token>` which returns the details of a order.

The response data is slightly different from the ordinary order endpoints as the public facing app needs less details.
Also, the nested company is expanded as the app needs extra data and adding an extra company endpoint is overkilled.

An order can only be accessed by its public token and only if its status is not in draft/cancelled.