### PR TITLE
Enhance OMIS order search

### DIFF
--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -89,10 +89,28 @@ def test_get_basic_search_query():
                         }
                     }, {
                         'nested': {
+                            'path': 'company',
+                            'query': {
+                                'match': {
+                                    'company.name_trigram': 'test'
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
                             'path': 'contact',
                             'query': {
                                 'match': {
                                     'contact.name': 'test'
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'contact',
+                            'query': {
+                                'match': {
+                                    'contact.name_trigram': 'test'
                                 }
                             }
                         }
@@ -163,6 +181,10 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
+                        'match': {
+                            'reference': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'registered_address_country',
                             'query': {
@@ -211,6 +233,10 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
+                        'match': {
+                            'total_cost_string': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'trading_address_country',
                             'query': {
@@ -245,7 +271,7 @@ def test_get_basic_search_query():
                         'match': {
                             'website': 'test'
                         }
-                    }
+                    },
                 ]
             }
         },

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -19,8 +19,8 @@ def client(request):
     return client
 
 
-@fixture
-def setup_es(client):
+@fixture(scope='session')
+def setup_es_indexes(client):
     """Sets up ES and makes the client available."""
     create_test_index(client, settings.ES_INDEX)
 
@@ -38,6 +38,18 @@ def setup_es(client):
 
     for search_app in get_search_apps():
         search_app.disconnect_signals()
+
+
+@fixture
+def setup_es(setup_es_indexes):
+    """Sets up ES and deletes all the records after each run."""
+    yield setup_es_indexes
+
+    setup_es_indexes.delete_by_query(
+        settings.ES_INDEX,
+        body={'query': {'match_all': {}}},
+        ignore=(409,)
+    )
 
 
 def create_test_index(client, index):

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -89,10 +89,28 @@ def test_get_basic_search_query():
                         }
                     }, {
                         'nested': {
+                            'path': 'company',
+                            'query': {
+                                'match': {
+                                    'company.name_trigram': 'test'
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
                             'path': 'contact',
                             'query': {
                                 'match': {
                                     'contact.name': 'test'
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'contact',
+                            'query': {
+                                'match': {
+                                    'contact.name_trigram': 'test'
                                 }
                             }
                         }
@@ -163,6 +181,10 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
+                        'match': {
+                            'reference': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'registered_address_country',
                             'query': {
@@ -209,6 +231,10 @@ def test_get_basic_search_query():
                                     'teams.name': 'test'
                                 }
                             }
+                        }
+                    }, {
+                        'match': {
+                            'total_cost_string': 'test'
                         }
                     }, {
                         'nested': {

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -91,10 +91,28 @@ def test_get_basic_search_query():
                         }
                     }, {
                         'nested': {
+                            'path': 'company',
+                            'query': {
+                                'match': {
+                                    'company.name_trigram': 'test'
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
                             'path': 'contact',
                             'query': {
                                 'match': {
                                     'contact.name': 'test'
+                                }
+                            }
+                        }
+                    }, {
+                        'nested': {
+                            'path': 'contact',
+                            'query': {
+                                'match': {
+                                    'contact.name_trigram': 'test'
                                 }
                             }
                         }
@@ -165,6 +183,10 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
+                        'match': {
+                            'reference': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'registered_address_country',
                             'query': {
@@ -211,6 +233,10 @@ def test_get_basic_search_query():
                                     'teams.name': 'test'
                                 }
                             }
+                        }
+                    }, {
+                        'match': {
+                            'total_cost_string': 'test'
                         }
                     }, {
                         'nested': {

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -12,8 +12,8 @@ class Order(DocType, MapDBModelToDict):
     id = Keyword()
     reference = dsl_utils.SortableCaseInsensitiveKeywordText()
     status = dsl_utils.SortableCaseInsensitiveKeywordText()
-    company = dsl_utils.id_name_mapping()
-    contact = dsl_utils.contact_or_adviser_mapping('contact')
+    company = dsl_utils.id_name_partial_mapping('company')
+    contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
     created_by = dsl_utils.contact_or_adviser_mapping('created_by')
     created_on = Date()
     modified_on = Date()
@@ -35,7 +35,8 @@ class Order(DocType, MapDBModelToDict):
     net_cost = Integer(index=False)
     subtotal_cost = Integer(index=False)
     vat_cost = Integer(index=False)
-    total_cost = Integer()
+    total_cost_string = Keyword()
+    total_cost = Integer(copy_to=['total_cost_string'])
 
     billing_contact_name = Text()
     billing_email = dsl_utils.SortableCaseInsensitiveKeywordText()
@@ -78,7 +79,12 @@ class Order(DocType, MapDBModelToDict):
         'payments',
     )
 
-    SEARCH_FIELDS = []
+    SEARCH_FIELDS = (
+        'reference',
+        'contact.name_trigram',
+        'company.name_trigram',
+        'total_cost_string',
+    )
 
     class Meta:
         """Default document meta data."""

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -106,9 +106,15 @@ def test_mapping(setup_es):
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
+                            'copy_to': ['company.name_trigram'],
                             'fielddata': True,
                             'type': 'text'
-                        }
+                        },
+                        'name_trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        },
                     },
                     'type': 'nested'
                 },
@@ -129,9 +135,15 @@ def test_mapping(setup_es):
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
+                            'copy_to': ['contact.name_trigram'],
                             'fielddata': True,
                             'type': 'text'
-                        }
+                        },
+                        'name_trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        },
                     },
                     'type': 'nested'
                 },
