### PR TITLE
Add is_event virtual field to interaction

### DIFF
--- a/datahub/core/test/test_validate_utils.py
+++ b/datahub/core/test/test_validate_utils.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
-from datahub.core.validate_utils import DataCombiner, is_blank
+from datahub.core.validate_utils import DataCombiner, is_blank, is_not_blank
 
 
 @pytest.mark.parametrize('value,blank', (
@@ -17,6 +17,20 @@ from datahub.core.validate_utils import DataCombiner, is_blank
 def test_is_blank(value, blank):
     """Tests is_blank() for various values."""
     assert is_blank(value) == blank
+
+
+@pytest.mark.parametrize('value,blank', (
+    (None, False),
+    ('', False),
+    ([], False),
+    (0, True),
+    (2323, True),
+    ('dfdf', True),
+    ([1234], True),
+))
+def test_is_not_blank(value, blank):
+    """Tests is_not_blank() for various values."""
+    assert is_not_blank(value) == blank
 
 
 class TestDataCombiner:

--- a/datahub/core/validate_utils.py
+++ b/datahub/core/validate_utils.py
@@ -47,3 +47,8 @@ class DataCombiner:
 def is_blank(value):
     """Returns True if a value is considered empty or blank."""
     return value in (None, '') or (isinstance(value, Sequence) and len(value) == 0)
+
+
+def is_not_blank(value):
+    """Returns True if a value is not considered empty or blank."""
+    return not is_blank(value)

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -71,6 +71,13 @@ class Interaction(BaseModel):
         on_delete=models.CASCADE
     )
 
+    @property
+    def is_event(self):
+        """Whether this service delivery is for an event."""
+        if self.kind == self.KINDS.service_delivery:
+            return bool(self.event)
+        return None
+
     def __str__(self):
         """Human-readable representation."""
         return self.subject

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -19,10 +19,10 @@ class InteractionSerializer(serializers.ModelSerializer):
 
     default_error_messages = {
         'invalid_for_interaction': ugettext_lazy(
-            'This field cannot be specified for an interaction.'
+            'This field is only valid for service deliveries.'
         ),
         'invalid_for_service_delivery': ugettext_lazy(
-            'This field cannot be specified for a service delivery.'
+            'This field is only valid for interactions.'
         ),
         'invalid_for_non_event': ugettext_lazy(
             'This field is only valid for event service deliveries.'
@@ -49,7 +49,8 @@ class InteractionSerializer(serializers.ModelSerializer):
         """
         Removes the semi-virtual field is_event from the data.
 
-        This is removed because the value is inferred from the event field during serialisation.
+        This is removed because the value is not stored; it is instead inferred from contents
+        of the the event field during serialisation.
         """
         if 'is_event' in data:
             del data['is_event']

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -47,7 +47,7 @@ class ServiceDeliveryFactory(factory.django.DjangoModelFactory):
     modified_by = factory.SubFactory(AdviserFactory)
     company = factory.SubFactory(CompanyFactory)
     contact = factory.SubFactory(ContactFactory)
-    event = factory.SubFactory(EventFactory)
+    event = None
     subject = factory.Faker('sentence', nb_words=8)
     date = now()
     notes = factory.Faker('paragraph', nb_sentences=10)
@@ -58,6 +58,12 @@ class ServiceDeliveryFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'interaction.Interaction'
+
+
+class EventServiceDeliveryFactory(ServiceDeliveryFactory):
+    """Event service delivery factory."""
+
+    event = factory.SubFactory(EventFactory)
 
 
 class LegacyServiceDeliveryFactory(factory.django.DjangoModelFactory):

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -1,4 +1,5 @@
 from datetime import date
+
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -7,7 +8,9 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory, Conta
 from datahub.core.constants import InteractionType, Service, Team
 from datahub.core.test_utils import APITestMixin
 from datahub.event.test.factories import EventFactory
-from datahub.interaction.test.factories import InteractionFactory
+from datahub.interaction.test.factories import (
+    EventServiceDeliveryFactory, InteractionFactory, ServiceDeliveryFactory
+)
 from datahub.investment.test.factories import InvestmentProjectFactory
 
 
@@ -49,6 +52,7 @@ class TestInteractionV3(APITestMixin):
         assert response_data == {
             'id': response_data['id'],
             'kind': 'interaction',
+            'is_event': None,
             'communication_channel': {
                 'id': InteractionType.face_to_face.value.id,
                 'name': InteractionType.face_to_face.value.name
@@ -97,8 +101,8 @@ class TestInteractionV3(APITestMixin):
         }
 
     @freeze_time('2017-04-18 13:25:30.986208+00:00')
-    def test_add_service_delivery_with_event(self):
-        """Test add new service delivery with an event."""
+    def test_add_event_service_delivery(self):
+        """Test adding a new event service delivery."""
         adviser = AdviserFactory()
         company = CompanyFactory()
         contact = ContactFactory()
@@ -106,6 +110,7 @@ class TestInteractionV3(APITestMixin):
         url = reverse('api-v3:interaction:collection')
         request_data = {
             'kind': 'service_delivery',
+            'is_event': True,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
@@ -123,6 +128,7 @@ class TestInteractionV3(APITestMixin):
         assert response_data == {
             'id': response_data['id'],
             'kind': 'service_delivery',
+            'is_event': True,
             'communication_channel': None,
             'subject': 'whatever',
             'date': '2017-04-18',
@@ -170,15 +176,43 @@ class TestInteractionV3(APITestMixin):
             'modified_on': '2017-04-18T13:25:30.986208'
         }
 
-    @freeze_time('2017-04-18 13:25:30.986208+00:00')
-    def test_add_service_delivery_without_event(self):
-        """Test add new service delivery without an event."""
+    def test_add_event_service_delivery_missing_event(self):
+        """Test adding a new event service delivery without specifying an event."""
         adviser = AdviserFactory()
         company = CompanyFactory()
         contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         request_data = {
             'kind': 'service_delivery',
+            'is_event': True,
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_adviser': adviser.pk,
+            'notes': 'hello',
+            'company': company.pk,
+            'contact': contact.pk,
+            'event': None,
+            'service': Service.trade_enquiry.value.id,
+            'dit_team': Team.healthcare_uk.value.id
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data == {
+            'event': ['This field is required.']
+        }
+
+    @freeze_time('2017-04-18 13:25:30.986208+00:00')
+    def test_add_non_event_service_delivery(self):
+        """Test adding a new non-event service delivery."""
+        adviser = AdviserFactory()
+        company = CompanyFactory()
+        contact = ContactFactory()
+        url = reverse('api-v3:interaction:collection')
+        request_data = {
+            'kind': 'service_delivery',
+            'is_event': False,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
@@ -194,6 +228,7 @@ class TestInteractionV3(APITestMixin):
         response_data = response.json()
         assert response_data == {
             'id': response_data['id'],
+            'is_event': False,
             'kind': 'service_delivery',
             'communication_channel': None,
             'subject': 'whatever',
@@ -237,6 +272,34 @@ class TestInteractionV3(APITestMixin):
             },
             'created_on': '2017-04-18T13:25:30.986208',
             'modified_on': '2017-04-18T13:25:30.986208'
+        }
+
+    def test_add_non_event_service_delivery_with_event(self):
+        """Test add new non-event service delivery with an event specified."""
+        adviser = AdviserFactory()
+        company = CompanyFactory()
+        contact = ContactFactory()
+        event = EventFactory()
+        url = reverse('api-v3:interaction:collection')
+        request_data = {
+            'kind': 'service_delivery',
+            'is_event': False,
+            'subject': 'whatever',
+            'date': date.today().isoformat(),
+            'dit_adviser': adviser.pk,
+            'event': event.pk,
+            'notes': 'hello',
+            'company': company.pk,
+            'contact': contact.pk,
+            'service': Service.trade_enquiry.value.id,
+            'dit_team': Team.healthcare_uk.value.id
+        }
+        response = self.api_client.post(url, request_data, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data == {
+            'event': ['This field is only valid for event service deliveries.']
         }
 
     def test_add_interaction_project_missing_fields(self):
@@ -289,6 +352,7 @@ class TestInteractionV3(APITestMixin):
         url = reverse('api-v3:interaction:collection')
         request_data = {
             'kind': 'interaction',
+            'is_event': False,
             'communication_channel': InteractionType.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -304,7 +368,8 @@ class TestInteractionV3(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'event': ['This field cannot be specified for an interaction.'],
+            'is_event': ['This field cannot be specified for an interaction.'],
+            'event': ['This field is only valid for event service deliveries.'],
         }
 
     def test_add_service_delivery_with_interaction_fields(self):
@@ -315,6 +380,7 @@ class TestInteractionV3(APITestMixin):
         url = reverse('api-v3:interaction:collection')
         request_data = {
             'kind': 'service_delivery',
+            'is_event': True,
             'communication_channel': InteractionType.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -397,6 +463,40 @@ class TestInteractionV3(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['subject'] == 'I am another subject'
+
+    def test_change_non_event_service_delivery_to_event(self):
+        """Test making a non-event service delivery an event service delivery."""
+        service_delivery = ServiceDeliveryFactory()
+        event = EventFactory()
+
+        url = reverse('api-v3:interaction:item', kwargs={'pk': service_delivery.pk})
+        response = self.api_client.patch(url, {
+            'is_event': True,
+            'event': event.pk
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['is_event'] is True
+        assert response_data['event'] == {
+            'id': str(event.pk),
+            'name': event.name,
+        }
+
+    def test_change_event_service_delivery_to_non_event(self):
+        """Test making an event service delivery a non-event service delivery."""
+        service_delivery = EventServiceDeliveryFactory()
+
+        url = reverse('api-v3:interaction:item', kwargs={'pk': service_delivery.pk})
+        response = self.api_client.patch(url, {
+            'is_event': False,
+            'event': None
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['is_event'] is False
+        assert response_data['event'] is None
 
     def test_date_validation(self):
         """Test validation when an invalid date is provided."""

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -368,7 +368,7 @@ class TestInteractionV3(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'is_event': ['This field cannot be specified for an interaction.'],
+            'is_event': ['This field is only valid for service deliveries.'],
             'event': ['This field is only valid for event service deliveries.'],
         }
 
@@ -396,7 +396,7 @@ class TestInteractionV3(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'communication_channel': ['This field cannot be specified for a service delivery.'],
+            'communication_channel': ['This field is only valid for interactions.'],
         }
 
     @freeze_time('2017-04-18 13:25:30.986208+00:00')

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -1,5 +1,7 @@
+from operator import attrgetter
+
 from django.conf import settings
-from elasticsearch_dsl import Date, DocType, Keyword
+from elasticsearch_dsl import Boolean, Date, DocType, Keyword
 
 from datahub.search import dict_utils, dsl_utils
 from datahub.search.models import MapDBModelToDict
@@ -13,6 +15,7 @@ class Interaction(DocType, MapDBModelToDict):
     date = Date()
     company = dsl_utils.id_name_partial_mapping('company')
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
+    is_event = Boolean()
     event = dsl_utils.id_name_partial_mapping('event')
     service = dsl_utils.id_name_mapping()
     subject = dsl_utils.SortableCaseInsensitiveKeywordText(copy_to='subject_english')
@@ -37,7 +40,9 @@ class Interaction(DocType, MapDBModelToDict):
         'investment_project': dict_utils.id_name_dict,
     }
 
-    COMPUTED_MAPPINGS = {}
+    COMPUTED_MAPPINGS = {
+        'is_event': attrgetter('is_event')
+    }
 
     IGNORED_FIELDS = (
         'created_by',

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -29,6 +29,7 @@ def test_interaction_to_dict():
             'name': interaction.contact.name,
             'last_name': interaction.contact.last_name,
         },
+        'is_event': interaction.is_event,
         'event': None,
         'service': {
             'id': str(interaction.service.pk),

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -183,6 +183,7 @@ class TestViews(APITestMixin):
                 'name': interaction.contact.name,
                 'last_name': interaction.contact.last_name,
             },
+            'is_event': None,
             'event': None,
             'service': {
                 'id': str(interaction.service.pk),


### PR DESCRIPTION
This is to resolve a problem around validation for the 'Is this an event?' question in the front end, as this isn't a field in the model (as it can be inferred by checking whether the event field is set). We agreed to solve this by adding it as a virtual field and performing some validation around it at the API level, so this is what this PR does.