### PR TITLE
Fix collectstatic for GOV.UK PaaS

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: python manage.py distributed_migrate --noinput && gunicorn config.wsgi --config config/gunicorn.py
+web: python manage.py collectstatic --noinput && python manage.py distributed_migrate --noinput && gunicorn config.wsgi --config config/gunicorn.py
 init_rev: python manage.py createinitialrevisions

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -154,11 +154,6 @@ PUBLIC_ROOT = str(ROOT_DIR('public'))
 STATIC_ROOT = str(ROOT_DIR('staticfiles'))
 STATIC_URL = '/static/'
 
-# Extra places for collectstatic to find static files.
-STATICFILES_DIRS = (
-    str(ROOT_DIR.path('static')),
-)
-
 # DRF
 REST_FRAMEWORK = {
     'UNAUTHENTICATED_USER': None,

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -14,7 +14,8 @@ from .companieshouse import *
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 
-ROOT_DIR = environ.Path(__file__) - 2
+CONFIG_DIR = environ.Path(__file__) - 2
+ROOT_DIR = CONFIG_DIR - 1
 
 env = environ.Env()
 
@@ -88,7 +89,7 @@ ROOT_URLCONF = 'config.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [(ROOT_DIR - 1)('templates')],
+        'DIRS': [(ROOT_DIR)('templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -150,8 +151,8 @@ OAUTH2_PROVIDER = {
 
 LANGUAGE_CODE = 'en-gb'
 USE_L10N = True
-PUBLIC_ROOT = str(ROOT_DIR('public'))
-STATIC_ROOT = str(ROOT_DIR('staticfiles'))
+PUBLIC_ROOT = str(CONFIG_DIR('public'))
+STATIC_ROOT = str(CONFIG_DIR('staticfiles'))
 STATIC_URL = '/static/'
 
 # DRF

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
 - buildpack: python_buildpack
-  command:  python manage.py distributed_migrate --noinput && gunicorn config.wsgi --config config/gunicorn.py
+  command:  python manage.py collectstatic --noinput && python manage.py distributed_migrate --noinput && gunicorn config.wsgi --config config/gunicorn.py


### PR DESCRIPTION
Moves collectstatic invocation to the Procfile because of problems when it's run by the build pack. 

Also removes config/static from the stac file directories, and reduces some confusion around ROOT_DIR in the config.