### PR TITLE
Add get/accept quote via public facing API

### DIFF
--- a/datahub/omis/order/manager.py
+++ b/datahub/omis/order/manager.py
@@ -1,0 +1,20 @@
+from django.db import models
+
+from .constants import OrderStatus
+
+
+class OrderQuerySet(models.QuerySet):
+    """Custom Order QuerySet."""
+
+    def publicly_accessible(self):
+        """
+        Only returns the orders that can be safely be accessible by the end client.
+        """
+        return self.filter(
+            status__in=(
+                OrderStatus.quote_awaiting_acceptance,
+                OrderStatus.quote_accepted,
+                OrderStatus.paid,
+                OrderStatus.complete,
+            )
+        )

--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -19,6 +19,7 @@ from datahub.omis.quote.models import Quote
 
 from . import validators
 from .constants import DEFAULT_HOURLY_RATE, OrderStatus, VATStatus
+from .manager import OrderQuerySet
 from .signals import quote_generated
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -209,6 +210,8 @@ class Order(BaseModel):
         help_text='Legacy field. Can DIT speak to the contacts?'
     )
 
+    objects = OrderQuerySet.as_manager()
+
     def __str__(self):
         """Human-readable representation"""
         return self.reference
@@ -307,7 +310,6 @@ class Order(BaseModel):
         for validator in [
             validators.OrderInStatusValidator(
                 allowed_statuses=(
-                    OrderStatus.draft,
                     OrderStatus.quote_awaiting_acceptance,
                     OrderStatus.quote_accepted,
                 )

--- a/datahub/omis/order/test/test_managers.py
+++ b/datahub/omis/order/test/test_managers.py
@@ -1,0 +1,33 @@
+import pytest
+
+from .factories import OrderFactory
+from ..constants import OrderStatus
+from ..models import Order
+
+
+pytestmark = pytest.mark.django_db
+
+
+class TestOrderManager:
+    """Tests for the Order Manager."""
+
+    def test_publicly_accessible(self):
+        """
+        Test that `publicly_accessible()` only returns the publicly accessible orders.
+        """
+        for order_status_choice in OrderStatus:
+            order_status = order_status_choice[0]
+            OrderFactory(
+                status=order_status,
+                reference=f'{order_status}'
+            )
+
+        publicly_accessible_qs = Order.objects.publicly_accessible()
+        publicly_accessible_refs = list(publicly_accessible_qs.values_list('reference', flat=True))
+
+        assert publicly_accessible_refs == [
+            OrderStatus.quote_awaiting_acceptance,
+            OrderStatus.quote_accepted,
+            OrderStatus.paid,
+            OrderStatus.complete,
+        ]

--- a/datahub/omis/order/test/views/test_public_order_details.py
+++ b/datahub/omis/order/test/views/test_public_order_details.py
@@ -90,8 +90,8 @@ class TestViewPublicOrderDetails(APITestMixin):
             },
         }
 
