### PR TITLE
Improve search filter validation.

### DIFF
--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -1,12 +1,29 @@
-from ..serializers import SearchSerializer
+from rest_framework import serializers
+
+from ..serializers import (
+    SearchSerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
 
 
 class SearchCompanySerializer(SearchSerializer):
     """Serialiser used to validate company search POST bodies."""
 
+    account_manager = SingleOrListField(child=StringUUIDField(), required=False)
+    trading_name = serializers.CharField(required=False)
+    description = serializers.CharField(required=False)
+    export_to_country = SingleOrListField(child=StringUUIDField(), required=False)
+    future_interest_country = SingleOrListField(child=StringUUIDField(), required=False)
+    name = serializers.CharField(required=False)
+    sector = SingleOrListField(child=StringUUIDField(), required=False)
+    trading_address_country = SingleOrListField(child=StringUUIDField(), required=False)
+    uk_based = serializers.BooleanField(required=False)
+    uk_region = serializers.BooleanField(required=False)
+
     SORT_BY_FIELDS = (
         'account_manager.name',
-        'alias',
+        'trading_name',
         'archived',
         'archived_by',
         'business_type.name',

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -109,6 +109,7 @@ class TestSearch(APITestMixin):
         }, format='json')
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {'uk_region': ['This field may not be null.']}
 
     def test_company_search_paging(self, setup_data):
         """Tests pagination of results."""

