### PR TITLE
Fix/event dates mandatory

### DIFF
--- a/datahub/event/serializers.py
+++ b/datahub/event/serializers.py
@@ -13,8 +13,6 @@ class EventSerializer(serializers.ModelSerializer):
 
     default_error_messages = {
         'lead_team_not_in_teams': ugettext_lazy('Lead team must be in teams array.'),
-        'end_date_without_start_date': ugettext_lazy('Cannot have an end date without a start '
-                                                     'date.'),
         'end_date_before_start_date': ugettext_lazy('End date cannot be before start date.'),
         'uk_region_non_uk_country': ugettext_lazy('Cannot specify a UK region for a non-UK '
                                                   'country.')

--- a/datahub/event/serializers.py
+++ b/datahub/event/serializers.py
@@ -19,7 +19,7 @@ class EventSerializer(serializers.ModelSerializer):
         'uk_region_non_uk_country': ugettext_lazy('Cannot specify a UK region for a non-UK '
                                                   'country.')
     }
-    end_date = serializers.DateField(required=False, allow_null=True)
+    end_date = serializers.DateField()
     event_type = NestedRelatedField('event.EventType')
     location_type = NestedRelatedField('event.LocationType', required=False, allow_null=True)
     organiser = NestedAdviserField(required=False, allow_null=True)
@@ -31,16 +31,7 @@ class EventSerializer(serializers.ModelSerializer):
         'event.Programme', many=True, required=False, allow_empty=True
     )
     service = NestedRelatedField('metadata.Service')
-    start_date = serializers.DateField(required=False, allow_null=True)
-
-    def __init__(self, *args, **kwargs):
-        """Makes start_date and end_date fields required when creating an Event."""
-        super().__init__(*args, **kwargs)
-
-        if not self.instance:
-            for field in ('start_date', 'end_date', ):
-                self.fields[field].required = True
-                self.fields[field].allow_null = True
+    start_date = serializers.DateField()
 
     def validate(self, data):
         """Performs cross-field validation."""

--- a/datahub/event/serializers.py
+++ b/datahub/event/serializers.py
@@ -19,7 +19,7 @@ class EventSerializer(serializers.ModelSerializer):
         'uk_region_non_uk_country': ugettext_lazy('Cannot specify a UK region for a non-UK '
                                                   'country.')
     }
-    end_date = serializers.DateField()
+    end_date = serializers.DateField(required=False, allow_null=True)
     event_type = NestedRelatedField('event.EventType')
     location_type = NestedRelatedField('event.LocationType', required=False, allow_null=True)
     organiser = NestedAdviserField(required=False, allow_null=True)
@@ -31,7 +31,16 @@ class EventSerializer(serializers.ModelSerializer):
         'event.Programme', many=True, required=False, allow_empty=True
     )
     service = NestedRelatedField('metadata.Service')
-    start_date = serializers.DateField()
+    start_date = serializers.DateField(required=False, allow_null=True)
+
+    def __init__(self, *args, **kwargs):
+        """Makes start_date and end_date fields required when creating an Event."""
+        super().__init__(*args, **kwargs)
+
+        if not self.instance:
+            for field in ('start_date', 'end_date', ):
+                self.fields[field].required = True
+                self.fields[field].allow_null = True
 
     def validate(self, data):
         """Performs cross-field validation."""
@@ -64,10 +73,11 @@ class EventSerializer(serializers.ModelSerializer):
 
     def _validate_dates(self, combiner):
         errors = {}
+
         start_date = combiner.get_value('start_date')
         end_date = combiner.get_value('end_date')
 
-        if end_date < start_date:
+        if start_date and end_date and end_date < start_date:
             errors['end_date'] = self.error_messages['end_date_before_start_date']
 
         return errors

--- a/datahub/event/serializers.py
+++ b/datahub/event/serializers.py
@@ -19,7 +19,7 @@ class EventSerializer(serializers.ModelSerializer):
         'uk_region_non_uk_country': ugettext_lazy('Cannot specify a UK region for a non-UK '
                                                   'country.')
     }
-
+    end_date = serializers.DateField()
     event_type = NestedRelatedField('event.EventType')
     location_type = NestedRelatedField('event.LocationType', required=False, allow_null=True)
     organiser = NestedAdviserField(required=False, allow_null=True)
