### PR TITLE
Make company reference code visible from admin

### DIFF
--- a/datahub/company/admin.py
+++ b/datahub/company/admin.py
@@ -24,6 +24,7 @@ class CompanyAdmin(BaseModelVersionAdmin):
     )
     readonly_fields = (
         'archived_documents_url_path',
+        'reference_code',
     )
 
 

--- a/datahub/company/migrations/0017_add_reference_code.py
+++ b/datahub/company/migrations/0017_add_reference_code.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='company',
             name='reference_code',
-            field=models.CharField(blank=True, editable=False, max_length=255),
+            field=models.CharField(blank=True, max_length=255),
         ),
     ]

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -57,7 +57,7 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
     )
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
-    reference_code = models.CharField(max_length=MAX_LENGTH, blank=True, editable=False)
+    reference_code = models.CharField(max_length=MAX_LENGTH, blank=True)
     company_number = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     vat_number = models.CharField(max_length=MAX_LENGTH, blank=True)
     alias = models.CharField(

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -314,5 +314,6 @@ class CompanySerializer(serializers.ModelSerializer):
             'archived_documents_url_path',
             'archived_on',
             'archived_reason',
+            'reference_code',
         )
         validators = [RequiredUnlessAlreadyBlankValidator('sector', 'business_type')]


### PR DESCRIPTION
Removes editable=False from the model field, as that was hiding it in admin. Instead it is added to readonly_fields in admin.