### PR TITLE
Add investor country and client rel. manager team to investment response

### DIFF
--- a/datahub/investment/models.py
+++ b/datahub/investment/models.py
@@ -142,6 +142,20 @@ class IProjectAbstract(models.Model):
         except ObjectDoesNotExist:
             return None
 
+    @property
+    def investor_company_country(self):
+        """The country of the investor company."""
+        if self.investor_company:
+            return self.investor_company.registered_address_country
+        return None
+
+    @property
+    def client_relationship_manager_team(self):
+        """The DIT team associated with the client relationship manager."""
+        if self.client_relationship_manager:
+            return self.client_relationship_manager.dit_team
+        return None
+
 
 class IProjectValueAbstract(models.Model):
     """The value part of an investment project."""

--- a/datahub/investment/serializers.py
+++ b/datahub/investment/serializers.py
@@ -21,12 +21,18 @@ class IProjectSummarySerializer(serializers.ModelSerializer):
     country_lost_to = NestedRelatedField(meta_models.Country, required=False, allow_null=True)
     project_shareable = serializers.BooleanField(required=True)
     investor_company = NestedRelatedField(Company, required=True, allow_null=False)
+    investor_company_country = NestedRelatedField(
+        meta_models.Country, read_only=True
+    )
     intermediate_company = NestedRelatedField(Company, required=False, allow_null=True)
     client_contacts = NestedRelatedField(
         Contact, many=True, required=True, allow_null=False, allow_empty=False
     )
 
     client_relationship_manager = NestedAdviserField(required=True, allow_null=False)
+    client_relationship_manager_team = NestedRelatedField(
+        meta_models.Team, read_only=True
+    )
     referral_source_adviser = NestedAdviserField(required=True, allow_null=False)
     referral_source_activity = NestedRelatedField(
         meta_models.ReferralSourceActivity, required=True, allow_null=False
@@ -102,9 +108,11 @@ class IProjectSummarySerializer(serializers.ModelSerializer):
             'date_lost',
             'country_lost_to',
             'investor_company',
+            'investor_company_country',
             'intermediate_company',
             'client_contacts',
             'client_relationship_manager',
+            'client_relationship_manager_team',
             'referral_source_adviser',
             'referral_source_activity',
             'referral_source_activity_website',

--- a/datahub/investment/test/test_models.py
+++ b/datahub/investment/test/test_models.py
@@ -36,6 +36,42 @@ def test_no_project_code():
     assert project.project_code is None
 
 
+def test_client_relationship_manager_team_none():
+    """
+    Tests client_relationship_manager_team for a project without a client relationship
+    manager.
+    """
+    project = InvestmentProjectFactory(client_relationship_manager=None)
+    assert project.client_relationship_manager_team is None
+
+
+def test_client_relationship_manager_team_valid():
+    """
+    Tests client_relationship_manager_team for a project with a client relationship
+    manager.
+    """
+    project = InvestmentProjectFactory()
+    assert project.client_relationship_manager_team
+
+
+def test_investor_company_country_none():
+    """
+    Tests client_relationship_manager_team for a project without a client relationship
+    manager.
+    """
+    project = InvestmentProjectFactory(investor_company=None)
+    assert project.investor_company_country is None
+
+
+def test_investor_company_country_valid():
+    """
+    Tests client_relationship_manager_team for a project with a client relationship
+    manager.
+    """
+    project = InvestmentProjectFactory()
+    assert project.investor_company_country
+
+
 def test_project_manager_team_none():
     """Tests project_manager_team for a project without a project manager."""
     project = InvestmentProjectFactory()

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -267,8 +267,46 @@ class TestUnifiedViews(APITestMixin):
         assert response_data['estimated_land_date'] == str(project.estimated_land_date)
         assert response_data['investment_type']['id'] == str(project.investment_type.id)
         assert (response_data['stage']['id'] == str(project.stage.id))
+        investor_company = project.investor_company
+        assert response_data['investor_company'] == {
+            'id': str(investor_company.id),
+            'name': investor_company.name
+        }
+        assert response_data['investor_company_country'] == {
+            'id': str(investor_company.registered_address_country.id),
+            'name': investor_company.registered_address_country.name
+        }
+        client_relationship_manager = project.client_relationship_manager
+        assert response_data['client_relationship_manager'] == {
+            'id': str(client_relationship_manager.id),
+            'first_name': client_relationship_manager.first_name,
+            'name': client_relationship_manager.name,
+            'last_name': client_relationship_manager.last_name,
+        }
+        assert response_data['client_relationship_manager_team'] == {
+            'id': str(client_relationship_manager.dit_team.id),
+            'name': client_relationship_manager.dit_team.name
+        }
         assert sorted(contact['id'] for contact in response_data[
             'client_contacts']) == sorted(contacts)
+
+    def test_get_project_no_investor_and_crm(self):
+        """
+        Test getting a company when investor_company and client_relationship_manager are None.
+        """
+        project = InvestmentProjectFactory(
+            investor_company=None,
+            client_relationship_manager=None,
+        )
+        url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
+        response = self.api_client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['id'] == str(project.id)
+        assert response_data['investor_company'] is None
+        assert response_data['investor_company_country'] is None
+        assert response_data['client_relationship_manager'] is None
+        assert response_data['client_relationship_manager_team'] is None
 
     def test_get_project_status(self):
         """Test getting project status fields."""


### PR DESCRIPTION
Requested by the MI team. 

Added in the same pattern as project_manager_team and project_assurance_team.