### PR TITLE
Update notify template variables

### DIFF
--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -70,6 +70,7 @@ class Notify:
             'order ref': order.reference,
             'company name': order.company.name,
             'embedded link': order.get_datahub_frontend_url(),
+            'primary market': order.primary_market.name,
             **(data or {})
         }
 


### PR DESCRIPTION
The template for the notification sent when a quote is awaiting acceptance now requires a new variable `primary market`.