### PR TITLE
Notify customer/advisers on order cancelled

### DIFF
--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -151,12 +151,12 @@ class Notify:
 
     def quote_generated(self, order):
         """
-        Send a notification to the customer that a quote has just been created
-        and needs to be accepted.
+        Send a notification to the customer and the advisers
+        that a quote has just been created and needs to be accepted.
         """
         #  notify customer
         self._send_email(
-            email_address=order.contact.email,
+            email_address=order.get_current_contact_email(),
             template_id=Template.quote_sent_for_customer.value,
             personalisation=self._prepare_personalisation(
                 order,
@@ -172,6 +172,34 @@ class Notify:
             self._send_email(
                 email_address=adviser.get_current_email(),
                 template_id=Template.quote_sent_for_adviser.value,
+                personalisation=self._prepare_personalisation(
+                    order, {'recipient name': adviser.name}
+                )
+            )
+
+    def order_cancelled(self, order):
+        """
+        Send a notification to the customer and the advisers
+        that the order has just been cancelled.
+        """
+        #  notify customer
+        self._send_email(
+            email_address=order.get_current_contact_email(),
+            template_id=Template.order_cancelled_for_customer.value,
+            personalisation=self._prepare_personalisation(
+                order,
+                {
+                    'recipient name': order.contact.name,
+                    'embedded link': order.get_public_facing_url(),
+                }
+            )
+        )
+
+        #  notify advisers
+        for adviser in self._get_all_advisers(order):
+            self._send_email(
+                email_address=adviser.get_current_email(),
+                template_id=Template.order_cancelled_for_adviser.value,
                 personalisation=self._prepare_personalisation(
                     order, {'recipient name': adviser.name}
                 )

--- a/datahub/omis/notification/constants.py
+++ b/datahub/omis/notification/constants.py
@@ -9,3 +9,5 @@ class Template(Enum):
     you_have_been_added_for_adviser = '1c631f72-4d33-41f5-ba9b-12862b5b273a'
     quote_sent_for_customer = '5b68a6e2-539f-4b1b-8c54-0ead23c7ca1b'
     quote_sent_for_adviser = '77157de5-43b3-4988-a4e9-c6073c18be47'
+    order_cancelled_for_customer = '3f30d3b0-78cb-4b1b-a2bc-9c19b0aeedf4'
+    order_cancelled_for_adviser = '723583be-af37-4e13-b2b0-ea496de5450e'

--- a/datahub/omis/notification/signal_receivers.py
+++ b/datahub/omis/notification/signal_receivers.py
@@ -3,7 +3,7 @@ from django.dispatch import receiver
 
 from datahub.omis.notification.client import notify
 from datahub.omis.order.models import Order, OrderAssignee, OrderSubscriber
-from datahub.omis.order.signals import quote_generated
+from datahub.omis.order.signals import order_cancelled, quote_generated
 
 
 @receiver(post_save, sender=Order, dispatch_uid='notify_post_save_order')
@@ -18,14 +18,20 @@ def notify_post_save_order(sender, instance, created, raw=False, **kwargs):
 
 @receiver(quote_generated, sender=Order, dispatch_uid='notify_post_quote_generated')
 def notify_post_quote_generated(sender, order, **kwargs):
-    """Notify contact that a quote has been generated."""
+    """Notify people that a quote has been generated."""
     notify.quote_generated(order)
+
+
+@receiver(order_cancelled, sender=Order, dispatch_uid='notify_post_order_cancelled')
+def notify_post_order_cancelled(sender, order, **kwargs):
+    """Notify people that an order has been cancelled."""
+    notify.order_cancelled(order)
 
 
 @receiver(post_save, sender=OrderAssignee, dispatch_uid='notify_post_save_assignee')
 @receiver(post_save, sender=OrderSubscriber, dispatch_uid='notify_post_save_subscriber')
 def notify_post_save_order_adviser(sender, instance, created, raw=False, **kwargs):
-    """Notify adviser that they have been added to the order"""
+    """Notify people that they have been added to the order"""
     if raw:  # e.g. when loading fixtures
         return
 

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -69,7 +69,7 @@ class TestSendEmail:
 
 
 @mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
-class TestNotifyOnOrderCreated:
+class TestNotifyOrderCreated:
     """Tests for notifications sent when an order is created."""
 
     def test_email_sent_to_manager(self):
@@ -223,7 +223,7 @@ class TestNotifyQuoteGenerated:
 
         assert notify.client.send_email_notification.called
         call_args = notify.client.send_email_notification.call_args_list[0][1]
-        assert call_args['email_address'] == order.contact.email
+        assert call_args['email_address'] == order.contact_email
         assert call_args['template_id'] == Template.quote_sent_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
@@ -255,6 +255,59 @@ class TestNotifyQuoteGenerated:
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
             assert call['template_id'] == Template.quote_sent_for_adviser.value
+            assert call['personalisation']['recipient name'] == item.adviser.name
+            assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
+
+
+@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+class TestNotifyOrderCancelled:
+    """Tests for the order_cancelled logic."""
+
+    def test_customer_notified(self):
+        """
+        Test that calling `order_cancelled` sends an email notifying the customer that
+        the order has been cancelled.
+        """
+        order = OrderWithOpenQuoteFactory()
+
+        notify.client.reset_mock()
+
+        notify.order_cancelled(order)
+
+        assert notify.client.send_email_notification.called
+        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert call_args['email_address'] == order.contact_email
+        assert call_args['template_id'] == Template.order_cancelled_for_customer.value
+        assert call_args['personalisation']['recipient name'] == order.contact.name
+        assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
+
+    def test_advisers_notified(self):
+        """
+        Test that calling `order_cancelled` sends an email to all advisers notifying them that
+        the order has been cancelled.
+        """
+        order = OrderWithOpenQuoteFactory(assignees=[])
+        assignees = OrderAssigneeFactory.create_batch(2, order=order)
+        subscribers = OrderSubscriberFactory.create_batch(2, order=order)
+
+        notify.client.reset_mock()
+
+        notify.order_cancelled(order)
+
+        assert notify.client.send_email_notification.called
+        # 1 = customer, 4 = assignees/subscribers
+        assert len(notify.client.send_email_notification.call_args_list) == (4 + 1)
+
+        calls_by_email = {
+            data['email_address']: {
+                'template_id': data['template_id'],
+                'personalisation': data['personalisation'],
+            }
+            for _, data in notify.client.send_email_notification.call_args_list
+        }
+        for item in itertools.chain(assignees, subscribers):
+            call = calls_by_email[item.adviser.get_current_email()]
+            assert call['template_id'] == Template.order_cancelled_for_adviser.value
             assert call['personalisation']['recipient name'] == item.adviser.name
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -88,3 +88,16 @@ class TestTemplates:
             by=AdviserFactory(),
             creation_date=dateutil_parse('2017-05-18')
         )
+
+    def test_order_cancelled(self, settings):
+        """
+        Test templates of order cancelled for customer and advisers.
+        If the template variables have been changed in GOV.UK notifications this
+        is going to raise HTTPError (400 - Bad Request).
+        """
+        settings.OMIS_NOTIFICATION_API_KEY = settings.OMIS_NOTIFICATION_TEST_API_KEY
+        notify = Notify()
+
+        order = OrderWithOpenQuoteFactory()
+
+        notify.order_cancelled(order)

--- a/datahub/omis/order/signals.py
+++ b/datahub/omis/order/signals.py
@@ -2,3 +2,4 @@ import django.dispatch
 
 
 quote_generated = django.dispatch.Signal(providing_args=['order'])
+order_cancelled = django.dispatch.Signal(providing_args=['order'])


### PR DESCRIPTION
This sends a notification to the customer and all the advisers on the order when this gets cancelled.