@@ -31,6 +31,7 @@ class EventSerializer(serializers.ModelSerializer):
         'event.Programme', many=True, required=False, allow_empty=True
     )
     service = NestedRelatedField('metadata.Service')
+    start_date = serializers.DateField()
 
     def validate(self, data):
         """Performs cross-field validation."""
@@ -66,11 +67,8 @@ class EventSerializer(serializers.ModelSerializer):
         start_date = combiner.get_value('start_date')
         end_date = combiner.get_value('end_date')
 
-        if end_date:
-            if not start_date:
-                errors['end_date'] = self.error_messages['end_date_without_start_date']
-            elif end_date < start_date:
-                errors['end_date'] = self.error_messages['end_date_before_start_date']
+        if end_date < start_date:
+            errors['end_date'] = self.error_messages['end_date_before_start_date']
 
         return errors
 

--- a/datahub/event/test/factories.py
+++ b/datahub/event/test/factories.py
@@ -17,6 +17,7 @@ class EventFactory(factory.django.DjangoModelFactory):
     name = factory.Faker('text')
     event_type_id = EventType.seminar.value.id
     start_date = factory.Faker('date')
+    end_date = factory.LazyAttribute(lambda event: event.start_date)
     location_type_id = LocationType.hq.value.id
     address_1 = factory.Faker('text')
     address_2 = factory.Faker('text')

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -364,11 +364,11 @@ class TestCreateEventView(APITestMixin):
             'address_1': '',
             'address_country': None,
             'address_town': '',
-            'end_date': '',
+            'end_date': None,
             'event_type': None,
             'name': '',
             'service': None,
-            'start_date': '',
+            'start_date': None,
         }
         response = self.api_client.post(url, format='json', data=request_data)
 
@@ -378,13 +378,11 @@ class TestCreateEventView(APITestMixin):
             'address_1': ['This field may not be blank.'],
             'address_country': ['This field may not be null.'],
             'address_town': ['This field may not be blank.'],
-            'end_date':
-                ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]].'],
+            'end_date': ['This field may not be null.'],
             'event_type': ['This field may not be null.'],
             'name': ['This field may not be blank.'],
             'service': ['This field may not be null.'],
-            'start_date':
-                ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]].'],
+            'start_date': ['This field may not be null.'],
         }
 
 

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -487,8 +487,8 @@ class TestUpdateEventView(APITestMixin):
         response_data = _get_canonical_response_data(response)
         assert response_data['lead_team']['id'] == Team.healthcare_uk.value.id
 
-    def test_patch_no_end_date_no_original_end_date(self):
-        """Test updating an event's lead team."""
+    def test_patch_null_end_date_failure(self):
+        """Test updating an event's end date with null."""
         event = EventFactory(end_date=None)
         url = reverse('api-v3:event:item', kwargs={'pk': event.pk})
 
@@ -498,8 +498,8 @@ class TestUpdateEventView(APITestMixin):
         response = self.api_client.patch(url, request_data, format='json')
 
         response_data = response.json()
-        assert response.status_code == status.HTTP_200_OK
-        assert response_data['end_date'] is None
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response_data['end_date'] == ['This field may not be null.']
 
     def test_patch_lead_team_failure(self):
         """Test updating an event's lead team to an invalid team."""

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -487,6 +487,20 @@ class TestUpdateEventView(APITestMixin):
         response_data = _get_canonical_response_data(response)
         assert response_data['lead_team']['id'] == Team.healthcare_uk.value.id
 
+    def test_patch_no_end_date_no_original_end_date(self):
+        """Test updating an event's lead team."""
+        event = EventFactory(end_date=None)
+        url = reverse('api-v3:event:item', kwargs={'pk': event.pk})
+
+        request_data = {
+            'end_date': None,
+        }
+        response = self.api_client.patch(url, request_data, format='json')
+
+        response_data = response.json()
+        assert response.status_code == status.HTTP_200_OK
+        assert response_data['end_date'] is None
+
     def test_patch_lead_team_failure(self):
         """Test updating an event's lead team to an invalid team."""
         event = EventFactory()

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -100,6 +100,7 @@ class TestCreateEventView(APITestMixin):
     def test_create_minimal_success(self):
         """Tests successfully creating an event with only the required fields."""
         url = reverse('api-v3:event:collection')
