### PR TITLE
Use company address instead of CH address

### DIFF
--- a/datahub/omis/order/test/test_utils.py
+++ b/datahub/omis/order/test/test_utils.py
@@ -21,17 +21,9 @@ class CompanyWithRegAddressFactory(CompanyFactory):
     registered_address_county = factory.Faker('text')
     registered_address_postcode = factory.Faker('text')
     registered_address_country_id = constants.Country.japan.value.id
-
-
-class CompaniesHouseWithRegAddressFactory(CompaniesHouseCompanyFactory):
-    """Factory for a companies house model with all registered address filled in."""
-
-    registered_address_1 = factory.Faker('text')
-    registered_address_2 = factory.Faker('text')
-    registered_address_town = factory.Faker('text')
-    registered_address_county = factory.Faker('text')
-    registered_address_postcode = factory.Faker('text')
-    registered_address_country_id = constants.Country.japan.value.id
+    company_number = factory.LazyFunction(
+        lambda: CompaniesHouseCompanyFactory().company_number
+    )
 
 
 class OrderWithoutBillingDataFactory(OrderFactory):
@@ -52,27 +44,13 @@ class OrderWithoutBillingDataFactory(OrderFactory):
 class TestPopulateBillingData:
     """Tests for the populate_billing_data logic."""
 
-    @pytest.mark.parametrize(
-        'CHFactory',  # noqa: N803
-        (
-            lambda: None,
-            CompaniesHouseWithRegAddressFactory,
-        )
-    )
-    def test_with_empty_order(self, CHFactory):
+    def test_with_empty_order(self):
         """
         Test that an order without any of the billing fields filled in is populated
         with the company/contact details.
-
-        If the company is linked to a companies house record, the billing address
-        should be the companies house registered address.
-        Otherwise it should be the Data Hub company registered address.
         """
         contact = ContactFactory()
-        ch_company = CHFactory()
-        company = CompanyWithRegAddressFactory(
-            company_number=None if not ch_company else ch_company.company_number
-        )
+        company = CompanyWithRegAddressFactory()
         order = OrderWithoutBillingDataFactory(
             company=company,
             contact=contact
@@ -84,17 +62,13 @@ class TestPopulateBillingData:
         assert order.billing_email == contact.email
         assert order.billing_phone == contact.telephone_number
 
-        # if the company is linked to a companies house record, the billing address
-        # should be the CH registered address
-        # otherwise it should be the DH company registered address
-        expected_company = ch_company or company
-        assert order.billing_company_name == expected_company.name
-        assert order.billing_address_1 == expected_company.registered_address_1
-        assert order.billing_address_2 == expected_company.registered_address_2
-        assert order.billing_address_town == expected_company.registered_address_town
-        assert order.billing_address_county == expected_company.registered_address_county
-        assert order.billing_address_postcode == expected_company.registered_address_postcode
-        assert order.billing_address_country == expected_company.registered_address_country
+        assert order.billing_company_name == company.name
+        assert order.billing_address_1 == company.registered_address_1
+        assert order.billing_address_2 == company.registered_address_2
+        assert order.billing_address_town == company.registered_address_town
+        assert order.billing_address_county == company.registered_address_county
+        assert order.billing_address_postcode == company.registered_address_postcode
+        assert order.billing_address_country == company.registered_address_country
 
     def test_with_null_values(self):
         """

--- a/datahub/omis/order/utils.py
+++ b/datahub/omis/order/utils.py
@@ -6,8 +6,7 @@ def populate_billing_data(order):
     :returns: order with billing_* fields filled in
     """
     contact = order.contact
-    # use CH address if it exists or fall back to DH company instead
-    company = order.company.companies_house_data or order.company
+    company = order.company
 
     # get default and current order values of billing details
     default_billing_details = {

--- a/datahub/omis/quote/test/test_utils.py
+++ b/datahub/omis/quote/test/test_utils.py
@@ -59,7 +59,8 @@ class TestGenerateQuoteContent:
             registered_address_town='London',
             registered_address_county='County',
             registered_address_postcode='SW1A 1AA',
-            registered_address_country_id=Country.united_kingdom.value.id
+            registered_address_country_id=Country.united_kingdom.value.id,
+            company_number=CompaniesHouseCompanyFactory().company_number
         )
         contact = ContactFactory(
             company=company,
@@ -122,40 +123,6 @@ class TestGenerateQuoteContent:
         )
 
         assert 'line 1, London, SW1A 1AA' in content
-
-    @freeze_time('2017-04-18 13:00:00.000000')
-    def test_with_ch_address(self):
-        """
-        Test that if the company has a companies house record attached,
-        its registered address is used instead.
-        """
-        ch_company = CompaniesHouseCompanyFactory(
-            registered_address_1='ch 1',
-            registered_address_2='ch 2',
-            registered_address_town='Bath',
-            registered_address_county='ch county',
-            registered_address_postcode='BA1 0AA',
-            registered_address_country_id=Country.united_kingdom.value.id
-        )
-        company = CompanyFactory(
-            registered_address_1='line 1',
-            registered_address_2='line 2',
-            registered_address_town='London',
-            registered_address_county='County',
-            registered_address_postcode='SW1A 1AA',
-            registered_address_country_id=Country.united_kingdom.value.id,
-            company_number=ch_company.company_number
-        )
-        order = OrderFactory(
-            company=company,
-            contact=ContactFactory(company=company)
-        )
-        content = generate_quote_content(
-            order=order,
-            expires_on=dateutil_parse('2017-05-18').date()
-        )
-
-        assert 'ch 1, ch 2, ch county, Bath, BA1 0AA, United Kingdom' in content
 
     @freeze_time('2017-04-18 13:00:00.000000')
     def test_pricing_format(self):

--- a/datahub/omis/quote/utils.py
+++ b/datahub/omis/quote/utils.py
@@ -55,7 +55,7 @@ def generate_quote_content(order, expires_on):
     """
     :returns: the content of the quote populated with the given order details.
     """
-    company = order.company.companies_house_data or order.company
+    company = order.company
     company_address = ', '.join(
         field for field in (
             company.registered_address_1,


### PR DESCRIPTION
As we are using company data instead of Companies House data everywhere else at the moment, it makes more sense for OMIS to use that as well.