### PR TITLE
Include user's permissions in whoami endpoint response.

### DIFF
--- a/datahub/core/permissions.py
+++ b/datahub/core/permissions.py
@@ -1,6 +1,6 @@
+from collections import defaultdict
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework.permissions import BasePermission, DjangoModelPermissions
-from collections import defaultdict
 
 
 class DjangoCrudPermission(DjangoModelPermissions):
@@ -26,6 +26,9 @@ class UserHasPermissions(BasePermission):
 
 
 def serialize_permissions(permissions):
+    """
+    Serialize permissions into simplified structure
+    """
     formatted_permissions = defaultdict(list)
     for perm in permissions:
         app, action_model = perm.split('.', 1)
@@ -34,4 +37,3 @@ def serialize_permissions(permissions):
         formatted_permissions[model].append(action)
 
     return formatted_permissions
-

--- a/datahub/core/permissions.py
+++ b/datahub/core/permissions.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework.permissions import BasePermission, DjangoModelPermissions
+from collections import defaultdict
 
 
 class DjangoCrudPermission(DjangoModelPermissions):
@@ -22,3 +23,14 @@ class UserHasPermissions(BasePermission):
         if not hasattr(view, 'permission_required'):
             raise ImproperlyConfigured()
         return request.user and request.user.has_perm(view.permission_required)
+
+
+def serialize_permissions(permissions):
+    formatted_permissions = defaultdict(lambda: defaultdict(list))
+    for perm in permissions:
+        app, action_model = perm.split('.')
+        action, model = action_model.split('_')
+        formatted_permissions[app][model].append(action)
+
+    return formatted_permissions
+

--- a/datahub/core/permissions.py
+++ b/datahub/core/permissions.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework.permissions import BasePermission, DjangoModelPermissions
 
@@ -25,15 +24,7 @@ class UserHasPermissions(BasePermission):
         return request.user and request.user.has_perm(view.permission_required)
 
 
-def serialize_permissions(permissions):
     """
-    Serialize permissions into simplified structure
     """
-    formatted_permissions = defaultdict(list)
-    for perm in permissions:
-        app, action_model = perm.split('.', 1)
-        action, model = action_model.split('_', 1)
 
-        formatted_permissions[model].append(action)
 
-    return formatted_permissions

--- a/datahub/core/permissions.py
+++ b/datahub/core/permissions.py
@@ -26,11 +26,12 @@ class UserHasPermissions(BasePermission):
 
 
 def serialize_permissions(permissions):
-    formatted_permissions = defaultdict(lambda: defaultdict(list))
+    formatted_permissions = defaultdict(list)
     for perm in permissions:
-        app, action_model = perm.split('.')
-        action, model = action_model.split('_')
-        formatted_permissions[app][model].append(action)
+        app, action_model = perm.split('.', 1)
+        action, model = action_model.split('_', 1)
+
+        formatted_permissions[model].append(action)
 
     return formatted_permissions
 

--- a/datahub/core/permissions.py
+++ b/datahub/core/permissions.py
@@ -22,9 +22,3 @@ class UserHasPermissions(BasePermission):
         if not hasattr(view, 'permission_required'):
             raise ImproperlyConfigured()
         return request.user and request.user.has_perm(view.permission_required)
-
-
-    """
-    """
-
-

--- a/datahub/core/test/factories.py
+++ b/datahub/core/test/factories.py
@@ -60,3 +60,14 @@ class GroupFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'auth.Group'
+
+
+class PermissionFactory(factory.django.DjangoModelFactory):
+    """Permission Factory"""
+
+    name = factory.Faker('name')
+    codename = factory.Faker('codename')
+    content_type = factory.SubFactory()
+
+    class Meta:
+        model = 'auth.Permission'

--- a/datahub/core/test/factories.py
+++ b/datahub/core/test/factories.py
@@ -66,8 +66,8 @@ class GroupFactory(factory.django.DjangoModelFactory):
 class PermissionFactory(factory.django.DjangoModelFactory):
     """Permission Factory"""
 
-    name = factory.Faker('name')
-    codename = factory.Faker('name')
+    name = factory.Faker('word')
+    codename = factory.Faker('word')
     content_type = factory.Iterator(ContentType.objects.all())
 
     class Meta:

--- a/datahub/core/test/factories.py
+++ b/datahub/core/test/factories.py
@@ -1,6 +1,7 @@
 from functools import wraps
 
 import factory
+from django.contrib.contenttypes.models import ContentType
 
 
 def to_many_field(wrapped_func):
@@ -66,8 +67,8 @@ class PermissionFactory(factory.django.DjangoModelFactory):
     """Permission Factory"""
 
     name = factory.Faker('name')
