### PR TITLE
OMIS - populate billing fields

### DIFF
--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -21,6 +21,7 @@ from . import validators
 from .constants import DEFAULT_HOURLY_RATE, OrderStatus, VATStatus
 from .manager import OrderQuerySet
 from .signals import quote_generated
+from .utils import populate_billing_data
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -290,6 +291,7 @@ class Order(BaseModel):
 
         self.quote = Quote.objects.create_from_order(order=self, by=by, commit=commit)
         self.status = OrderStatus.quote_awaiting_acceptance
+        populate_billing_data(self)
 
         if commit:
             self.save()

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -185,32 +185,10 @@ class OrderSerializer(serializers.ModelSerializer):
         return data
 
 
-class CompanyWithAddressSerializer(serializers.ModelSerializer):
-    """
-    Read-only DRF Serializer for Company with id, name an registered address.
-    """
-
-    registered_address_country = NestedRelatedField(Country)
-
-    class Meta:  # noqa: D101
-        model = Company
-        fields = (
-            'id',
-            'name',
-            'registered_address_1',
-            'registered_address_2',
-            'registered_address_county',
-            'registered_address_postcode',
-            'registered_address_town',
-            'registered_address_country',
-        )
-        read_only_fields = fields
-
-
 class PublicOrderSerializer(serializers.ModelSerializer):
     """DRF serializer for public facing API."""
 
-    company = CompanyWithAddressSerializer()
+    company = NestedRelatedField(Company)
     contact = NestedRelatedField(Contact)
     billing_address_country = NestedRelatedField(Country)
 

--- a/datahub/omis/order/test/test_utils.py
+++ b/datahub/omis/order/test/test_utils.py
@@ -1,0 +1,195 @@
+import factory
+import pytest
+
+from datahub.company.test.factories import (
+    CompaniesHouseCompanyFactory, CompanyFactory, ContactFactory
+)
+from datahub.core import constants
+
+from .factories import OrderFactory
+from ..utils import populate_billing_data
+
+pytestmark = pytest.mark.django_db
+
+
+class CompanyWithRegAddressFactory(CompanyFactory):
+    """Factory for a company with all registered address filled in."""
+
+    registered_address_1 = factory.Faker('text')
+    registered_address_2 = factory.Faker('text')
+    registered_address_town = factory.Faker('text')
+    registered_address_county = factory.Faker('text')
+    registered_address_postcode = factory.Faker('text')
+    registered_address_country_id = constants.Country.japan.value.id
+
+
+class CompaniesHouseWithRegAddressFactory(CompaniesHouseCompanyFactory):
+    """Factory for a companies house model with all registered address filled in."""
+
+    registered_address_1 = factory.Faker('text')
+    registered_address_2 = factory.Faker('text')
+    registered_address_town = factory.Faker('text')
+    registered_address_county = factory.Faker('text')
+    registered_address_postcode = factory.Faker('text')
+    registered_address_country_id = constants.Country.japan.value.id
+
+
+class OrderWithoutBillingDataFactory(OrderFactory):
+    """Factory for order without billing fields."""
+
+    billing_contact_name = ''
+    billing_email = ''
+    billing_phone = ''
+    billing_address_1 = ''
+    billing_address_2 = ''
+    billing_address_town = ''
+    billing_address_county = ''
+    billing_address_postcode = ''
+    billing_address_country = None
+
+
+class TestPopulateBillingData:
+    """Tests for the populate_billing_data logic."""
+
+    @pytest.mark.parametrize(
+        'CHFactory',  # noqa: N803
+        (
+            lambda: None,
+            CompaniesHouseWithRegAddressFactory
+        )
+    )
+    def test_with_empty_order(self, CHFactory):
+        """
+        Test that an order without any of the billing fields filled in is populated
+        with the company/contact details.
+
+        If the company is linked to a companies house record, the billing address
+        should be the companies house registered address.
+        Otherwise it should be the Data Hub company registered address.
+        """
+        contact = ContactFactory()
+        ch_company = CHFactory()
+        company = CompanyWithRegAddressFactory(
+            company_number=None if not ch_company else ch_company.company_number
+        )
+        order = OrderWithoutBillingDataFactory(
+            company=company,
+            contact=contact
+        )
+
+        populate_billing_data(order)
+
+        assert order.billing_contact_name == contact.name
+        assert order.billing_email == contact.email
+        assert order.billing_phone == contact.telephone_number
+
+        # if the company is linked to a companies house record, the billing address
+        # should be the CH registered address
+        # otherwise it should be the DH company registered address
+        expected_company = ch_company or company
+        assert order.billing_address_1 == expected_company.registered_address_1
+        assert order.billing_address_2 == expected_company.registered_address_2
+        assert order.billing_address_town == expected_company.registered_address_town
+        assert order.billing_address_county == expected_company.registered_address_county
+        assert order.billing_address_postcode == expected_company.registered_address_postcode
+        assert order.billing_address_country == expected_company.registered_address_country
+
+    def test_with_null_values(self):
+        """
+        Test that if a company has address fields with null values, they are translated into
+        empty strings when copied over.
+
+        This is because the Company model contains a bug that allows null values for CharFields.
+        """
+        company = CompanyFactory(
+            registered_address_2=None,
+            registered_address_county=None,
+            registered_address_postcode=None,
+            registered_address_country_id=None
+        )
+        order = OrderFactory(
+            company=company,
+            billing_address_2='',
+            billing_address_county='',
+            billing_address_postcode='',
+            billing_address_country=None
+        )
+
+        populate_billing_data(order)
+
+        assert order.billing_address_2 == ''
+        assert order.billing_address_county == ''
+        assert order.billing_address_postcode == ''
+        assert order.billing_address_country is None
+
+    @pytest.mark.parametrize(
+        'order_field,order_value',
+        (
+            ('billing_contact_name', 'Another John'),
+            ('billing_email', 'another-email@example.com'),
+            ('billing_phone', '99 001122'),
+        )
+    )
+    def test_with_already_populated_billing_detail(self, order_field, order_value):
+        """
+        Test that if the order has an order details field already populated,
+        it does not get overridden.
+        """
+        billing_details = {
+            'billing_contact_name': '',
+            'billing_email': '',
+            'billing_phone': '',
+        }
+
+        contact = ContactFactory()
+        order = OrderFactory(
+            contact=contact,
+            **{
+                **billing_details,
+                order_field: order_value
+            },
+        )
+
+        populate_billing_data(order)
+
+        assert getattr(order, order_field) == order_value
+        for populated_field in set(billing_details.keys()) - set(order_field):
+            assert getattr(order, populated_field)
+
+    @pytest.mark.parametrize(
+        'billing_address',
+        (
+            {
+                'billing_address_1': 'Populated address 1',
+                'billing_address_2': 'Populated address 2',
+                'billing_address_town': 'Populated address town',
+                'billing_address_county': 'Populated address county',
+                'billing_address_postcode': 'Populated address postcode',
+                'billing_address_country_id': constants.Country.italy.value.id
+            },
+            {
+                'billing_address_1': '',
+                'billing_address_2': '',
+                'billing_address_town': 'Populated address town',
+                'billing_address_county': '',
+                'billing_address_postcode': '',
+                'billing_address_country_id': constants.Country.italy.value.id
+            },
+        )
+    )
+    def test_with_already_populated_billing_address(self, billing_address):
+        """
+        Test that if the order has some billing address fields already populated,
+        none of the address fields get overridden.
+        """
+        company = CompanyWithRegAddressFactory()
+        order = OrderFactory(
+            company=company,
+            **billing_address
+        )
+
+        populate_billing_data(order)
+
+        # check that the fields didn't get overridden
+        for field in billing_address:
+            assert str(getattr(order, field)) == str(billing_address[field])

