### PR TITLE
Add setup_es fixture to tests to teardown ES data

### DIFF
--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -7,7 +7,7 @@ from ..models import Company as ESCompany
 pytestmark = pytest.mark.django_db
 
 
-def test_company_dbmodel_to_dict():
+def test_company_dbmodel_to_dict(setup_es):
     """Tests conversion of db model to dict."""
     company = CompanyFactory()
 
@@ -32,7 +32,7 @@ def test_company_dbmodel_to_dict():
     assert set(result.keys()) == keys
 
 
-def test_company_dbmodels_to_es_documents():
+def test_company_dbmodels_to_es_documents(setup_es):
     """Tests conversion of db models to Elasticsearch documents."""
     companies = CompanyFactory.create_batch(2)
 

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -50,6 +50,7 @@ def setup_es(setup_es_indexes):
         body={'query': {'match_all': {}}},
         ignore=(409,)
     )
+    setup_es_indexes.indices.refresh()
 
 
 def create_test_index(client, index):

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -7,7 +7,7 @@ from ..models import Contact as ESContact
 pytestmark = pytest.mark.django_db
 
 
-def test_contact_dbmodel_to_dict():
+def test_contact_dbmodel_to_dict(setup_es):
     """Tests conversion of db model to dict."""
     contact = ContactFactory()
 
@@ -28,7 +28,7 @@ def test_contact_dbmodel_to_dict():
     assert set(result.keys()) == keys
 
 
-def test_contact_dbmodels_to_es_documents():
+def test_contact_dbmodels_to_es_documents(setup_es):
     """Tests conversion of db models to Elasticsearch documents."""
     contacts = ContactFactory.create_batch(2)
 
@@ -37,7 +37,7 @@ def test_contact_dbmodels_to_es_documents():
     assert len(list(result)) == len(contacts)
 
 
-def test_contact_dbmodels_to_es_documents_without_country():
+def test_contact_dbmodels_to_es_documents_without_country(setup_es):
     """
     Tests conversion of db models to Elasticsearch documents when
     country is None.

--- a/datahub/search/event/tests/test_models.py
+++ b/datahub/search/event/tests/test_models.py
@@ -6,7 +6,7 @@ from ..models import Event as ESEvent
 pytestmark = pytest.mark.django_db
 
 
-def test_event_dbmodel_to_dict():
+def test_event_dbmodel_to_dict(setup_es):
     """Tests conversion of db model to dict."""
     event = EventFactory()
 
@@ -40,7 +40,7 @@ def test_event_dbmodel_to_dict():
     assert result.keys() == keys
 
 
-def test_event_dbmodels_to_es_documents():
+def test_event_dbmodels_to_es_documents(setup_es):
     """Tests conversion of db models to Elasticsearch documents."""
     events = EventFactory.create_batch(2)
 

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -7,7 +7,7 @@ from datahub.search.interaction.models import Interaction
 pytestmark = pytest.mark.django_db
 
 
-def test_interaction_to_dict():
+def test_interaction_to_dict(setup_es):
     """Test converting an interaction to a dict."""
     interaction = InteractionFactory(
         investment_project=InvestmentProjectFactory()
@@ -60,7 +60,7 @@ def test_interaction_to_dict():
     }
 
 
-def test_interactions_to_es_documents():
+def test_interactions_to_es_documents(setup_es):
     """Test converting 2 orders to Elasticsearch documents."""
     interactions = InteractionFactory.create_batch(2)
 

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -7,7 +7,7 @@ from ..models import InvestmentProject as ESInvestmentProject
 pytestmark = pytest.mark.django_db
 
 
-def test_investment_project_to_dict():
+def test_investment_project_to_dict(setup_es):
     """Tests conversion of db model to dict."""
     project = InvestmentProjectFactory()
     result = ESInvestmentProject.dbmodel_to_dict(project)
@@ -93,7 +93,7 @@ def test_investment_project_to_dict():
     assert set(result.keys()) == keys
 
 
-def test_investment_project_dbmodels_to_es_documents():
+def test_investment_project_dbmodels_to_es_documents(setup_es):
     """Tests conversion of db models to Elasticsearch documents."""
     projects = InvestmentProjectFactory.create_batch(2)
 

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -9,7 +9,7 @@ from ..models import Order as ESOrder
 pytestmark = pytest.mark.django_db
 
 
-def test_order_to_dict():
+def test_order_to_dict(setup_es):
     """Test converting an order to dict."""
     order = OrderFactory()
     OrderSubscriberFactory.create_batch(2, order=order)
@@ -109,7 +109,7 @@ def test_order_to_dict():
     }
 
 
-def test_orders_to_es_documents():
+def test_orders_to_es_documents(setup_es):
     """Test converting 2 orders to Elasticsearch documents."""
     orders = OrderFactory.create_batch(2)
 

--- a/datahub/search/test/test_management_commands.py
+++ b/datahub/search/test/test_management_commands.py
@@ -31,7 +31,7 @@ def test_batch_rows():
 
 @mock.patch('datahub.search.management.commands.sync_es.bulk')
 @mock.patch('datahub.search.management.commands.sync_es.get_datasets')
-def test_sync_dataset(get_datasets, bulk):
+def test_sync_dataset(get_datasets, bulk, setup_es):
     """Tests syncing dataset up to Elasticsearch."""
     get_datasets.return_value = (
         DataSet([CompanyFactory(), CompanyFactory()], ESCompany),


### PR DESCRIPTION
This adds `setup_es` to extra tests so that all the ES data gets deleted after their execution.