### PR TITLE
User without team now returns proper 403

### DIFF
--- a/datahub/core/auth.py
+++ b/datahub/core/auth.py
@@ -159,9 +159,9 @@ class TeamModelPermissionsBackend(CDMSUserBackend):
         This method is called by the ModelBackend _get_permissions() dynamically
         as part of aggregating user, group and team permissions
         """
-        try:
+        if user_obj.dit_team and user_obj.dit_team.role:
             groups = user_obj.dit_team.role.groups.all()
-        except AttributeError:
+        else:
             groups = []
 
         return Permission.objects.filter(group__in=groups)

--- a/datahub/core/auth.py
+++ b/datahub/core/auth.py
@@ -159,7 +159,11 @@ class TeamModelPermissionsBackend(CDMSUserBackend):
         This method is called by the ModelBackend _get_permissions() dynamically
         as part of aggregating user, group and team permissions
         """
-        groups = user_obj.dit_team.role.groups.all()
+        try:
+            groups = user_obj.dit_team.role.groups.all()
+        except AttributeError:
+            groups = []
+
         return Permission.objects.filter(group__in=groups)
 
     def get_team_permissions(self, user_obj, obj=None):

--- a/datahub/core/test/test_advisor_permissions.py
+++ b/datahub/core/test/test_advisor_permissions.py
@@ -50,3 +50,22 @@ class TestPermissions(APITestMixin):
         response = my_view(request)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_user_without_team_returns_403(self):
+        """
+        Tests view returns 403 for user without team and permission
+        """
+        self._user = get_test_user()
+        self._user.dit_team = None
+        self._user.save()
+
+        token = self.get_token()
+
+        request = factory.get('/', data={}, content_type='application/json',
+                              Authorization=f'Bearer {token}')
+        my_view = PermissionModelViewset.as_view(
+            actions={'get': 'list'}
+        )
+        response = my_view(request)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN


### PR DESCRIPTION
... if he has no permission, rather than blowing up