### PR TITLE
Add a fixture for UAT that is CH only

### DIFF
--- a/fixtures/test_ch_data.yaml
+++ b/fixtures/test_ch_data.yaml
@@ -15,3 +15,14 @@
     registered_address_postcode: LL53 5RN
     incorporation_date: 2000-12-14
     company_category: Private Limited Company
+
+- model: company.companieshousecompany
+  fields:
+    name: "Exobite Skeletons Ltd"
+    company_number: 99929
+    registered_address_country: 80756b9a-5d95-e211-a939-e4115bead28a
+    registered_address_1: 999 Juliet Street
+    registered_address_town: Llangefni
+    registered_address_postcode: LL77 5RN
+    incorporation_date: 2000-12-25
+    company_category: Private Limited Company


### PR DESCRIPTION
The existing companies house entry in the fixture data already has a data hub company associated with it. In order to test the front end an entry is required in the companies house table and index that isn't in the companyh table.