### PR TITLE
Return payment_due_date in search and allow sort

### DIFF
--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -39,6 +39,7 @@ class Order(DocType, MapDBModelToDict):
     vat_cost = Integer(index=False)
     total_cost_string = Keyword()
     total_cost = Integer(copy_to=['total_cost_string'])
+    payment_due_date = Date()
 
     billing_contact_name = Text()
     billing_email = dsl_utils.SortableCaseInsensitiveKeywordText()
@@ -65,6 +66,10 @@ class Order(DocType, MapDBModelToDict):
             dict_utils.contact_or_adviser_dict(c.adviser, include_dit_team=True) for c in col.all()
         ],
         'billing_address_country': dict_utils.id_name_dict,
+    }
+
+    COMPUTED_MAPPINGS = {
+        'payment_due_date': lambda x: x.invoice.payment_due_date if x.invoice else None,
     }
 
     IGNORED_FIELDS = (

--- a/datahub/search/omis/serializers.py
+++ b/datahub/search/omis/serializers.py
@@ -10,4 +10,5 @@ class SearchOrderSerializer(SearchSerializer):
         'created_on',
         'modified_on',
         'delivery_date',
+        'payment_due_date',
     )

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -9,8 +9,10 @@ from datahub.core import constants
 from datahub.core.test_utils import APITestMixin
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.models import Order
-from datahub.omis.order.test.factories import OrderAssigneeFactory, OrderFactory, \
-    OrderSubscriberFactory
+from datahub.omis.order.test.factories import (
+    OrderAssigneeFactory, OrderFactory,
+    OrderSubscriberFactory, OrderWithAcceptedQuoteFactory
+)
 
 
 pytestmark = pytest.mark.django_db
@@ -46,7 +48,7 @@ def setup_data(setup_es):
     with freeze_time('2017-02-01 13:00:00'):
         company = CompanyFactory(name='Venus Ltd')
         contact = ContactFactory(company=company, first_name='Jenny', last_name='Cakeman')
-        order = OrderFactory(
+        order = OrderWithAcceptedQuoteFactory(
             reference='efgh',
             primary_market_id=constants.Country.france.value.id,
             assignees=[],
@@ -201,6 +203,14 @@ class TestSearchOrder(APITestMixin):
             ),
             (  # sort by delivery_date DESC
                 {'sortby': 'delivery_date:desc'},
+                ['efgh', 'abcd']
+            ),
+            (  # sort by payment_due_date ASC
+                {'sortby': 'payment_due_date:asc'},
+                ['abcd', 'efgh']
+            ),
+            (  # sort by payment_due_date DESC
+                {'sortby': 'payment_due_date:desc'},
                 ['efgh', 'abcd']
             ),
         )


### PR DESCRIPTION
This:
- indexes and returns payment_due_date from the search API
- adds the ability to sort by payment_due_date