### PR TITLE
Make subject sortable.

### DIFF
--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -198,6 +198,10 @@ def test_get_basic_search_query():
                             'subject': 'test'
                         }
                     }, {
+                        'match': {
+                            'subject_english': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'teams',
                             'query': {

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -198,6 +198,10 @@ def test_get_basic_search_query():
                             'subject': 'test'
                         }
                     }, {
+                        'match': {
+                            'subject_english': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'teams',
                             'query': {

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -15,7 +15,8 @@ class Interaction(DocType, MapDBModelToDict):
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
     event = dsl_utils.id_name_partial_mapping('event')
     service = dsl_utils.id_name_mapping()
-    subject = dsl_utils.EnglishString(fielddata=True)
+    subject = Keyword(copy_to='subject_english')
+    subject_english = dsl_utils.EnglishString()
     dit_adviser = dsl_utils.contact_or_adviser_partial_mapping('dit_adviser')
     notes = dsl_utils.EnglishString()
     dit_team = dsl_utils.id_name_mapping()
@@ -45,6 +46,7 @@ class Interaction(DocType, MapDBModelToDict):
 
     SEARCH_FIELDS = [
         'subject',
+        'subject_english',
         'company.name',
         'contact.name',
         'dit_team.name',

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -22,7 +22,9 @@ def interactions(setup_es):
     with freeze_time('2017-01-01 13:00:00'):
         data.extend([
             InteractionFactory(subject='Exports meeting'),
+            InteractionFactory(subject='A coffee'),
             InteractionFactory(subject='Email about exhibition'),
+            InteractionFactory(subject='Talking about cats'),
             InteractionFactory(subject='Event at HQ'),
         ])
 
@@ -73,7 +75,7 @@ class TestViews(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
-        assert len(response_data['results']) == 2
+        assert len(response_data['results']) == 4
 
     def test_sort_by_subject_asc(self, interactions):
         """Tests sorting of results by subject (ascending)."""

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -200,6 +200,10 @@ def test_get_basic_search_query():
                             'subject': 'test'
                         }
                     }, {
+                        'match': {
+                            'subject_english': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'teams',
                             'query': {


### PR DESCRIPTION
Field that we want to sort by must not be analysed. I created separated field `subject_english` with English analyzer for search, enabling `subject` field to be sortable.
