### PR TITLE
Add companies house company search app.

### DIFF
--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -75,7 +75,7 @@ class TestCompany(APITestMixin):
                 'registered_address_2': None,
                 'registered_address_town': 'Fooland',
                 'registered_address_country': {
-                    'id': str(Country.united_states.value.id),
+                    'id': str(ch_company.registered_address_country.id),
                     'disabled_on': None,
                     'name': ch_company.registered_address_country.name,
                 },
@@ -94,7 +94,7 @@ class TestCompany(APITestMixin):
             'registered_address_2': None,
             'registered_address_town': 'Fooland',
             'registered_address_country': {
-                'id': str(Country.united_states.value.id),
+                'id': str(ch_company.registered_address_country.id),
                 'name': ch_company.registered_address_country.name,
             },
             'registered_address_county': None,
@@ -131,7 +131,7 @@ class TestCompany(APITestMixin):
                 'id': str(company.sector.id),
                 'name': company.sector.name,
             },
-            'trading_address_1': '2 Fake Lane',
+            'trading_address_1': company.trading_address_1,
             'trading_address_2': None,
             'trading_address_country': {
                 'id': str(company.trading_address_country.id),

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -8,6 +8,7 @@ from .models import DataSet
 
 
 SEARCH_APPS = [
+    'datahub.search.companieshousecompany.CompaniesHouseCompanySearchApp',
     'datahub.search.company.CompanySearchApp',
     'datahub.search.contact.ContactSearchApp',
     'datahub.search.event.EventSearchApp',

--- a/datahub/search/companieshousecompany/__init__.py
+++ b/datahub/search/companieshousecompany/__init__.py
@@ -1,0 +1,3 @@
+from .apps import CompaniesHouseCompanySearchApp
+
+__all__ = ('CompaniesHouseCompanySearchApp',)

--- a/datahub/search/companieshousecompany/apps.py
+++ b/datahub/search/companieshousecompany/apps.py
@@ -1,10 +1,7 @@
 from datahub.company.models import CompaniesHouseCompany as DBCompaniesHouseCompany
 from datahub.search.apps import SearchApp
 from datahub.search.companieshousecompany.models import CompaniesHouseCompany
-from datahub.search.companieshousecompany.views import (
-    SearchCompaniesHouseCompanyAPIView,
-    SearchCompaniesHouseCompanyExportAPIView
-)
+from datahub.search.companieshousecompany.views import SearchCompaniesHouseCompanyAPIView
 
 
 class CompaniesHouseCompanySearchApp(SearchApp):
@@ -13,7 +10,6 @@ class CompaniesHouseCompanySearchApp(SearchApp):
     name = 'companieshousecompany'
     ESModel = CompaniesHouseCompany
     view = SearchCompaniesHouseCompanyAPIView
-    export_view = SearchCompaniesHouseCompanyExportAPIView
     queryset = DBCompaniesHouseCompany.objects.prefetch_related(
         'registered_address_country',
     )

--- a/datahub/search/companieshousecompany/apps.py
+++ b/datahub/search/companieshousecompany/apps.py
@@ -1,0 +1,19 @@
+from datahub.company.models import CompaniesHouseCompany as DBCompaniesHouseCompany
+from datahub.search.apps import SearchApp
+from datahub.search.companieshousecompany.models import CompaniesHouseCompany
+from datahub.search.companieshousecompany.views import (
+    SearchCompaniesHouseCompanyAPIView,
+    SearchCompaniesHouseCompanyExportAPIView
+)
+
+
+class CompaniesHouseCompanySearchApp(SearchApp):
+    """SearchApp for companies house companies."""
+
+    name = 'companieshousecompany'
+    ESModel = CompaniesHouseCompany
+    view = SearchCompaniesHouseCompanyAPIView
+    export_view = SearchCompaniesHouseCompanyExportAPIView
+    queryset = DBCompaniesHouseCompany.objects.prefetch_related(
+        'registered_address_country',
+    )

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -21,11 +21,11 @@ class CompaniesHouseCompany(DocType, MapDBModelToDict):
     company_number = dsl_utils.SortableCaseInsensitiveKeywordText()
     company_category = dsl_utils.SortableCaseInsensitiveKeywordText()
     company_status = dsl_utils.SortableCaseInsensitiveKeywordText()
-    sic_code_1 = dsl_utils.SortableCaseInsensitiveKeywordText()
-    sic_code_2 = dsl_utils.SortableCaseInsensitiveKeywordText()
-    sic_code_3 = dsl_utils.SortableCaseInsensitiveKeywordText()
-    sic_code_4 = dsl_utils.SortableCaseInsensitiveKeywordText()
-    uri = dsl_utils.SortableCaseInsensitiveKeywordText()
+    sic_code_1 = Text()
+    sic_code_2 = Text()
+    sic_code_3 = Text()
+    sic_code_4 = Text()
+    uri = Text()
     incorporation_date = Date()
 
     MAPPINGS = {

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -1,0 +1,44 @@
+from django.conf import settings
+from elasticsearch_dsl import Date, DocType, Keyword, Text
+
+from datahub.search import dict_utils, dsl_utils
+from datahub.search.models import MapDBModelToDict
+
+
+class CompaniesHouseCompany(DocType, MapDBModelToDict):
+    """Elasticsearch representation of CompaniesHouseCompany model."""
+
+    id = Keyword()
+    name = dsl_utils.SortableText(copy_to=['name_keyword', 'name_trigram'])
+    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
+    name_trigram = dsl_utils.TrigramText()
+    registered_address_1 = Text()
+    registered_address_2 = Text()
+    registered_address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
+    registered_address_county = Text()
+    registered_address_postcode = Text()
+    registered_address_country = dsl_utils.id_name_mapping()
+    company_number = dsl_utils.SortableCaseInsensitiveKeywordText()
+    company_category = dsl_utils.SortableCaseInsensitiveKeywordText()
+    company_status = dsl_utils.SortableCaseInsensitiveKeywordText()
+    sic_code_1 = dsl_utils.SortableCaseInsensitiveKeywordText()
+    sic_code_2 = dsl_utils.SortableCaseInsensitiveKeywordText()
+    sic_code_3 = dsl_utils.SortableCaseInsensitiveKeywordText()
+    sic_code_4 = dsl_utils.SortableCaseInsensitiveKeywordText()
+    uri = dsl_utils.SortableCaseInsensitiveKeywordText()
+    incorporation_date = Date()
+
+    MAPPINGS = {
+        'id': str,
+        'registered_address_country': dict_utils.id_name_dict,
+    }
+
+    SEARCH_FIELDS = [
+        'company_number',
+    ]
+
+    class Meta:
+        """Default document meta data."""
+
+        index = settings.ES_INDEX
+        doc_type = 'companieshousecompany'

--- a/datahub/search/companieshousecompany/serializers.py
+++ b/datahub/search/companieshousecompany/serializers.py
@@ -1,0 +1,22 @@
+from rest_framework import serializers
+
+from ..serializers import (
+    RelaxedDateTimeField,
+    SearchSerializer,
+    SingleOrListField,
+)
+
+
+class SearchCompaniesHouseCompanySerializer(SearchSerializer):
+    """Serialiser used to validate companies house company POST bodies."""
+
+    name = serializers.CharField(required=False)
+    company_number = serializers.CharField(required=False)
+    company_status = SingleOrListField(child=serializers.CharField(), required=False)
+    incorporation_date_after = RelaxedDateTimeField(required=False)
+    incorporation_date_before = RelaxedDateTimeField(required=False)
+
+    SORT_BY_FIELDS = (
+        'incorporated_date',
+        'name',
+    )

--- a/datahub/search/companieshousecompany/signals.py
+++ b/datahub/search/companieshousecompany/signals.py
@@ -1,36 +1,15 @@
-from django.db import transaction
-from django.db.models.signals import post_save
-
-from datahub.company.models import CompaniesHouseCompany as DBCompaniesHouseCompany
-
-from .models import CompaniesHouseCompany as ESCompaniesHouseCompany
-from ..signals import sync_es
-
-
-def companieshousecompany_sync_es(sender, instance, **kwargs):
-    """Sync companies house company to the Elasticsearch."""
-    transaction.on_commit(
-        lambda: sync_es(
-            ESCompaniesHouseCompany,
-            DBCompaniesHouseCompany,
-            str(instance.pk)
-        )
-    )
+"""
+Signals for companieshousecompany are not connected, because the data will only
+change via sync_ch command. After syncing Companies House data, sync_es command
+should be issued to sync db with Elasticsearch.
+"""
 
 
 def connect_signals():
     """Connect signals for ES sync."""
-    post_save.connect(
-        companieshousecompany_sync_es,
-        sender=DBCompaniesHouseCompany,
-        dispatch_uid='companieshousecompany_sync_es'
-    )
+    pass
 
 
 def disconnect_signals():
     """Disconnect signals from ES sync."""
-    post_save.disconnect(
-        companieshousecompany_sync_es,
-        sender=DBCompaniesHouseCompany,
-        dispatch_uid='companieshousecompany_sync_es'
-    )
+    pass

--- a/datahub/search/companieshousecompany/signals.py
+++ b/datahub/search/companieshousecompany/signals.py
@@ -1,0 +1,36 @@
+from django.db import transaction
+from django.db.models.signals import post_save
+
+from datahub.company.models import CompaniesHouseCompany as DBCompaniesHouseCompany
+
+from .models import CompaniesHouseCompany as ESCompaniesHouseCompany
+from ..signals import sync_es
+
+
+def companieshousecompany_sync_es(sender, instance, **kwargs):
+    """Sync companies house company to the Elasticsearch."""
+    transaction.on_commit(
+        lambda: sync_es(
+            ESCompaniesHouseCompany,
+            DBCompaniesHouseCompany,
+            str(instance.pk)
+        )
+    )
+
+
+def connect_signals():
+    """Connect signals for ES sync."""
+    post_save.connect(
+        companieshousecompany_sync_es,
+        sender=DBCompaniesHouseCompany,
+        dispatch_uid='companieshousecompany_sync_es'
+    )
+
+
+def disconnect_signals():
+    """Disconnect signals from ES sync."""
+    post_save.disconnect(
+        companieshousecompany_sync_es,
+        sender=DBCompaniesHouseCompany,
+        dispatch_uid='companieshousecompany_sync_es'
+    )

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -5,7 +5,7 @@ from elasticsearch_dsl import Mapping
 from datahub.company.test.factories import (
     CompaniesHouseCompanyFactory
 )
-
+from datahub.core.test_utils import format_date_or_datetime
 from .. import CompaniesHouseCompanySearchApp
 from ..models import CompaniesHouseCompany as ESCompaniesHouseCompany
 from ... import elasticsearch
@@ -157,6 +157,6 @@ def test_indexed_doc(setup_es):
             'sic_code_3': ch_company.sic_code_3,
             'sic_code_4': ch_company.sic_code_4,
             'uri': ch_company.uri,
-            'incorporation_date': ch_company.incorporation_date.isoformat(),
+            'incorporation_date': format_date_or_datetime(ch_company.incorporation_date),
         }
     }

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -1,0 +1,162 @@
+import pytest
+from django.conf import settings
+from elasticsearch_dsl import Mapping
+
+from datahub.company.test.factories import (
+    CompaniesHouseCompanyFactory
+)
+
+from .. import CompaniesHouseCompanySearchApp
+from ..models import CompaniesHouseCompany as ESCompaniesHouseCompany
+from ... import elasticsearch
+
+pytestmark = pytest.mark.django_db
+
+
+def test_mapping(setup_es):
+    """Test the ES mapping for a companies house company."""
+    mapping = Mapping.from_es(settings.ES_INDEX, CompaniesHouseCompanySearchApp.name)
+
+    assert mapping.to_dict() == {
+        'companieshousecompany': {
+            'properties': {
+                'company_category': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'company_number': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'company_status': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'id': {
+                    'type': 'keyword'
+                },
+                'incorporation_date': {
+                    'type': 'date'
+                },
+                'name': {
+                    'copy_to': ['name_keyword', 'name_trigram'],
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'name_keyword': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'name_trigram': {
+                    'analyzer': 'trigram_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'registered_address_1': {
+                    'type': 'text'
+                },
+                'registered_address_2': {
+                    'type': 'text'
+                },
+                'registered_address_country': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword'
+                        },
+                        'name': {
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        }
+                    },
+                    'type': 'nested'
+                },
+                'registered_address_county': {
+                    'type': 'text'
+                },
+                'registered_address_postcode': {
+                    'type': 'text'
+                },
+                'registered_address_town': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'sic_code_1': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'sic_code_2': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'sic_code_3': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'sic_code_4': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                },
+                'uri': {
+                    'analyzer': 'lowercase_keyword_analyzer',
+                    'fielddata': True,
+                    'type': 'text'
+                }
+            }
+        }
+    }
+
+
+def test_indexed_doc(setup_es):
+    """Test the ES data of an indexed companies house company."""
+    ch_company = CompaniesHouseCompanyFactory()
+
+    doc = ESCompaniesHouseCompany.es_document(ch_company)
+    elasticsearch.bulk(actions=(doc, ), chunk_size=1)
+
+    setup_es.indices.refresh()
+
+    indexed_ch_company = setup_es.get(
+        index=settings.ES_INDEX,
+        doc_type=CompaniesHouseCompanySearchApp.name,
+        id=ch_company.pk
+    )
+
+    assert indexed_ch_company == {
+        '_index': settings.ES_INDEX,
+        '_type': CompaniesHouseCompanySearchApp.name,
+        '_id': str(ch_company.pk),
+        '_version': indexed_ch_company['_version'],
+        'found': True,
+        '_source': {
+            'id': str(ch_company.pk),
+            'name': ch_company.name,
+            'registered_address_1': ch_company.registered_address_1,
+            'registered_address_2': ch_company.registered_address_2,
+            'registered_address_town': ch_company.registered_address_town,
+            'registered_address_county': ch_company.registered_address_county,
+            'registered_address_postcode': ch_company.registered_address_postcode,
+            'registered_address_country': {
+                'id': str(ch_company.registered_address_country.pk),
+                'name': ch_company.registered_address_country.name
+            },
+            'company_number': ch_company.company_number,
+            'company_category': ch_company.company_category,
+            'company_status': ch_company.company_status,
+            'sic_code_1': ch_company.sic_code_1,
+            'sic_code_2': ch_company.sic_code_2,
+            'sic_code_3': ch_company.sic_code_3,
+            'sic_code_4': ch_company.sic_code_4,
+            'uri': ch_company.uri,
+            'incorporation_date': ch_company.incorporation_date.isoformat(),
+        }
+    }

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -87,28 +87,18 @@ def test_mapping(setup_es):
                     'type': 'text'
                 },
                 'sic_code_1': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'fielddata': True,
                     'type': 'text'
                 },
                 'sic_code_2': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'fielddata': True,
                     'type': 'text'
                 },
                 'sic_code_3': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'fielddata': True,
                     'type': 'text'
                 },
                 'sic_code_4': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'fielddata': True,
                     'type': 'text'
                 },
                 'uri': {
-                    'analyzer': 'lowercase_keyword_analyzer',
-                    'fielddata': True,
                     'type': 'text'
                 }
             }

