### PR TITLE
Add billing_company_name to OMIS invoice endpoint

### DIFF
--- a/datahub/omis/invoice/serializers.py
+++ b/datahub/omis/invoice/serializers.py
@@ -12,6 +12,7 @@ class InvoiceSerializer(serializers.ModelSerializer):
     invoice_address_country = NestedRelatedField(Country)
 
     billing_contact_name = serializers.ReadOnlyField(source='order.billing_contact_name')
+    billing_company_name = serializers.ReadOnlyField(source='order.billing_company_name')
     billing_address_1 = serializers.ReadOnlyField(source='order.billing_address_1')
     billing_address_2 = serializers.ReadOnlyField(source='order.billing_address_2')
     billing_address_county = serializers.ReadOnlyField(source='order.billing_address_county')
@@ -35,6 +36,7 @@ class InvoiceSerializer(serializers.ModelSerializer):
             'invoice_vat_number',
             'payment_due_date',
             'billing_contact_name',
+            'billing_company_name',
             'billing_address_1',
             'billing_address_2',
             'billing_address_county',

--- a/datahub/omis/invoice/test/views/test_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_invoice_details.py
@@ -36,6 +36,7 @@ class TestGetInvoice(APITestMixin):
             'payment_due_date': invoice.payment_due_date.isoformat(),
 
             'billing_contact_name': order.billing_contact_name,
+            'billing_company_name': order.billing_company_name,
             'billing_address_1': order.billing_address_1,
             'billing_address_2': order.billing_address_2,
             'billing_address_county': order.billing_address_county,

--- a/datahub/omis/invoice/test/views/test_public_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_public_invoice_details.py
@@ -60,6 +60,7 @@ class TestPublicGetInvoice(APITestMixin):
             'payment_due_date': invoice.payment_due_date.isoformat(),
 
             'billing_contact_name': order.billing_contact_name,
+            'billing_company_name': order.billing_company_name,
             'billing_address_1': order.billing_address_1,
             'billing_address_2': order.billing_address_2,
             'billing_address_county': order.billing_address_county,


### PR DESCRIPTION
This adds `billing_company_name` to the response body of the OMIS invoice endpoints.