### PR TITLE
Add ability to filter orders by status

### DIFF
--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -17,6 +17,7 @@ class SearchOrderParams:
         'created_on_after',
         'assigned_to_adviser',
         'assigned_to_team',
+        'status',
     ]
 
     REMAP_FIELDS = {


### PR DESCRIPTION
This adds the ability to filter orders by `status` and refactors the tests to use `@pytest.mark.parametrize` instead of single test methods.