### PR TITLE
Remove expand param from quote endpoints

### DIFF
--- a/datahub/omis/quote/serializers.py
+++ b/datahub/omis/quote/serializers.py
@@ -7,26 +7,12 @@ from datahub.core.serializers import NestedRelatedField
 from .models import Quote
 
 
-class ExpandParamSerializer(serializers.Serializer):
-    """Holds the `expand` param for getting the complete details of an object."""
+class QuoteSerializer(serializers.ModelSerializer):
+    """Quote DRF serializer."""
 
-    expand = serializers.BooleanField(default=False)
-
-
-class BasicQuoteSerializer(serializers.ModelSerializer):
-    """
-    Basic Quote DRF serializer.
-
-    It does not include the content of a quote which is usually long.
-    """
-
-    created_on = serializers.DateTimeField(read_only=True)
     created_by = NestedAdviserField(read_only=True)
-    cancelled_on = serializers.DateTimeField(read_only=True)
     cancelled_by = NestedAdviserField(read_only=True)
-    accepted_on = serializers.DateTimeField(read_only=True)
     accepted_by = NestedRelatedField(Contact, read_only=True)
-    expires_on = serializers.DateTimeField(read_only=True)
 
     def preview(self):
         """Same as create but without saving the changes."""
@@ -60,19 +46,6 @@ class BasicQuoteSerializer(serializers.ModelSerializer):
             'accepted_on',
             'accepted_by',
             'expires_on',
-        ]
-
-
-class ExpandedQuoteSerializer(BasicQuoteSerializer):
-    """
-    Expanded Quote DRF serializer.
-
-    It includes the content of a quote which is usually long.
-    """
-
-    content = serializers.CharField(read_only=True)
-
-    class Meta(BasicQuoteSerializer.Meta):  # noqa: D101
-        fields = BasicQuoteSerializer.Meta.fields + [
             'content',
         ]
+        read_only_fields = fields

--- a/datahub/omis/quote/test/test_views.py
+++ b/datahub/omis/quote/test/test_views.py
@@ -224,8 +224,8 @@ class TestCreatePreviewOrder(APITestMixin):
 class TestGetQuote(APITestMixin):
     """Get quote test case."""
 
-    def test_get_basic(self):
-        """Test a successful call to get a basic quote (without `expand` param)."""
+    def test_get(self):
+        """Test a successful call to get a quote."""
         order = OrderWithOpenQuoteFactory()
         quote = order.quote
 
@@ -246,53 +246,7 @@ class TestGetQuote(APITestMixin):
             'accepted_on': None,
             'accepted_by': None,
             'expires_on': quote.expires_on.isoformat(),
-        }
-
-    def test_get_expanded(self):
-        """Test a successful call to get a quote and its content (with `expand` param)."""
-        order = OrderWithOpenQuoteFactory()
-        quote = order.quote
-
-        url = reverse('api-v3:omis:quote:item', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(
-            url,
-            {'expand': True},
-            format='json'
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {
-            'created_on': quote.created_on.isoformat(),
-            'created_by': {
-                'id': str(quote.created_by.pk),
-                'first_name': quote.created_by.first_name,
-                'last_name': quote.created_by.last_name,
-                'name': quote.created_by.name
-            },
             'content': quote.content,
-            'cancelled_on': None,
-            'cancelled_by': None,
-            'accepted_on': None,
-            'accepted_by': None,
-            'expires_on': quote.expires_on.isoformat(),
-        }
-
-    def test_400_with_invalid_expand_value(self):
-        """Test if `expand` is not a boolean value, 400 is returned."""
-        order = OrderWithOpenQuoteFactory()
-
-        url = reverse('api-v3:omis:quote:item', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(
-            url,
-            {'expand': 'invalid-value'},
-            format='json'
-        )
-
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == {
-            'expand': [
-                '"invalid-value" is not a valid boolean.'
-            ]
         }
 
     def test_404_if_order_doesnt_exist(self):
@@ -401,6 +355,7 @@ class TestCancelOrder(APITestMixin):
                 'accepted_on': None,
                 'accepted_by': None,
                 'expires_on': quote.expires_on.isoformat(),
+                'content': quote.content
             }
 
             quote.refresh_from_db()
@@ -438,6 +393,7 @@ class TestCancelOrder(APITestMixin):
                 'accepted_on': None,
                 'accepted_by': None,
                 'expires_on': quote.expires_on.isoformat(),
+                'content': quote.content
             }
 
             quote.refresh_from_db()

--- a/datahub/omis/quote/views.py
+++ b/datahub/omis/quote/views.py
@@ -8,7 +8,7 @@ from datahub.oauth.scopes import Scope
 from datahub.omis.order.models import Order
 
 from .models import Quote
-from .serializers import BasicQuoteSerializer, ExpandedQuoteSerializer, ExpandParamSerializer
+from .serializers import QuoteSerializer
 
 
 class QuoteViewSet(CoreViewSetV3):
@@ -16,8 +16,7 @@ class QuoteViewSet(CoreViewSetV3):
 
     required_scopes = (Scope.internal_front_end,)
     queryset = Quote.objects.none()
-    basic_serializer_class = BasicQuoteSerializer
-    expanded_serializer_class = ExpandedQuoteSerializer
+    serializer_class = QuoteSerializer
 
     order_lookup_url_kwarg = 'order_pk'
 
@@ -62,29 +61,6 @@ class QuoteViewSet(CoreViewSetV3):
         if not quote:
             raise Http404('The specified quote does not exist.')
         return quote
-
-    def _requires_expanded(self):
-        """
-        :returns: True if expanded response required, False otherwise
-
-        This can be implicit from the action or explicitly requested with the
-        `expand` query param.
-        """
-        if self.action in ('create', 'preview'):
-            return True
-
-        param_serializer = ExpandParamSerializer(data=self.request.GET)
-        param_serializer.is_valid(raise_exception=True)
-        return param_serializer.validated_data['expand']
-
-    def get_serializer_class(self):
-        """
-        :returns: different serializers depending on if the action requires an expanded response
-            or the `expand` param has been specified.
-        """
-        if self._requires_expanded():
-            return self.expanded_serializer_class
-        return self.basic_serializer_class
 
     def get_serializer_context(self):
         """Extra context provided to the serializer class."""


### PR DESCRIPTION
This removes the unnecessary logic behind the `expand` param to get the content of a quote.

The frontend does not use this feature for now and it's good to remove complexity especially as we need to add public facing API as well.

The quote endpoints will always return its content for now.