### PR TITLE
Update disabled_on values of service types

### DIFF
--- a/datahub/omis/order/fixtures/service_types.yaml
+++ b/datahub/omis/order/fixtures/service_types.yaml
@@ -27,19 +27,19 @@
   fields: {name: Training, disabled_on: null, order: 900.0}
 - model: order.servicetype
   pk: 57c9b720-40b5-433f-9d3c-9137fb758bed
-  fields: {name: Event group, disabled_on: '2017-10-24T11:00:00.000000Z', order: 1000.0}
+  fields: {name: Event group, disabled_on: '2017-11-23T11:00:00.000000Z', order: 1000.0}
 - model: order.servicetype
   pk: 50f9539f-d750-4836-b929-67c82051bcdb
-  fields: {name: Event solo, disabled_on: '2017-10-24T11:00:00.000000Z', order: 1100.0}
+  fields: {name: Event solo, disabled_on: '2017-11-23T11:00:00.000000Z', order: 1100.0}
 - model: order.servicetype
   pk: 9766ff17-398e-4156-9426-9687378fedff
-  fields: {name: Market selection service request, disabled_on: '2017-10-24T11:00:00.000000Z', order: 1200.0}
+  fields: {name: Market selection service request, disabled_on: '2017-11-23T11:00:00.000000Z', order: 1200.0}
 - model: order.servicetype
   pk: 622aedd8-8936-4e62-99f2-2b8bb3783166
-  fields: {name: Strategic offer, disabled_on: '2017-10-24T11:00:00.000000Z', order: 1300.0}
+  fields: {name: Strategic offer, disabled_on: '2017-11-23T11:00:00.000000Z', order: 1300.0}
 - model: order.servicetype
   pk: 66b57a5b-ca6e-4d6e-9941-4a6e7f9aa3ae
-  fields: {name: Subscription, disabled_on: '2017-10-24T11:00:00.000000Z', order: 1400.0}
+  fields: {name: Subscription, disabled_on: '2017-11-23T11:00:00.000000Z', order: 1400.0}
 - model: order.servicetype
   pk: 80beb270-c1ce-40a3-8ad4-20a569a7bca0
-  fields: {name: Retainer, disabled_on: '2017-10-24T11:00:00.000000Z', order: 1500.0}
+  fields: {name: Retainer, disabled_on: '2017-11-23T11:00:00.000000Z', order: 1500.0}

--- a/datahub/omis/order/test/views/test_order_details.py
+++ b/datahub/omis/order/test/views/test_order_details.py
@@ -225,7 +225,7 @@ class TestAddOrderDetails(APITestMixin):
             'primary_market': ['This field is required.'],
         }
 
-    @freeze_time('2017-10-25 11:00:00.000000')
+    @freeze_time('2017-11-23 11:00:00.000000')
     def test_fails_if_service_type_disabled(self):
         """Test that if a service type specified is disabled, the creation fails."""
         company = CompanyFactory()
@@ -618,7 +618,7 @@ class TestChangeOrderDetails(APITestMixin):
             ],
         }
 
-    @freeze_time('2017-10-25 11:00:00.000000')
+    @freeze_time('2017-11-23 11:00:00.000000')
     def test_fails_if_service_type_disabled(self):
         """Test that if a service type specified is disabled, the update fails."""
         order = OrderFactory()


### PR DESCRIPTION
As CDMS has been made readonly, we can now update the `disabled_on` values of the service types that will become inactive with the new OMIS.