### PR TITLE
Add the datetime modified_on property to company.contact fixtures

### DIFF
--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -159,6 +159,7 @@
     contactable_by_email: false
     contactable_by_phone: true
     notes: This is a dummy contact for testing
+    modified_on: '2017-06-05T00:00:00Z'
 
 - model: company.contact
   pk: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
@@ -178,6 +179,7 @@
     contactable_by_email: true
     contactable_by_phone: false
     notes: This is a dummy contact for testing
+    modified_on: '2016-06-05T00:00:00Z'
 
 - model: company.contact
   pk: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
@@ -197,6 +199,7 @@
     contactable_by_email: true
     contactable_by_phone: false
     notes: This is a dummy contact for testing
+    modified_on: '2017-06-08T00:00:00Z'
 
 - model: company.contact
   pk: 048f2edc-e7ed-4881-b1cc-29142a80238a
@@ -219,6 +222,7 @@
     contactable_by_email: false
     contactable_by_phone: true
     notes: This is a dummy contact for testing
+    modified_on: '2017-04-05T00:00:00Z'
 
 - model: interaction.interaction
   pk: 236b656c-ae26-43ca-bb51-c72d553383f3


### PR DESCRIPTION
We are currently missing the `modified_on` date time in fixtures, this work adds in a `datatime` for the `modified_on` property.

![screen shot 2017-11-15 at 10 35 11](https://user-images.githubusercontent.com/2305016/32831577-afb6f8ca-c9f0-11e7-9d33-b79f70480e3b.png)