-    codename = factory.Faker('codename')
-    content_type = factory.SubFactory()
+    codename = factory.Faker('name')
+    content_type = factory.Iterator(ContentType.objects.all())
 
     class Meta:
         model = 'auth.Permission'

--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -7,6 +7,7 @@ class WhoAmISerializer(serializers.ModelSerializer):
     """Adviser serializer for that includes a permissions"""
 
     name = serializers.CharField()
+    permissions = serializers.SerializerMethodField()
 
     class Meta:
         model = Advisor
@@ -20,13 +21,14 @@ class WhoAmISerializer(serializers.ModelSerializer):
             'contact_email',
             'telephone_number',
             'dit_team',
+            'permissions',
         )
         depth = 2
 
-    def serialize_permissions(self, permissions):
+    def get_permissions(self, obj):
         """Serialize permissions into simplified structure."""
         formatted_permissions = {}
-        for perm in permissions:
+        for perm in obj.get_all_permissions():
             app, action_model = perm.split('.', 1)
             action, model = action_model.split('_', 1)
 
@@ -36,11 +38,3 @@ class WhoAmISerializer(serializers.ModelSerializer):
                 formatted_permissions[model] = [action]
 
         return formatted_permissions
-
-    @property
-    def data(self):
-        """Data property."""
-        ret = super().data
-        ret['permissions'] = self.serialize_permissions(self.instance.get_all_permissions())
-
-        return ret

--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from rest_framework import serializers
 
 from datahub.company.models.adviser import Advisor
@@ -28,11 +26,12 @@ class WhoAmISerializer(serializers.ModelSerializer):
 
     def get_permissions(self, obj):
         """Serialize permissions into simplified structure."""
-        formatted_permissions = defaultdict(dict)
+        formatted_permissions = {}
         for perm in obj.get_all_permissions():
             _, action_model = perm.split('.', 1)
             action, model = action_model.split('_', 1)
 
-            formatted_permissions[model][action] = True
+            model_dict = formatted_permissions.setdefault(model, {})
+            model_dict[action] = True
 
         return formatted_permissions

--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from rest_framework import serializers
 
 from datahub.company.models.adviser import Advisor
@@ -6,7 +8,6 @@ from datahub.company.models.adviser import Advisor
 class WhoAmISerializer(serializers.ModelSerializer):
     """Adviser serializer for that includes a permissions"""
 
-    name = serializers.CharField()
     permissions = serializers.SerializerMethodField()
 
     class Meta:
@@ -27,14 +28,11 @@ class WhoAmISerializer(serializers.ModelSerializer):
 
     def get_permissions(self, obj):
         """Serialize permissions into simplified structure."""
-        formatted_permissions = {}
+        formatted_permissions = defaultdict(dict)
         for perm in obj.get_all_permissions():
-            app, action_model = perm.split('.', 1)
+            _, action_model = perm.split('.', 1)
             action, model = action_model.split('_', 1)
 
-            if model in formatted_permissions:
-                formatted_permissions[model][action] = True
-            else:
-                formatted_permissions[model] = {action: True}
+            formatted_permissions[model][action] = True
 
         return formatted_permissions

--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -1,0 +1,46 @@
+from rest_framework import serializers
+
+from datahub.company.models.adviser import Advisor
+
+
+class WhoAmISerializer(serializers.ModelSerializer):
+    """Adviser serializer for that includes a permissions"""
+
+    name = serializers.CharField()
+
+    class Meta:
+        model = Advisor
+        fields = (
+            'id',
+            'name',
+            'last_login',
+            'first_name',
+            'last_name',
+            'email',
+            'contact_email',
+            'telephone_number',
+            'dit_team',
+        )
+        depth = 2
+
+    def serialize_permissions(self, permissions):
+        """Serialize permissions into simplified structure."""
+        formatted_permissions = {}
+        for perm in permissions:
+            app, action_model = perm.split('.', 1)
+            action, model = action_model.split('_', 1)
+
+            if model in formatted_permissions:
+                formatted_permissions[model].append(action)
+            else:
+                formatted_permissions[model] = [action]
+
+        return formatted_permissions
+
+    @property
+    def data(self):
+        """Data property."""
+        ret = super().data
+        ret['permissions'] = self.serialize_permissions(self.instance.get_all_permissions())
+
+        return ret

--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -1,12 +1,14 @@
 from rest_framework import serializers
 
 from datahub.company.models.adviser import Advisor
+from datahub.metadata.serializers import TeamSerializer
 
 
 class WhoAmISerializer(serializers.ModelSerializer):
     """Adviser serializer for that includes a permissions"""
 
     permissions = serializers.SerializerMethodField()
+    dit_team = TeamSerializer(read_only=True)
 
     class Meta:
         model = Advisor

