### PR TITLE
[DH-813] Refactor how permission-related tests create test users

### DIFF
--- a/datahub/company/test/test_advisor_views.py
+++ b/datahub/company/test/test_advisor_views.py
@@ -1,7 +1,7 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 from .factories import AdviserFactory
 
@@ -11,10 +11,10 @@ class TestAdviser(APITestMixin):
 
     def test_adviser_list_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v1:advisor-list')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_adviser_list_view(self):

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -12,7 +12,7 @@ from datahub.company.test.factories import CompaniesHouseCompanyFactory, Company
 from datahub.core.constants import (
     BusinessType, CompanyClassification, Country, HeadquarterType, Sector, UKRegion
 )
-from datahub.core.test_utils import APITestMixin, format_date_or_datetime, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import TeamFactory
 
@@ -22,10 +22,10 @@ class TestCompany(APITestMixin):
 
     def test_companies_list_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:company:collection')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_list_companies(self):

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -9,7 +9,7 @@ from rest_framework.reverse import reverse
 from reversion.models import Version
 
 from datahub.core import constants
-from datahub.core.test_utils import APITestMixin, format_date_or_datetime, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
 from datahub.metadata.test.factories import TeamFactory
 from .factories import CompanyFactory, ContactFactory
 
@@ -553,10 +553,10 @@ class TestContactList(APITestMixin):
 
     def test_contact_list_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:contact:list')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_all(self):

--- a/datahub/core/test/test_advisor_permissions.py
+++ b/datahub/core/test/test_advisor_permissions.py
@@ -4,7 +4,7 @@ from rest_framework.test import APIRequestFactory
 
 from datahub.core.test.factories import GroupFactory
 from datahub.core.test.support.views import PermissionModelViewset
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 
 factory = APIRequestFactory()
@@ -22,8 +22,8 @@ class TestPermissions(APITestMixin):
         permission_group.permissions.add(permission)
         team = TeamFactory()
         team.role.groups.add(permission_group)
-        self._user = get_test_user(team=team)
-        token = self.get_token()
+        user = create_test_user(team=team)
+        token = self.get_token(user=user)
 
         request = factory.get('/', data={}, content_type='application/json',
                               Authorization=f'Bearer {token}')
@@ -38,9 +38,8 @@ class TestPermissions(APITestMixin):
         """
         Tests view returns 403
         """
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
-        token = self.get_token()
+        user = create_test_user(team=TeamFactory())
+        token = self.get_token(user=user)
 
         request = factory.get('/', data={}, content_type='application/json',
                               Authorization=f'Bearer {token}')
@@ -55,11 +54,9 @@ class TestPermissions(APITestMixin):
         """
         Tests view returns 403 for user without team and permission
         """
-        self._user = get_test_user()
-        self._user.dit_team = None
-        self._user.save()
+        user = create_test_user()
 
-        token = self.get_token()
+        token = self.get_token(user=user)
 
         request = factory.get('/', data={}, content_type='application/json',
                               Authorization=f'Bearer {token}')

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -3,38 +3,50 @@ from secrets import token_hex
 
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.test.client import Client
 from django.utils.timezone import now
 from oauth2_provider.models import AccessToken, Application
 from rest_framework.fields import DateField, DateTimeField
 from rest_framework.test import APIClient
 
+from datahub.company.test.factories import AdviserFactory
 from datahub.metadata.models import Team
 from datahub.oauth.scopes import Scope
 
 
-def get_test_user(team=None):
+def get_default_test_user():
     """Return the test user."""
     user_model = get_user_model()
     try:
         test_user = user_model.objects.get(email='Testo@Useri.com')
     except user_model.DoesNotExist:
+        team = Team.objects.filter(
+            role__groups__name='DIT_staff'
+        ).first()
         test_user = user_model(
             first_name='Testo',
             last_name='Useri',
             email='Testo@Useri.com',
             date_joined=now(),
+            dit_team=team,
         )
