### PR TITLE
Abstract out creation of datetime based references

### DIFF
--- a/datahub/omis/core/utils.py
+++ b/datahub/omis/core/utils.py
@@ -1,3 +1,8 @@
+from datetime import datetime
+
+from django.utils.timezone import now
+
+
 def generate_reference(model, gen, field='reference', prefix='', max_retries=10):
     """
     Generate a unique reference given:
@@ -18,3 +23,41 @@ def generate_reference(model, gen, field='reference', prefix='', max_retries=10)
             return reference
 
     raise RuntimeError('Cannot generate random reference')
+
+
+def generate_datetime_based_reference(model, field='reference', prefix='', max_retries=10):
+    """
+    Generate a unique datetime based reference of type:
+        <year><month><day><4-digit-seq> e.g. 201702300001
+
+    :param model: the class of the django model
+    :param field: reference field of the model that needs to be unique
+    :param prefix: optional prefix
+    :param max_retries: max number of retries before failing
+
+    :raises RuntimeError: after trying max_retries times without being able to generate a
+        valid value
+    """
+    current_date = now()
+    dt_prefix = datetime.strftime(current_date, '%Y%m%d')
+
+    def gen():
+        # the select_for_update + len reduces race conditions (do not use .count()).
+        # The problem could still occur when creating the first record of the day
+        # but it's unlikely and if the transaction is atomic, it would not put
+        # the db in an inconsistent state.
+        start_count = len(
+            model.objects.select_for_update().filter(created_on__date=current_date.date())
+        )
+
+        while True:
+            start_count += 1
+            yield f'{start_count:04}'
+
+    return generate_reference(
+        model=model,
+        gen=gen().__next__,
+        prefix=f'{prefix}{dt_prefix}',
+        field=field,
+        max_retries=max_retries
+    )

--- a/datahub/omis/invoice/manager.py
+++ b/datahub/omis/invoice/manager.py
@@ -1,7 +1,9 @@
 from django.db import models
 
+from datahub.omis.core.utils import generate_datetime_based_reference
+
 from . import constants
-from .utils import calculate_payment_due_date, generate_invoice_number
+from .utils import calculate_payment_due_date
 
 
 class InvoiceManager(models.Manager):
@@ -14,7 +16,7 @@ class InvoiceManager(models.Manager):
         :returns: Invoice object generated from the order
         """
         return self.create(
-            invoice_number=generate_invoice_number(),
+            invoice_number=generate_datetime_based_reference(self.model, field='invoice_number'),
             payment_due_date=calculate_payment_due_date(order),
             invoice_company_name=constants.DIT_COMPANY_NAME,
             invoice_address_1=constants.DIT_ADDRESS_1,

--- a/datahub/omis/invoice/test/test_managers.py
+++ b/datahub/omis/invoice/test/test_managers.py
@@ -14,16 +14,16 @@ class TestInvoiceManager:
     """Tests for the Invoice Manager."""
 
     @mock.patch('datahub.omis.invoice.manager.calculate_payment_due_date')
-    @mock.patch('datahub.omis.invoice.manager.generate_invoice_number')
+    @mock.patch('datahub.omis.invoice.manager.generate_datetime_based_reference')
     def test_create_from_order(
         self,
-        mocked_generate_invoice_number,
+        mocked_generate_datetime_based_reference,
         mocked_calculate_payment_due_date
     ):
         """Test that Invoice.objects.create_from_order creates an invoice."""
         payment_due_date = dateutil_parse('2030-01-01').date()
 
-        mocked_generate_invoice_number.return_value = '201702010004'
+        mocked_generate_datetime_based_reference.return_value = '201702010004'
         mocked_calculate_payment_due_date.return_value = payment_due_date
 
         invoice = Invoice.objects.create_from_order(mock.MagicMock())

--- a/datahub/omis/invoice/test/test_utils.py
+++ b/datahub/omis/invoice/test/test_utils.py
@@ -3,13 +3,21 @@ import pytest
 from dateutil.parser import parse as dateutil_parse
 from freezegun import freeze_time
 
+from datahub.omis.core.utils import generate_datetime_based_reference
+
 from .factories import InvoiceFactory
-from ..utils import calculate_payment_due_date, generate_invoice_number
+from ..models import Invoice
+from ..utils import calculate_payment_due_date
 
 
 @pytest.mark.django_db
 class TestGenerateInvoiceNumber:
-    """Tests for the generate_invoice_number logic."""
+    """
+    Tests for generating the invoice number using `generate_datetime_based_reference`.
+
+    These are really extra tests just to make sure things work as expected as the main
+    logic is been tested by the generic generate_datetime_based_reference tests.
+    """
 
     def test_first_invoice_number_of_the_day(self):
         """Test that the first invoice number of the day is generated as expected."""
@@ -25,7 +33,7 @@ class TestGenerateInvoiceNumber:
                 InvoiceFactory()
 
         with freeze_time('2017-02-01 13:00:00'):
-            invoice_number = generate_invoice_number()
+            invoice_number = generate_datetime_based_reference(Invoice, field='invoice_number')
 
         assert invoice_number == '201702010001'
 
@@ -47,23 +55,9 @@ class TestGenerateInvoiceNumber:
                 InvoiceFactory()
 
         with freeze_time('2017-02-01 13:00:00'):
-            invoice_number = generate_invoice_number()
+            invoice_number = generate_datetime_based_reference(Invoice, field='invoice_number')
 
         assert invoice_number == '201702010004'
-
-    def test_invoice_collision(self):
-        """
-        Test that if the invoice number has already been used,
-        the next available one is generated.
-        """
-        with freeze_time('2017-01-01 13:00:00'):
-            InvoiceFactory(invoice_number='201702010001')
-            InvoiceFactory(invoice_number='201702010002')
-
-        with freeze_time('2017-02-01 13:00:00'):
-            invoice_number = generate_invoice_number()
-
-        assert invoice_number == '201702010003'
 
 
 class TestCalculatePaymentDueDate:

--- a/datahub/omis/invoice/utils.py
+++ b/datahub/omis/invoice/utils.py
@@ -1,38 +1,6 @@
-from datetime import datetime, timedelta
-
-from django.utils.timezone import now
-
-from datahub.omis.core.utils import generate_reference
+from datetime import timedelta
 
 from .constants import PAYMENT_DUE_DAYS_BEFORE_DELIVERY, PAYMENT_DUE_DAYS_FROM_NOW
-
-
-def generate_invoice_number():
-    """
-    :returns: an unused invoice number
-    :raises RuntimeError: if no reference can be generated.
-    """
-    from .models import Invoice
-
-    current_date = now()
-    prefix = datetime.strftime(current_date, '%Y%m%d')
-
-    def gen():
-        # the select_for_update + len reduces race conditions (do not use .count()).
-        # The problem could still occur when creating the first invoice of the day
-        # but it's unlikely and the whole transaction is atomic so it would not put
-        # the db in an inconsistent state.
-        start_count = len(
-            Invoice.objects.select_for_update().filter(created_on__date=now().date())
-        )
-
-        while True:
-            start_count += 1
-            yield f'{start_count:04}'
-
-    return generate_reference(
-        model=Invoice, gen=gen().__next__, prefix=prefix, field='invoice_number'
-    )
 
 
 def calculate_payment_due_date(order):


### PR DESCRIPTION
This abstracts out the `generate_invoice_number` logic and moves it to omis.core.utils.
This way, it can be used in other modules (e.g. payment references).