--- a/datahub/search/companieshousecompany/tests/test_views.py
+++ b/datahub/search/companieshousecompany/tests/test_views.py
@@ -1,0 +1,140 @@
+import pytest
+from dateutil.parser import parse as dateutil_parse
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.test.factories import CompaniesHouseCompanyFactory
+from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.metadata.test.factories import TeamFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def setup_data(setup_es):
+    """Sets up data for the tests."""
+    CompaniesHouseCompanyFactory(
+        name='Pallas',
+        company_number='111',
+        incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
+        company_status='jumping',
+    )
+    CompaniesHouseCompanyFactory(
+        name='Jaguarundi',
+        company_number='222',
+        incorporation_date=dateutil_parse('2015-09-12T00:00:00Z'),
+        company_status='sleeping',
+    )
+    CompaniesHouseCompanyFactory(
+        name='Cheetah',
+        company_number='333',
+        incorporation_date=dateutil_parse('2016-09-12T00:00:00Z'),
+        company_status='purring',
+    )
+
+    setup_es.indices.refresh()
+
+
+class TestSearchCompaniesHouseCompany(APITestMixin):
+    """Test specific search for companies house companys."""
+
+    def test_no_permissions(self):
+        """Should return 403"""
+        team = TeamFactory()
+        self._user = get_test_user(team=team)
+        url = reverse('api-v3:search:companieshousecompany')
+        response = self.api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        'data,results',
+        (
+            (  # no filter => return all records
+                {},
+                ['111', '222', '333']
+            ),
+            (  # pagination
+                {'limit': 1, 'offset': 1},
+                ['222']
+            ),
+            (  # company number filter
+                {'company_number': '222'},
+                ['222'],
+            ),
+            (  # incorporation date filter
+                {
+                    'incorporation_date_after': '2014'
+                },
+                ['222', '333'],
+            ),
+            (  # incorporation date filter
+                {
+                    'incorporation_date_before': '2014'
+                },
+                ['111'],
+            ),
+            (  # incorporation date filter
+                {
+                    'incorporation_date_after': '2014',
+                    'incorporation_date_before': '2017'
+                },
+                ['222', '333'],
+            ),
+            (  # incorporation date filter
+                {
+                    'incorporation_date_after': '2010',
+                    'incorporation_date_before': '2015-10-01'
+                },
+                ['111', '222'],
+            ),
+            (  # company status filter
+                {
+                    'company_status': ['purring', 'sleeping'],
+                },
+                ['222', '333'],
+            ),
+            (  # company name filter
+                {
+                    'name': 'pallas',
+                },
+                ['111'],
+            ),
+            (  # original query match
+                {
+                    'original_query': '111',
+                },
+                ['111'],
+            ),
+            (  # original query partial match
+                {
+                    'original_query': 'jaguar',
+                },
+                ['222'],
+            ),
+        )
+    )
+    def test_search(self, setup_data, data, results):
+        """Test search results."""
+        url = reverse('api-v3:search:companieshousecompany')
+
+        response = self.api_client.post(url, data, format='json')
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()['results']) == len(results)
+        assert [
+            item['company_number'] for item in response.json()['results']
+        ] == results
+
+    def test_incorrect_date_raise_validation_error(self, setup_data):
+        """Test that if the date is not in a valid format, the API return a validation error."""
+        url = reverse('api-v3:search:companieshousecompany')
+
+        response = self.api_client.post(url, {
+            'incorporation_date_after': 'invalid',
+            'incorporation_date_before': 'invalid',
+        }, format='json')
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            'incorporation_date_after': ['Date is in incorrect format.'],
+            'incorporation_date_before': ['Date is in incorrect format.']
+        }

