### PR TITLE
Specify decimal places in quote content

### DIFF
--- a/datahub/omis/quote/templates/content.md
+++ b/datahub/omis/quote/templates/content.md
@@ -10,7 +10,7 @@ The **Services** are those described below:
 
 DIT will deliver the Services on or before the **Delivery Date** which shall be {{order.delivery_date|date:"j F Y"}}.
 
-In exchange for these Services you agree to pay the **Charges** which shall be £{{pound_pricing.subtotal_cost}} (excluding VAT) on or before the **Payment Date** which shall be the earliest of: the date 30 days from the date of the relevant invoice; or the date 10 days before the Delivery Date. The Payment Date will be specified on your invoice.
+In exchange for these Services you agree to pay the **Charges** which shall be £{{pound_pricing.subtotal_cost|floatformat:2}} (excluding VAT) on or before the **Payment Date** which shall be the earliest of: the date 30 days from the date of the relevant invoice; or the date 10 days before the Delivery Date. The Payment Date will be specified on your invoice.
 
 All correspondence will be between our representatives set out below:
 

--- a/datahub/omis/quote/test/test_utils.py
+++ b/datahub/omis/quote/test/test_utils.py
@@ -156,6 +156,29 @@ class TestGenerateQuoteContent:
 
         assert 'ch 1, ch 2, ch county, Bath, BA1 0AA, United Kingdom' in content
 
+    @freeze_time('2017-04-18 13:00:00.000000')
+    def test_pricing_format(self):
+        """Test that the pricing is formatted as expected (xx.yy)"""
+        hourly_rate = HourlyRateFactory(rate_value=1250, vat_value=Decimal(20))
+        order = OrderFactory(
+            discount_value=0,
+            hourly_rate=hourly_rate,
+            assignees=[],
+            vat_status=VATStatus.uk
+        )
+        OrderAssigneeFactory(
+            order=order,
+            estimated_time=120,
+            is_lead=True
+        )
+
+        content = generate_quote_content(
+            order=order,
+            expires_on=dateutil_parse('2017-05-18').date()
+        )
+
+        assert '25.00' in content
+
 
 class TestCalculateQuoteExpiryDate:
     """Tests for the calculate_quote_expiry_date logic."""


### PR DESCRIPTION
This makes sure that the pricing in quotes is formatted with always 2 decimal places.