-        if team is None:
-            test_user.dit_team = Team.objects.filter(
-                role__groups__name='DIT_staff'
-            ).first()
-        else:
-            test_user.dit_team = team
-
-        test_user.set_password('password')
         test_user.save()
     return test_user
+
+
+def create_test_user(team=None, permissions=()):
+    """Return the test user."""
+    # Because AdviserFactory sets dit_team_id, passing dit_team to it doesn't work
+    dit_team_id = team.id if team else None
+    user = AdviserFactory(dit_team_id=dit_team_id)
+
+    for permission in permissions:
+        user.user_permissions.add(
+            Permission.objects.get(codename=permission)
+        )
+
+    return user
 
 
 def get_admin_user(password=None):
@@ -85,25 +97,29 @@ class APITestMixin:
     def user(self):
         """Return the user."""
         if not hasattr(self, '_user'):
-            self._user = get_test_user()
+            self._user = get_default_test_user()
         return self._user
 
-    def get_token(self, *scopes, grant_type=Application.GRANT_PASSWORD):
+    def get_token(self, *scopes, grant_type=Application.GRANT_PASSWORD, user=None):
         """Get access token for user test."""
         if not hasattr(self, '_tokens'):
             self._tokens = {}
 
+        if user is None and grant_type != Application.GRANT_CLIENT_CREDENTIALS:
+            user = self.user
+
         scope = ' '.join(scopes)
 
-        if scope not in self._tokens:
-            self._tokens[scope] = AccessToken.objects.create(
-                user=None if grant_type == Application.GRANT_CLIENT_CREDENTIALS else self.user,
+        token_cache_key = (user.email if user else None, scope)
+        if token_cache_key not in self._tokens:
+            self._tokens[token_cache_key] = AccessToken.objects.create(
+                user=user,
                 application=self.get_application(grant_type),
                 token=token_hex(16),
                 expires=now() + timedelta(hours=1),
                 scope=scope
             )
-        return self._tokens[scope]
+        return self._tokens[token_cache_key]
 
     @property
     def api_client(self):
@@ -111,9 +127,9 @@ class APITestMixin:
         return self.create_api_client()
 
     def create_api_client(self, scope=Scope.internal_front_end, *additional_scopes,
-                          grant_type=Application.GRANT_PASSWORD):
+                          grant_type=Application.GRANT_PASSWORD, user=None):
         """Creates an API client associated with an OAuth token with the specified scope."""
-        token = self.get_token(scope, *additional_scopes, grant_type=grant_type)
+        token = self.get_token(scope, *additional_scopes, grant_type=grant_type, user=user)
         client = APIClient()
         client.credentials(Authorization=f'Bearer {token}')
         return client

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -35,16 +35,14 @@ def get_default_test_user():
     return test_user
 
 
-def create_test_user(team=None, permissions=()):
+def create_test_user(team=None, permission_codenames=()):
     """Return the test user."""
     # Because AdviserFactory sets dit_team_id, passing dit_team to it doesn't work
     dit_team_id = team.id if team else None
     user = AdviserFactory(dit_team_id=dit_team_id)
 
-    for permission in permissions:
-        user.user_permissions.add(
-            Permission.objects.get(codename=permission)
-        )
+    permissions = Permission.objects.filter(codename__in=permission_codenames)
+    user.user_permissions.set(permissions)
 
     return user
 

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -5,7 +5,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import Country, Service, Team, UKRegion
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.event.constants import EventType, LocationType, Programme
 from datahub.event.test.factories import EventFactory
 from datahub.metadata.test.factories import TeamFactory
