### PR TITLE
Create an Access token to bypass SSO in datahub-frontend UAT

### DIFF
--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -7,23 +7,22 @@ python /app/manage.py migrate
 python /app/manage.py loadmetadata
 python /app/manage.py load_omis_metadata
 
-echo "from oauth2_provider.models import Application;
-from datahub.oauth.models import OAuthApplicationScope;
-app = Application.objects.create(
-    name='circleci',
-    client_id='${API_CLIENT_ID}',
-    client_secret='${API_CLIENT_SECRET}',
-    client_type=Application.CLIENT_CONFIDENTIAL,
-    authorization_grant_type=Application.GRANT_PASSWORD
-);
-OAuthApplicationScope.objects.create(application=app, scopes=['data-hub:internal-front-end'])" | /app/manage.py shell
+echo "import datetime
+from oauth2_provider.models import AccessToken
+from django.utils.timezone import now
+from datahub.company.models import Advisor
 
-echo "from datahub.company.models import Advisor;
-Advisor.objects.create_user(
+user = Advisor.objects.create_user(
     email='${QA_USER_EMAIL}',
-    password='${QA_USER_PASSWORD}',
     first_name='Circle',
     last_name='Ci'
+)
+
+AccessToken.objects.create(
+    user=user,
+    token='${OAUTH2_DEV_TOKEN}',
+    expires=now() + datetime.timedelta(days=1),
+    scope='data-hub:internal-front-end'
 )" | /app/manage.py shell
 
 python /app/manage.py loaddata /app/fixtures/test_ch_data.yaml


### PR DESCRIPTION
This work enables an Access token (with a value provided via `$OAUTH2_DEV_TOKEN`) to be created within the backend for CircleCi User Acceptance tests. The same access token value is then used in `datahub-frontend` to byPass SSO on CircleCi.

### Of Note
To cover not running SSO in UAT for `data-hub-frontend`:
- @r4vi and @lgarvey have spoken about an SSO stub. When this has been built we can look at integration testing for `data-hub-frontend` -> `SSO`
- I have asked the SSO team if they can add a healthcheck endpoint so we can add this to the `data-hub-frontend` health check and in the future potentially a separately hosted `data-hub-frontend` status page.

This work is related to [#877](https://github.com/uktrade/data-hub-frontend/pull/877)

This branch is green when run with `data-hub-frontend` on CircleCi in job: https://circleci.com/gh/uktrade/data-hub-frontend/9987