--- a/datahub/search/contact/serializers.py
+++ b/datahub/search/contact/serializers.py
@@ -1,8 +1,19 @@
-from ..serializers import SearchSerializer
+from rest_framework import serializers
+
+from ..serializers import (
+    SearchSerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
 
 
 class SearchContactSerializer(SearchSerializer):
     """Serialiser used to validate contact search POST bodies."""
+
+    company_name = serializers.CharField(required=False)
+    company_sector = SingleOrListField(child=StringUUIDField(), required=False)
+    company_uk_region = SingleOrListField(child=StringUUIDField(), required=False)
+    address_country = SingleOrListField(child=StringUUIDField(), required=False)
 
     SORT_BY_FIELDS = (
         'address_country.name',

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -1,7 +1,6 @@
 from collections import defaultdict
 from itertools import chain
 
-import dateutil.parser
 from django.conf import settings
 from elasticsearch.helpers import bulk as es_bulk
 from elasticsearch_dsl import analysis, Index, Search
@@ -297,9 +296,9 @@ def date_range_fields(fields):
             range_key = k[:k.rindex('_')]
 
             if k.endswith('_before'):
-                ranges[range_key]['lte'] = dateutil.parser.parse(fields[k])
+                ranges[range_key]['lte'] = fields[k]
             if k.endswith('_after'):
-                ranges[range_key]['gte'] = dateutil.parser.parse(fields[k])
+                ranges[range_key]['gte'] = fields[k]
 
             continue
 

--- a/datahub/search/event/serializers.py
+++ b/datahub/search/event/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from ..serializers import (
-    DateTimeyField,
+    RelaxedDateTimeField,
     SearchSerializer,
     SingleOrListField,
     StringUUIDField,
@@ -13,15 +13,15 @@ class SearchEventSerializer(SearchSerializer):
 
     address_country = SingleOrListField(child=StringUUIDField(), required=False)
     disabled_on_exists = serializers.BooleanField(required=False)
-    disabled_on_after = DateTimeyField(required=False)
-    disabled_on_before = DateTimeyField(required=False)
+    disabled_on_after = RelaxedDateTimeField(required=False)
+    disabled_on_before = RelaxedDateTimeField(required=False)
     event_type = SingleOrListField(child=StringUUIDField(), required=False)
     lead_team = SingleOrListField(child=StringUUIDField(), required=False)
     name = serializers.CharField(required=False)
     organiser = SingleOrListField(child=StringUUIDField(), required=False)
     organiser_name = serializers.CharField(required=False)
-    start_date_after = DateTimeyField(required=False)
-    start_date_before = DateTimeyField(required=False)
+    start_date_after = RelaxedDateTimeField(required=False)
+    start_date_before = RelaxedDateTimeField(required=False)
     teams = SingleOrListField(child=StringUUIDField(), required=False)
     uk_region = SingleOrListField(child=StringUUIDField(), required=False)
 

--- a/datahub/search/event/serializers.py
+++ b/datahub/search/event/serializers.py
@@ -1,8 +1,29 @@
-from ..serializers import SearchSerializer
+from rest_framework import serializers
+
+from ..serializers import (
+    DateTimeyField,
+    SearchSerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
 
 
 class SearchEventSerializer(SearchSerializer):
     """Serialiser used to validate Event search POST bodies."""
+
+    address_country = SingleOrListField(child=StringUUIDField(), required=False)
+    disabled_on_exists = serializers.BooleanField(required=False)
+    disabled_on_after = DateTimeyField(required=False)
+    disabled_on_before = DateTimeyField(required=False)
+    event_type = SingleOrListField(child=StringUUIDField(), required=False)
+    lead_team = SingleOrListField(child=StringUUIDField(), required=False)
+    name = serializers.CharField(required=False)
+    organiser = SingleOrListField(child=StringUUIDField(), required=False)
+    organiser_name = serializers.CharField(required=False)
+    start_date_after = DateTimeyField(required=False)
+    start_date_before = DateTimeyField(required=False)
+    teams = SingleOrListField(child=StringUUIDField(), required=False)
+    uk_region = SingleOrListField(child=StringUUIDField(), required=False)
 
     SORT_BY_FIELDS = (
         'id',

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -1,8 +1,26 @@
-from ..serializers import SearchSerializer
+from rest_framework import serializers
+
+from ..serializers import (
+    SearchSerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
 
 
 class SearchInteractionSerializer(SearchSerializer):
     """Serialiser used to validate interaction search POST bodies."""
+
+    kind = SingleOrListField(child=serializers.CharField(), required=False)
+    company = SingleOrListField(child=StringUUIDField(), required=False)
+    company_name = serializers.CharField(required=False)
+    contact = SingleOrListField(child=StringUUIDField(), required=False)
+    contact_name = serializers.CharField(required=False)
+    dit_adviser = SingleOrListField(child=StringUUIDField(), required=False)
+    dit_adviser_name = serializers.CharField(required=False)
+    dit_team = SingleOrListField(child=StringUUIDField(), required=False)
+    communication_channel = SingleOrListField(child=StringUUIDField(), required=False)
+    investment_project = SingleOrListField(child=StringUUIDField(), required=False)
+    service = SingleOrListField(child=StringUUIDField(), required=False)
 
     DEFAULT_ORDERING = 'date:desc'
 

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -1,8 +1,26 @@
-from ..serializers import SearchSerializer
+from rest_framework import serializers
+
+from ..serializers import (
+    DateTimeyField,
+    SearchSerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
 
 
 class SearchInvestmentProjectSerializer(SearchSerializer):
     """Serialiser used to validate investment project search POST bodies."""
+
+    client_relationship_manager = SingleOrListField(child=StringUUIDField(), required=False)
+    estimated_land_date_after = DateTimeyField(required=False)
+    estimated_land_date_before = DateTimeyField(required=False)
+    investment_type = SingleOrListField(child=StringUUIDField(), required=False)
+    investor_company = SingleOrListField(child=StringUUIDField(), required=False)
+    investor_company_country = SingleOrListField(child=StringUUIDField(), required=False)
+    sector = SingleOrListField(child=StringUUIDField(), required=False)
+    stage = SingleOrListField(child=StringUUIDField(), required=False)
+    status = serializers.CharField(required=False)
+    uk_region_location = SingleOrListField(child=StringUUIDField(), required=False)
 
     SORT_BY_FIELDS = (
         'actual_land_date',

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from ..serializers import (
-    DateTimeyField,
+    RelaxedDateTimeField,
     SearchSerializer,
     SingleOrListField,
     StringUUIDField,
@@ -12,8 +12,8 @@ class SearchInvestmentProjectSerializer(SearchSerializer):
     """Serialiser used to validate investment project search POST bodies."""
 
     client_relationship_manager = SingleOrListField(child=StringUUIDField(), required=False)
-    estimated_land_date_after = DateTimeyField(required=False)
-    estimated_land_date_before = DateTimeyField(required=False)
+    estimated_land_date_after = RelaxedDateTimeField(required=False)
+    estimated_land_date_before = RelaxedDateTimeField(required=False)
     investment_type = SingleOrListField(child=StringUUIDField(), required=False)
     investor_company = SingleOrListField(child=StringUUIDField(), required=False)
     investor_company_country = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/omis/serializers.py
+++ b/datahub/search/omis/serializers.py
@@ -1,8 +1,28 @@
-from ..serializers import SearchSerializer
+from rest_framework import serializers
+
+from ..serializers import (
+    DateTimeyField,
+    SearchSerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
 
 
 class SearchOrderSerializer(SearchSerializer):
     """Serialiser used to validate OMIS search POST bodies."""
+
+    primary_market = SingleOrListField(child=StringUUIDField(), required=False)
+    created_on_before = DateTimeyField(required=False)
+    created_on_after = DateTimeyField(required=False)
+    assigned_to_adviser = SingleOrListField(child=StringUUIDField(), required=False)
+    assigned_to_team = SingleOrListField(child=StringUUIDField(), required=False)
+    status = SingleOrListField(child=serializers.CharField(), required=False)
+    reference = SingleOrListField(child=serializers.CharField(), required=False)
+    total_cost = serializers.IntegerField(required=False)
+    subtotal_cost = serializers.IntegerField(required=False)
+    contact_name = serializers.CharField(required=False)
+    company = SingleOrListField(child=StringUUIDField(), required=False)
+    company_name = serializers.CharField(required=False)
 
     DEFAULT_ORDERING = 'created_on:desc'
 

--- a/datahub/search/omis/serializers.py
+++ b/datahub/search/omis/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from ..serializers import (
-    DateTimeyField,
+    RelaxedDateTimeField,
     SearchSerializer,
     SingleOrListField,
     StringUUIDField,
@@ -12,8 +12,8 @@ class SearchOrderSerializer(SearchSerializer):
     """Serialiser used to validate OMIS search POST bodies."""
 
     primary_market = SingleOrListField(child=StringUUIDField(), required=False)
-    created_on_before = DateTimeyField(required=False)
-    created_on_after = DateTimeyField(required=False)
+    created_on_before = RelaxedDateTimeField(required=False)
+    created_on_after = RelaxedDateTimeField(required=False)
     assigned_to_adviser = SingleOrListField(child=StringUUIDField(), required=False)
     assigned_to_team = SingleOrListField(child=StringUUIDField(), required=False)
     status = SingleOrListField(child=serializers.CharField(), required=False)

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -91,10 +91,6 @@ class TestSearchOrder(APITestMixin):
                 {'primary_market': constants.Country.france.value.id},
                 ['efgh']
             ),
-            (  # invalid market => no results
-                {'primary_market': 'invalid'},
-                []
-            ),
             (  # filter by a range of date for created_on
                 {
                     'created_on_before': '2017-02-02',
@@ -252,7 +248,21 @@ class TestSearchOrder(APITestMixin):
         }, format='json')
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == {'non_field_errors': 'Date(s) in incorrect format.'}
+        assert response.json() == {'created_on_before': ['Date is in incorrect format.']}
+
+    def test_incorrect_primary_market_raise_validation_error(self, setup_data):
+        """
+        Test that if the primary_market is not in a valid format,
+        then the API return a validation error.
+        """
+        url = reverse('api-v3:search:order')
+
+        response = self.api_client.post(url, {
+            'primary_market': 'invalid',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {'primary_market': ['String can not be parsed as UUID.']}
 
     def test_filter_by_assigned_to_assignee_adviser(self, setup_data):
         """Test that results can be filtered by assignee."""

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -15,7 +15,6 @@ from datahub.omis.order.test.factories import (
     OrderSubscriberFactory, OrderWithAcceptedQuoteFactory
 )
 
-
 pytestmark = pytest.mark.django_db
 
 
@@ -262,7 +261,7 @@ class TestSearchOrder(APITestMixin):
         }, format='json')
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == {'primary_market': ['String can not be parsed as UUID.']}
+        assert response.json() == {'primary_market': ['"invalid" is not a valid UUID.']}
 
     def test_filter_by_assigned_to_assignee_adviser(self, setup_data):
         """Test that results can be filtered by assignee."""

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -1,6 +1,52 @@
+from uuid import UUID
+
+from dateutil.parser import parse as dateutil_parse
 from rest_framework import serializers
 from rest_framework.settings import api_settings
+
 from datahub.search.elasticsearch import MAX_RESULTS
+
+
+class DateTimeyField(serializers.Field):
+    """String Date time field."""
+
+    default_error_messages = {
+        'invalid': 'Date is in incorrect format.'
+    }
+
+    def to_internal_value(self, data):
+        """Parses data into datetime."""
+        try:
+            data = dateutil_parse(data)
+        except ValueError:
+            self.fail('invalid', value=data)
+        return data
+
+
+class SingleOrListField(serializers.ListField):
+    """Field can be single instance or list."""
+
+    def to_internal_value(self, data):
+        """If data is str, creates a list."""
+        if isinstance(data, str):
+            data = [data]
+        return super().to_internal_value(data)
+
+
+class StringUUIDField(serializers.Field):
+    """String UUID field."""
+
+    default_error_messages = {
+        'invalid': 'String can not be parsed as UUID.'
+    }
+
+    def to_internal_value(self, data):
+        """Checks if data is UUID."""
+        try:
+            UUID(hex=data)
+        except ValueError:
+            self.fail('invalid', value=data)
+        return data
 
 
 class LimitOffsetSerializer(serializers.Serializer):

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -81,7 +81,7 @@ def test_remap_sort_field():
 
 def test_date_range_fields():
     """Tests date range fields."""
-    now = '2017-06-13T09:44:31.062870'
+    now = datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)
     fields = {
         'estimated_land_date_after': now,
         'estimated_land_date_before': now,
@@ -95,8 +95,8 @@ def test_date_range_fields():
     }
     assert ranges == {
         'estimated_land_date': {
-            'gte': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870),
-            'lte': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)
+            'gte': now,
+            'lte': now
         }
     }
 


### PR DESCRIPTION
This adds validation to search filters using DRF serializers. I needed to add three serializers:

`RelaxedDateTimeField` - which handles date sent in different formats.
`StringUUIDField` - we can't use UUID in the ES queries, so this only ensures that given string can be parsed as UUID and returns a string.
`SingleOrListField` - this extends `ListField` serializer. If data input is a string, it creates a list of one element. This is to handle case when filter can be either single value or an array.

It changes behaviour in case of date validation, as it now returns which field has a problem, not an error in general.