-    def test_not_found_with_invalid_public_token(self):
-        """Test 404 when getting a non-existent order."""
+    def test_404_with_invalid_public_token(self):
+        """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse(
             'api-v3:omis-public:order:detail',
             kwargs={'public_token': ('1234-abcd-' * 5)}  # len(token) == 50
@@ -108,8 +108,8 @@ class TestViewPublicOrderDetails(APITestMixin):
         'order_status',
         (OrderStatus.draft, OrderStatus.cancelled)
     )
-    def test_not_found_if_in_disallowed_status(self, order_status):
-        """Test 404 when the order is not in an allowed state."""
+    def test_404_if_in_disallowed_status(self, order_status):
+        """Test that if the order is not in an allowed state, the endpoint returns 404."""
         order = OrderFactory(status=order_status)
 
         url = reverse(
@@ -147,7 +147,7 @@ class TestViewPublicOrderDetails(APITestMixin):
         'scope',
         (s.value for s in Scope if s != Scope.public_omis_front_end.value)
     )
-    def test_other_scopes_not_allowed(self, scope):
+    def test_403_if_scope_not_allowed(self, scope):
         """Test that other oauth2 scopes are not allowed."""
         order = OrderFactory(
             quote=QuoteFactory(),

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -6,7 +6,6 @@ from rest_framework.views import APIView
 from datahub.core.viewsets import CoreViewSetV3
 from datahub.oauth.scopes import Scope
 
-from .constants import OrderStatus
 from .models import Order
 from .serializers import (
     OrderAssigneeSerializer,
@@ -35,14 +34,7 @@ class PublicOrderViewSet(CoreViewSetV3):
 
     required_scopes = (Scope.public_omis_front_end,)
     serializer_class = PublicOrderSerializer
-    queryset = Order.objects.filter(
-        status__in=(
-            OrderStatus.quote_awaiting_acceptance,
-            OrderStatus.quote_accepted,
-            OrderStatus.paid,
-            OrderStatus.complete,
-        )
-    ).select_related(
+    queryset = Order.objects.publicly_accessible().select_related(
         'company',
         'contact'
     )

--- a/datahub/omis/quote/serializers.py
+++ b/datahub/omis/quote/serializers.py
@@ -49,3 +49,26 @@ class QuoteSerializer(serializers.ModelSerializer):
             'content',
         ]
         read_only_fields = fields
+
+
+class PublicQuoteSerializer(serializers.ModelSerializer):
+    """Public Quote DRF serializer."""
+
+    def accept(self):
+        """Call `order.accept_quote` to accept this quote."""
+        order = self.context['order']
+
+        order.accept_quote(by=order.contact)  # assume that the contact accepted the quote
+        self.instance = order.quote
+        return self.instance
+
+    class Meta:  # noqa: D101
+        model = Quote
+        fields = [
+            'created_on',
+            'cancelled_on',
+            'accepted_on',
+            'expires_on',
+            'content',
+        ]
+        read_only_fields = fields

--- a/datahub/omis/quote/test/views/test_public_quote_details.py
+++ b/datahub/omis/quote/test/views/test_public_quote_details.py
@@ -1,0 +1,236 @@
+import pytest
+
+from django.utils.timezone import now
+from freezegun import freeze_time
+from oauth2_provider.models import Application
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.core.test_utils import APITestMixin
+from datahub.oauth.scopes import Scope
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.test.factories import OrderFactory, OrderWithOpenQuoteFactory
+
+from ..factories import QuoteFactory
+
+
+class TestPublicGetQuote(APITestMixin):
+    """Get public quote test case."""
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (
+            OrderStatus.quote_awaiting_acceptance,
+            OrderStatus.quote_accepted,
+            OrderStatus.paid,
+            OrderStatus.complete
+        )
+    )
+    def test_get(self, order_status):
+        """Test a successful call to get a quote."""
+        # in practice, accepted_on and cancelled_on will never be both set,
+        # they are here just to check the response body
+        order = OrderFactory(
+            quote=QuoteFactory(
+                accepted_on=now(),
+                cancelled_on=now(),
+            ),
+            status=order_status
+        )
+
+        url = reverse(
+            'api-v3:omis-public:quote:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url, format='json')
+
+        quote = order.quote
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'created_on': quote.created_on.isoformat(),
+            'cancelled_on': quote.cancelled_on.isoformat(),
+            'accepted_on': quote.accepted_on.isoformat(),
+            'expires_on': quote.expires_on.isoformat(),
+            'content': quote.content
+        }
+
+    def test_404_if_order_doesnt_exist(self):
+        """Test that if the order doesn't exist, the endpoint returns 404."""
+        url = reverse(
+            'api-v3:omis-public:quote:detail',
+            kwargs={'public_token': ('1234-abcd-' * 5)}  # len(token) == 50
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_if_quote_doesnt_exist(self):
+        """Test that if the quote doesn't exist, the endpoint returns 404."""
+        order = OrderFactory(status=OrderStatus.quote_awaiting_acceptance)
+        assert not order.quote
+
+        url = reverse(
+            'api-v3:omis-public:quote:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (OrderStatus.draft, OrderStatus.cancelled)
+    )
+    def test_404_if_in_disallowed_status(self, order_status):
+        """Test that if the order is not in an allowed state, the endpoint returns 404."""
+        order = OrderFactory(status=order_status)
+
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, verb):
+        """Test that makes sure the other verbs are not allowed."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=OrderStatus.quote_awaiting_acceptance
+        )
+
+        url = reverse(
+            'api-v3:omis-public:quote:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = getattr(client, verb)(url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    @pytest.mark.parametrize(
+        'scope',
+        (s.value for s in Scope if s != Scope.public_omis_front_end.value)
+    )
+    def test_403_if_scope_not_allowed(self, scope):
+        """Test that other oauth2 scopes are not allowed."""
+        order = OrderFactory(
+            quote=QuoteFactory(),
+            status=OrderStatus.quote_awaiting_acceptance
+        )
+
+        url = reverse(
+            'api-v3:omis-public:quote:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=scope,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestAcceptOrder(APITestMixin):
+    """Tests for accepting a quote."""
+
+    def test_404_if_order_doesnt_exist(self):
+        """Test that if the order doesn't exist, the endpoint returns 404."""
+        url = reverse(
+            'api-v3:omis-public:quote:accept',
+            kwargs={'public_token': ('1234-abcd-' * 5)}  # len(token) == 50
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.post(url, format='json')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        'disallowed_status',
+        (
+            OrderStatus.quote_accepted,
+            OrderStatus.paid,
+            OrderStatus.complete,
+        )
+    )
+    def test_409_if_order_in_disallowed_status(self, disallowed_status):
+        """
+        Test that if the order is not in one of the allowed statuses, the endpoint
+        returns 409.
+        """
+        quote = QuoteFactory()
+        order = OrderFactory(
+            status=disallowed_status,
+            quote=quote
+        )
+
+        url = reverse(
+            f'api-v3:omis-public:quote:accept',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.post(url, format='json')
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json() == {
+            'detail': (
+                'The action cannot be performed '
+                f'in the current status {OrderStatus[disallowed_status]}.'
+            )
+        }
+
+    def test_accept(self):
+        """Test that a quote can get accepted."""
+        order = OrderWithOpenQuoteFactory()
+        quote = order.quote
+
+        url = reverse(
+            f'api-v3:omis-public:quote:accept',
+            kwargs={'public_token': order.public_token}
+        )
+
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        with freeze_time('2017-07-12 13:00') as mocked_now:
+            response = client.post(url, format='json')
+
+            assert response.status_code == status.HTTP_200_OK
+            assert response.json() == {
+                'created_on': quote.created_on.isoformat(),
+                'accepted_on': mocked_now().isoformat(),
+                'cancelled_on': None,
+                'expires_on': quote.expires_on.isoformat(),
+                'content': quote.content
+            }
+
+            quote.refresh_from_db()
+            assert quote.is_accepted()
+            assert quote.accepted_on == mocked_now()

--- a/datahub/omis/quote/urls.py
+++ b/datahub/omis/quote/urls.py
@@ -1,16 +1,17 @@
 from django.conf.urls import url
 
-from .views import QuoteViewSet
+from .views import PublicQuoteViewSet, QuoteViewSet
 
 
-urlpatterns = [
+# internal frontend API
+internal_frontend_urls = [
     url(
         r'^order/(?P<order_pk>[0-9a-z-]{36})/quote$',
         QuoteViewSet.as_view({
             'post': 'create',
             'get': 'retrieve',
         }),
-        name='item'
+        name='detail'
     ),
     url(
         r'^order/(?P<order_pk>[0-9a-z-]{36})/quote/preview$',
@@ -21,5 +22,19 @@ urlpatterns = [
         r'^order/(?P<order_pk>[0-9a-z-]{36})/quote/cancel$',
         QuoteViewSet.as_view({'post': 'cancel'}),
         name='cancel'
+    ),
+]
+
+# public facing API
+public_urls = [
+    url(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/quote$',
+        PublicQuoteViewSet.as_view({'get': 'retrieve'}),
+        name='detail'
+    ),
+    url(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/quote/accept$',
+        PublicQuoteViewSet.as_view({'post': 'accept'}),
+        name='accept'
     ),
 ]

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -5,9 +5,10 @@ from .quote import urls as quote_urls
 
 internal_frontend_urls = [
     url(r'^', include((order_urls.internal_frontend_urls, 'order'), namespace='order')),
-    url(r'^', include((quote_urls, 'quote'), namespace='quote')),
+    url(r'^', include((quote_urls.internal_frontend_urls, 'quote'), namespace='quote')),
 ]
 
 public_urls = [
     url(r'^', include((order_urls.public_urls, 'order'), namespace='order')),
+    url(r'^', include((quote_urls.public_urls, 'quote'), namespace='quote')),
 ]


### PR DESCRIPTION
This adds two endpoints:
`GET /v3/order/public/<public_token>/quote` which returns details of a quote

`POST /v3/order/public/<public_token>/quote/accept` which accepts a quote

It also changes the way an order is reopened.

**Before**: you could reopen an order even if it was in draft already.

**After**: if the order is in draft and you try to reopen it a 409 is returned. 
This is to be consistent with all the other state change methods.