### PR TITLE
Restore further_info and existing_agents fields

### DIFF
--- a/datahub/omis/order/migrations/0001_squashed_0030_cancellation.py
+++ b/datahub/omis/order/migrations/0001_squashed_0030_cancellation.py
@@ -158,7 +158,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='order',
             name='contacts_not_to_approach',
-            field=models.TextField(blank=True, help_text='Are there contacts that DIT should not approach?'),
+            field=models.TextField(blank=True, help_text='Specific people or organisations the company does not want DIT to talk to.'),
         ),
         migrations.AddField(
             model_name='order',
@@ -168,12 +168,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='order',
             name='existing_agents',
-            field=models.TextField(blank=True, editable=False, help_text='Legacy field. Details of any existing agents.'),
+            field=models.TextField(blank=True, help_text='Contacts the company already has in the market.'),
         ),
         migrations.AddField(
             model_name='order',
             name='further_info',
-            field=models.TextField(blank=True, editable=False, help_text='Legacy field. Further information.'),
+            field=models.TextField(blank=True, help_text='Additional notes and useful information.'),
         ),
         migrations.AddField(
             model_name='order',

--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -143,7 +143,15 @@ class Order(BaseModel):
     )
     contacts_not_to_approach = models.TextField(
         blank=True,
-        help_text='Are there contacts that DIT should not approach?'
+        help_text='Specific people or organisations the company does not want DIT to talk to.'
+    )
+    further_info = models.TextField(
+        blank=True,
+        help_text='Additional notes and useful information.'
+    )
+    existing_agents = models.TextField(
+        blank=True,
+        help_text='Contacts the company already has in the market.'
     )
 
     delivery_date = models.DateField(blank=True, null=True)
@@ -235,14 +243,6 @@ class Order(BaseModel):
     product_info = models.TextField(
         blank=True, editable=False,
         help_text='Legacy field. What is the product?'
-    )
-    further_info = models.TextField(
-        blank=True, editable=False,
-        help_text='Legacy field. Further information.'
-    )
-    existing_agents = models.TextField(
-        blank=True, editable=False,
-        help_text='Legacy field. Details of any existing agents.'
     )
     permission_to_approach_contacts = models.TextField(
         blank=True, editable=False,

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -39,6 +39,8 @@ class OrderSerializer(serializers.ModelSerializer):
 
     description = serializers.CharField(allow_blank=True, required=False)
     contacts_not_to_approach = serializers.CharField(allow_blank=True, required=False)
+    further_info = serializers.CharField(allow_blank=True, required=False)
+    existing_agents = serializers.CharField(allow_blank=True, required=False)
 
     delivery_date = serializers.DateField(required=False, allow_null=True)
 
@@ -110,8 +112,6 @@ class OrderSerializer(serializers.ModelSerializer):
             'contact_email',
             'contact_phone',
             'product_info',
-            'further_info',
-            'existing_agents',
             'permission_to_approach_contacts',
             'discount_value',
             'net_cost',

--- a/datahub/omis/order/test/views/test_order_details.py
+++ b/datahub/omis/order/test/views/test_order_details.py
@@ -50,6 +50,8 @@ class TestAddOrderDetails(APITestMixin):
                 ],
                 'description': 'Description test',
                 'contacts_not_to_approach': 'Contacts not to approach details',
+                'further_info': 'Additional notes',
+                'existing_agents': 'Contacts in the market',
                 'delivery_date': '2017-04-20',
                 'po_number': 'PO 123',
                 'vat_status': VATStatus.eu,
@@ -108,8 +110,8 @@ class TestAddOrderDetails(APITestMixin):
             'description': 'Description test',
             'contacts_not_to_approach': 'Contacts not to approach details',
             'product_info': '',
-            'further_info': '',
-            'existing_agents': '',
+            'further_info': 'Additional notes',
+            'existing_agents': 'Contacts in the market',
             'permission_to_approach_contacts': '',
             'delivery_date': '2017-04-20',
             'contact_email': '',
@@ -312,8 +314,6 @@ class TestAddOrderDetails(APITestMixin):
                 'contact': {'id': contact.pk},
                 'primary_market': {'id': country.id},
                 'product_info': 'lorem ipsum',
-                'further_info': 'lorem ipsum',
-                'existing_agents': 'lorem ipsum',
                 'permission_to_approach_contacts': 'lorem ipsum',
                 'archived_documents_url_path': '/documents/123',
             },
