### PR TITLE
Add uk_region to OMIS subscribers endpoint

### DIFF
--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -327,6 +327,21 @@ class SubscribedAdviserListSerializer(serializers.ListSerializer):
             )
 
 
+class TeamWithRegionSerializer(serializers.ModelSerializer):
+    """DRF serializer for teams with region."""
+
+    uk_region = NestedRelatedField(Team, read_only=True)
+
+    class Meta:
+        model = Team
+        fields = (
+            'id',
+            'name',
+            'uk_region',
+        )
+        read_only_fields = fields
+
+
 class SubscribedAdviserSerializer(serializers.Serializer):
     """
     DRF serializer for an adviser subscribed to an order.
@@ -336,7 +351,7 @@ class SubscribedAdviserSerializer(serializers.Serializer):
     first_name = serializers.CharField(read_only=True)
     last_name = serializers.CharField(read_only=True)
     name = serializers.CharField(read_only=True)
-    dit_team = NestedRelatedField(Team, read_only=True)
+    dit_team = TeamWithRegionSerializer(read_only=True)
 
     class Meta:
         list_serializer_class = SubscribedAdviserListSerializer

--- a/datahub/omis/order/test/views/test_subscriber_list.py
+++ b/datahub/omis/order/test/views/test_subscriber_list.py
@@ -55,7 +55,11 @@ class TestGetSubscriberList(APITestMixin):
                 'name': adviser.name,
                 'dit_team': {
                     'id': str(adviser.dit_team.id),
-                    'name': adviser.dit_team.name
+                    'name': adviser.dit_team.name,
+                    'uk_region': {
+                        'id': str(adviser.dit_team.uk_region.pk),
+                        'name': adviser.dit_team.uk_region.name
+                    }
                 }
             }
             for adviser in advisers[:2]


### PR DESCRIPTION
This adds UK region to the response body of the endpoints related to order subscribers under adviser.dit_team.