### PR TITLE
Set Sentry environment tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `OMIS_NOTIFICATION_API_KEY`  | Yes | |
 | `OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL`  | No | |
 | `OMIS_PUBLIC_BASE_URL`  | Yes | |
+| `SENTRY_ENVIRONMENT`  | Yes | Value for the environment tag in Sentry. |
 | `WEB_CONCURRENCY` | No | Number of Gunicorn workers (set automatically by Heroku, otherwise defaults to 1). |
 
 

--- a/config/settings/common_sentry.py
+++ b/config/settings/common_sentry.py
@@ -48,5 +48,6 @@ LOGGING = {
 
 RAVEN_CONFIG = {
     'dsn': env('DJANGO_SENTRY_DSN'),
-    'include_paths': ['datahub']
+    'include_paths': ['datahub'],
+    'environment': env('SENTRY_ENVIRONMENT'),
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       DJANGO_SETTINGS_MODULE: config.settings.local
       COV_TOKEN: ${COV_TOKEN}
       ES_INDEX: test_index
-      ES_URL: http://es:9200
+      ES5_URL: http://es:9200
       CDMS_AUTH_URL: http://example.com
       AWS_DEFAULT_REGION: eu-west-2
       AWS_ACCESS_KEY_ID: foo


### PR DESCRIPTION
Using the SENTRY_ENVIRONMENT environment variable (that's what the Node.js client uses).