@@ -322,8 +322,6 @@ class TestAddOrderDetails(APITestMixin):
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()['product_info'] == ''
-        assert response.json()['further_info'] == ''
-        assert response.json()['existing_agents'] == ''
         assert response.json()['permission_to_approach_contacts'] == ''
         assert response.json()['archived_documents_url_path'] == ''
 
@@ -443,6 +441,8 @@ class TestChangeOrderDetails(APITestMixin):
                 ],
                 'description': 'Updated description',
                 'contacts_not_to_approach': 'Updated contacts not to approach',
+                'further_info': 'Updated additional notes',
+                'existing_agents': 'Updated contacts in the market',
                 'delivery_date': '2017-04-21',
                 'po_number': 'NEW PO 321',
                 'vat_status': VATStatus.eu,
@@ -502,8 +502,8 @@ class TestChangeOrderDetails(APITestMixin):
             'description': 'Updated description',
             'contacts_not_to_approach': 'Updated contacts not to approach',
             'product_info': order.product_info,
-            'further_info': order.further_info,
-            'existing_agents': order.existing_agents,
+            'further_info': 'Updated additional notes',
+            'existing_agents': 'Updated contacts in the market',
             'permission_to_approach_contacts': order.permission_to_approach_contacts,
             'delivery_date': '2017-04-21',
             'contact_email': order.contact_email,
@@ -718,8 +718,6 @@ class TestChangeOrderDetails(APITestMixin):
             {
                 'status': OrderStatus.complete,
                 'product_info': 'Updated product info',
-                'further_info': 'Updated further info',
-                'existing_agents': 'Updated existing agents',
                 'permission_to_approach_contacts': 'Updated permission to approach contacts',
                 'contact_email': 'updated-email@email.com',
                 'contact_phone': '1234',
@@ -744,8 +742,6 @@ class TestChangeOrderDetails(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['status'] == OrderStatus.draft
         assert response.json()['product_info'] != 'Updated product info'
-        assert response.json()['further_info'] != 'Updated further info'
-        assert response.json()['existing_agents'] != 'Updated existing agents'
         assert response.json()['permission_to_approach_contacts'] != \
             'Updated permission to approach contacts'
         assert response.json()['contact_email'] != 'updated-email@email.com'

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -22,6 +22,8 @@ class Order(DocType, MapDBModelToDict):
     sector = dsl_utils.id_name_mapping()
     description = dsl_utils.EnglishText()
     contacts_not_to_approach = Text()
+    further_info = Text()
+    existing_agents = Text(index=False)
     delivery_date = Date()
     service_types = dsl_utils.id_name_mapping()
     contact_email = dsl_utils.SortableCaseInsensitiveKeywordText()
@@ -84,8 +86,6 @@ class Order(DocType, MapDBModelToDict):
     IGNORED_FIELDS = (
         'modified_by',
         'product_info',
-        'further_info',
-        'existing_agents',
         'permission_to_approach_contacts',
         'quote',
         'hourly_rate',

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -162,6 +162,13 @@ def test_mapping(setup_es):
                 'contacts_not_to_approach': {
                     'type': 'text'
                 },
+                'further_info': {
+                    'type': 'text'
+                },
+                'existing_agents': {
+                    'index': False,
+                    'type': 'text'
+                },
                 'created_by': {
                     'properties': {
                         'first_name': {
@@ -481,6 +488,8 @@ def test_indexed_doc(Factory, setup_es):
             'status': order.status,
             'description': order.description,
             'contacts_not_to_approach': order.contacts_not_to_approach,
+            'further_info': order.further_info,
+            'existing_agents': order.existing_agents,
             'delivery_date': order.delivery_date.isoformat(),
             'contact_email': order.contact_email,
             'contact_phone': order.contact_phone,

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -69,6 +69,8 @@ def test_order_to_dict(Factory, setup_es):
         'status': order.status,
         'description': order.description,
         'contacts_not_to_approach': order.contacts_not_to_approach,
+        'further_info': order.further_info,
+        'existing_agents': order.existing_agents,
         'delivery_date': order.delivery_date,
         'contact_email': order.contact_email,
         'contact_phone': order.contact_phone,


### PR DESCRIPTION
The OMIS order fields further_info and existing_agents are not legacy fields any more as we realised that we need them.

This restores them and allow them to be changes.