### PR TITLE
Fix test_publicly_accessible sorting

### DIFF
--- a/datahub/omis/order/test/test_managers.py
+++ b/datahub/omis/order/test/test_managers.py
@@ -23,11 +23,11 @@ class TestOrderManager:
             )
 
         publicly_accessible_qs = Order.objects.publicly_accessible()
-        publicly_accessible_refs = list(publicly_accessible_qs.values_list('reference', flat=True))
+        publicly_accessible_refs = set(publicly_accessible_qs.values_list('reference', flat=True))
 
-        assert publicly_accessible_refs == [
+        assert publicly_accessible_refs == {
             OrderStatus.quote_awaiting_acceptance,
             OrderStatus.quote_accepted,
             OrderStatus.paid,
             OrderStatus.complete,
-        ]
+        }


### PR DESCRIPTION
The `test_publicly_accessible` test was using comparing lists, it now uses sets.