### PR TITLE
Add ability to select payment method

### DIFF
--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -398,14 +398,16 @@ class Order(BaseModel):
 
         :param by: the adviser who created the record
         :param payments_data: list of payments data.
-            Each item should at least contain `amount` and `received_on`
+            Each item should at least contain `amount`, `received_on` and `method`
             e.g. [
                 {
                     'amount': 1000,
+                    'method': 'bacs',
                     'received_on': ...
                 },
                 {
                     'amount': 1001,
+                    'method': 'manual',
                     'received_on': ...
                 }
             ]

--- a/datahub/omis/payment/serializers.py
+++ b/datahub/omis/payment/serializers.py
@@ -12,18 +12,21 @@ class PaymentListSerializer(serializers.ListSerializer):
         order = self.context['order']
         created_by = self.context['current_user']
 
-        # add bacs method
-        payments_data = [
-            {**data, 'method': PaymentMethod.bacs}
-            for data in validated_data
-        ]
-
-        order.mark_as_paid(created_by, payments_data)
+        order.mark_as_paid(created_by, validated_data)
         return list(order.payments.all())
 
 
 class PaymentSerializer(serializers.ModelSerializer):
     """Payment DRF serializer."""
+
+    method = serializers.ChoiceField(
+        choices=[
+            method
+            for method in PaymentMethod
+            if method[0] in ('bacs', 'manual')
+        ],
+        default=PaymentMethod.bacs
+    )
 
     class Meta:
         model = Payment
@@ -41,5 +44,4 @@ class PaymentSerializer(serializers.ModelSerializer):
             'created_on',
             'reference',
             'additional_reference',
-            'method',
         )

--- a/datahub/omis/payment/test/views/test_payments.py
+++ b/datahub/omis/payment/test/views/test_payments.py
@@ -86,6 +86,7 @@ class TestCreatePayments(APITestMixin):
                 {
                     'transaction_reference': 'some ref2',
                     'amount': order.total_cost - 1,
+                    'method': PaymentMethod.manual,
                     'received_on': '2017-04-21'
                 }
             ],
@@ -100,7 +101,7 @@ class TestCreatePayments(APITestMixin):
                 'transaction_reference': 'some ref1',
                 'additional_reference': '',
                 'amount': 1,
-                'method': PaymentMethod.bacs,
+                'method': PaymentMethod.bacs,  # bacs is the default one
                 'received_on': '2017-04-20'
             },
             {
@@ -109,7 +110,7 @@ class TestCreatePayments(APITestMixin):
                 'transaction_reference': 'some ref2',
                 'additional_reference': '',
                 'amount': order.total_cost - 1,
-                'method': PaymentMethod.bacs,
+                'method': PaymentMethod.manual,
                 'received_on': '2017-04-21'
             }
         ]
@@ -117,63 +118,55 @@ class TestCreatePayments(APITestMixin):
         assert order.status == OrderStatus.paid
         assert order.paid_on == dateutil_parse('2017-04-21T00:00:00Z')
 
-    def test_400_if_amounts_less_than_total_cost(self):
-        """
-        Test that if the sum of the amounts is less than order.total_cost,
-        the endpoint returns 400.
-        """
-        order = OrderWithAcceptedQuoteFactory()
-
-        url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': order.pk})
-        response = self.api_client.post(
-            url,
-            [
+    @pytest.mark.parametrize(
+        'data,errors',
+        (
+            # amount != from order total cost
+            (
+                [
+                    {'amount': 1, 'received_on': '2017-04-20', 'method': PaymentMethod.bacs},
+                    {'amount': 0, 'received_on': '2017-04-21', 'method': PaymentMethod.bacs}
+                ],
                 {
-                    'amount': 1,
-                    'received_on': '2017-04-20'
-                },
-                {
-                    'amount': order.total_cost - 2,
-                    'received_on': '2017-04-21'
+                    'non_field_errors': (
+                        'The sum of the amounts has to be equal or greater than the order total.'
+                    )
                 }
-            ],
-            format='json'
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == {
-            'non_field_errors': (
-                'The sum of the amounts has to be equal or '
-                'greater than the order total.'
+            ),
+            # required fields
+            (
+                [
+                    {'amount': 1, 'received_on': '2017-04-20', 'method': PaymentMethod.bacs},
+                    {'received_on': '2017-04-21', 'method': PaymentMethod.bacs},
+                    {'amount': 0, 'method': PaymentMethod.bacs}
+                ],
+                [
+                    {},
+                    {'amount': ['This field is required.']},
+                    {'received_on': ['This field is required.']}
+                ]
+            ),
+            # payment method not allowed
+            (
+                [
+                    {'amount': 1, 'received_on': '2017-04-20', 'method': PaymentMethod.card},
+                    {'amount': 1, 'received_on': '2017-04-20', 'method': PaymentMethod.cheque},
+                ],
+                [
+                    {'method': ['"card" is not a valid choice.']},
+                    {'method': ['"cheque" is not a valid choice.']}
+                ]
             )
-        }
-
-    def test_400_generic_validation(self):
-        """Test generic validation errors."""
+        )
+    )
+    def test_400_validation(self, data, errors):
+        """Test validation errors."""
         order = OrderWithAcceptedQuoteFactory()
 
         url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': order.pk})
-        response = self.api_client.post(
-            url,
-            [
-                {
-                    'amount': 1,
-                    'received_on': '2017-04-20'
-                },
-                {
-                    'received_on': '2017-04-21'
-                },
-                {
-                    'amount': order.total_cost - 1
-                }
-            ],
-            format='json'
-        )
+        response = self.api_client.post(url, data, format='json')
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == [
-            {},
-            {'amount': ['This field is required.']},
-            {'received_on': ['This field is required.']}
-        ]
+        assert response.json() == errors
 
     def test_ok_if_amounts_greater_than_total_cost(self):
         """
@@ -188,10 +181,12 @@ class TestCreatePayments(APITestMixin):
             [
                 {
                     'amount': order.total_cost,
+                    'method': PaymentMethod.bacs,
                     'received_on': '2017-04-20'
                 },
                 {
                     'amount': 1,
+                    'method': PaymentMethod.bacs,
                     'received_on': '2017-04-21'
                 }
             ],


### PR DESCRIPTION
Before:
The create payments endpoint assumed all methods were bacs.

After:
The create payments endpoint now requires a value for 'method' which can be 'bacs' or 'manual'. The options 'cheque' or 'card' are not supported via this endpoint.