--- a/datahub/search/companieshousecompany/tests/test_views.py
+++ b/datahub/search/companieshousecompany/tests/test_views.py
@@ -36,7 +36,7 @@ def setup_data(setup_es):
 
 
 class TestSearchCompaniesHouseCompany(APITestMixin):
-    """Test specific search for companies house companys."""
+    """Test specific search for companies house companies."""
 
     def test_no_permissions(self):
         """Should return 403"""

--- a/datahub/search/companieshousecompany/views.py
+++ b/datahub/search/companieshousecompany/views.py
@@ -1,0 +1,42 @@
+from datahub.oauth.scopes import Scope
+from .models import CompaniesHouseCompany
+from .serializers import SearchCompaniesHouseCompanySerializer
+from ..views import SearchAPIView, SearchExportAPIView
+
+
+class SearchCompaniesHouseCompanyParams:
+    """Search company parameters."""
+
+    required_scopes = (Scope.internal_front_end,)
+    entity = CompaniesHouseCompany
+    serializer_class = SearchCompaniesHouseCompanySerializer
+
+    FILTER_FIELDS = (
+        'name',
+        'company_number',
+        'company_status',
+        'incorporation_date_after',
+        'incorporation_date_before',
+    )
+
+    REMAP_FIELDS = {
+        'name': 'name_trigram',
+    }
+
+
+class SearchCompaniesHouseCompanyAPIView(
+    SearchCompaniesHouseCompanyParams,
+    SearchAPIView
+):
+    """Filtered company search view."""
+
+    permission_required = 'company.read_companieshousecompany'
+
+
+class SearchCompaniesHouseCompanyExportAPIView(
+    SearchCompaniesHouseCompanyParams,
+    SearchExportAPIView
+):
+    """Filtered company search export view."""
+
+    permission_required = 'company.read_companieshousecompany'

