### PR TITLE
Fix Company Filters.

### DIFF
--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -18,6 +18,7 @@ class SearchCompanySerializer(SearchSerializer):
     name = serializers.CharField(required=False)
     sector = SingleOrListField(child=StringUUIDField(), required=False)
     trading_address_country = SingleOrListField(child=StringUUIDField(), required=False)
+    country = SingleOrListField(child=StringUUIDField(), required=False)
     uk_based = serializers.BooleanField(required=False)
     uk_region = SingleOrListField(child=StringUUIDField(), required=False)
 

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -19,7 +19,7 @@ class SearchCompanySerializer(SearchSerializer):
     sector = SingleOrListField(child=StringUUIDField(), required=False)
     trading_address_country = SingleOrListField(child=StringUUIDField(), required=False)
     uk_based = serializers.BooleanField(required=False)
-    uk_region = serializers.BooleanField(required=False)
+    uk_region = SingleOrListField(child=StringUUIDField(), required=False)
 
     SORT_BY_FIELDS = (
         'account_manager.name',

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -466,7 +466,7 @@ def test_limited_get_search_by_entity_query():
                         'bool': {
                             'should': [
                                 {
-                                    'term': {
+                                    'match': {
                                         'address_town': 'Woodside'
                                     }
                                 }
@@ -480,7 +480,7 @@ def test_limited_get_search_by_entity_query():
                                     'nested': {
                                         'path': 'trading_address_country',
                                         'query': {
-                                            'term': {
+                                            'match_phrase': {
                                                 'trading_address_country.id':
                                                     '80756b9a-5d95-e211-a939-e4115bead28a'
                                             }

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -13,12 +13,12 @@ class SearchCompanyParams:
 
     FILTER_FIELDS = (
         'account_manager',
-        'trading_name',
         'description',
         'export_to_country',
         'future_interest_country',
         'name',
         'sector',
+        'country',
         'trading_address_country',
         'trading_address_postcode',
         'trading_address_town',
@@ -27,8 +27,6 @@ class SearchCompanyParams:
     )
 
     REMAP_FIELDS = {
-        'name': 'name_trigram',
-        'trading_name': 'trading_name_trigram',
         'account_manager': 'account_manager.id',
         'export_to_country': 'export_to_countries.id',
         'future_interest_country': 'future_interest_countries.id',
@@ -36,6 +34,11 @@ class SearchCompanyParams:
         'registered_address_country': 'address_country.id',
         'trading_address_country': 'trading_address_country.id',
         'uk_region': 'uk_region.id',
+    }
+
+    COMPOSITE_FILTERS = {
+        'name': ['name_trigram', 'trading_name_trigram'],
+        'country': ['trading_address_country.id', 'registered_address_country.id'],
     }
 
 

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -27,6 +27,7 @@ class SearchCompanyParams:
     )
 
     REMAP_FIELDS = {
+        'name': 'name_trigram',
         'trading_name': 'trading_name_trigram',
         'account_manager': 'account_manager.id',
         'export_to_country': 'export_to_countries.id',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -421,7 +421,7 @@ def test_get_limited_search_by_entity_query():
             'bool': {
                 'must': [{
                     'bool': {
-                        'should': [{'term': {'address_town': 'Woodside'}}],
+                        'should': [{'match': {'address_town': 'Woodside'}}],
                         'minimum_should_match': 1
                     }
                 }, {
@@ -430,7 +430,7 @@ def test_get_limited_search_by_entity_query():
                             'nested': {
                                 'path': 'trading_address_country',
                                 'query': {
-                                    'term': {
+                                    'match_phrase': {
                                         'trading_address_country.id':
                                         '80756b9a-5d95-e211-a939-e4115bead28a'
                                     }

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -429,7 +429,7 @@ def test_limited_get_search_by_entity_query():
             'bool': {
                 'must': [{
                     'bool': {
-                        'should': [{'term': {'address_town': 'Woodside'}}],
+                        'should': [{'match': {'address_town': 'Woodside'}}],
                         'minimum_should_match': 1
                     }
                 }, {
@@ -438,7 +438,7 @@ def test_limited_get_search_by_entity_query():
                             'nested': {
                                 'path': 'trading_address_country',
                                 'query': {
-                                    'term': {
+                                    'match_phrase': {
                                         'trading_address_country.id':
                                         '80756b9a-5d95-e211-a939-e4115bead28a'
                                     }

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -36,7 +36,7 @@ def test_get_search_term_query():
                     'nested': {
                         'path': 'country',
                         'query': {
-                            'match': {
+                            'match_phrase': {
                                 'country.id': 'hello'
                             }
                         }

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -99,6 +99,10 @@ class SearchAPIView(APIView):
     FILTER_FIELDS = []
     REMAP_FIELDS = {}
 
+    # creates "or" query with a list of fields for given filter name
+    # filter must exist in FILTER_FIELDS
+    COMPOSITE_FILTERS = {}
+
     serializer_class = SearchSerializer
     entity = None
 
@@ -156,6 +160,7 @@ class SearchAPIView(APIView):
             entity=self.entity,
             term=validated_data['original_query'],
             filters=filters,
+            composite_filters=self.COMPOSITE_FILTERS,
             ranges=ranges,
             field_order=validated_data['sortby'],
             aggregations=aggregations,


### PR DESCRIPTION
This fixes companies entity search `uk_region` filter and `name` filter.

It adds new "composite" filters, to allow filtering by multiple fields using one filter. 
For example `name` filter in companies now looks up `name_trigram` and `trading_name_trigram`.

It adds new `country` composite filter that looks up `registered_address_country` and `trading_address_country`.

It also has a little bit of clean up of query generation, which my other PR for "and" operator will be based on.
