### PR TITLE
Make sure lead assignee set before creating quote

### DIFF
--- a/datahub/omis/order/test/test_validators.py
+++ b/datahub/omis/order/test/test_validators.py
@@ -171,6 +171,21 @@ class TestAssigneesFilledInValidator:
             'assignees': ['You need to add at least one assignee.']
         }
 
+    def test_no_lead_assignee_fails(self):
+        """Test that the validation fails if there's no lead assignee."""
+        order = OrderFactory()
+        order.assignees.update(is_lead=False)
+
+        validator = AssigneesFilledInValidator()
+        validator.set_instance(order)
+
+        with pytest.raises(ValidationError) as exc:
+            validator()
+
+        assert exc.value.detail == {
+            'assignee_lead': ['You need to set a lead assignee.']
+        }
+
     def test_no_estimated_time_fails(self):
         """
         Test that the validation fails if the combined estimated time of the assignees

--- a/datahub/omis/order/validators.py
+++ b/datahub/omis/order/validators.py
@@ -124,6 +124,7 @@ class AssigneesFilledInValidator:
     """Validator which checks that the order has enough information about assignees."""
 
     no_assignees_message = 'You need to add at least one assignee.'
+    no_lead_assignee_message = 'You need to set a lead assignee.'
     no_estimated_time_message = 'The total estimated time cannot be zero.'
 
     def __init__(self):
@@ -139,6 +140,11 @@ class AssigneesFilledInValidator:
         if not self.instance.assignees.count():
             raise ValidationError({
                 'assignees': [self.no_assignees_message]
+            })
+
+        if not self.instance.assignees.filter(is_lead=True).count():
+            raise ValidationError({
+                'assignee_lead': [self.no_lead_assignee_message]
             })
 
         if not self.instance.assignees.aggregate(sum=models.Sum('estimated_time'))['sum']:


### PR DESCRIPTION
This adds a validation check so that a quote cannot be created if no lead assignee has been set.