### PR TITLE
Allow updating subscribers in more order statuses

### DIFF
--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -289,7 +289,14 @@ class SubscribedAdviserListSerializer(serializers.ListSerializer):
     """DRF List serializer for OrderSubscriber(s)."""
 
     default_validators = [
-        OrderInStatusValidator(allowed_statuses=(OrderStatus.draft,))
+        OrderInStatusValidator(
+            allowed_statuses=(
+                OrderStatus.draft,
+                OrderStatus.quote_awaiting_acceptance,
+                OrderStatus.quote_accepted,
+                OrderStatus.paid,
+            )
+        )
     ]
 
     def save(self, **kwargs):


### PR DESCRIPTION
**Before:**
Subscribers could be added or removed only if an order was in `draft`.

**After:**
Subscribers can be added or removed if an order is in `draft`, `quote_awaiting_acceptance`, `quote_accepted or paid`.

They still can't be changed if the order is complete or cancelled.