--- a/datahub/search/companieshousecompany/views.py
+++ b/datahub/search/companieshousecompany/views.py
@@ -1,7 +1,7 @@
 from datahub.oauth.scopes import Scope
 from .models import CompaniesHouseCompany
 from .serializers import SearchCompaniesHouseCompanySerializer
-from ..views import SearchAPIView, SearchExportAPIView
+from ..views import SearchAPIView
 
 
 class SearchCompaniesHouseCompanyParams:
@@ -29,14 +29,5 @@ class SearchCompaniesHouseCompanyAPIView(
     SearchAPIView
 ):
     """Filtered company search view."""
-
-    permission_required = 'company.read_companieshousecompany'
-
-
-class SearchCompaniesHouseCompanyExportAPIView(
-    SearchCompaniesHouseCompanyParams,
-    SearchExportAPIView
-):
-    """Filtered company search export view."""
 
     permission_required = 'company.read_companieshousecompany'

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -92,6 +92,10 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
+                        'match': {
+                            'company_number': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'contact',
                             'query': {

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -14,7 +14,8 @@ def test_get_basic_search_query():
                     {
                         'match_phrase': {
                             'name_keyword': {
-                                'query': 'test', 'boost': 2
+                                'query': 'test',
+                                'boost': 2
                             }
                         }
                     }, {
@@ -89,6 +90,10 @@ def test_get_basic_search_query():
                                     'company.name_trigram': 'test'
                                 }
                             }
+                        }
+                    }, {
+                        'match': {
+                            'company_number': 'test'
                         }
                     }, {
                         'nested': {

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -159,7 +159,14 @@ def get_sort_query(qs, field_order=None):
     return qs
 
 
-def get_basic_search_query(term, entities=None, field_order=None, offset=0, limit=100):
+def get_basic_search_query(
+        term,
+        entities=None,
+        field_order=None,
+        ignored_entities=(),
+        offset=0,
+        limit=100
+):
     """Performs basic search looking for name and then SEARCH_FIELDS in entity.
 
     Also returns number of results in other entities.
@@ -176,7 +183,10 @@ def get_basic_search_query(term, entities=None, field_order=None, offset=0, limi
     query = get_search_term_query(term, fields=fields)
     s = Search(index=settings.ES_INDEX).query(query)
     s = s.post_filter(
-        Q('bool', should=[Q('term', _type=entity._doc_type.name) for entity in entities])
+        Q('bool', should=[
+            Q('term', _type=entity._doc_type.name) for entity in entities
+            if entity._doc_type.name not in ignored_entities
+        ])
     )
 
     s = get_sort_query(s, field_order=field_order)

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -93,6 +93,10 @@ def test_get_basic_search_query():
                             }
                         }
                     }, {
+                        'match': {
+                            'company_number': 'test'
+                        }
+                    }, {
                         'nested': {
                             'path': 'contact',
                             'query': {

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -36,6 +36,10 @@ class SearchBasicAPIView(APIView):
 
     DEFAULT_ENTITY = 'company'
 
+    IGNORED_ENTITIES = (
+        'companieshousecompany',
+    )
+
     def __init__(self, *args, **kwargs):
         """Initialises self.entity_by_name dynamically."""
         super().__init__(*args, **kwargs)
@@ -73,6 +77,7 @@ class SearchBasicAPIView(APIView):
             term=term,
             entities=(self.entity_by_name[entity].model,),
             field_order=sortby,
+            ignored_entities=self.IGNORED_ENTITIES,
             offset=offset,
             limit=limit
         ).execute()


### PR DESCRIPTION
This adds companies house company search app that enables syncing companieshousecompany model to ES and searching.

Basic search has got extra parameter `ignored_entities`, so that entities in that list will not be included in aggregation, as I believe we don't want companies house companies visible in global search at present.

This enables FE to search for companies house company during the add company stage.