### PR TITLE
Update notify template after deletion

### DIFF
--- a/datahub/omis/notification/constants.py
+++ b/datahub/omis/notification/constants.py
@@ -4,7 +4,7 @@ from enum import Enum
 class Template(Enum):
     """GOV.UK notifications template ids."""
 
-    generic_order_info = 'd2a758c5-7fa0-4ac5-8ba0-653aa3ef2133'
+    generic_order_info = '53055338-6acd-4dd6-b315-d1bd74015eb2'
 
     order_created_for_post_manager = '335f5402-f610-43ef-bfcf-e196215b3cf1'
     you_have_been_added_for_adviser = '1c631f72-4d33-41f5-ba9b-12862b5b273a'


### PR DESCRIPTION
A notify template got deleted by mistake and I had to recreate it and update the related id.