### PR TITLE
Notify advisers when a quote is sent

### DIFF
--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -146,7 +146,7 @@ class Notify:
         """
         self._send_email(
             email_address=order.contact.email,
-            template_id=Template.quote_awaiting_acceptance_for_customer.value,
+            template_id=Template.quote_sent_for_customer.value,
             personalisation=self._prepare_personalisation(
                 order,
                 {

--- a/datahub/omis/notification/constants.py
+++ b/datahub/omis/notification/constants.py
@@ -7,4 +7,4 @@ class Template(Enum):
     generic_order_info = 'd2a758c5-7fa0-4ac5-8ba0-653aa3ef2133'
     order_created_for_post_manager = '335f5402-f610-43ef-bfcf-e196215b3cf1'
     you_have_been_added_for_adviser = '1c631f72-4d33-41f5-ba9b-12862b5b273a'
-    quote_awaiting_acceptance_for_customer = '5b68a6e2-539f-4b1b-8c54-0ead23c7ca1b'
+    quote_sent_for_customer = '5b68a6e2-539f-4b1b-8c54-0ead23c7ca1b'

--- a/datahub/omis/notification/constants.py
+++ b/datahub/omis/notification/constants.py
@@ -8,3 +8,4 @@ class Template(Enum):
     order_created_for_post_manager = '335f5402-f610-43ef-bfcf-e196215b3cf1'
     you_have_been_added_for_adviser = '1c631f72-4d33-41f5-ba9b-12862b5b273a'
     quote_sent_for_customer = '5b68a6e2-539f-4b1b-8c54-0ead23c7ca1b'
+    quote_sent_for_adviser = '77157de5-43b3-4988-a4e9-c6073c18be47'

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -1,3 +1,4 @@
+import itertools
 from unittest import mock
 
 import pytest
@@ -10,7 +11,10 @@ from notifications_python_client.errors import APIError
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import synchronous_executor_submit
 from datahub.omis.market.models import Market
-from datahub.omis.order.test.factories import OrderFactory, OrderWithOpenQuoteFactory
+from datahub.omis.order.test.factories import (
+    OrderAssigneeFactory, OrderFactory,
+    OrderSubscriberFactory, OrderWithOpenQuoteFactory
+)
 
 from ..client import notify, send_email
 from ..constants import Template
@@ -223,6 +227,36 @@ class TestNotifyQuoteGenerated:
         assert call_args['template_id'] == Template.quote_sent_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
+
+    def test_advisers_notified(self):
+        """
+        Test that calling `quote_generated` sends an email to all advisers notifying them that
+        the quote has been sent.
+        """
+        order = OrderWithOpenQuoteFactory(assignees=[])
+        assignees = OrderAssigneeFactory.create_batch(2, order=order)
+        subscribers = OrderSubscriberFactory.create_batch(2, order=order)
+
+        notify.client.reset_mock()
+
+        notify.quote_generated(order)
+
+        assert notify.client.send_email_notification.called
+        # 1 = customer, 4 = assignees/subscribers
+        assert len(notify.client.send_email_notification.call_args_list) == (4 + 1)
+
+        calls_by_email = {
+            data['email_address']: {
+                'template_id': data['template_id'],
+                'personalisation': data['personalisation'],
+            }
+            for _, data in notify.client.send_email_notification.call_args_list
+        }
+        for item in itertools.chain(assignees, subscribers):
+            call = calls_by_email[item.adviser.get_current_email()]
+            assert call['template_id'] == Template.quote_sent_for_adviser.value
+            assert call['personalisation']['recipient name'] == item.adviser.name
+            assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
 @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -220,7 +220,7 @@ class TestNotifyQuoteGenerated:
         assert notify.client.send_email_notification.called
         call_args = notify.client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.contact.email
-        assert call_args['template_id'] == Template.quote_awaiting_acceptance_for_customer.value
+        assert call_args['template_id'] == Template.quote_sent_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 

--- a/datahub/omis/notification/test/test_signal_receivers.py
+++ b/datahub/omis/notification/test/test_signal_receivers.py
@@ -50,7 +50,7 @@ class TestNotifyPostQuoteGenerated:
 
         assert notify.client.send_email_notification.called
         call_args = notify.client.send_email_notification.call_args_list[0][1]
-        assert call_args['template_id'] == Template.quote_awaiting_acceptance_for_customer.value
+        assert call_args['template_id'] == Template.quote_sent_for_customer.value
 
 
 @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)

--- a/datahub/omis/notification/test/test_signal_receivers.py
+++ b/datahub/omis/notification/test/test_signal_receivers.py
@@ -42,15 +42,27 @@ class TestNotifyPostQuoteGenerated:
 
     def test_notify_on_quote_generated(self):
         """Test that a notification is triggered when a quote is generated."""
-        order = OrderFactory()
+        order = OrderFactory(assignees=[])
+        OrderAssigneeFactory.create_batch(1, order=order, is_lead=True)
+        OrderSubscriberFactory.create_batch(2, order=order)
 
         notify.client.reset_mock()
 
         order.generate_quote(by=None)
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
-        assert call_args['template_id'] == Template.quote_sent_for_customer.value
+        #  1 = customer, 3 = assignees/subscribers
+        assert len(notify.client.send_email_notification.call_args_list) == (3 + 1)
+
+        templates_called = [
+            data[1]['template_id']
+            for data in notify.client.send_email_notification.call_args_list
+        ]
+        assert templates_called == [
+            Template.quote_sent_for_customer.value,
+            Template.quote_sent_for_adviser.value,
+            Template.quote_sent_for_adviser.value,
+            Template.quote_sent_for_adviser.value,
+        ]
 
 
 @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -58,9 +58,9 @@ class TestTemplates:
 
         notify.order_info(OrderFactory(), what_happened='', why='')
 
-    def test_quote_sent_for_customer(self, settings):
+    def test_quote_sent(self, settings):
         """
-        Test the quote generated template.
+        Test templates of quote sent for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
         is going to raise HTTPError (400 - Bad Request).
         """

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -58,7 +58,7 @@ class TestTemplates:
 
         notify.order_info(OrderFactory(), what_happened='', why='')
 
-    def test_quote_awaiting_acceptance_for_customer(self, settings):
+    def test_quote_sent_for_customer(self, settings):
         """
         Test the quote generated template.
         If the template variables have been changed in GOV.UK notifications this


### PR DESCRIPTION
Not only the customer but also all the advisers on the order should be notified when a quote is sent.