@@ -286,7 +298,11 @@ def test_mapping(setup_es):
                     'index': False,
                     'type': 'integer'
                 },
+                'total_cost_string': {
+                    'type': 'keyword'
+                },
                 'total_cost': {
+                    'copy_to': ['total_cost_string'],
                     'type': 'integer'
                 },
                 'vat_cost': {

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -3,7 +3,7 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.company.test.factories import AdviserFactory
+from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
 from datahub.core.test_utils import APITestMixin
 from datahub.omis.order.constants import OrderStatus
@@ -11,18 +11,24 @@ from datahub.omis.order.models import Order
 from datahub.omis.order.test.factories import OrderAssigneeFactory, OrderFactory, \
     OrderSubscriberFactory
 
+
 pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data():
+def setup_data(setup_es):
     """Sets up data for the tests."""
     with freeze_time('2017-01-01 13:00:00'):
+        company = CompanyFactory(name='Mercury trading')
+        contact = ContactFactory(company=company, first_name='John', last_name='Doe')
         order = OrderFactory(
             reference='ref1',
             primary_market_id=constants.Country.japan.value.id,
             assignees=[],
-            status=OrderStatus.draft
+            status=OrderStatus.draft,
+            company=company,
+            contact=contact,
+            discount_value=0
         )
         OrderSubscriberFactory(
             order=order,
@@ -30,15 +36,21 @@ def setup_data():
         )
         OrderAssigneeFactory(
             order=order,
-            adviser=AdviserFactory(dit_team_id=constants.Team.tees_valley_lep.value.id)
+            adviser=AdviserFactory(dit_team_id=constants.Team.tees_valley_lep.value.id),
+            estimated_time=60
         )
 
     with freeze_time('2017-02-01 13:00:00'):
+        company = CompanyFactory(name='Venus Ltd')
+        contact = ContactFactory(company=company, first_name='Jenny', last_name='Cakeman')
         order = OrderFactory(
             reference='ref2',
             primary_market_id=constants.Country.france.value.id,
             assignees=[],
-            status=OrderStatus.quote_awaiting_acceptance
+            status=OrderStatus.quote_awaiting_acceptance,
+            company=company,
+            contact=contact,
+            discount_value=0
         )
         OrderSubscriberFactory(
             order=order,
@@ -46,8 +58,11 @@ def setup_data():
         )
         OrderAssigneeFactory(
             order=order,
-            adviser=AdviserFactory(dit_team_id=constants.Team.food_from_britain.value.id)
+            adviser=AdviserFactory(dit_team_id=constants.Team.food_from_britain.value.id),
+            estimated_time=120
         )
+
+        setup_es.indices.refresh()
 
 
 class TestSearchOrder(APITestMixin):
@@ -95,12 +110,58 @@ class TestSearchOrder(APITestMixin):
                 {'status': 'invalid'},
                 []
             ),
