### PR TITLE
Add OMIS market to get public order endpoint

### DIFF
--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -239,6 +239,7 @@ class CancelOrderSerializer(OrderSerializer):
 class PublicOrderSerializer(serializers.ModelSerializer):
     """DRF serializer for public facing API."""
 
+    primary_market = NestedRelatedField(Country)
     company = NestedRelatedField(Company)
     contact = NestedRelatedField(Contact)
     billing_address_country = NestedRelatedField(Country)
@@ -252,6 +253,7 @@ class PublicOrderSerializer(serializers.ModelSerializer):
             'created_on',
             'company',
             'contact',
+            'primary_market',
             'contact_email',
             'contact_phone',
             'vat_status',

--- a/datahub/omis/order/test/views/test_public_order_details.py
+++ b/datahub/omis/order/test/views/test_public_order_details.py
@@ -59,6 +59,10 @@ class TestViewPublicOrderDetails(APITestMixin):
                 'id': str(order.contact.pk),
                 'name': order.contact.name
             },
+            'primary_market': {
+                'id': str(order.primary_market.id),
+                'name': order.primary_market.name
+            },
             'contact_email': order.contact_email,
             'contact_phone': order.contact_phone,
             'vat_status': order.vat_status,


### PR DESCRIPTION
This adds primary_market to the response body of the public get order endpoint.