--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -27,13 +27,5 @@ class WhoAmISerializer(serializers.ModelSerializer):
         depth = 2
 
     def get_permissions(self, obj):
-        """Serialize permissions into simplified structure."""
-        formatted_permissions = {}
-        for perm in obj.get_all_permissions():
-            _, action_model = perm.split('.', 1)
-            action, model = action_model.split('_', 1)
-
-            model_dict = formatted_permissions.setdefault(model, {})
-            model_dict[action] = True
-
-        return formatted_permissions
+        """Serialize permissions."""
+        return obj.get_all_permissions()

--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -33,8 +33,8 @@ class WhoAmISerializer(serializers.ModelSerializer):
             action, model = action_model.split('_', 1)
 
             if model in formatted_permissions:
-                formatted_permissions[model].append(action)
+                formatted_permissions[model][action] = True
             else:
-                formatted_permissions[model] = [action]
+                formatted_permissions[model] = {action: True}
 
         return formatted_permissions

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -38,6 +38,4 @@ class TestUserView(APITestMixin):
         assert response.data['id'] == str(user_test.pk)
         assert response.data['team'] == team.name
         assert response.data['team_role'] == role.name
-        assert response.data.get('permissions') is not None
-        for model in (model_name_1, model_name_2):
-            assert action in response.data['permissions'][model]
+        assert response.data.get('permissions') == {model_name_1: [action], model_name_2: [action]}

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -33,9 +33,37 @@ class TestUserView(APITestMixin):
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['name'] == user_test.name
-        assert response.data['first_name'] == user_test.first_name
-        assert response.data['id'] == str(user_test.pk)
-        assert response.data['team'] == team.name
-        assert response.data['team_role'] == role.name
-        assert response.data.get('permissions') == {model_name_1: [action], model_name_2: [action]}
+        assert response.json() == {
+            'id': str(user_test.id),
+            'name': user_test.name,
+            'last_login': None,
+            'first_name': user_test.first_name,
+            'last_name': user_test.last_name,
+            'email': user_test.email,
+            'contact_email': '',
+            'telephone_number': '',
+            'dit_team': {
+                'id': str(team.id),
+                'disabled_on': None,
+                'name': 'Test Team',
+                'role': {
+                    'id': str(role.id),
+                    'disabled_on': None,
+                    'name': 'Test Role',
+                    'groups': [group.id],
+                },
+                'uk_region': {
+                    'id': str(team.uk_region_id),
+                    'disabled_on': None,
+                    'name': 'East Midlands',
+                },
+                'country': {
+                    'id': str(team.country_id),
+                    'disabled_on': None,
+                    'name': 'France',
+                }
+            },
+            'permissions': {
+                model_name_1: [action],
+                model_name_2: [action],
+            }}

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -1,9 +1,9 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test.factories import PermissionFactory
+from datahub.core.test.factories import PermissionFactory, GroupFactory
 from datahub.core.test_utils import APITestMixin, get_test_user
-from datahub.metadata.test.factories import TeamFactory
+from datahub.metadata.test.factories import TeamFactory, TeamRoleFactory
 
 
 class TestUserView(APITestMixin):
@@ -11,14 +11,23 @@ class TestUserView(APITestMixin):
 
     def test_who_am_i_authenticated(self):
         """Who am I."""
-        team_permission = PermissionFactory()
-        user_permission = PermissionFactory()
+        action = 'read'
+        model_name_1 = 'lorem'
+        model_name_2 = 'ipsum'
 
-        team = TeamFactory()
-        team.role.team_role_permissions.add(team_permission)
+        team_permission = PermissionFactory(codename=f'{action}_{model_name_1}')
+        user_permission = PermissionFactory(codename=f'{action}_{model_name_2}')
 
-        user_test = get_test_user()
-        user_test.permissions.add(user_permission)
+        group = GroupFactory()
+        group.permissions.add(team_permission)
+
+        role = TeamRoleFactory(name='Test Role')
+
+        team = TeamFactory(name='Test Team', role=role)
+        team.role.groups.add(group)
+
+        user_test = get_test_user(team=team)
+        user_test.user_permissions.add(user_permission)
 
         url = reverse('who_am_i')
         response = self.api_client.get(url)
@@ -27,3 +36,8 @@ class TestUserView(APITestMixin):
         assert response.data['name'] == user_test.name
         assert response.data['first_name'] == user_test.first_name
         assert response.data['id'] == str(user_test.pk)
+        assert response.data['team'] == team.name
+        assert response.data['team_role'] == role.name
+        assert response.data.get('permissions') is not None
+        for model in (model_name_1, model_name_2):
+            assert action in response.data['permissions'][model]

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -1,7 +1,9 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.core.test.factories import PermissionFactory
 from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.metadata.test.factories import TeamFactory
 
 
 class TestUserView(APITestMixin):