+            (  # search by reference
+                {'original_query': 'ref2'},
+                ['ref2']
+            ),
+            (  # search by contact name exact
+                {'original_query': 'Jenny Cakeman'},
+                ['ref2']
+            ),
+            (  # search by contact name partial
+                {'original_query': 'Jenny Cakem'},
+                ['ref2']
+            ),
+            (  # search by company name exact
+                {'original_query': 'Venus Ltd'},
+                ['ref2']
+            ),
+            (  # search by company name partial
+                {'original_query': 'Venus'},
+                ['ref2']
+            ),
+            (  # search by total_cost
+                {'original_query': '2000'},
+                ['ref2']
+            ),
+            (  # search by reference
+                {'reference': 'ref2'},
+                ['ref2']
+            ),
+            (  # search by reference
+                {'total_cost': 2000},
+                ['ref2']
+            ),
+            (  # search by contact name exact
+                {'contact_name': 'Jenny Cakeman'},
+                ['ref2']
+            ),
+            (  # search by contact name partial
+                {'contact_name': 'Jenny Cakem'},
+                ['ref2']
+            ),
+            (  # search by company name exact
+                {'company_name': 'Venus Ltd'},
+                ['ref2']
+            ),
+            (  # search by company name partial
+                {'company_name': 'Venus'},
+                ['ref2']
+            ),
         )
     )
-    def test_search(self, setup_es, setup_data, data, results):
+    def test_search(self, setup_data, data, results):
         """Test search results."""
-        setup_es.indices.refresh()
-
         url = reverse('api-v3:search:order')
 
         response = self.api_client.post(url, data, format='json')
@@ -111,10 +172,8 @@ class TestSearchOrder(APITestMixin):
             item['reference'] for item in response.json()['results']
         ] == results
 
-    def test_incorrect_dates_raise_validation_error(self, setup_es, setup_data):
+    def test_incorrect_dates_raise_validation_error(self, setup_data):
         """Test that if the dates are not in a valid format, the API return a validation error."""
