### PR TITLE
Return reopened orders in public OMIS API

### DIFF
--- a/datahub/omis/order/test/test_managers.py
+++ b/datahub/omis/order/test/test_managers.py
@@ -1,5 +1,7 @@
 import pytest
 
+from datahub.omis.quote.test.factories import CancelledQuoteFactory
+
 from .factories import OrderFactory
 from ..constants import OrderStatus
 from ..models import Order
@@ -11,23 +13,39 @@ pytestmark = pytest.mark.django_db
 class TestOrderManager:
     """Tests for the Order Manager."""
 
-    def test_publicly_accessible(self):
+    @pytest.mark.parametrize(
+        'include_reopened', (False, True)
+    )
+    def test_publicly_accessible(self, include_reopened):
         """
         Test that `publicly_accessible()` only returns the publicly accessible orders.
         """
+        # set up db
         for order_status_choice in OrderStatus:
             order_status = order_status_choice[0]
             OrderFactory(
                 status=order_status,
                 reference=f'{order_status}'
             )
+        OrderFactory(
+            status=OrderStatus.draft,
+            quote=CancelledQuoteFactory(),
+            reference='draft_with_cancelled_quote'
+        )
 
-        publicly_accessible_qs = Order.objects.publicly_accessible()
-        publicly_accessible_refs = set(publicly_accessible_qs.values_list('reference', flat=True))
-
-        assert publicly_accessible_refs == {
+        # define expectation
+        expected_orders = {
             OrderStatus.quote_awaiting_acceptance,
             OrderStatus.quote_accepted,
             OrderStatus.paid,
             OrderStatus.complete,
         }
+        if include_reopened:
+            expected_orders.add('draft_with_cancelled_quote')
+
+        # get result
+        publicly_accessible_qs = Order.objects.publicly_accessible(
+            include_reopened=include_reopened
+        )
+        publicly_accessible_refs = set(publicly_accessible_qs.values_list('reference', flat=True))
+        assert publicly_accessible_refs == expected_orders

--- a/datahub/omis/order/test/views/test_public_order_details.py
+++ b/datahub/omis/order/test/views/test_public_order_details.py
@@ -8,7 +8,7 @@ from datahub.core.test_utils import APITestMixin
 from datahub.oauth.scopes import Scope
 from datahub.omis.quote.test.factories import QuoteFactory
 
-from ..factories import OrderFactory
+from ..factories import OrderFactory, OrderWithCancelledQuoteFactory
 from ...constants import OrderStatus
 
 
@@ -80,6 +80,22 @@ class TestViewPublicOrderDetails(APITestMixin):
                 'name': order.billing_address_country.name
             },
         }
+
+    def test_get_draft_with_cancelled_quote(self):
+        """Test getting an order in draft with a cancelled quote is allowed."""
+        order = OrderWithCancelledQuoteFactory()
+
+        url = reverse(
+            'api-v3:omis-public:order:detail',
+            kwargs={'public_token': order.public_token}
+        )
+        client = self.create_api_client(
+            scope=Scope.public_omis_front_end,
+            grant_type=Application.GRANT_CLIENT_CREDENTIALS
+        )
+        response = client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
 
     def test_404_with_invalid_public_token(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -34,7 +34,9 @@ class PublicOrderViewSet(CoreViewSetV3):
 
     required_scopes = (Scope.public_omis_front_end,)
     serializer_class = PublicOrderSerializer
-    queryset = Order.objects.publicly_accessible().select_related(
+    queryset = Order.objects.publicly_accessible(
+        include_reopened=True
+    ).select_related(
         'company',
         'contact'
     )

--- a/datahub/omis/quote/views.py
+++ b/datahub/omis/quote/views.py
@@ -60,7 +60,7 @@ class PublicQuoteViewSet(BaseQuoteViewSet):
 
     order_lookup_field = 'public_token'
     order_lookup_url_kwarg = 'public_token'
-    order_queryset = Order.objects.publicly_accessible()
+    order_queryset = Order.objects.publicly_accessible(include_reopened=True)
 
     def accept(self, request, *args, **kwargs):
         """Accept a quote."""


### PR DESCRIPTION
When an adviser reopens an order, the status changes back from _'Quote Awaiting Acceptance'_ to _'Draft'_ and the related quote cancelled.

In the meantime, the client might have received a notification asking to accept the quote.
Instead of returning a 404 as the order is in draft, we allow the API to return the order and the cancelled quote.
This way, the frontend can show that the order can't be progressed as the related quote got cancelled and they are working on a new version.