@@ -9,9 +11,17 @@ class TestUserView(APITestMixin):
 
     def test_who_am_i_authenticated(self):
         """Who am I."""
+        team_permission = PermissionFactory()
+        user_permission = PermissionFactory()
+
+        team = TeamFactory()
+        team.role.team_role_permissions.add(team_permission)
+
+        user_test = get_test_user()
+        user_test.permissions.add(user_permission)
+
         url = reverse('who_am_i')
         response = self.api_client.get(url)
-        user_test = get_test_user()
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['name'] == user_test.name

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -64,6 +64,6 @@ class TestUserView(APITestMixin):
                 }
             },
             'permissions': {
-                model_name_1: [action],
-                model_name_2: [action],
+                model_name_1: {action: True},
+                model_name_2: {action: True},
             }}

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test.factories import PermissionFactory, GroupFactory
+from datahub.core.test.factories import GroupFactory, PermissionFactory
 from datahub.core.test_utils import APITestMixin, get_test_user
 from datahub.metadata.test.factories import TeamFactory, TeamRoleFactory
 

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -44,22 +44,17 @@ class TestUserView(APITestMixin):
             'telephone_number': '',
             'dit_team': {
                 'id': str(team.id),
-                'disabled_on': None,
                 'name': 'Test Team',
                 'role': {
                     'id': str(role.id),
-                    'disabled_on': None,
                     'name': 'Test Role',
-                    'groups': [group.id],
                 },
                 'uk_region': {
                     'id': str(team.uk_region_id),
-                    'disabled_on': None,
                     'name': 'East Midlands',
                 },
                 'country': {
                     'id': str(team.country_id),
-                    'disabled_on': None,
                     'name': 'France',
                 }
             },

--- a/datahub/user/views.py
+++ b/datahub/user/views.py
@@ -1,8 +1,10 @@
+from django.contrib import auth
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from datahub.company.serializers import AdviserSerializer
+from datahub.core.permissions import serialize_permissions
 
 
 @api_view()
@@ -10,4 +12,14 @@ from datahub.company.serializers import AdviserSerializer
 def who_am_i(request):
     """Return the current user. This view is behind a login."""
     serializer = AdviserSerializer(request.user)
-    return Response(data=serializer.data)
+    data = serializer.data
+
+    permissions = set()
+    for backend in auth.get_backends():
+        try:
+            permissions.update(backend.get_all_permissions(user_obj=request.user))
+        except AttributeError:
+            pass
+
+    data['permissions'] = serialize_permissions(permissions)
+    return Response(data=data)

--- a/datahub/user/views.py
+++ b/datahub/user/views.py
@@ -13,6 +13,8 @@ def who_am_i(request):
     """Return the current user. This view is behind a login."""
     serializer = AdviserSerializer(request.user)
     data = serializer.data
+    data['team'] = request.user.dit_team.name
+    data['team_role'] = request.user.dit_team.role.name
 
     permissions = set()
     for backend in auth.get_backends():

--- a/datahub/user/views.py
+++ b/datahub/user/views.py
@@ -1,27 +1,13 @@
-from django.contrib import auth
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-
-from datahub.company.serializers import AdviserSerializer
-from datahub.core.permissions import serialize_permissions
+from datahub.company.serializers import UserSerializer
 
 
 @api_view()
 @permission_classes([IsAuthenticated])
 def who_am_i(request):
     """Return the current user. This view is behind a login."""
-    serializer = AdviserSerializer(request.user)
-    data = serializer.data
-    data['team'] = request.user.dit_team.name
-    data['team_role'] = request.user.dit_team.role.name
+    serializer = UserSerializer(request.user)
 
-    permissions = set()
-    for backend in auth.get_backends():
-        try:
-            permissions.update(backend.get_all_permissions(user_obj=request.user))
-        except AttributeError:
-            pass
-
-    data['permissions'] = serialize_permissions(permissions)
-    return Response(data=data)
+    return Response(data=serializer.data)

--- a/datahub/user/views.py
+++ b/datahub/user/views.py
@@ -1,13 +1,14 @@
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from datahub.company.serializers import UserSerializer
+
+from datahub.user.serializers import WhoAmISerializer
 
 
 @api_view()
 @permission_classes([IsAuthenticated])
 def who_am_i(request):
     """Return the current user. This view is behind a login."""
-    serializer = UserSerializer(request.user)
+    serializer = WhoAmISerializer(request.user)
 
     return Response(data=serializer.data)


### PR DESCRIPTION
Adding a set of permissions into a who_am_i API response to allow FE to filter menus for different users.