### PR TITLE
Improved trigram.

### DIFF
--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -129,6 +129,24 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['company']['name'] == company.name
 
+    def test_company_name_trigram_filter(self, setup_es):
+        """Tests edge case of partially matching company name."""
+        company = CompanyFactory(name='United States')
+        ContactFactory(
+            company=company
+        )
+        setup_es.indices.refresh()
+
+        url = reverse('api-v3:search:contact')
+
+        response = self.api_client.post(url, {
+            'company_name': 'scared Squirrel',
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 0
+        assert len(response.data['results']) == 0
+
     def test_search_contact_no_filters(self, setup_es, setup_data):
         """Tests case where there is no filters provided."""
         setup_es.indices.refresh()

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -19,7 +19,13 @@ lowercase_keyword_analyzer = analysis.CustomAnalyzer(
 )
 
 # Trigram tokenizer enables us to support partial matching
-trigram = analysis.tokenizer('trigram', 'nGram', min_gram=3, max_gram=3)
+trigram = analysis.tokenizer(
+    'trigram',
+    'nGram',
+    min_gram=3,
+    max_gram=3,
+    token_chars=('letter', 'digit',)
+)
 
 # Filters out "-" so that t-shirt and tshirt can be matched
 special_chars = analysis.char_filter('special_chars', 'mapping', mappings=('-=>',))


### PR DESCRIPTION
This makes trigram to use only letters and digits as tokens, so that query like "Scared Squirrel" will not match "United States".

It is not _the_ fix, but an improvement. 
