### PR TITLE
Add trading_name to global search.

### DIFF
--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -1,3 +1,5 @@
+from operator import attrgetter
+
 from django.conf import settings
 from elasticsearch_dsl import Boolean, Date, DocType, Keyword, Text
 
@@ -11,7 +13,9 @@ class Company(DocType, MapDBModelToDict):
 
     id = Keyword()
     account_manager = dsl_utils.contact_or_adviser_mapping('account_manager')
-    alias = dsl_utils.SortableText()
+    trading_name = dsl_utils.SortableText(copy_to=['trading_name_keyword', 'trading_name_trigram'])
+    trading_name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
+    trading_name_trigram = dsl_utils.TrigramText()
     archived = Boolean()
     archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
     contacts = dsl_utils.contact_or_adviser_mapping('contacts')
@@ -51,6 +55,10 @@ class Company(DocType, MapDBModelToDict):
     export_to_countries = dsl_utils.id_name_mapping()
     future_interest_countries = dsl_utils.id_name_mapping()
 
+    COMPUTED_MAPPINGS = {
+        'trading_name': attrgetter('alias')
+    }
+
     MAPPINGS = {
         'companies_house_data': dict_utils.company_dict,
         'account_manager': dict_utils.contact_or_adviser_dict,
@@ -75,6 +83,7 @@ class Company(DocType, MapDBModelToDict):
     }
 
     IGNORED_FIELDS = (
+        'alias',
         'business_leads',
         'children',
         'created_by',
@@ -90,6 +99,8 @@ class Company(DocType, MapDBModelToDict):
     )
 
     SEARCH_FIELDS = [
+        'trading_name_keyword',
+        'trading_name_trigram',
         'classification.name',
         'export_to_countries.name',
         'future_interest_countries.name',

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -14,26 +14,21 @@ def test_get_basic_search_query():
                     {
                         'match_phrase': {
                             'name_keyword': {
-                                'query': 'test', 'boost': 2
+                                'query': 'test',
+                                'boost': 2
                             }
                         }
                     }, {
                         'match_phrase': {
-                            'id': {
-                                'query': 'test'
-                            }
+                            'id': 'test'
                         }
                     }, {
                         'match': {
-                            'name': {
-                                'query': 'test'
-                            }
+                            'name': 'test'
                         }
                     }, {
                         'match_phrase': {
-                            'name_trigram': {
-                                'query': 'test'
-                            }
+                            'name_trigram': 'test'
                         }
                     }, {
                         'match': {
@@ -41,8 +36,7 @@ def test_get_basic_search_query():
                         }
                     }, {
                         'match': {
-                            'address_2': 'test'
-                        }
+                            'address_2': 'test'}
                     }, {
                         'nested': {
                             'path': 'address_country',
@@ -91,7 +85,7 @@ def test_get_basic_search_query():
                         'nested': {
                             'path': 'company',
                             'query': {
-                                'match': {
+                                'match_phrase': {
                                     'company.name_trigram': 'test'
                                 }
                             }
@@ -109,7 +103,7 @@ def test_get_basic_search_query():
                         'nested': {
                             'path': 'contact',
                             'query': {
-                                'match': {
+                                'match_phrase': {
                                     'contact.name_trigram': 'test'
                                 }
                             }
@@ -181,7 +175,7 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
-                        'match': {
+                        'match_phrase': {
                             'reference_trigram': 'test'
                         }
                     }, {
@@ -252,6 +246,14 @@ def test_get_basic_search_query():
                     }, {
                         'match': {
                             'trading_address_town': 'test'
+                        }
+                    }, {
+                        'match_phrase': {
+                            'trading_name_keyword': 'test'
+                        }
+                    }, {
+                        'match_phrase': {
+                            'trading_name_trigram': 'test'
                         }
                     }, {
                         'nested': {
@@ -346,21 +348,23 @@ def test_limited_get_search_by_entity_query():
                                     }
                                 }, {
                                     'match_phrase': {
-                                        'id': {
-                                            'query': 'test'
-                                        }
+                                        'id': 'test'
                                     }
                                 }, {
                                     'match': {
-                                        'name': {
-                                            'query': 'test'
-                                        }
+                                        'name': 'test'
                                     }
                                 }, {
                                     'match_phrase': {
-                                        'name_trigram': {
-                                            'query': 'test'
-                                        }
+                                        'name_trigram': 'test'
+                                    }
+                                }, {
+                                    'match_phrase': {
+                                        'trading_name_keyword': 'test'
+                                    }
+                                }, {
+                                    'match_phrase': {
+                                        'trading_name_trigram': 'test'
                                     }
                                 }, {
                                     'nested': {

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -36,7 +36,8 @@ def test_get_basic_search_query():
                         }
                     }, {
                         'match': {
-                            'address_2': 'test'}
+                            'address_2': 'test'
+                        }
                     }, {
                         'nested': {
                             'path': 'address_country',

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -21,7 +21,7 @@ def test_company_dbmodel_to_dict(setup_es):
             'archived_reason', 'archived_by', 'name',
             'registered_address_1', 'registered_address_2',
             'registered_address_town', 'registered_address_county',
-            'registered_address_postcode', 'company_number', 'alias',
+            'registered_address_postcode', 'company_number', 'trading_name',
             'employee_range', 'turnover_range', 'account_manager',
             'description', 'website', 'trading_address_1',
             'trading_address_2', 'trading_address_town',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -19,21 +19,15 @@ def test_get_basic_search_query():
                         }
                     }, {
                         'match_phrase': {
-                            'id': {
-                                'query': 'test'
-                            }
+                            'id': 'test'
                         }
                     }, {
                         'match': {
-                            'name': {
-                                'query': 'test'
-                            }
+                            'name': 'test'
                         }
                     }, {
                         'match_phrase': {
-                            'name_trigram': {
-                                'query': 'test'
-                            }
+                            'name_trigram': 'test'
                         }
                     }, {
                         'match': {
@@ -91,7 +85,7 @@ def test_get_basic_search_query():
                         'nested': {
                             'path': 'company',
                             'query': {
-                                'match': {
+                                'match_phrase': {
                                     'company.name_trigram': 'test'
                                 }
                             }
@@ -109,7 +103,7 @@ def test_get_basic_search_query():
                         'nested': {
                             'path': 'contact',
                             'query': {
-                                'match': {
+                                'match_phrase': {
                                     'contact.name_trigram': 'test'
                                 }
                             }
@@ -181,7 +175,7 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
-                        'match': {
+                        'match_phrase': {
                             'reference_trigram': 'test'
                         }
                     }, {
@@ -252,6 +246,14 @@ def test_get_basic_search_query():
                     }, {
                         'match': {
                             'trading_address_town': 'test'
+                        }
+                    }, {
+                        'match_phrase': {
+                            'trading_name_keyword': 'test'
+                        }
+                    }, {
+                        'match_phrase': {
+                            'trading_name_trigram': 'test'
                         }
                     }, {
                         'nested': {
@@ -347,21 +349,15 @@ def test_get_limited_search_by_entity_query():
                                     }
                                 }, {
                                     'match_phrase': {
-                                        'id': {
-                                            'query': 'test'
-                                        }
+                                        'id': 'test'
                                     }
                                 }, {
                                     'match': {
-                                        'name': {
-                                            'query': 'test'
-                                        }
+                                        'name': 'test'
                                     }
                                 }, {
                                     'match_phrase': {
-                                        'name_trigram': {
-                                            'query': 'test'
-                                        }
+                                        'name_trigram': 'test'
                                     }
                                 }, {
                                     'match': {

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -21,21 +21,15 @@ def test_get_basic_search_query():
                         }
                     }, {
                         'match_phrase': {
-                            'id': {
-                                'query': 'test'
-                            }
+                            'id': 'test'
                         }
                     }, {
                         'match': {
-                            'name': {
-                                'query': 'test'
-                            }
+                            'name': 'test'
                         }
                     }, {
                         'match_phrase': {
-                            'name_trigram': {
-                                'query': 'test'
-                            }
+                            'name_trigram': 'test'
                         }
                     }, {
                         'match': {
@@ -93,7 +87,7 @@ def test_get_basic_search_query():
                         'nested': {
                             'path': 'company',
                             'query': {
-                                'match': {
+                                'match_phrase': {
                                     'company.name_trigram': 'test'
                                 }
                             }
@@ -111,7 +105,7 @@ def test_get_basic_search_query():
                         'nested': {
                             'path': 'contact',
                             'query': {
-                                'match': {
+                                'match_phrase': {
                                     'contact.name_trigram': 'test'
                                 }
                             }
@@ -183,7 +177,7 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
-                        'match': {
+                        'match_phrase': {
                             'reference_trigram': 'test'
                         }
                     }, {
@@ -254,6 +248,14 @@ def test_get_basic_search_query():
                     }, {
                         'match': {
                             'trading_address_town': 'test'
+                        }
+                    }, {
+                        'match_phrase': {
+                            'trading_name_keyword': 'test'
+                        }
+                    }, {
+                        'match_phrase': {
+                            'trading_name_trigram': 'test'
                         }
                     }, {
                         'nested': {
@@ -349,21 +351,15 @@ def test_limited_get_search_by_entity_query():
                                     }
                                 }, {
                                     'match_phrase': {
-                                        'id': {
-                                            'query': 'test'
-                                        }
+                                        'id': 'test'
                                     }
                                 }, {
                                     'match': {
-                                        'name': {
-                                            'query': 'test'
-                                        }
+                                        'name': 'test'
                                     }
                                 }, {
                                     'match_phrase': {
-                                        'name_trigram': {
-                                            'query': 'test'
-                                        }
+                                        'name_trigram': 'test'
                                     }
                                 }, {
                                     'nested': {

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -22,21 +22,15 @@ def test_get_search_term_query():
                     }
                 }, {
                     'match_phrase': {
-                        'id': {
-                            'query': 'hello'
-                        }
+                        'id': 'hello'
                     }
                 }, {
                     'match': {
-                        'name': {
-                            'query': 'hello'
-                        }
+                        'name': 'hello'
                     }
                 }, {
                     'match_phrase': {
-                        'name_trigram': {
-                            'query': 'hello'
-                        }
+                        'name_trigram': 'hello'
                     }
                 }, {
                     'nested': {


### PR DESCRIPTION
As in the title, it adds `trading_name` (alias for `alias` :) ) to the global search. It also has a small cleanup of tests and small improvement to queries.