### PR TITLE
OMIS get invoice endpoints

### DIFF
--- a/datahub/omis/invoice/serializers.py
+++ b/datahub/omis/invoice/serializers.py
@@ -1,0 +1,45 @@
+from rest_framework import serializers
+
+from datahub.core.serializers import NestedRelatedField
+from datahub.metadata.models import Country
+
+from .models import Invoice
+
+
+class InvoiceSerializer(serializers.ModelSerializer):
+    """Invoice DRF serializer."""
+
+    invoice_address_country = NestedRelatedField(Country)
+
+    billing_contact_name = serializers.ReadOnlyField(source='order.billing_contact_name')
+    billing_address_1 = serializers.ReadOnlyField(source='order.billing_address_1')
+    billing_address_2 = serializers.ReadOnlyField(source='order.billing_address_2')
+    billing_address_county = serializers.ReadOnlyField(source='order.billing_address_county')
+    billing_address_postcode = serializers.ReadOnlyField(source='order.billing_address_postcode')
+    billing_address_town = serializers.ReadOnlyField(source='order.billing_address_town')
+    billing_address_country = NestedRelatedField(Country, source='order.billing_address_country')
+    po_number = serializers.ReadOnlyField(source='order.po_number')
+
+    class Meta:  # noqa: D101
+        model = Invoice
+        fields = (
+            'created_on',
+            'invoice_number',
+            'invoice_company_name',
+            'invoice_address_1',
+            'invoice_address_2',
+            'invoice_address_town',
+            'invoice_address_county',
+            'invoice_address_postcode',
+            'invoice_address_country',
+            'invoice_vat_number',
+            'billing_contact_name',
+            'billing_address_1',
+            'billing_address_2',
+            'billing_address_county',
+            'billing_address_postcode',
+            'billing_address_town',
+            'billing_address_country',
+            'po_number',
+        )
+        read_only_fields = fields

