### PR TITLE
Order assignees can be added at later stage.

### DIFF
--- a/datahub/omis/order/test/test_validators.py
+++ b/datahub/omis/order/test/test_validators.py
@@ -16,7 +16,6 @@ from ..constants import OrderStatus, VATStatus
 from ..models import Order
 from ..validators import (
     AddressValidator,
-    AssigneeExistsRule,
     AssigneesFilledInValidator,
     CompletableOrderValidator,
     ContactWorksAtCompanyValidator,
@@ -791,18 +790,3 @@ def test_order_in_status_rule(order_status, expected_status, res):
 
     rule = OrderInStatusRule(expected_status)
     assert rule(combiner) == res
-
-
-@pytest.mark.parametrize(
-    'assignee_exists',
-    (True, False)
-)
-def test_assignee_exists_rule(assignee_exists):
-    """Tests for AssigneeExistsRule."""
-    order = mock.Mock()
-    order.assignees.filter().exists.return_value = assignee_exists
-    combiner = mock.Mock()
-    combiner.serializer.context = {'order': order}
-
-    rule = AssigneeExistsRule('adviser')
-    assert rule(combiner) == assignee_exists

--- a/datahub/omis/order/validators.py
+++ b/datahub/omis/order/validators.py
@@ -407,9 +407,9 @@ class AddressValidator:
 class OrderInStatusRule(AbstractRule):
     """Rule for checking that an order is in the expected state."""
 
-    def __init__(self, order_status):
+    def __init__(self, order_statuses):
         """Initialise the rule."""
-        self.order_status = order_status
+        self.order_statuses = order_statuses
 
     @property
     def field(self):
@@ -419,18 +419,7 @@ class OrderInStatusRule(AbstractRule):
     def __call__(self, combiner):
         """Check that order is in the expected state."""
         order = combiner.serializer.context['order']
-        return order.status == self.order_status
-
-
-class AssigneeExistsRule(BaseRule):
-    """Rule for checking that the adviser (value) is assigned to the order."""
-
-    def __call__(self, combiner):
-        """Check that the adviser (value) is an order assignee."""
-        order = combiner.serializer.context['order']
-        value = combiner.get_value(self.field)
-
-        return order.assignees.filter(adviser=value).exists()
+        return order.status in self.order_statuses
 
 
 class ForceDeleteRule(BaseRule):


### PR DESCRIPTION
This adds the ability to add new assignees when the order is in quote awaiting acceptance, quote accepted or paid.
Assignees can be added but the props estimated_time and is_lead cannot be set at this stage otherwise the overall price of the order would change.