### PR TITLE
Add ability to mark an order as complete

### DIFF
--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -198,6 +198,13 @@ class OrderSerializer(serializers.ModelSerializer):
         data = self._reset_vat_fields_if_necessary(data)
         return data
 
+    def complete(self):
+        """Mark an order as complete."""
+        self.instance.complete(
+            by=self.context['current_user']
+        )
+        return self.instance
+
 
 class PublicOrderSerializer(serializers.ModelSerializer):
     """DRF serializer for public facing API."""

--- a/datahub/omis/order/test/factories.py
+++ b/datahub/omis/order/test/factories.py
@@ -145,6 +145,12 @@ class OrderAssigneeFactory(factory.django.DjangoModelFactory):
         model = 'order.OrderAssignee'
 
 
+class OrderAssigneeCompleteFactory(OrderAssigneeFactory):
+    """Order Assignee factory with actual time set."""
+
+    actual_time = factory.Faker('random_int', min=10, max=100)
+
+
 class HourlyRateFactory(factory.django.DjangoModelFactory):
     """HourlyRate factory."""
 

--- a/datahub/omis/order/test/test_models.py
+++ b/datahub/omis/order/test/test_models.py
@@ -17,8 +17,10 @@ from datahub.omis.payment.models import Payment
 from datahub.omis.quote.models import Quote
 
 from .factories import (
+    OrderAssigneeCompleteFactory,
     OrderAssigneeFactory,
     OrderFactory,
+    OrderPaidFactory,
     OrderWithAcceptedQuoteFactory,
     OrderWithOpenQuoteFactory,
 )
@@ -273,7 +275,7 @@ class TestReopen:
         try:
             order.reopen(by=AdviserFactory())
         except Exception:
-            pytest.fail('Should not raise a validator error.')
+            pytest.fail('Should not raise any exception.')
 
         assert order.status == OrderStatus.draft
 
@@ -330,7 +332,7 @@ class TestAcceptQuote:
         try:
             order.accept_quote(by=contact)
         except Exception:
-            pytest.fail('Should not raise a validator error.')
+            pytest.fail('Should not raise any exception.')
 
         order.refresh_from_db()
         assert order.status == OrderStatus.quote_accepted
@@ -401,7 +403,7 @@ class TestMarkOrderAsPaid:
                 ]
             )
         except Exception:
-            pytest.fail('Should not raise a validator error.')
+            pytest.fail('Should not raise any exception.')
 
         order.refresh_from_db()
         assert order.status == OrderStatus.paid
@@ -470,6 +472,82 @@ class TestMarkOrderAsPaid:
                     }
                 ]
             )
+
+
+class TestCompleteOrder:
+    """Tests for when an order is marked as complete."""
+
+    @pytest.mark.parametrize(
+        'allowed_status',
+        (OrderStatus.paid,)
+    )
+    def test_ok_if_order_in_allowed_status(self, allowed_status):
+        """
+        Test that the order can be marked as complete if it's in one of the allowed statuses.
+        """
+        order = OrderPaidFactory(status=allowed_status, assignees=[])
+        OrderAssigneeCompleteFactory(order=order)
+        adviser = AdviserFactory()
+
+        try:
+            with freeze_time('2018-07-12 13:00'):
+                order.complete(by=adviser)
+        except Exception:
+            pytest.fail('Should not raise any exception.')
+
+        order.refresh_from_db()
+        assert order.status == OrderStatus.complete
+        assert order.completed_on == dateutil_parse('2018-07-12 13:00')
+        assert order.completed_by == adviser
+
+    @pytest.mark.parametrize(
+        'disallowed_status',
+        (
+            OrderStatus.draft,
+            OrderStatus.quote_awaiting_acceptance,
+            OrderStatus.quote_accepted,
+            OrderStatus.complete,
+            OrderStatus.cancelled,
+        )
+    )
+    def test_fails_if_order_not_in_allowed_status(self, disallowed_status):
+        """
+        Test that if the order is in a disallowed status, the order cannot be marked as complete.
+        """
+        order = OrderFactory(status=disallowed_status)
+        with pytest.raises(Conflict):
+            order.complete(by=None)
+
+        assert order.status == disallowed_status
+
+    def test_atomicity(self):
+        """
+        Test that if there's a problem with saving the order, nothing gets saved.
+        """
+        order = OrderPaidFactory(assignees=[])
+        OrderAssigneeCompleteFactory(order=order)
+        with mock.patch.object(order, 'save') as mocked_save:
+            mocked_save.side_effect = Exception()
+
+            with pytest.raises(Exception):
+                order.complete(by=None)
+
+            order.refresh_from_db()
+            assert order.status == OrderStatus.paid
+            assert not order.completed_on
+            assert not order.completed_by
+
+    def test_validation_error_if_not_all_actual_time_set(self):
+        """
+        Test that if not all assignee actual time fields have been set,
+        a validation error is raised and the call fails.
+        """
+        order = OrderPaidFactory(assignees=[])
+        OrderAssigneeCompleteFactory(order=order)
+        OrderAssigneeFactory(order=order)
+
+        with pytest.raises(ValidationError):
+            order.complete(by=None)
 
 
 class TestOrderAssignee:

--- a/datahub/omis/order/urls.py
+++ b/datahub/omis/order/urls.py
@@ -5,19 +5,21 @@ from django.conf.urls import url
 from .views import AssigneeView, OrderViewSet, PublicOrderViewSet, SubscriberListView
 
 # internal frontend API
-order_collection = OrderViewSet.as_view({
-    'post': 'create'
-})
-
-order_item = OrderViewSet.as_view({
-    'get': 'retrieve',
-    'patch': 'partial_update'
-})
-
-
 internal_frontend_urls = [
-    url(r'^order$', order_collection, name='list'),
-    url(r'^order/(?P<pk>[0-9a-z-]{36})$', order_item, name='detail'),
+    url(r'^order$', OrderViewSet.as_view({'post': 'create'}), name='list'),
+    url(
+        r'^order/(?P<pk>[0-9a-z-]{36})$',
+        OrderViewSet.as_view({
+            'get': 'retrieve',
+            'patch': 'partial_update'
+        }),
+        name='detail'
+    ),
+    url(
+        r'^order/(?P<pk>[0-9a-z-]{36})/complete$',
+        OrderViewSet.as_view({'post': 'complete'}),
+        name='complete'
+    ),
 
     url(
         r'^order/(?P<order_pk>[0-9a-z-]{36})/subscriber-list$',
@@ -34,10 +36,10 @@ internal_frontend_urls = [
 
 
 # public facing API
-public_order_item = PublicOrderViewSet.as_view({
-    'get': 'retrieve'
-})
-
 public_urls = [
-    url(r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})$', public_order_item, name='detail'),
+    url(
+        r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})$',
+        PublicOrderViewSet.as_view({'get': 'retrieve'}),
+        name='detail'
+    ),
 ]

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -1,5 +1,6 @@
 from django.http import Http404
 
+from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -25,6 +26,19 @@ class OrderViewSet(CoreViewSetV3):
         'contact',
         'primary_market',
     )
+
+    def complete(self, request, *args, **kwargs):
+        """Complete an order."""
+        serializer = self.get_serializer(self.get_object())
+        serializer.complete()
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def get_serializer_context(self):
+        """Extra context provided to the serializer class."""
+        return {
+            **super().get_serializer_context(),
+            'current_user': self.request.user,
+        }
 
 
 class PublicOrderViewSet(CoreViewSetV3):


### PR DESCRIPTION
This adds the ability to mark an order as complete via a new endpoint `/v3/omis/order/<pk>/complete`