--- a/datahub/omis/invoice/test/views/test_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_invoice_details.py
@@ -1,0 +1,66 @@
+import uuid
+
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.core.test_utils import APITestMixin
+from datahub.omis.order.test.factories import OrderFactory, OrderWithAcceptedQuoteFactory
+
+
+class TestGetInvoice(APITestMixin):
+    """Get invoice test case."""
+
+    def test_get(self):
+        """Test a successful call to get a invoice."""
+        order = OrderWithAcceptedQuoteFactory()
+        invoice = order.invoice
+
+        url = reverse('api-v3:omis:invoice:detail', kwargs={'order_pk': order.pk})
+        response = self.api_client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'created_on': invoice.created_on.isoformat(),
+
+            'invoice_number': invoice.invoice_number,
+            'invoice_company_name': invoice.invoice_company_name,
+            'invoice_address_1': invoice.invoice_address_1,
+            'invoice_address_2': invoice.invoice_address_2,
+            'invoice_address_county': invoice.invoice_address_county,
+            'invoice_address_town': invoice.invoice_address_town,
+            'invoice_address_postcode': invoice.invoice_address_postcode,
+            'invoice_address_country': {
+                'id': str(invoice.invoice_address_country.pk),
+                'name': invoice.invoice_address_country.name
+            },
+            'invoice_vat_number': invoice.invoice_vat_number,
+
+            'billing_contact_name': order.billing_contact_name,
+            'billing_address_1': order.billing_address_1,
+            'billing_address_2': order.billing_address_2,
+            'billing_address_county': order.billing_address_county,
+            'billing_address_postcode': order.billing_address_postcode,
+            'billing_address_town': order.billing_address_town,
+            'billing_address_country': {
+                'id': str(order.billing_address_country.pk),
+                'name': order.billing_address_country.name
+            },
+            'po_number': order.po_number,
+        }
+
+    def test_404_if_order_doesnt_exist(self):
+        """Test that if the order doesn't exist, the endpoint returns 404."""
+        url = reverse('api-v3:omis:invoice:detail', kwargs={'order_pk': uuid.uuid4()})
+        response = self.api_client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_if_invoice_doesnt_exist(self):
+        """Test that if the invoice doesn't exist, the endpoint returns 404."""
+        order = OrderFactory()
+        assert not order.invoice
+
+        url = reverse('api-v3:omis:invoice:detail', kwargs={'order_pk': order.pk})
+        response = self.api_client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/datahub/omis/invoice/test/views/test_public_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_public_invoice_details.py
@@ -1,0 +1,161 @@
+import pytest
+
+from oauth2_provider.models import Application
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.core.test_utils import APITestMixin
+from datahub.oauth.scopes import Scope
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.test.factories import OrderFactory, OrderWithAcceptedQuoteFactory
+
+from ..factories import InvoiceFactory
+
+
+class TestPublicGetInvoice(APITestMixin):
+    """Get public invoice test case."""
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (
+            OrderStatus.quote_accepted,
+            OrderStatus.paid,
+            OrderStatus.complete
+        )
+    )
+    def test_get(self, order_status):
+        """Test a successful call to get a invoice."""
+        order = OrderFactory(
+            invoice=InvoiceFactory(),
+            status=order_status
+        )
+
+        url = reverse(
+            'api-v3:omis-public:invoice:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url, format='json')
+
+        invoice = order.invoice
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'created_on': invoice.created_on.isoformat(),
+
+            'invoice_number': invoice.invoice_number,
+            'invoice_company_name': invoice.invoice_company_name,
+            'invoice_address_1': invoice.invoice_address_1,
+            'invoice_address_2': invoice.invoice_address_2,
+            'invoice_address_county': invoice.invoice_address_county,
+            'invoice_address_town': invoice.invoice_address_town,
+            'invoice_address_postcode': invoice.invoice_address_postcode,
+            'invoice_address_country': {
+                'id': str(invoice.invoice_address_country.pk),
+                'name': invoice.invoice_address_country.name
+            },
+            'invoice_vat_number': invoice.invoice_vat_number,
+
+            'billing_contact_name': order.billing_contact_name,
+            'billing_address_1': order.billing_address_1,
+            'billing_address_2': order.billing_address_2,
+            'billing_address_county': order.billing_address_county,
+            'billing_address_postcode': order.billing_address_postcode,
+            'billing_address_town': order.billing_address_town,
+            'billing_address_country': {
+                'id': str(order.billing_address_country.pk),
+                'name': order.billing_address_country.name
+            },
+            'po_number': order.po_number,
+        }
+
+    def test_404_if_order_doesnt_exist(self):
+        """Test that if the order doesn't exist, the endpoint returns 404."""
+        url = reverse(
+            'api-v3:omis-public:invoice:detail',
+            kwargs={'public_token': ('1234-abcd-' * 5)}  # len(token) == 50
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_404_if_invoice_doesnt_exist(self):
+        """Test that if the invoice doesn't exist, the endpoint returns 404."""
+        order = OrderFactory(status=OrderStatus.quote_accepted)
+        assert not order.invoice
+
+        url = reverse(
+            'api-v3:omis-public:invoice:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize(
+        'order_status',
+        (OrderStatus.draft, OrderStatus.quote_awaiting_acceptance, OrderStatus.cancelled)
+    )
+    def test_404_if_in_disallowed_status(self, order_status):
+        """Test that if the order is not in an allowed state, the endpoint returns 404."""
+        order = OrderFactory(
+            status=order_status,
+            invoice=InvoiceFactory()
+        )
+
+        url = reverse(
+            'api-v3:omis-public:invoice:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
+    def test_verbs_not_allowed(self, verb):
+        """Test that makes sure the other verbs are not allowed."""
+        order = OrderWithAcceptedQuoteFactory()
+
+        url = reverse(
+            'api-v3:omis-public:invoice:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = getattr(client, verb)(url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    @pytest.mark.parametrize(
+        'scope',
+        (s.value for s in Scope if s != Scope.public_omis_front_end.value)
+    )
+    def test_403_if_scope_not_allowed(self, scope):
+        """Test that other oauth2 scopes are not allowed."""
+        order = OrderWithAcceptedQuoteFactory()
+
+        url = reverse(
+            'api-v3:omis-public:invoice:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=scope,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/omis/invoice/urls.py
+++ b/datahub/omis/invoice/urls.py
@@ -1,0 +1,22 @@
+from django.conf.urls import url
+
+from .views import InvoiceViewSet, PublicInvoiceViewSet
+
+
+# internal frontend API
+internal_frontend_urls = [
+    url(
+        r'^order/(?P<order_pk>[0-9a-z-]{36})/invoice$',
+        InvoiceViewSet.as_view({'get': 'retrieve'}),
+        name='detail'
+    ),
+]
+
+# public facing API
+public_urls = [
+    url(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/invoice$',
+        PublicInvoiceViewSet.as_view({'get': 'retrieve'}),
+        name='detail'
+    ),
+]

--- a/datahub/omis/invoice/views.py
+++ b/datahub/omis/invoice/views.py
@@ -1,0 +1,45 @@
+from django.http import Http404
+
+from datahub.oauth.scopes import Scope
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.models import Order
+from datahub.omis.order.views import BaseNestedOrderViewSet
+
+from .models import Invoice
+from .serializers import InvoiceSerializer
+
+
+class BaseInvoiceViewSet(BaseNestedOrderViewSet):
+    """Base Invoice ViewSet."""
+
+    queryset = Invoice.objects.none()
+    serializer_class = InvoiceSerializer
+
+    def get_object(self):
+        """
+        :returns: the invoice related to the order.
+
+        :raises Http404: if the invoice doesn't exist
+        """
+        invoice = self.get_order().invoice
+        if not invoice:
+            raise Http404('The specified invoice does not exist.')
+        return invoice
+
+
+class InvoiceViewSet(BaseInvoiceViewSet):
+    """Invoice ViewSet."""
+
+    required_scopes = (Scope.internal_front_end,)
+
+
+class PublicInvoiceViewSet(BaseInvoiceViewSet):
+    """ViewSet for public facing API."""
+
+    required_scopes = (Scope.public_omis_front_end,)
+
+    order_lookup_field = 'public_token'
+    order_lookup_url_kwarg = 'public_token'
+    order_queryset = Order.objects.publicly_accessible().exclude(
+        status=OrderStatus.quote_awaiting_acceptance
+    )

--- a/datahub/omis/quote/views.py
+++ b/datahub/omis/quote/views.py
@@ -3,37 +3,18 @@ from django.http import Http404
 from rest_framework import status
 from rest_framework.response import Response
 
-from datahub.core.viewsets import CoreViewSetV3
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.models import Order
+from datahub.omis.order.views import BaseNestedOrderViewSet
 
 from .models import Quote
 from .serializers import PublicQuoteSerializer, QuoteSerializer
 
 
-class BaseQuoteViewSet(CoreViewSetV3):
+class BaseQuoteViewSet(BaseNestedOrderViewSet):
     """Quote ViewSet."""
 
     queryset = Quote.objects.none()
-    serializer_class = None
-
-    order_lookup_field = 'pk'
-    order_lookup_url_kwarg = 'order_pk'
-    order_queryset = Order.objects
-
-    def get_order(self):
-        """
-        :returns: the main order from url kwargs.
-
-        :raises Http404: if the order doesn't exist
-        """
-        try:
-            order = self.order_queryset.get(
-                **{self.order_lookup_field: self.kwargs[self.order_lookup_url_kwarg]}
-            )
-        except Order.DoesNotExist:
-            raise Http404('The specified order does not exist.')
-        return order
 
     def get_object(self):
         """
@@ -45,14 +26,6 @@ class BaseQuoteViewSet(CoreViewSetV3):
         if not quote:
             raise Http404('The specified quote does not exist.')
         return quote
-
-    def get_serializer_context(self):
-        """Extra context provided to the serializer class."""
-        return {
-            **super().get_serializer_context(),
-            'order': self.get_order(),
-            'current_user': self.request.user,
-        }
 
 
 class QuoteViewSet(BaseQuoteViewSet):

--- a/datahub/omis/quote/views.py
+++ b/datahub/omis/quote/views.py
@@ -12,7 +12,7 @@ from .serializers import PublicQuoteSerializer, QuoteSerializer
 
 
 class BaseQuoteViewSet(BaseNestedOrderViewSet):
-    """Quote ViewSet."""
+    """Base Quote ViewSet."""
 
     queryset = Quote.objects.none()
 

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -1,14 +1,17 @@
 from django.conf.urls import include, url
 
+from .invoice import urls as invoice_urls
 from .order import urls as order_urls
 from .quote import urls as quote_urls
 
 internal_frontend_urls = [
     url(r'^', include((order_urls.internal_frontend_urls, 'order'), namespace='order')),
     url(r'^', include((quote_urls.internal_frontend_urls, 'quote'), namespace='quote')),
+    url(r'^', include((invoice_urls.internal_frontend_urls, 'invoice'), namespace='invoice')),
 ]
 
 public_urls = [
     url(r'^', include((order_urls.public_urls, 'order'), namespace='order')),
     url(r'^', include((quote_urls.public_urls, 'quote'), namespace='quote')),
+    url(r'^', include((invoice_urls.public_urls, 'invoice'), namespace='invoice')),
 ]


### PR DESCRIPTION
This adds two readonly endpoints:
- `/v3/order/<order-id>/invoice` for the internal frontend
- `/v3/order/<public-token>/invoice` for the public OMIS app
