### PR TITLE
Fix non-random invoice number in tests

### DIFF
--- a/datahub/omis/invoice/test/factories.py
+++ b/datahub/omis/invoice/test/factories.py
@@ -8,7 +8,7 @@ class InvoiceFactory(factory.django.DjangoModelFactory):
     """Invoice factory."""
 
     id = factory.LazyFunction(uuid.uuid4)
-    invoice_number = factory.Faker('text', max_nb_chars=10)
+    invoice_number = factory.Faker('pystr')
     invoice_company_name = constants.DIT_COMPANY_NAME
     invoice_address_1 = constants.DIT_ADDRESS_1
     invoice_address_2 = constants.DIT_ADDRESS_2


### PR DESCRIPTION
`Faker('text')` does not generate random values and this was causing some tests to fail because of unique constraints.
Switched to using ~`get_random_string`~ `Faker('pystr')` instead. 