@@ -17,10 +17,10 @@ class TestGetEventView(APITestMixin):
     def test_event_details_no_permissions(self):
         """Should return 403"""
         event = EventFactory()
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:event:item', kwargs={'pk': event.pk})
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_get(self):
@@ -95,10 +95,10 @@ class TestListEventView(APITestMixin):
 
     def test_event_list_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:event:collection')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_list(self):

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -6,7 +6,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core.constants import InteractionType, Service, Team
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.test.factories import (
     EventServiceDeliveryFactory, InteractionFactory, ServiceDeliveryFactory
@@ -21,10 +21,10 @@ class TestInteractionV3(APITestMixin):
     def test_interaction_no_permissions(self):
         """Should return 403"""
         interaction = InteractionFactory()
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_interaction_detail_view(self):

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -1978,6 +1978,6 @@ def test_view_set_name(view_set):
 
 
 def _create_user_and_api_client(test_instance, team, permissions):
-    user = create_test_user(team=team, permissions=permissions)
+    user = create_test_user(team=team, permission_codenames=permissions)
     api_client = test_instance.create_api_client(user=user)
     return user, api_client

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -8,7 +8,6 @@ from unittest.mock import patch
 
 import pytest
 import reversion
-from django.contrib.auth.models import Permission
 from django.utils.timezone import now, utc
 from freezegun import freeze_time
 from oauth2_provider.models import Application
@@ -19,7 +18,7 @@ from reversion.models import Version
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
 from datahub.core.test_utils import (
-    APITestMixin, format_date_or_datetime, get_test_user, synchronous_executor_submit,
+    APITestMixin, create_test_user, format_date_or_datetime, synchronous_executor_submit,
     synchronous_transaction_on_commit
 )
 from datahub.core.utils import executor
@@ -47,10 +46,10 @@ class TestListView(APITestMixin):
 
     def test_investments_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
         url = reverse('api-v3:investment:investment-collection')
-        response = self.api_client.get(url)
+        api_client = self.create_api_client(user=user)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_list_projects_success(self):
@@ -205,7 +204,7 @@ class TestListView(APITestMixin):
         adviser_1 = AdviserFactory(dit_team_id=team.id)
         adviser_2 = AdviserFactory(dit_team_id=team_others.id)
 
-        _create_user(self, team, permissions)
+        _, api_client = _create_user_and_api_client(self, team, permissions)
 
         iproject_1 = InvestmentProjectFactory()
         iproject_2 = InvestmentProjectFactory()
@@ -214,7 +213,7 @@ class TestListView(APITestMixin):
         InvestmentProjectTeamMemberFactory(adviser=adviser_2, investment_project=iproject_2)
 
         url = reverse('api-v3:investment:investment-collection')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -230,7 +229,7 @@ class TestListView(APITestMixin):
         adviser_other = AdviserFactory(dit_team_id=team_others.id)
         adviser_same_team = AdviserFactory(dit_team_id=team.id)
 
-        _create_user(self, team, [Permissions.read_associated])
+        _, api_client = _create_user_and_api_client(self, team, [Permissions.read_associated])
 
         project_other = InvestmentProjectFactory()
         project_1 = InvestmentProjectFactory()
@@ -243,7 +242,7 @@ class TestListView(APITestMixin):
         InvestmentProjectTeamMemberFactory(adviser=adviser_same_team, investment_project=project_1)
 
         url = reverse('api-v3:investment:investment-collection')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -718,13 +717,15 @@ class TestRetrieveView(APITestMixin):
         team_associated = TeamFactory()
         adviser_1 = AdviserFactory(dit_team_id=team_associated.id)
 
-        _create_user(self, team_requester, [Permissions.read_associated])
+        _, api_client = _create_user_and_api_client(
+            self, team_requester, [Permissions.read_associated]
+        )
 
         iproject_1 = InvestmentProjectFactory()
         InvestmentProjectTeamMemberFactory(adviser=adviser_1, investment_project=iproject_1)
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': iproject_1.pk})
-        response = self.api_client.get(url)
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -738,13 +739,13 @@ class TestRetrieveView(APITestMixin):
         team_associated = TeamFactory()
         adviser_1 = AdviserFactory(dit_team_id=team_associated.id)
 
-        _create_user(self, team_requester, permissions)
+        _, api_client = _create_user_and_api_client(self, team_requester, permissions)
 
         iproject_1 = InvestmentProjectFactory()
         InvestmentProjectTeamMemberFactory(adviser=adviser_1, investment_project=iproject_1)
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': iproject_1.pk})
-        response = self.api_client.get(url)
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -752,13 +753,13 @@ class TestRetrieveView(APITestMixin):
         """Tests that restricted users can see a project associated to them via a team member."""
         team = TeamFactory()
         adviser_1 = AdviserFactory(dit_team_id=team.id)
-        _create_user(self, team, [Permissions.read_associated])
+        _, api_client = _create_user_and_api_client(self, team, [Permissions.read_associated])
 
         iproject_1 = InvestmentProjectFactory()
         InvestmentProjectTeamMemberFactory(adviser=adviser_1, investment_project=iproject_1)
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': iproject_1.pk})
-        response = self.api_client.get(url)
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -767,12 +768,12 @@ class TestRetrieveView(APITestMixin):
         team = TeamFactory()
         adviser_1 = AdviserFactory(dit_team_id=team.id)
 
-        _create_user(self, team, [Permissions.read_associated])
+        _, api_client = _create_user_and_api_client(self, team, [Permissions.read_associated])
 
         iproject_1 = InvestmentProjectFactory(created_by=adviser_1)
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': iproject_1.pk})
-        response = self.api_client.get(url)
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -1173,13 +1174,15 @@ class TestPartialUpdateView(APITestMixin):
         team_associated = TeamFactory()
         adviser = AdviserFactory(dit_team_id=team_associated.id)
 
-        _create_user(self, team_requester, [Permissions.change_associated])
+        _, api_client = _create_user_and_api_client(
+            self, team_requester, [Permissions.change_associated]
+        )
 
         project = InvestmentProjectFactory(name='old name')
         InvestmentProjectTeamMemberFactory(adviser=adviser, investment_project=project)
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
-        response = self.api_client.patch(url, {
+        response = api_client.patch(url, {
             'name': 'new name'
         })
 
@@ -1195,13 +1198,13 @@ class TestPartialUpdateView(APITestMixin):
         team_associated = TeamFactory()
         adviser = AdviserFactory(dit_team_id=team_associated.id)
 
-        _create_user(self, team_requester, permissions)
+        _, api_client = _create_user_and_api_client(self, team_requester, permissions)
 
         project = InvestmentProjectFactory(name='old name')
         InvestmentProjectTeamMemberFactory(adviser=adviser, investment_project=project)
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
-        response = self.api_client.patch(url, {
+        response = api_client.patch(url, {
             'name': 'new name'
         })
 
@@ -1215,13 +1218,15 @@ class TestPartialUpdateView(APITestMixin):
         """
         team = TeamFactory()
         adviser = AdviserFactory(dit_team_id=team.id)
-        _create_user(self, team, [Permissions.change_associated])
+        _, api_client = _create_user_and_api_client(
+            self, team, [Permissions.change_associated]
+        )
 
         project = InvestmentProjectFactory(name='old name')
         InvestmentProjectTeamMemberFactory(adviser=adviser, investment_project=project)
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
-        response = self.api_client.patch(url, {
+        response = api_client.patch(url, {
             'name': 'new name'
         })
 
@@ -1234,12 +1239,14 @@ class TestPartialUpdateView(APITestMixin):
         team = TeamFactory()
         adviser = AdviserFactory(dit_team_id=team.id)
 
-        _create_user(self, team, [Permissions.change_associated])
+        _, api_client = _create_user_and_api_client(
+            self, team, [Permissions.change_associated]
+        )
 
         project = InvestmentProjectFactory(name='old name', created_by=adviser)
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
-        response = self.api_client.patch(url, {
+        response = api_client.patch(url, {
             'name': 'new name'
         })
 
@@ -1532,7 +1539,7 @@ class TestAuditLogView(APITestMixin):
     def test_audit_log_non_restricted_user(self, permissions):
         """Test retrieval of audit log for a non-restricted user."""
         team = TeamFactory()
-        _create_user(self, team, permissions)
+        user, api_client = _create_user_and_api_client(self, team, permissions)
 
         initial_datetime = now()
         with reversion.create_revision():
@@ -1542,7 +1549,7 @@ class TestAuditLogView(APITestMixin):
 
             reversion.set_comment('Initial')
             reversion.set_date_created(initial_datetime)
-            reversion.set_user(self.user)
+            reversion.set_user(user)
 
         changed_datetime = now()
         with reversion.create_revision():
@@ -1551,14 +1558,14 @@ class TestAuditLogView(APITestMixin):
 
             reversion.set_comment('Changed')
             reversion.set_date_created(changed_datetime)
-            reversion.set_user(self.user)
+            reversion.set_user(user)
 
         versions = Version.objects.get_for_object(iproject)
         version_id = versions[0].id
         url = reverse('api-v3:investment:audit-item',
                       kwargs={'pk': iproject.pk})
 
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         response_data = response.json()['results']
 
         # No need to test the whole response
@@ -1566,7 +1573,7 @@ class TestAuditLogView(APITestMixin):
         entry = response_data[0]
 
         assert entry['id'] == version_id
-        assert entry['user']['name'] == self.user.name, 'Valid user captured'
+        assert entry['user']['name'] == user.name, 'Valid user captured'
         assert entry['comment'] == 'Changed', 'Comments can be set manually'
         assert entry['timestamp'] == format_date_or_datetime(changed_datetime), \
             'TS can be set manually'
@@ -1579,7 +1586,7 @@ class TestAuditLogView(APITestMixin):
         """Test retrieval of audit log for a restricted user and an associated project."""
         team = TeamFactory()
         adviser = AdviserFactory(dit_team_id=team.id)
-        _create_user(self, team, [Permissions.read_associated])
+        user, api_client = _create_user_and_api_client(self, team, [Permissions.read_associated])
 
         initial_datetime = now()
         with reversion.create_revision():
@@ -1590,7 +1597,7 @@ class TestAuditLogView(APITestMixin):
 
             reversion.set_comment('Initial')
             reversion.set_date_created(initial_datetime)
-            reversion.set_user(self.user)
+            reversion.set_user(user)
 
         changed_datetime = now()
         with reversion.create_revision():
@@ -1599,14 +1606,14 @@ class TestAuditLogView(APITestMixin):
 
             reversion.set_comment('Changed')
             reversion.set_date_created(changed_datetime)
-            reversion.set_user(self.user)
+            reversion.set_user(user)
 
         versions = Version.objects.get_for_object(iproject)
         version_id = versions[0].id
         url = reverse('api-v3:investment:audit-item',
                       kwargs={'pk': iproject.pk})
 
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         response_data = response.json()['results']
 
         # No need to test the whole response
@@ -1614,7 +1621,7 @@ class TestAuditLogView(APITestMixin):
         entry = response_data[0]
 
         assert entry['id'] == version_id
-        assert entry['user']['name'] == self.user.name, 'Valid user captured'
+        assert entry['user']['name'] == user.name, 'Valid user captured'
         assert entry['comment'] == 'Changed', 'Comments can be set manually'
         assert entry['timestamp'] == format_date_or_datetime(changed_datetime), \
             'TS can be set manually'
@@ -1626,14 +1633,14 @@ class TestAuditLogView(APITestMixin):
     def test_audit_log_restricted_user_non_associated_project(self):
         """Test retrieval of audit log for a restricted user and a non-associated project."""
         team = TeamFactory()
-        _create_user(self, team, [Permissions.read_associated])
+        _, api_client = _create_user_and_api_client(self, team, [Permissions.read_associated])
 
         iproject = InvestmentProjectFactory(
             description='Initial desc',
         )
         url = reverse('api-v3:investment:audit-item', kwargs={'pk': iproject.pk})
 
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -1647,49 +1654,53 @@ class TestArchiveViews(APITestMixin):
     def test_archive_project_non_restricted_user(self, permissions):
         """Tests archiving a project for a non-restricted user."""
         team = TeamFactory()
-        _create_user(self, team, permissions)
+        user, api_client = _create_user_and_api_client(self, team, permissions)
 
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url, format='json', data={
+        response = api_client.post(url, format='json', data={
             'reason': 'archive reason'
         })
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['archived'] is True
-        assert response_data['archived_by']['id'] == str(self.user.pk)
+        assert response_data['archived_by']['id'] == str(user.pk)
         assert response_data['archived_reason'] == 'archive reason'
 
     def test_archive_project_restricted_user_associated_project(self):
         """Tests archiving a project for a restricted user."""
         team = TeamFactory()
         adviser = AdviserFactory(dit_team_id=team.id)
-        _create_user(self, team, [Permissions.change_associated])
+        user, api_client = _create_user_and_api_client(
+            self, team, [Permissions.change_associated]
+        )
 
         project = InvestmentProjectFactory(created_by=adviser)
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url, format='json', data={
+        response = api_client.post(url, format='json', data={
             'reason': 'archive reason'
         })
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['archived'] is True
-        assert response_data['archived_by']['id'] == str(self.user.pk)
+        assert response_data['archived_by']['id'] == str(user.pk)
         assert response_data['archived_reason'] == 'archive reason'
 
     def test_archive_project_restricted_user_non_associated_project(self):
         """Test that a restricted user cannot archive a non-associated project."""
         team = TeamFactory()
-        _create_user(self, team, [Permissions.change_associated])
+        _, api_client = _create_user_and_api_client(
+            self, team, [Permissions.change_associated]
+        )
 
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url, format='json', data={
+        response = api_client.post(url, format='json', data={
             'reason': 'archive reason'
         })
 
@@ -1742,14 +1753,14 @@ class TestArchiveViews(APITestMixin):
     def test_unarchive_project_non_restricted_user(self, permissions):
         """Tests unarchiving a project for a non-restricted user."""
         team = TeamFactory()
-        _create_user(self, team, permissions)
+        _, api_client = _create_user_and_api_client(self, team, permissions)
 
         project = InvestmentProjectFactory(
             archived=True, archived_reason='reason'
         )
         url = reverse('api-v3:investment:unarchive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url)
+        response = api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -1761,7 +1772,9 @@ class TestArchiveViews(APITestMixin):
         """Tests unarchiving a project for a restricted user and associated project."""
         team = TeamFactory()
         adviser = AdviserFactory(dit_team_id=team.id)
-        _create_user(self, team, [Permissions.change_associated])
+        _, api_client = _create_user_and_api_client(
+            self, team, [Permissions.change_associated]
+        )
 
         project = InvestmentProjectFactory(
             archived=True,
@@ -1770,7 +1783,7 @@ class TestArchiveViews(APITestMixin):
         )
         url = reverse('api-v3:investment:unarchive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url)
+        response = api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -1782,7 +1795,9 @@ class TestArchiveViews(APITestMixin):
         """Test that a restricted user cannot unarchive a non-associated project."""
         team = TeamFactory()
         AdviserFactory(dit_team_id=team.id)
-        _create_user(self, team, [Permissions.change_associated])
+        _, api_client = _create_user_and_api_client(
+            self, team, [Permissions.change_associated]
+        )
 
         project = InvestmentProjectFactory(
             archived=True,
@@ -1790,7 +1805,7 @@ class TestArchiveViews(APITestMixin):
         )
         url = reverse('api-v3:investment:unarchive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url)
+        response = api_client.post(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -1962,9 +1977,7 @@ def test_view_set_name(view_set):
     assert isinstance(view_set().get_view_name(), str)
 
 
-def _create_user(test_instance, team, permissions):
-    test_instance._user = get_test_user(team=team)
-    for permission in permissions:
-        test_instance._user.user_permissions.add(
-            Permission.objects.get(codename=permission)
-        )
+def _create_user_and_api_client(test_instance, team, permissions):
+    user = create_test_user(team=team, permissions=permissions)
+    api_client = test_instance.create_api_client(user=user)
+    return user, api_client

--- a/datahub/leads/test/test_views.py
+++ b/datahub/leads/test/test_views.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.leads.test.factories import BusinessLeadFactory
 from datahub.metadata.test.factories import TeamFactory
 
@@ -19,10 +19,10 @@ class TestBusinessLeadViews(APITestMixin):
 
     def test_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:business-leads:lead-collection')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_list_leads_success(self):

--- a/datahub/search/companieshousecompany/tests/test_views.py
+++ b/datahub/search/companieshousecompany/tests/test_views.py
@@ -5,7 +5,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.models import CompaniesHouseCompany as DBCompaniesHouseCompany
 from datahub.company.test.factories import CompaniesHouseCompanyFactory
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 from datahub.search.companieshousecompany.models import (
     CompaniesHouseCompany as ESCompaniesHouseCompany
@@ -50,10 +50,10 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
 
     def test_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:companieshousecompany')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -14,7 +14,7 @@ from datahub.company.models import Company
 from datahub.company.test.factories import (AdviserFactory, CompaniesHouseCompanyFactory,
                                             CompanyFactory, ContactFactory)
 from datahub.core import constants
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 
 pytestmark = pytest.mark.django_db
@@ -48,10 +48,10 @@ class TestSearch(APITestMixin):
 
     def test_company_search_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:company')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_trading_address_country_filter(self, setup_data):

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -5,7 +5,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core.constants import Country, Sector, UKRegion
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 
 pytestmark = pytest.mark.django_db
@@ -26,10 +26,10 @@ class TestSearch(APITestMixin):
 
     def test_company_search_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:contact')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_search_contact(self, setup_es, setup_data):

--- a/datahub/search/event/tests/test_views.py
+++ b/datahub/search/event/tests/test_views.py
@@ -7,7 +7,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core import constants
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.event.test.factories import EventFactory
 from datahub.metadata.test.factories import TeamFactory
 
@@ -26,10 +26,10 @@ class TestSearch(APITestMixin):
 
     def test_event_search_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:event')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_search_event(self, setup_es, setup_data):

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -11,7 +11,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.interaction.models import Interaction
 from datahub.interaction.test.factories import InteractionFactory, ServiceDeliveryFactory
 from datahub.metadata.test.factories import TeamFactory
@@ -57,10 +57,10 @@ class TestViews(APITestMixin):
 
     def test_interaction_search_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:interaction')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_get_all(self, interactions):

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -5,7 +5,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core import constants
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.investment.models import InvestmentProject
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import TeamFactory
@@ -71,10 +71,10 @@ class TestSearch(APITestMixin):
 
     def test_investment_project_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:investment_project')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_search_investment_project_json(self, setup_data):

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -7,7 +7,7 @@ from rest_framework.reverse import reverse
 from datahub.company.models import Company
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.models import Order
@@ -80,10 +80,10 @@ class TestSearchOrder(APITestMixin):
 
     def test_no_permissions(self):
         """Should return 403"""
-        team = TeamFactory()
-        self._user = get_test_user(team=team)
+        user = create_test_user(team=TeamFactory())
+        api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:order')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test.factories import GroupFactory, PermissionFactory
-from datahub.core.test_utils import APITestMixin, get_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory, TeamRoleFactory
 
 
@@ -34,11 +34,12 @@ class TestUserView(APITestMixin):
         team = TeamFactory(name='Test Team', role=role)
         team.role.groups.add(group)
 
-        user_test = get_test_user(team=team)
+        user_test = create_test_user(team=team)
         user_test.user_permissions.set(permissions[1:])
+        api_client = self.create_api_client(user=user_test)
 
         url = reverse('who_am_i')
-        response = self.api_client.get(url)
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -59,8 +60,8 @@ class TestUserView(APITestMixin):
             'first_name': user_test.first_name,
             'last_name': user_test.last_name,
             'email': user_test.email,
-            'contact_email': '',
-            'telephone_number': '',
+            'contact_email': user_test.contact_email,
+            'telephone_number': user_test.telephone_number,
             'dit_team': {
                 'id': str(team.id),
                 'name': 'Test Team',


### PR DESCRIPTION
Stops such tests overwriting self._user (which was hacky and confusing).