### PR TITLE
Update interaction validation

### DIFF
--- a/datahub/core/test/test_validate_utils.py
+++ b/datahub/core/test/test_validate_utils.py
@@ -61,16 +61,20 @@ def test_validation_condition(data, field, op, args, res):
     assert condition(combiner) == res
 
 
-@pytest.mark.parametrize('data,field,op,condition,res', (
-    ({'colour': 'red', 'valid': True}, 'valid', bool, lambda x: True, True),
-    ({'colour': 'red', 'valid': False}, 'valid', bool, lambda x: True, False),
-    ({'colour': 'red', 'valid': True}, 'valid', bool, lambda x: False, True),
-    ({'colour': 'red', 'valid': False}, 'valid', bool, lambda x: False, True),
+@pytest.mark.parametrize('data,field,op,extra_args,condition,res', (
+    ({'colour': 'red', 'valid': True}, 'valid', bool, (), lambda x: True, True),
+    ({'colour': 'red', 'valid': False}, 'valid', bool, (), lambda x: True, False),
+    ({'colour': 'red', 'valid': True}, 'valid', bool, (), lambda x: False, True),
+    ({'colour': 'red', 'valid': False}, 'valid', bool, (), lambda x: False, True),
+    ({'colour': 'red', 'valid': False}, 'colour', eq, ('red',), lambda x: True, True),
+    ({'colour': 'red', 'valid': False}, 'colour', eq, ('blue',), lambda x: True, False),
 ))
-def test_validation_rule(data, field, op, condition, res):
+def test_validation_rule(data, field, op, extra_args, condition, res):
     """Tests ValidationRule for various cases."""
     combiner = Mock(spec_set=DataCombiner, get_value=lambda field_: data[field_])
-    rule = ValidationRule('error_key', field, op, condition=condition)
+    rule = ValidationRule(
+        'error_key', field, op, operator_extra_args=extra_args, condition=condition
+    )
     assert rule(combiner) == res
 
 

--- a/datahub/core/test/test_validate_utils.py
+++ b/datahub/core/test/test_validate_utils.py
@@ -1,3 +1,4 @@
+from operator import eq
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock
 
@@ -5,7 +6,8 @@ import pytest
 from rest_framework.exceptions import ValidationError
 
 from datahub.core.validate_utils import (
-    AnyOfValidator, DataCombiner, is_blank, RequiredUnlessAlreadyBlank
+    AnyOfValidator, DataCombiner, is_blank, RequiredUnlessAlreadyBlank, ValidationCondition,
+    ValidationRule
 )
 
 
@@ -46,6 +48,30 @@ def test_any_of_all():
 def test_is_blank(value, blank):
     """Tests is_blank() for various values."""
     assert is_blank(value) == blank
+
+
+@pytest.mark.parametrize('data,field,op,args,res', (
+    ({'colour': 'red'}, 'colour', eq, ('red',), True),
+    ({'colour': 'red'}, 'colour', eq, ('blue',), False),
+))
+def test_validation_condition(data, field, op, args, res):
+    """Tests ValidationCondition for various cases."""
+    combiner = Mock(spec_set=DataCombiner, get_value=lambda field_: data[field_])
+    condition = ValidationCondition(field, op, args)
+    assert condition(combiner) == res
+
+
+@pytest.mark.parametrize('data,field,op,condition,res', (
+    ({'colour': 'red', 'valid': True}, 'valid', bool, lambda x: True, True),
+    ({'colour': 'red', 'valid': False}, 'valid', bool, lambda x: True, False),
+    ({'colour': 'red', 'valid': True}, 'valid', bool, lambda x: False, True),
+    ({'colour': 'red', 'valid': False}, 'valid', bool, lambda x: False, True),
+))
+def test_validation_rule(data, field, op, condition, res):
+    """Tests ValidationRule for various cases."""
+    combiner = Mock(spec_set=DataCombiner, get_value=lambda field_: data[field_])
+    rule = ValidationRule('error_key', field, op, condition=condition)
+    assert rule(combiner) == res
 
 
 class TestDataCombiner:

--- a/datahub/core/validate_utils.py
+++ b/datahub/core/validate_utils.py
@@ -155,7 +155,7 @@ class ValidationRule:
         return (
             f'{self.__class__.__name__}({self.error_key!r}, {self.rule.field!r}, '
             f'{self.rule.operator!r}, operator_extra_args={self.rule.operator_extra_args!r}, '
-            f'condition={self.rule.condition!r})'
+            f'condition={self.condition!r})'
         )
 
 

--- a/datahub/core/validate_utils.py
+++ b/datahub/core/validate_utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from typing import Callable, NamedTuple, Sequence
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -103,6 +103,41 @@ class RequiredUnlessAlreadyBlank:
     def __repr__(self):
         """Returns the string representation of this object."""
         return f'{self.__class__.__name__}(*{self.fields!r})'
+
+
+class ValidationCondition(NamedTuple):
+    """Validation condition."""
+
+    field: str
+    operator: Callable
+    operator_extra_args: Sequence = ()
+
+    def __call__(self, combiner):
+        """Test whether the condition is True or False."""
+        value = combiner.get_value(self.field)
+        return self.operator(value, *self.operator_extra_args)
+
+
+class ValidationRule:
+    """Validation rule."""
+
+    def __init__(self,
+                 error_key: str,
+                 field: str,
+                 operator_: Callable,
+                 operator_extra_args: Sequence = (),
+                 condition: ValidationCondition = None):
+        """Initialises a validation rule."""
+        self.error_key = error_key
+        self.condition = condition
+        self.rule = ValidationCondition(field, operator_, operator_extra_args)
+
+    def __call__(self, combiner):
+        """Test whether the rule passes or fails."""
+        if self.condition and not self.condition(combiner):
+            return True
+
+        return self.rule(combiner)
 
 
 class DataCombiner:

--- a/datahub/core/validate_utils.py
+++ b/datahub/core/validate_utils.py
@@ -127,7 +127,18 @@ class ValidationRule:
                  operator_: Callable,
                  operator_extra_args: Sequence = (),
                  condition: Condition = None):
-        """Initialises a validation rule."""
+        """
+        Initialises a validation rule.
+
+        :param error_key: The key of the error message associated with this rule.
+        :param field:     The name of the field the rule applies to.
+        :param operator_: Callable that returns a truthy or falsey value (indicating whether the
+                          value is valid). Will be called with the field value as the first
+                          argument.
+        :param operator_extra_args: Extra arguments to pass to operator_.
+        :param condition: Optional conditional rule to check before applying this rule.
+                          If the condition evaluates to False, validation passes.
+        """
         self.error_key = error_key
         self.condition = condition
         self.rule = Condition(field, operator_, operator_extra_args)

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -1,9 +1,14 @@
+from operator import eq, not_
+
+from django.utils.translation import ugettext_lazy
 from rest_framework import serializers
 
 from datahub.company.models import Company, Contact
 from datahub.company.serializers import AdviserSerializer, NestedAdviserField
 from datahub.core.serializers import NestedRelatedField
-from datahub.core.validate_utils import AnyOfValidator, DataCombiner, RequiredUnlessAlreadyBlank
+from datahub.core.validate_utils import (
+    AnyOfValidator, DataCombiner, RequiredUnlessAlreadyBlank, ValidationCondition, ValidationRule
+)
 from datahub.event.models import Event
 from datahub.investment.models import InvestmentProject
 from datahub.metadata.models import Service, Team
@@ -37,8 +42,33 @@ class InteractionSerializerWriteV1(serializers.ModelSerializer):
         ]
 
 