+
         request_data = {
             'name': 'Grand exhibition',
             'event_type': EventType.seminar.value.id,
@@ -107,6 +108,8 @@ class TestCreateEventView(APITestMixin):
             'address_town': 'New York',
             'address_country': Country.united_states.value.id,
             'service': Service.trade_enquiry.value.id,
+            'start_date': '2010-09-12',
+            'end_date': '2010-09-12',
         }
         response = self.api_client.post(url, format='json', data=request_data)
 
@@ -119,8 +122,8 @@ class TestCreateEventView(APITestMixin):
                 'id': EventType.seminar.value.id,
                 'name': EventType.seminar.value.name,
             },
-            'start_date': None,
-            'end_date': None,
+            'start_date': '2010-09-12',
+            'end_date': '2010-09-12',
             'location_type': None,
             'notes': '',
             'address_1': 'Grand Court Exhibition Centre',
@@ -230,6 +233,7 @@ class TestCreateEventView(APITestMixin):
         url = reverse('api-v3:event:collection')
         request_data = {
             'name': 'Grand exhibition',
+            'end_date': '2010-09-12',
             'event_type': EventType.seminar.value.id,
             'address_1': 'Grand Court Exhibition Centre',
             'address_town': 'London',
@@ -238,6 +242,7 @@ class TestCreateEventView(APITestMixin):
             'lead_team': Team.crm.value.id,
             'teams': [Team.healthcare_uk.value.id],
             'service': Service.trade_enquiry.value.id,
+            'start_date': '2010-09-12',
         }
         response = self.api_client.post(url, format='json', data=request_data)
 
@@ -252,11 +257,13 @@ class TestCreateEventView(APITestMixin):
         url = reverse('api-v3:event:collection')
         request_data = {
             'name': 'Grand exhibition',
+            'end_date': '2010-09-12',
             'event_type': EventType.seminar.value.id,
             'address_1': 'Grand Court Exhibition Centre',
             'address_town': 'London',
             'address_country': Country.united_kingdom.value.id,
             'service': Service.trade_enquiry.value.id,
+            'start_date': '2010-09-12',
         }
         response = self.api_client.post(url, format='json', data=request_data)
 
@@ -272,11 +279,13 @@ class TestCreateEventView(APITestMixin):
         request_data = {
             'name': 'Grand exhibition',
             'event_type': EventType.seminar.value.id,
+            'end_date': '2010-09-12',
             'address_1': 'Grand Court Exhibition Centre',
             'address_town': 'London',
             'address_country': Country.united_states.value.id,
             'uk_region': UKRegion.east_of_england.value.id,
             'service': Service.trade_enquiry.value.id,
+            'start_date': '2010-09-12',
         }
         response = self.api_client.post(url, format='json', data=request_data)
 
@@ -304,7 +313,7 @@ class TestCreateEventView(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'end_date': ['Cannot have an end date without a start date.']
+            'start_date': ['This field is required.']
         }
 
     def test_create_end_date_before_start_date(self):
@@ -341,9 +350,11 @@ class TestCreateEventView(APITestMixin):
             'address_1': ['This field is required.'],
             'address_country': ['This field is required.'],
             'address_town': ['This field is required.'],
+            'end_date': ['This field is required.'],
             'event_type': ['This field is required.'],
             'name': ['This field is required.'],
             'service': ['This field is required.'],
+            'start_date': ['This field is required.'],
         }
 
     def test_create_blank_failure(self):
@@ -353,9 +364,11 @@ class TestCreateEventView(APITestMixin):
             'address_1': '',
             'address_country': None,
             'address_town': '',
+            'end_date': '',
             'event_type': None,
             'name': '',
             'service': None,
+            'start_date': '',
         }
         response = self.api_client.post(url, format='json', data=request_data)
 
@@ -365,9 +378,13 @@ class TestCreateEventView(APITestMixin):
             'address_1': ['This field may not be blank.'],
             'address_country': ['This field may not be null.'],
             'address_town': ['This field may not be blank.'],
+            'end_date':
+                ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]].'],
             'event_type': ['This field may not be null.'],
             'name': ['This field may not be blank.'],
             'service': ['This field may not be null.'],
+            'start_date':
+                ['Date has wrong format. Use one of these formats instead: YYYY[-MM[-DD]].'],
         }
 
 


### PR DESCRIPTION
This makes `start_date` and `end_date` Event fields mandatory ~when creating an Event.~ at all times.
 