### PR TITLE
add Mercury Ltd ch fixtures for UAT tests

### DIFF
--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -26,6 +26,7 @@ Advisor.objects.create_user(
     last_name='Ci'
 )" | /app/manage.py shell
 
+python /app/manage.py loaddata /app/fixtures/test_ch_data.yaml
 python /app/manage.py loaddata /app/fixtures/test_data.yaml
 python /app/manage.py createinitialrevisions
 python /app/manage.py sync_es


### PR DESCRIPTION
We also need the ch data for the Mercury Ltd fixture in UAT tests. This work adds that information in.