-        setup_es.indices.refresh()
-
         url = reverse('api-v3:search:order')
 
         response = self.api_client.post(url, {
@@ -124,10 +183,8 @@ class TestSearchOrder(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'non_field_errors': 'Date(s) in incorrect format.'}
 
-    def test_filter_by_assigned_to_assignee_adviser(self, setup_es, setup_data):
+    def test_filter_by_assigned_to_assignee_adviser(self, setup_data):
         """Test that results can be filtered by assignee."""
-        setup_es.indices.refresh()
-
         assignee = Order.objects.get(reference='ref2').assignees.first()
 
         url = reverse('api-v3:search:order')
@@ -140,10 +197,8 @@ class TestSearchOrder(APITestMixin):
         assert len(response.json()['results']) == 1
         assert response.json()['results'][0]['reference'] == 'ref2'
 
-    def test_filter_by_assigned_to_assignee_adviser_team(self, setup_es, setup_data):
+    def test_filter_by_assigned_to_assignee_adviser_team(self, setup_data):
         """Test that results can be filtered by the assignee's team."""
-        setup_es.indices.refresh()
-
         assignee = Order.objects.get(reference='ref2').assignees.first()
 
         url = reverse('api-v3:search:order')
@@ -155,3 +210,56 @@ class TestSearchOrder(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == 1
         assert response.json()['results'][0]['reference'] == 'ref2'
+
+
+class TestGlobalSearch(APITestMixin):
+    """Test global search for orders."""
+
+    @pytest.mark.parametrize(
+        'term,results',
+        (
+            (  # no filter => return all records
+                '',
+                ['ref1', 'ref2']
+            ),
+            (  # search by reference
+                'ref2',
+                ['ref2']
+            ),
+            (  # search by contact name exact
+                'Jenny Cakeman',
+                ['ref2']
+            ),
+            (  # search by contact name partial
+                'Jenny Cakem',
+                ['ref2']
+            ),
+            (  # search by company name exact
+                'Venus Ltd',
+                ['ref2']
+            ),
+            (  # search by company name partial
+                'Venus',
+                ['ref2']
+            ),
+            (  # search by total_cost
+                '2000',
+                ['ref2']
+            ),
+        )
+    )
+    def test_search(self, setup_data, term, results):
+        """Test search results."""
+        url = reverse('api-v3:search:basic')
+
+        response = self.api_client.get(url, {
+            'term': term,
+            'sortby': 'created_on:asc',
+            'entity': 'order'
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()['results']) == len(results)
+        assert [
+            item['reference'] for item in response.json()['results']
+        ] == results

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -18,12 +18,18 @@ class SearchOrderParams:
         'assigned_to_adviser',
         'assigned_to_team',
         'status',
+        'reference',
+        'total_cost',
+        'contact_name',
+        'company_name',
     ]
 
     REMAP_FIELDS = {
         'primary_market': 'primary_market.id',
         'assigned_to_adviser': 'assignees.id',
         'assigned_to_team': 'assignees.dit_team.id',
+        'contact_name': 'contact.name_trigram',
+        'company_name': 'company.name_trigram',
     }
 
 

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -15,18 +15,36 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture
 def setup_data():
     """Sets up the data and makes the ES client available."""
-    ContactFactory(first_name='abc', last_name='defg')
-    ContactFactory(first_name='first', last_name='last')
+    ContactFactory(
+        first_name='abc',
+        last_name='defg',
+        company=CompanyFactory(name='name0')
+    )
+    ContactFactory(
+        first_name='first',
+        last_name='last',
+        company=CompanyFactory(name='name1')
+    )
     InvestmentProjectFactory(
         name='abc defg',
         description='investmentproject1',
-        estimated_land_date=datetime.datetime(2011, 6, 13, 9, 44, 31, 62870)
+        estimated_land_date=datetime.datetime(2011, 6, 13, 9, 44, 31, 62870),
+        project_manager=AdviserFactory(first_name='name 0', last_name='surname 0'),
+        project_assurance_adviser=AdviserFactory(first_name='name 1', last_name='surname 1'),
+        investor_company=CompanyFactory(name='name3'),
+        client_relationship_manager=AdviserFactory(first_name='name 2', last_name='surname 2'),
+        referral_source_adviser=AdviserFactory(first_name='name 3', last_name='surname 3'),
+        client_contacts=[]
     )
     InvestmentProjectFactory(
         description='investmentproject2',
         estimated_land_date=datetime.datetime(2057, 6, 13, 9, 44, 31, 62870),
-        project_manager=AdviserFactory(),
-        project_assurance_adviser=AdviserFactory(),
+        project_manager=AdviserFactory(first_name='name 4', last_name='surname 4'),
+        project_assurance_adviser=AdviserFactory(first_name='name 5', last_name='surname 5'),
+        investor_company=CompanyFactory(name='name4'),
+        client_relationship_manager=AdviserFactory(first_name='name 6', last_name='surname 6'),
+        referral_source_adviser=AdviserFactory(first_name='name 7', last_name='surname 7'),
+        client_contacts=[]
     )
 
     country_uk = constants.Country.united_kingdom.value.id


### PR DESCRIPTION
This adds the ability to:
- search for 'reference', 'total_cost', 'contact name', 'company name' using the global search view
- search for 'reference', 'total_cost', 'contact name', 'company name' using the specialised search view
- filter orders by the 'reference', 'total_cost', 'contact name', 'company name' fields

The way ES is set up during tests has changed as well.
All the ES records are deleted after each test instead of deleting the index itself every time.
This speeds the tests up quite a bit.