### PR TITLE
Remove pagination from OMIS payment list

### DIFF
--- a/datahub/omis/payment/tests/views/test_payments.py
+++ b/datahub/omis/payment/tests/views/test_payments.py
@@ -21,23 +21,18 @@ class TestGetPayments(APITestMixin):
         url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': order.pk})
         response = self.api_client.get(url, format='json')
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {
-            'count': 2,
-            'next': None,
-            'previous': None,
-            'results': [
-                {
-                    'created_on': payment.created_on.isoformat(),
-                    'reference': payment.reference,
-                    'transaction_reference': payment.transaction_reference,
-                    'additional_reference': payment.additional_reference,
-                    'amount': payment.amount,
-                    'method': payment.method,
-                    'received_on': payment.received_on.isoformat()
-                }
-                for payment in order.payments.all()
-            ]
-        }
+        assert response.json() == [
+            {
+                'created_on': payment.created_on.isoformat(),
+                'reference': payment.reference,
+                'transaction_reference': payment.transaction_reference,
+                'additional_reference': payment.additional_reference,
+                'amount': payment.amount,
+                'method': payment.method,
+                'received_on': payment.received_on.isoformat()
+            }
+            for payment in order.payments.all()
+        ]
 
     def test_404_if_order_doesnt_exist(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""
@@ -55,9 +50,4 @@ class TestGetPayments(APITestMixin):
         response = self.api_client.get(url, format='json')
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {
-            'count': 0,
-            'next': None,
-            'previous': None,
-            'results': []
-        }
+        assert response.json() == []

--- a/datahub/omis/payment/tests/views/test_public_payments.py
+++ b/datahub/omis/payment/tests/views/test_public_payments.py
@@ -41,23 +41,18 @@ class TestPublicGetPayments(APITestMixin):
         response = client.get(url, format='json')
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {
-            'count': 2,
-            'next': None,
-            'previous': None,
-            'results': [
-                {
-                    'created_on': payment.created_on.isoformat(),
-                    'reference': payment.reference,
-                    'transaction_reference': payment.transaction_reference,
-                    'additional_reference': payment.additional_reference,
-                    'amount': payment.amount,
-                    'method': payment.method,
-                    'received_on': payment.received_on.isoformat()
-                }
-                for payment in order.payments.all()
-            ]
-        }
+        assert response.json() == [
+            {
+                'created_on': payment.created_on.isoformat(),
+                'reference': payment.reference,
+                'transaction_reference': payment.transaction_reference,
+                'additional_reference': payment.additional_reference,
+                'amount': payment.amount,
+                'method': payment.method,
+                'received_on': payment.received_on.isoformat()
+            }
+            for payment in order.payments.all()
+        ]
 
     def test_404_if_order_doesnt_exist(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""

--- a/datahub/omis/payment/views.py
+++ b/datahub/omis/payment/views.py
@@ -11,6 +11,7 @@ class BasePaymentViewSet(BaseNestedOrderViewSet):
 
     queryset = Payment.objects.all()
     serializer_class = PaymentSerializer
+    pagination_class = None
 
     def get_queryset(self):
         """


### PR DESCRIPTION
As the numner of payments for an order is seldom going to be more than 2, paginating the response is not needed.