### PR TITLE
[DH-813] Fix browseable API for investment projects

### DIFF
--- a/datahub/core/permissions.py
+++ b/datahub/core/permissions.py
@@ -14,6 +14,7 @@ _VIEW_TO_ACTION_MAPPING = {
     'partial_update': 'change',
     'archive': 'change',
     'unarchive': 'change',
+    'metadata': 'read',
 }
 
 
@@ -85,6 +86,9 @@ class IsAssociatedToObjectPermission(BasePermission):
         return True
 
 
-def get_model_action_for_view_action(method):
+def get_model_action_for_view_action(http_method, view_action):
     """Gets the model action corresponding to a view action."""
-    return _VIEW_TO_ACTION_MAPPING[method]
+    if http_method == 'OPTIONS':
+        return 'read'
+
+    return _VIEW_TO_ACTION_MAPPING[view_action]

--- a/datahub/investment/permissions.py
+++ b/datahub/investment/permissions.py
@@ -62,15 +62,15 @@ class InvestmentProjectModelPermissions(BasePermission):
             return False
 
         model = view.get_queryset().model
-        perms = self._get_required_permissions(view, model)
+        perms = self._get_required_permissions(request, view, model)
 
         return any(request.user.has_perm(perm) for perm in perms)
 
-    def _get_required_permissions(self, view, model_cls):
+    def _get_required_permissions(self, request, view, model_cls):
         """
         Returns the permissions that a user should have one of for a particular method.
         """
-        action = get_model_action_for_view_action(view.action)
+        action = get_model_action_for_view_action(request.method, view.action)
 
         format_kwargs = {
             'app_label': model_cls._meta.app_label,
@@ -96,7 +96,7 @@ class InvestmentProjectAssociationChecker(ObjectAssociationCheckerBase):
 
     def should_apply_restrictions(self, request, view):
         """Check if restrictions should be applied."""
-        action = get_model_action_for_view_action(view.action)
+        action = get_model_action_for_view_action(request.method, view.action)
         if action not in self.restricted_actions:
             return False
 


### PR DESCRIPTION
Just some minor changes to get the DRF browseable API working with the investment permission changes. (OPTIONS and metadata operations possibly may not need to be protected by specific permissions, but since we don't otherwise use them it's simpler to just treat them as read actions.)