### PR TITLE
Add name property to contact response

### DIFF
--- a/datahub/company/models/contact.py
+++ b/datahub/company/models/contact.py
@@ -3,7 +3,6 @@ import uuid
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.functional import cached_property
 
 from datahub.core.models import ArchivableModel, BaseModel
 from datahub.metadata import models as metadata_models
@@ -70,9 +69,9 @@ class Contact(ArchivableModel, BaseModel):
     class Meta:
         permissions = (('read_contact', 'Can read contact'),)
 
-    @cached_property
+    @property
     def name(self):
-        """Need this for ES."""
+        """Full name."""
         return f'{self.first_name} {self.last_name}'
 
     def __str__(self):

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -98,6 +98,7 @@ class ContactSerializer(serializers.ModelSerializer):
             'title',
             'first_name',
             'last_name',
+            'name',
             'job_title',
             'company',
             'adviser',

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -69,6 +69,7 @@ class TestAddContact(APITestMixin):
             },
             'first_name': 'Oratio',
             'last_name': 'Nelson',
+            'name': 'Oratio Nelson',
             'job_title': constants.Role.owner.value.name,
             'company': {
                 'id': str(company.pk),
@@ -343,6 +344,7 @@ class TestEditContact(APITestMixin):
             },
             'first_name': 'New Oratio',
             'last_name': 'Nelson',
+            'name': 'New Oratio Nelson',
             'job_title': constants.Role.owner.value.name,
             'company': {
                 'id': str(company.pk),
@@ -501,6 +503,7 @@ class TestViewContact(APITestMixin):
             },
             'first_name': 'Oratio',
             'last_name': 'Nelson',
+            'name': 'Oratio Nelson',
             'job_title': constants.Role.owner.value.name,
             'company': {
                 'id': str(company.pk),


### PR DESCRIPTION
Also uses a normal propery for Contact.name rather than a cached one, as there's no need to cache that.