--- a/datahub/omis/order/test/views/test_public_order_details.py
+++ b/datahub/omis/order/test/views/test_public_order_details.py
@@ -54,15 +54,6 @@ class TestViewPublicOrderDetails(APITestMixin):
             'company': {
                 'id': str(order.company.pk),
                 'name': order.company.name,
-                'registered_address_1': order.company.registered_address_1,
-                'registered_address_2': order.company.registered_address_2,
-                'registered_address_county': order.company.registered_address_county,
-                'registered_address_postcode': order.company.registered_address_postcode,
-                'registered_address_town': order.company.registered_address_town,
-                'registered_address_country': {
-                    'id': str(order.company.registered_address_country.pk),
-                    'name': order.company.registered_address_country.name
-                },
             },
             'contact': {
                 'id': str(order.contact.pk),

--- a/datahub/omis/order/utils.py
+++ b/datahub/omis/order/utils.py
@@ -1,0 +1,51 @@
+def populate_billing_data(order):
+    """
+    Populate the order.billing_* fields from the company/contact if not set already.
+
+    :param order: Order to change if needed
+    :returns: order with billing_* fields filled in
+    """
+    contact = order.contact
+    # use CH address if it exists or fall back to DH company instead
+    company = order.company.companies_house_data or order.company
+
+    # get default and current order values of billing details
+    default_billing_details = {
+        'billing_contact_name': contact.name,
+        'billing_email': contact.email,
+        'billing_phone': contact.telephone_number,
+    }
+    order_billing_details = {
+        field_name: getattr(order, field_name)
+        for field_name in default_billing_details
+        if getattr(order, field_name)
+    }
+
+    # get default and current order values of billing address
+    default_billing_address = {
+        'billing_address_1': company.registered_address_1 or '',
+        'billing_address_2': company.registered_address_2 or '',
+        'billing_address_town': company.registered_address_town or '',
+        'billing_address_county': company.registered_address_county or '',
+        'billing_address_postcode': company.registered_address_postcode or '',
+        'billing_address_country': company.registered_address_country,
+    }
+    order_billing_address = {
+        field_name: getattr(order, field_name)
+        for field_name in default_billing_address
+    }
+
+    # compose the final data dict, default values are overridden
+    data = {
+        **default_billing_details,
+        **order_billing_details,
+        **(
+            order_billing_address
+            if any(order_billing_address.values())
+            else default_billing_address
+        )
+    }
+
+    # set order fields
+    for field_name, field_value in data.items():
+        setattr(order, field_name, field_value)


### PR DESCRIPTION
This populates all the billing details / address fields from company and contact when generating a quote.
If billing fields have been set by the user, the will not be overridden.

As the billing fields will always be present and populated, we don't need to return the company registered address any more so we can remove it from the public get order endpoint.