### PR TITLE
[DH-1288] Fix bug with CH view and non-numeric company numbers

### DIFF
--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -757,6 +757,18 @@ class TestCHCompany(APITestMixin):
         response_data = response.json()
         assert response_data['company_number'] == ch_company.company_number
 
+    def test_get_ch_company_alphanumeric(self):
+        """Test retrieving a single CH company where the company number contains letters."""
+        CompaniesHouseCompanyFactory(company_number='SC00001234')
+        url = reverse(
+            'api-v3:ch-company:item', kwargs={'company_number': 'SC00001234'}
+        )
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['company_number'] == 'SC00001234'
+
     def test_ch_company_cannot_be_written(self):
         """Test CH company POST is not allowed."""
         url = reverse('api-v3:ch-company:collection')

--- a/datahub/company/urls.py
+++ b/datahub/company/urls.py
@@ -88,6 +88,6 @@ company_urls = [
 ch_company_urls = [
     url(r'^ch-company$', ch_company_list,
         name='collection'),
-    url(r'^ch-company/(?P<company_number>[0-9]+)$', ch_company_item,
+    url(r'^ch-company/(?P<company_number>[\w]+)$', ch_company_item,
         name='item'),
 ]


### PR DESCRIPTION
The route was only allowing numbers, when company numbers can have letters in them (in our case particularly relevant for Northern Ireland and Scottish companies).