+VALIDATION_RULES = (
+    ValidationRule(
+        'required', 'communication_channel', bool,
+        condition=ValidationCondition('kind', eq, (Interaction.KINDS.interaction,))
+    ),
+    ValidationRule(
+        'invalid_for_service_delivery', 'communication_channel', not_,
+        condition=ValidationCondition('kind', eq, (Interaction.KINDS.service_delivery,))
+    ),
+    ValidationRule(
+        'invalid_for_interaction', 'event', not_,
+        condition=ValidationCondition('kind', eq, (Interaction.KINDS.interaction,))
+    ),
+)
+
+
 class InteractionSerializerV3(serializers.ModelSerializer):
     """V3 interaction serialiser."""
+
+    default_error_messages = {
+        'invalid_for_interaction': ugettext_lazy(
+            'This field cannot be specified for an interaction.'
+        ),
+        'invalid_for_service_delivery': ugettext_lazy(
+            'This field cannot be specified for a service delivery.'
+        ),
+    }
 
     company = NestedRelatedField(Company, required=False, allow_null=True)
     contact = NestedRelatedField(Contact, required=False, allow_null=True)
@@ -68,14 +98,15 @@ class InteractionSerializerV3(serializers.ModelSerializer):
 
         Called by DRF.
         """
+        errors = {}
         combiner = DataCombiner(instance=self.instance, update_data=data)
-        is_interaction = combiner.get_value('kind') == Interaction.KINDS.interaction
 
-        if is_interaction and not combiner.get_value('communication_channel'):
-            raise serializers.ValidationError({
-                'communication_channel': self.error_messages['required']
-            })
+        for rule in VALIDATION_RULES:
+            if not rule(combiner):
+                errors[rule.rule.field] = self.error_messages[rule.error_key]
 
+        if errors:
+            raise serializers.ValidationError(errors)
         return data
 
     class Meta:  # noqa: D101

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -55,7 +55,7 @@ class InteractionSerializerV3(serializers.ModelSerializer):
     }
 
     company = NestedRelatedField(Company, required=False, allow_null=True)
-    contact = NestedRelatedField(Contact, required=False, allow_null=True)
+    contact = NestedRelatedField(Contact)
     dit_adviser = NestedAdviserField()
     created_by = NestedAdviserField(read_only=True)
     dit_team = NestedRelatedField(Team)

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -26,9 +26,9 @@ class InteractionFactory(factory.django.DjangoModelFactory):
     modified_by = factory.SubFactory(AdviserFactory)
     company = factory.SubFactory(CompanyFactory)
     contact = factory.SubFactory(ContactFactory)
-    subject = 'foo'
+    subject = factory.Faker('sentence', nb_words=8)
     date = now()
-    notes = 'Bar'
+    notes = factory.Faker('paragraph', nb_sentences=10)
     dit_adviser = factory.SubFactory(AdviserFactory)
     service_id = constants.Service.trade_enquiry.value.id
     dit_team_id = constants.Team.healthcare_uk.value.id
@@ -48,9 +48,9 @@ class ServiceDeliveryFactory(factory.django.DjangoModelFactory):
     company = factory.SubFactory(CompanyFactory)
     contact = factory.SubFactory(ContactFactory)
     event = factory.SubFactory(EventFactory)
-    subject = 'foo'
+    subject = factory.Faker('sentence', nb_words=8)
     date = now()
-    notes = 'Bar'
+    notes = factory.Faker('paragraph', nb_sentences=10)
     dit_adviser = factory.SubFactory(AdviserFactory)
     service_id = constants.Service.trade_enquiry.value.id
     dit_team_id = constants.Team.healthcare_uk.value.id

--- a/datahub/interaction/test/test_interaction_views_v3.py
+++ b/datahub/interaction/test/test_interaction_views_v3.py
@@ -291,6 +291,58 @@ class TestInteractionV3(APITestMixin):
             'communication_channel': ['This field is required.'],
         }
 
+    def test_add_interaction_with_service_delivery_fields(self):
+        """Tests that adding an interaction with an event fails."""
+        adviser = AdviserFactory()
+        company = CompanyFactory()
+        contact = ContactFactory()
+        url = reverse('api-v3:interaction:collection')
+        request_data = {
+            'kind': 'interaction',
+            'communication_channel': InteractionType.face_to_face.value.id,
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_adviser': adviser.pk,
+            'notes': 'hello',
+            'company': company.pk,
+            'contact': contact.pk,
+            'service': Service.trade_enquiry.value.id,
+            'dit_team': Team.healthcare_uk.value.id,
+            'event': EventFactory().pk
+        }
+        response = self.api_client.post(url, request_data, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data == {
+            'event': ['This field cannot be specified for an interaction.'],
+        }
+
+    def test_add_service_delivery_with_interaction_fields(self):
+        """Tests that adding a service delivery with a communication channel fails."""
+        adviser = AdviserFactory()
+        company = CompanyFactory()
+        contact = ContactFactory()
+        url = reverse('api-v3:interaction:collection')
+        request_data = {
+            'kind': 'service_delivery',
+            'communication_channel': InteractionType.face_to_face.value.id,
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_adviser': adviser.pk,
+            'notes': 'hello',
+            'company': company.pk,
+            'contact': contact.pk,
+            'service': Service.trade_enquiry.value.id,
+            'dit_team': Team.healthcare_uk.value.id,
+            'event': EventFactory().pk
+        }
+        response = self.api_client.post(url, request_data, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data == {
+            'communication_channel': ['This field cannot be specified for a service delivery.'],
+        }
+
     @freeze_time('2017-04-18 13:25:30.986208+00:00')
     def test_add_interaction_project(self):
         """Test add new interaction for an investment project."""

--- a/datahub/interaction/test/test_interaction_views_v3.py
+++ b/datahub/interaction/test/test_interaction_views_v3.py
@@ -101,8 +101,8 @@ class TestInteractionV3(APITestMixin):
         }
 
     @freeze_time('2017-04-18 13:25:30.986208+00:00')
-    def test_add_service_delivery(self):
-        """Test add new service delivery."""
+    def test_add_service_delivery_with_event(self):
+        """Test add new service delivery with an event."""
         adviser = AdviserFactory()
         company = CompanyFactory()
         contact = ContactFactory()
@@ -150,6 +150,76 @@ class TestInteractionV3(APITestMixin):
                 'id': str(event.pk),
                 'name': event.name,
             },
+            'service': {
+                'id': str(Service.trade_enquiry.value.id),
+                'name': Service.trade_enquiry.value.name,
+            },
+            'dit_team': {
+                'id': str(Team.healthcare_uk.value.id),
+                'name': Team.healthcare_uk.value.name,
+            },
+            'investment_project': None,
+            'created_by': {
+                'id': str(self.user.pk),
+                'first_name': self.user.first_name,
+                'last_name': self.user.last_name,
+                'name': self.user.name
+            },
+            'modified_by': {
+                'id': str(self.user.pk),
+                'first_name': self.user.first_name,
+                'last_name': self.user.last_name,
+                'name': self.user.name
+            },
+            'created_on': '2017-04-18T13:25:30.986208',
+            'modified_on': '2017-04-18T13:25:30.986208'
+        }
+
+    @freeze_time('2017-04-18 13:25:30.986208+00:00')
+    def test_add_service_delivery_without_event(self):
+        """Test add new service delivery without an event."""
+        adviser = AdviserFactory()
+        company = CompanyFactory()
+        contact = ContactFactory()
+        url = reverse('api-v3:interaction:collection')
+        request_data = {
+            'kind': 'service_delivery',
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_adviser': adviser.pk,
+            'notes': 'hello',
+            'company': company.pk,
+            'contact': contact.pk,
+            'service': Service.trade_enquiry.value.id,
+            'dit_team': Team.healthcare_uk.value.id
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_201_CREATED
+        response_data = response.json()
+        assert response_data == {
+            'id': response_data['id'],
+            'kind': 'service_delivery',
+            'communication_channel': None,
+            'interaction_type': None,
+            'subject': 'whatever',
+            'date': '2017-04-18',
+            'dit_adviser': {
+                'id': str(adviser.pk),
+                'first_name': adviser.first_name,
+                'last_name': adviser.last_name,
+                'name': adviser.name
+            },
+            'notes': 'hello',
+            'company': {
+                'id': str(company.pk),
+                'name': company.name
+            },
+            'contact': {
+                'id': str(contact.pk),
+                'name': contact.name
+            },
+            'event': None,
             'service': {
                 'id': str(Service.trade_enquiry.value.id),
                 'name': Service.trade_enquiry.value.name,

--- a/datahub/interaction/test/test_interaction_views_v3.py
+++ b/datahub/interaction/test/test_interaction_views_v3.py
@@ -329,6 +329,7 @@ class TestInteractionV3(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
+            'contact': ['This field is required.'],
             'date': ['This field is required.'],
             'dit_adviser': ['This field is required.'],
             'dit_team': ['This field is required.'],
@@ -418,9 +419,11 @@ class TestInteractionV3(APITestMixin):
         """Test add new interaction for an investment project."""
         project = InvestmentProjectFactory()
         adviser = AdviserFactory()
+        contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         response = self.api_client.post(url, {
             'kind': 'interaction',
+            'contact': contact.pk,
             'communication_channel': InteractionType.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -442,8 +445,10 @@ class TestInteractionV3(APITestMixin):
         """Test add new interaction without a contact, company or
         investment project.
         """
+        contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         response = self.api_client.post(url, {
+            'contact': contact.pk,
             'communication_channel': InteractionType.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),


### PR DESCRIPTION
Adds some checks to reject fields that are invalid for the interaction kind. Also corrects contact to be required.

This adds a RulesBasedValidator class-level validator to do cross-field validation in a more declarative fashion. It's similar to how cross-field validation was done for investment, but more generic.

I'm planning to split up validate_utils into two modules in a separate PR.