### PR TITLE
Fully enforce model permissions in search

### DIFF
--- a/datahub/core/permissions.py
+++ b/datahub/core/permissions.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 
-from django.core.exceptions import ImproperlyConfigured
 from rest_framework.permissions import BasePermission, DjangoModelPermissions
 
 
@@ -23,21 +22,6 @@ class DjangoCrudPermission(DjangoModelPermissions):
 
     perms_map = DjangoModelPermissions.perms_map.copy()
     perms_map['GET'].append('%(app_label)s.read_%(model_name)s')
-
-
-class UserHasPermissions(BasePermission):
-    """
-    Check the permission_required on view against User Permissions
-    """
-
-    def has_permission(self, request, view):
-        """
-        Return `True` if permission is granted `False` otherwise.
-        Raises ImproperlyConfigured if permission_required is not set on view
-        """
-        if not hasattr(view, 'permission_required'):
-            raise ImproperlyConfigured()
-        return request.user and request.user.has_perm(view.permission_required)
 
 
 class ObjectAssociationCheckerBase(ABC):

--- a/datahub/core/permissions.py
+++ b/datahub/core/permissions.py
@@ -53,11 +53,11 @@ class ObjectAssociationCheckerBase(ABC):
     """
 
     @abstractmethod
-    def is_associated(self, request, view, obj) -> bool:
+    def is_associated(self, request, obj) -> bool:
         """Checks whether the user is associated with a particular object."""
 
     @abstractmethod
-    def should_apply_restrictions(self, request, view) -> bool:
+    def should_apply_restrictions(self, request, view_action, model) -> bool:
         """
         Checks whether a request should be restricted to objects that the user is associated with.
         """
@@ -81,8 +81,8 @@ class IsAssociatedToObjectPermission(BasePermission):
         """
         Determines whether the user has permission for the specified object, using checker_class.
         """
-        if self.checker.should_apply_restrictions(request, view):
-            return self.checker.is_associated(request, view, obj)
+        if self.checker.should_apply_restrictions(request, view.action, view.get_queryset().model):
+            return self.checker.is_associated(request, obj)
         return True
 
 

--- a/datahub/investment/admin.py
+++ b/datahub/investment/admin.py
@@ -9,9 +9,9 @@ from datahub.investment.models import (
     InvestorType,
     Involvement,
     IProjectDocument,
+    Permissions,
     SpecificProgramme,
 )
-from datahub.investment.permissions import Permissions
 
 
 @admin.register(InvestmentProject)

--- a/datahub/investment/models.py
+++ b/datahub/investment/models.py
@@ -15,10 +15,25 @@ from datahub.core.models import (
     BaseConstantModel,
     BaseModel,
 )
+from datahub.core.utils import StrEnum
 from datahub.documents.models import Document
-from datahub.investment.permissions import Permissions
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
+
+
+class Permissions(StrEnum):
+    """
+    Permission codename constants.
+
+    (Defined here rather than in permissions to avoid an import of that module.)
+    """
+
+    read_all = 'read_all_investmentproject'
+    read_associated = 'read_associated_investmentproject'
+    change_all = 'change_all_investmentproject'
+    change_associated = 'change_associated_investmentproject'
+    add = 'add_investmentproject'
+    delete = 'delete_investmentproject'
 
 
 class IProjectAbstract(models.Model):
@@ -282,14 +297,14 @@ class InvestmentProject(ArchivableModel, IProjectAbstract,
                         IProjectTeamAbstract, BaseModel):
     """An investment project."""
 
-    ASSOCIATED_ADVISER_TO_ONE_FIELDS = (
+    _ASSOCIATED_ADVISER_TO_ONE_FIELDS = (
         'created_by',
         'client_relationship_manager',
         'project_manager',
         'project_assurance_adviser',
     )
 
-    ASSOCIATED_ADVISER_TO_MANY_FIELDS = (
+    _ASSOCIATED_ADVISER_TO_MANY_FIELDS = (
         _AssociatedToManyField(
             field_name='team_members', subfield_name='adviser', es_field_name='team_members'
         ),
@@ -321,12 +336,22 @@ class InvestmentProject(ArchivableModel, IProjectAbstract,
             self._get_associated_to_many_advisers(),
         )
 
+    @classmethod
+    def get_association_fields(cls):
+        """
+        Gets a list of to-one association fields, and to-many association fields.
+
+        These are used (as part of permissions) to determine if an adviser's team is associated
+        with a project.
+        """
+        return cls._ASSOCIATED_ADVISER_TO_ONE_FIELDS, cls._ASSOCIATED_ADVISER_TO_MANY_FIELDS
+
     def _get_associated_to_one_advisers(self):
-        advisers = (getattr(self, field) for field in self.ASSOCIATED_ADVISER_TO_ONE_FIELDS)
+        advisers = (getattr(self, field) for field in self._ASSOCIATED_ADVISER_TO_ONE_FIELDS)
         return filter(None, advisers)
 
     def _get_associated_to_many_advisers(self):
-        for field in self.ASSOCIATED_ADVISER_TO_MANY_FIELDS:
+        for field in self._ASSOCIATED_ADVISER_TO_MANY_FIELDS:
             field_instance = getattr(self, field.field_name)
             for item in field_instance.all():
                 adviser = getattr(item, field.subfield_name)

--- a/datahub/investment/models.py
+++ b/datahub/investment/models.py
@@ -1,8 +1,8 @@
 """Investment project models."""
 
 import uuid
+from collections import namedtuple
 from itertools import chain
-from typing import NamedTuple
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -286,10 +286,9 @@ class IProjectTeamAbstract(models.Model):
         return None
 
 
-class _AssociatedToManyField(NamedTuple):
-    field_name: str
-    subfield_name: str
-    es_field_name: str
+_AssociatedToManyField = namedtuple(
+    '_AssociatedToManyField', ('field_name', 'subfield_name', 'es_field_name')
+)
 
 
 class InvestmentProject(ArchivableModel, IProjectAbstract,

--- a/datahub/investment/permissions.py
+++ b/datahub/investment/permissions.py
@@ -61,7 +61,7 @@ class InvestmentProjectModelPermissions(BasePermission):
         if not request.user or not request.user.is_authenticated:
             return False
 
-        model = _get_model_for_view(view)
+        model = view.get_queryset().model
         perms = self._get_required_permissions(request, view, model)
 
         return any(request.user.has_perm(perm) for perm in perms)
@@ -147,11 +147,3 @@ class IsAssociatedToInvestmentProjectFilter(BaseFilterBackend):
                 query |= Q(**{full_field_name: request.user.dit_team})
             return queryset.filter(query)
         return queryset
-
-
-def _get_model_for_view(view):
-    if hasattr(view, 'search_app'):
-        queryset = view.search_app.queryset
-    else:
-        queryset = view.get_queryset()
-    return queryset.model

--- a/datahub/investment/permissions.py
+++ b/datahub/investment/permissions.py
@@ -144,8 +144,9 @@ class IsAssociatedToInvestmentProjectFilter(BaseFilterBackend):
             for field in queryset.model.ASSOCIATED_ADVISER_TO_ONE_FIELDS:
                 query |= Q(**{f'{field}__dit_team': request.user.dit_team})
 
-            for field, subfield in queryset.model.ASSOCIATED_ADVISER_TO_MANY_FIELDS:
-                query |= Q(**{f'{field}__{subfield}__dit_team': request.user.dit_team})
+            for field in queryset.model.ASSOCIATED_ADVISER_TO_MANY_FIELDS:
+                full_field_name = f'{field.field_name}__{field.subfield_name}__dit_team'
+                query |= Q(**{full_field_name: request.user.dit_team})
             return queryset.filter(query)
         return queryset
 

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -25,9 +25,9 @@ from datahub.core.utils import executor
 from datahub.documents.av_scan import virus_scan_document
 from datahub.investment import views
 from datahub.investment.models import (
-    InvestmentProject, InvestmentProjectTeamMember, IProjectDocument
+    InvestmentProject, InvestmentProjectTeamMember, IProjectDocument,
+    Permissions
 )
-from datahub.investment.permissions import Permissions
 from datahub.investment.test.factories import (
     ActiveInvestmentProjectFactory, AssignPMInvestmentProjectFactory,
     InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
@@ -253,6 +253,27 @@ class TestListView(APITestMixin):
                         str(project_4.id), str(project_5.id)}
 
         assert {result['id'] for result in results} == expected_ids
+
+    def test_restricted_user_with_no_team_cannot_see_projects(self):
+        """
+        Checks that a restricted user that doesn't have a team cannot view any projects (in
+        particular projects associated with other advisers that don't have teams).
+        """
+        adviser_other = AdviserFactory(dit_team_id=None)
+        request_user = create_test_user(
+            permission_codenames=['read_associated_investmentproject']
+        )
+        api_client = self.create_api_client(user=request_user)
+
+        InvestmentProjectFactory()
+        InvestmentProjectFactory(created_by=adviser_other)
+
+        url = reverse('api-v3:investment:investment-collection')
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == 0
 
 
 class TestCreateView(APITestMixin):
@@ -749,7 +770,7 @@ class TestRetrieveView(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
 
-    def test_restricted_user_can_see_project_if_associated(self):
+    def test_restricted_user_can_see_project_if_associated_via_team_member(self):
         """Tests that restricted users can see a project associated to them via a team member."""
         team = TeamFactory()
         adviser_1 = AdviserFactory(dit_team_id=team.id)
@@ -763,19 +784,42 @@ class TestRetrieveView(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
 
-    def test_restricted_user_can_see_project_if_in_created_by_team(self):
+    @pytest.mark.parametrize('field', (
+        'created_by',
+        'client_relationship_manager',
+        'project_assurance_adviser',
+        'project_manager'))
+    def test_restricted_user_can_see_project_if_associated_via_field(self, field):
         """Tests that restricted users can see a project when in the team of the creator."""
         team = TeamFactory()
         adviser_1 = AdviserFactory(dit_team_id=team.id)
 
         _, api_client = _create_user_and_api_client(self, team, [Permissions.read_associated])
 
-        iproject_1 = InvestmentProjectFactory(created_by=adviser_1)
+        iproject_1 = InvestmentProjectFactory(**{field: adviser_1})
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': iproject_1.pk})
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
+
+    def test_restricted_user_with_no_team_cannot_view_project(self):
+        """
+        Checks that a restricted user that doesn't have a team cannot view a project created by
+        another user without a team.
+        """
+        adviser_other = AdviserFactory(dit_team_id=None)
+        request_user = create_test_user(
+            permission_codenames=['read_associated_investmentproject']
+        )
+        api_client = self.create_api_client(user=request_user)
+
+        project = InvestmentProjectFactory(created_by=adviser_other)
+
+        url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 class TestPartialUpdateView(APITestMixin):
@@ -1212,7 +1256,7 @@ class TestPartialUpdateView(APITestMixin):
         response_data = response.json()
         assert response_data['name'] == 'new name'
 
-    def test_restricted_user_can_update_project_if_associated(self):
+    def test_restricted_user_can_update_project_if_associated_via_team_member(self):
         """
         Tests that restricted users can update a project associated to them via a team member.
         """
@@ -1234,7 +1278,12 @@ class TestPartialUpdateView(APITestMixin):
         response_data = response.json()
         assert response_data['name'] == 'new name'
 
-    def test_restricted_user_can_update_project_if_in_created_by_team(self):
+    @pytest.mark.parametrize('field', (
+        'created_by',
+        'client_relationship_manager',
+        'project_assurance_adviser',
+        'project_manager'))
+    def test_restricted_user_can_update_project_if_associated_via_field(self, field):
         """Tests that restricted users can update a project when in the team of the creator."""
         team = TeamFactory()
         adviser = AdviserFactory(dit_team_id=team.id)
@@ -1243,7 +1292,7 @@ class TestPartialUpdateView(APITestMixin):
             self, team, [Permissions.change_associated]
         )
 
-        project = InvestmentProjectFactory(name='old name', created_by=adviser)
+        project = InvestmentProjectFactory(name='old name', **{field: adviser})
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
         response = api_client.patch(url, {

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -27,6 +27,7 @@ class SearchApp:
     view = None
     export_view = None
     queryset = None
+    permission_required = None
 
     def __init__(self, mod):
         """Create this search app without initialising any ES config."""

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -72,7 +72,7 @@ class SearchApp:
         """
         Gets filter arguments used to enforce permissions.
 
-        The returned dict containes rules in the form of field names and values. Results much
+        The returned dict contains rules in the form of field names and values. Results must
         match at least one of these rules.
         """
         return None

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -72,7 +72,8 @@ class SearchApp:
         """
         Gets filter arguments used to enforce permissions.
 
-        Results much match at least one of the rules in the dict returned.
+        The returned dict containes rules in the form of field names and values. Results much
+        match at least one of these rules.
         """
         return None
 

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -1,6 +1,5 @@
 from functools import lru_cache
 from importlib import import_module
-from typing import Optional
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -17,6 +16,9 @@ SEARCH_APPS = [
     'datahub.search.interaction.InteractionSearchApp',
     'datahub.search.omis.OrderSearchApp',
 ]
+
+
+EXCLUDE_ALL = object()
 
 
 class SearchApp:
@@ -68,12 +70,14 @@ class SearchApp:
 
         return DataSet(queryset, self.ESModel)
 
-    def get_permission_filters(self, request) -> Optional[dict]:
+    def get_permission_filters(self, request):
         """
         Gets filter arguments used to enforce permissions.
 
         The returned dict contains rules in the form of field names and values. Results must
         match at least one of these rules.
+
+        Can also return EXCLUDE_ALL when no results should be returned.
         """
         return None
 

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -1,5 +1,6 @@
 from functools import lru_cache
 from importlib import import_module
+from typing import Optional
 
 from django.apps import AppConfig
 from django.conf import settings
@@ -65,6 +66,14 @@ class SearchApp:
         queryset = self.get_queryset()
 
         return DataSet(queryset, self.ESModel)
+
+    def get_permission_filters(self, request) -> Optional[dict]:
+        """
+        Gets filter arguments used to enforce permissions.
+
+        Results much match at least one of the rules in the dict returned.
+        """
+        return None
 
 
 @lru_cache(maxsize=None)

--- a/datahub/search/companieshousecompany/apps.py
+++ b/datahub/search/companieshousecompany/apps.py
@@ -10,6 +10,7 @@ class CompaniesHouseCompanySearchApp(SearchApp):
     name = 'companieshousecompany'
     ESModel = CompaniesHouseCompany
     view = SearchCompaniesHouseCompanyAPIView
+    permission_required = ('company.read_companieshousecompany',)
     queryset = DBCompaniesHouseCompany.objects.prefetch_related(
         'registered_address_country',
     )

--- a/datahub/search/companieshousecompany/views.py
+++ b/datahub/search/companieshousecompany/views.py
@@ -29,5 +29,3 @@ class SearchCompaniesHouseCompanyAPIView(
     SearchAPIView
 ):
     """Filtered company search view."""
-
-    permission_required = 'company.read_companieshousecompany'

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -13,6 +13,7 @@ class CompanySearchApp(SearchApp):
     ESModel = Company
     view = SearchCompanyAPIView
     export_view = SearchCompanyExportAPIView
+    permission_required = ('company.read_company',)
     queryset = DBCompany.objects.prefetch_related(
         'account_manager',
         'archived_by',

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -45,10 +45,6 @@ class SearchCompanyParams:
 class SearchCompanyAPIView(SearchCompanyParams, SearchAPIView):
     """Filtered company search view."""
 
-    permission_required = 'company.read_company'
-
 
 class SearchCompanyExportAPIView(SearchCompanyParams, SearchExportAPIView):
     """Filtered company search export view."""
-
-    permission_required = 'company.read_company'

--- a/datahub/search/contact/apps.py
+++ b/datahub/search/contact/apps.py
@@ -13,6 +13,7 @@ class ContactSearchApp(SearchApp):
     ESModel = Contact
     view = SearchContactAPIView
     export_view = SearchContactExportAPIView
+    permission_required = ('company.read_contact',)
     queryset = DBContact.objects.prefetch_related(
         'title',
         'company',

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -59,7 +59,7 @@ class Contact(DocType, MapDBModelToDict):
     company = dsl_utils.id_name_partial_mapping('company')
     company_sector = dsl_utils.id_name_mapping()
     company_uk_region = dsl_utils.id_name_mapping()
-    created_by = dsl_utils.contact_or_adviser_mapping('created_by')
+    created_by = dsl_utils.contact_or_adviser_mapping('created_by', include_dit_team=True)
 
     MAPPINGS = {
         'id': str,
@@ -67,7 +67,7 @@ class Contact(DocType, MapDBModelToDict):
         'adviser': dict_utils.contact_or_adviser_dict,
         'company': dict_utils.id_name_dict,
         'archived_by': dict_utils.contact_or_adviser_dict,
-        'created_by': dict_utils.contact_or_adviser_dict,
+        'created_by': dict_utils.adviser_dict_with_team,
     }
 
     COMPUTED_MAPPINGS = {

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -48,11 +48,7 @@ class SearchContactParams:
 class SearchContactAPIView(SearchContactParams, SearchAPIView):
     """Filtered contact search view."""
 
-    permission_required = 'company.read_contact'
-
 
 class SearchContactExportAPIView(SearchContactParams,
                                  SearchExportAPIView):
     """Filtered contact search export view."""
-
-    permission_required = 'company.read_contact'

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -51,6 +51,11 @@ def contact_or_adviser_dict(obj, include_dit_team=False):
     return data
 
 
+def adviser_dict_with_team(obj):
+    """Creates a dictionary with adviser names fields and the adviser's team."""
+    return contact_or_adviser_dict(obj, include_dit_team=True)
+
+
 def computed_nested_id_name_dict(nested_field):
     """Creates dictionary with selected fields from nested_field."""
     def get_dict(obj):

--- a/datahub/search/event/apps.py
+++ b/datahub/search/event/apps.py
@@ -11,6 +11,7 @@ class EventSearchApp(SearchApp):
     ESModel = Event
     view = SearchEventAPIView
     export_view = SearchEventExportAPIView
+    permission_required = ('event.read_event',)
     queryset = DBEvent.objects.prefetch_related(
         'address_country',
         'event_type',

--- a/datahub/search/event/views.py
+++ b/datahub/search/event/views.py
@@ -44,10 +44,6 @@ class SearchEventParams:
 class SearchEventAPIView(SearchEventParams, SearchAPIView):
     """Filtered event search view."""
 
-    permission_required = 'event.read_event'
-
 
 class SearchEventExportAPIView(SearchEventParams, SearchExportAPIView):
     """Filtered event search export view."""
-
-    permission_required = 'event.read_event'

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -12,6 +12,7 @@ class InteractionSearchApp(SearchApp):
     ESModel = Interaction
     view = SearchInteractionAPIView
     export_view = SearchInteractionExportAPIView
+    permission_required = ('interaction.read_interaction',)
     queryset = DBInteraction.objects.prefetch_related(
         'company',
         'contact',

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -59,10 +59,6 @@ class SearchInteractionParams:
 class SearchInteractionAPIView(SearchInteractionParams, SearchAPIView):
     """Filtered interaction search view."""
 
-    permission_required = 'interaction.read_interaction'
-
 
 class SearchInteractionExportAPIView(SearchInteractionParams, SearchExportAPIView):
     """Filtered interaction search export view."""
-
-    permission_required = 'interaction.read_interaction'

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -5,7 +5,7 @@ from datahub.investment.models import (
     InvestmentProject as DBInvestmentProject,
     InvestmentProjectTeamMember as DBInvestmentProjectTeamMember
 )
-from datahub.investment.permissions import InvestmentProjectAssociationChecker
+from datahub.investment.permissions import InvestmentProjectAssociationChecker, Permissions
 
 from .models import InvestmentProject
 from .views import SearchInvestmentProjectAPIView, SearchInvestmentProjectExportAPIView
@@ -20,6 +20,10 @@ class InvestmentSearchApp(SearchApp):
     ESModel = InvestmentProject
     view = SearchInvestmentProjectAPIView
     export_view = SearchInvestmentProjectExportAPIView
+    permission_required = (
+        f'investment.{Permissions.read_all}',
+        f'investment.{Permissions.read_associated}'
+    )
     queryset = DBInvestmentProject.objects.prefetch_related(
         'archived_by',
         'average_salary',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -20,14 +20,23 @@ class InvestmentProject(DocType, MapDBModelToDict):
     actual_land_date_documents = dsl_utils.id_uri_mapping()
     business_activities = dsl_utils.id_name_mapping()
     client_contacts = dsl_utils.contact_or_adviser_mapping('client_contacts')
-    client_relationship_manager = dsl_utils.id_name_mapping()
-    project_manager = dsl_utils.contact_or_adviser_mapping('project_manager')
-    project_assurance_adviser = dsl_utils.contact_or_adviser_mapping('project_assurance_adviser')
+    client_relationship_manager = dsl_utils.contact_or_adviser_mapping(
+        'client_relationship_manager', include_dit_team=True
+    )
+    project_manager = dsl_utils.contact_or_adviser_mapping(
+        'project_manager', include_dit_team=True
+    )
+    project_assurance_adviser = dsl_utils.contact_or_adviser_mapping(
+        'project_assurance_adviser', include_dit_team=True
+    )
     team_members = dsl_utils.contact_or_adviser_mapping('team_members', include_dit_team=True)
     archived = Boolean()
     archived_reason = Text()
     archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
     created_on = Date()
+    created_by = dsl_utils.contact_or_adviser_mapping(
+        'created_by', include_dit_team=True
+    )
     modified_on = Date()
     description = dsl_utils.EnglishText()
     anonymous_description = dsl_utils.EnglishText()
@@ -78,7 +87,7 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'actual_land_date_documents': lambda col: [dict_utils.id_uri_dict(c) for c in col.all()],
         'business_activities': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'client_contacts': lambda col: [dict_utils.contact_or_adviser_dict(c) for c in col.all()],
-        'client_relationship_manager': dict_utils.id_name_dict,
+        'client_relationship_manager': dict_utils.adviser_dict_with_team,
         'team_members': lambda col: [
             dict_utils.contact_or_adviser_dict(c.adviser, include_dit_team=True) for c in col.all()
         ],
@@ -108,9 +117,10 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'project_code': str,
         'average_salary': dict_utils.id_name_dict,
         'archived_by': dict_utils.contact_or_adviser_dict,
-        'project_manager': dict_utils.contact_or_adviser_dict,
-        'project_assurance_adviser': dict_utils.contact_or_adviser_dict,
+        'project_manager': dict_utils.adviser_dict_with_team,
+        'project_assurance_adviser': dict_utils.adviser_dict_with_team,
         'country_lost_to': dict_utils.id_name_dict,
+        'created_by': dict_utils.adviser_dict_with_team,
     }
 
     COMPUTED_MAPPINGS = {
@@ -123,7 +133,6 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'cdms_project_code',
         'client_considering_other_countries',
         'competitor_countries',
-        'created_by',
         'documents',
         'interactions',
         'investmentprojectcode',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -141,7 +141,6 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'investor_company.name_trigram',
         'project_code_trigram',
         'sector.name_trigram',
-        'team_members.dit_team.id',
     )
 
     class Meta:

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -23,7 +23,7 @@ class InvestmentProject(DocType, MapDBModelToDict):
     client_relationship_manager = dsl_utils.id_name_mapping()
     project_manager = dsl_utils.contact_or_adviser_mapping('project_manager')
     project_assurance_adviser = dsl_utils.contact_or_adviser_mapping('project_assurance_adviser')
-    team_members = dsl_utils.contact_or_adviser_mapping('team_members')
+    team_members = dsl_utils.contact_or_adviser_mapping('team_members', include_dit_team=True)
     archived = Boolean()
     archived_reason = Text()
     archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
@@ -80,7 +80,7 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'client_contacts': lambda col: [dict_utils.contact_or_adviser_dict(c) for c in col.all()],
         'client_relationship_manager': dict_utils.id_name_dict,
         'team_members': lambda col: [
-            dict_utils.contact_or_adviser_dict(c.adviser) for c in col.all()
+            dict_utils.contact_or_adviser_dict(c.adviser, include_dit_team=True) for c in col.all()
         ],
         'fdi_type': dict_utils.id_name_dict,
         'fdi_type_documents': lambda col: [dict_utils.id_uri_dict(c) for c in col.all()],
@@ -141,6 +141,7 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'investor_company.name_trigram',
         'project_code_trigram',
         'sector.name_trigram',
+        'team_members.dit_team.id',
     )
 
     class Meta:

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -28,6 +28,7 @@ def test_investment_project_to_dict(setup_es):
         'sector',
         'project_code',
         'created_on',
+        'created_by',
         'modified_on',
         'archived',
         'archived_on',

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -6,8 +6,7 @@ from rest_framework.reverse import reverse
 from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core import constants
 from datahub.core.test_utils import APITestMixin, create_test_user
-from datahub.investment.models import InvestmentProject
-from datahub.investment.permissions import Permissions
+from datahub.investment.models import InvestmentProject, Permissions
 from datahub.investment.test.factories import (
     InvestmentProjectFactory, InvestmentProjectTeamMemberFactory
 )
@@ -311,8 +310,8 @@ class TestSearch(APITestMixin):
 
     def test_restricted_user_with_no_team_cannot_see_projects(self, setup_es):
         """
-        Checks that a restricted user that doesn't have a team cannot view projects associated
-        with other advisers that don't have teams.
+        Checks that a restricted user that doesn't have a team cannot view any projects (in
+        particular projects associated with other advisers that don't have teams).
         """
         url = reverse('api-v3:search:investment_project')
 

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -7,7 +7,9 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core import constants
 from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.investment.models import InvestmentProject
-from datahub.investment.test.factories import InvestmentProjectFactory
+from datahub.investment.test.factories import (
+    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory
+)
 from datahub.metadata.test.factories import TeamFactory
 
 pytestmark = pytest.mark.django_db
@@ -172,7 +174,6 @@ class TestSearch(APITestMixin):
         AND (stage = won OR stage = active)
         """
         url = reverse('api-v3:search:investment_project')
-
         investment_project1 = InvestmentProjectFactory(
             investment_type_id=constants.InvestmentType.fdi.value.id,
             stage_id=constants.InvestmentProjectStage.active.value.id
@@ -193,6 +194,84 @@ class TestSearch(APITestMixin):
         setup_es.indices.refresh()
 
         response = self.api_client.post(url, {
+            'investment_type': constants.InvestmentType.fdi.value.id,
+            'investor_company': [
+                investment_project1.investor_company.pk,
+                investment_project2.investor_company.pk,
+            ],
+            'stage': [
+                constants.InvestmentProjectStage.won.value.id,
+                constants.InvestmentProjectStage.active.value.id,
+            ],
+        }, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+        assert len(response.data['results']) == 2
+
+        # checks if we only have investment projects with stages we filtered
+        assert {
+            constants.InvestmentProjectStage.active.value.id,
+            constants.InvestmentProjectStage.won.value.id
+        } == {
+            investment_project['stage']['id']
+            for investment_project in response.data['results']
+        }
+
+        # checks if we only have investment projects with investor companies we filtered
+        assert {
+            str(investment_project1.investor_company.pk),
+            str(investment_project2.investor_company.pk)
+        } == {
+            investment_project['investor_company']['id']
+            for investment_project in response.data['results']
+        }
+
+        # checks if we only have investment projects with fdi investment type
+        assert {
+            constants.InvestmentType.fdi.value.id
+        } == {
+            investment_project['investment_type']['id']
+            for investment_project in response.data['results']
+        }
+
+    def test_search_investment_project_associated_users_autofilter(self, setup_es):
+        """
+        Automatic filter to see only associated IP for a specific (leps) user
+        """
+        url = reverse('api-v3:search:investment_project')
+
+        team = TeamFactory()
+        request_user = create_test_user(
+            team=team,
+            permission_codenames=['read_all_investmentproject']
+        )
+        api_client = self.create_api_client(user=request_user)
+        adviser = AdviserFactory(dit_team=team)
+
+        investment_project1 = InvestmentProjectFactory(
+            investment_type_id=constants.InvestmentType.fdi.value.id,
+            stage_id=constants.InvestmentProjectStage.active.value.id
+        )
+        InvestmentProjectTeamMemberFactory(adviser=adviser,
+                                           investment_project=investment_project1)
+
+        investment_project2 = InvestmentProjectFactory(
+            investment_type_id=constants.InvestmentType.fdi.value.id,
+            stage_id=constants.InvestmentProjectStage.won.value.id,
+        )
+
+        InvestmentProjectFactory(
+            stage_id=constants.InvestmentProjectStage.won.value.id
+        )
+        InvestmentProjectFactory(
+            investment_type_id=constants.InvestmentType.fdi.value.id,
+            stage_id=constants.InvestmentProjectStage.prospect.value.id,
+        )
+
+        setup_es.indices.refresh()
+
+        response = api_client.post(url, {
             'investment_type': constants.InvestmentType.fdi.value.id,
             'investor_company': [
                 investment_project1.investor_company.pk,

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -244,7 +244,7 @@ class TestSearch(APITestMixin):
         team = TeamFactory()
         request_user = create_test_user(
             team=team,
-            permission_codenames=['read_all_investmentproject']
+            permission_codenames=['read_associated_investmentproject']
         )
         api_client = self.create_api_client(user=request_user)
         adviser = AdviserFactory(dit_team=team)

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -1,8 +1,3 @@
-from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
-
-from datahub.investment.permissions import (
-    InvestmentProjectModelPermissions, IsAssociatedToInvestmentProjectPermission
-)
 from datahub.oauth.scopes import Scope
 from .models import InvestmentProject
 from .serializers import SearchInvestmentProjectSerializer
@@ -12,11 +7,6 @@ from ..views import SearchAPIView, SearchExportAPIView
 class SearchInvestmentProjectParams:
     """Search investment project params."""
 
-    permission_classes = (
-        IsAuthenticatedOrTokenHasScope,
-        InvestmentProjectModelPermissions,
-        IsAssociatedToInvestmentProjectPermission
-    )
     required_scopes = (Scope.internal_front_end,)
     entity = InvestmentProject
     serializer_class = SearchInvestmentProjectSerializer

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -1,9 +1,7 @@
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 
-from datahub.investment.models import InvestmentProject as DBInvestmentProject
 from datahub.investment.permissions import (
-    InvestmentProjectAssociationChecker, InvestmentProjectModelPermissions,
-    IsAssociatedToInvestmentProjectPermission, Permissions
+    InvestmentProjectModelPermissions, IsAssociatedToInvestmentProjectPermission
 )
 from datahub.oauth.scopes import Scope
 from .models import InvestmentProject
@@ -19,10 +17,8 @@ class SearchInvestmentProjectParams:
         InvestmentProjectModelPermissions,
         IsAssociatedToInvestmentProjectPermission
     )
-    permission_required = f'investment.{Permissions.read_all}'
     required_scopes = (Scope.internal_front_end,)
     entity = InvestmentProject
-    model = DBInvestmentProject
     serializer_class = SearchInvestmentProjectSerializer
 
     include_aggregations = True
@@ -49,26 +45,6 @@ class SearchInvestmentProjectParams:
         'stage': 'stage.id',
         'uk_region_location': 'uk_region_locations.id',
     }
-
-    def get_permission_filter_args(self):
-        """Gets permission filter arguments."""
-        checker = InvestmentProjectAssociationChecker()
-
-        if not checker.should_apply_restrictions(self.request, self):
-            return None
-
-        dit_team_id = str(self.request.user.dit_team_id) if self.request.user else None
-        filters = {
-            f'{field}.dit_team.id': dit_team_id
-            for field in DBInvestmentProject.ASSOCIATED_ADVISER_TO_ONE_FIELDS
-        }
-
-        filters.update({
-            f'{field.es_field_name}.dit_team.id': dit_team_id
-            for field in DBInvestmentProject.ASSOCIATED_ADVISER_TO_MANY_FIELDS
-        })
-
-        return filters
 
 
 class SearchInvestmentProjectAPIView(SearchInvestmentProjectParams, SearchAPIView):

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -1,4 +1,6 @@
-from datahub.investment.permissions import Permissions
+from datahub.investment.permissions import (
+    InvestmentProjectAssociationChecker, IsAssociatedToInvestmentProjectPermission, Permissions
+)
 from datahub.oauth.scopes import Scope
 from .models import InvestmentProject
 from .serializers import SearchInvestmentProjectSerializer
@@ -25,6 +27,7 @@ class SearchInvestmentProjectParams:
         'stage',
         'status',
         'uk_region_location',
+        'team_members.dit_team.id',
     )
 
     REMAP_FIELDS = {
@@ -38,9 +41,13 @@ class SearchInvestmentProjectParams:
     }
 
 
-class SearchInvestmentProjectAPIView(SearchInvestmentProjectParams, SearchAPIView):
+class SearchInvestmentProjectAPIView(InvestmentProjectAssociationChecker,
+                                     SearchInvestmentProjectParams,
+                                     SearchAPIView):
     """Filtered investment project search view."""
 
+    permission_classes = SearchAPIView.permission_classes + (
+        IsAssociatedToInvestmentProjectPermission,)
     permission_required = f'investment.{Permissions.read_all}'
 
 

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -57,10 +57,16 @@ class SearchInvestmentProjectParams:
         if not checker.should_apply_restrictions(self.request, self):
             return None
 
-        dit_team_id = self.request.user.dit_team_id if self.request.user else None
+        dit_team_id = str(self.request.user.dit_team_id) if self.request.user else None
         filters = {
-            'team_members.dit_team.id': str(dit_team_id)
+            f'{field}.dit_team.id': dit_team_id
+            for field in DBInvestmentProject.ASSOCIATED_ADVISER_TO_ONE_FIELDS
         }
+
+        filters.update({
+            f'{field.es_field_name}.dit_team.id': dit_team_id
+            for field in DBInvestmentProject.ASSOCIATED_ADVISER_TO_MANY_FIELDS
+        })
 
         return filters
 

--- a/datahub/search/omis/apps.py
+++ b/datahub/search/omis/apps.py
@@ -12,6 +12,7 @@ class OrderSearchApp(SearchApp):
     name = 'order'
     ESModel = Order
     view = SearchOrderAPIView
+    permission_required = ('order.read_order',)
     queryset = DBOrder.objects.prefetch_related(
         'company',
         'contact',

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -15,7 +15,7 @@ class Order(DocType, MapDBModelToDict):
     status = dsl_utils.SortableCaseInsensitiveKeywordText()
     company = dsl_utils.id_name_partial_mapping('company')
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
-    created_by = dsl_utils.contact_or_adviser_mapping('created_by')
+    created_by = dsl_utils.contact_or_adviser_mapping('created_by', include_dit_team=True)
     created_on = Date()
     modified_on = Date()
     primary_market = dsl_utils.id_name_mapping()
@@ -65,7 +65,7 @@ class Order(DocType, MapDBModelToDict):
         'id': str,
         'company': dict_utils.id_name_dict,
         'contact': dict_utils.contact_or_adviser_dict,
-        'created_by': dict_utils.contact_or_adviser_dict,
+        'created_by': dict_utils.adviser_dict_with_team,
         'primary_market': dict_utils.id_name_dict,
         'sector': dict_utils.id_name_dict,
         'uk_region': dict_utils.id_name_dict,

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -276,6 +276,20 @@ def test_mapping(setup_es):
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
                             'type': 'text'
+                        },
+                        'dit_team': {
+                            'include_in_parent': True,
+                            'properties': {
+                                'id': {
+                                    'type': 'keyword'
+                                },
+                                'name': {
+                                    'analyzer': 'lowercase_keyword_analyzer',
+                                    'fielddata': True,
+                                    'type': 'text'
+                                }
+                            },
+                            'type': 'nested'
                         }
                     },
                     'type': 'nested'
@@ -508,7 +522,11 @@ def test_indexed_doc(Factory, setup_es):
                 'id': str(order.created_by.pk),
                 'first_name': order.created_by.first_name,
                 'last_name': order.created_by.last_name,
-                'name': order.created_by.name
+                'name': order.created_by.name,
+                'dit_team': {
+                    'id': str(order.created_by.dit_team.id),
+                    'name': order.created_by.dit_team.name
+                }
             },
             'company': {
                 'id': str(order.company.pk),

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -66,7 +66,11 @@ def test_order_to_dict(Factory, setup_es):
             'id': str(order.created_by.pk),
             'first_name': order.created_by.first_name,
             'last_name': order.created_by.last_name,
-            'name': order.created_by.name
+            'name': order.created_by.name,
+            'dit_team': {
+                'id': str(order.created_by.dit_team.id),
+                'name': order.created_by.dit_team.name
+            }
         },
         'modified_on': order.modified_on,
         'reference': order.reference,

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -52,5 +52,3 @@ class SearchOrderParams:
 
 class SearchOrderAPIView(SearchOrderParams, SearchAPIView):
     """Filtered order search view."""
-
-    permission_required = 'order.read_order'

--- a/datahub/search/permissions.py
+++ b/datahub/search/permissions.py
@@ -3,15 +3,25 @@ from rest_framework.permissions import BasePermission
 
 class SearchAppPermissions(BasePermission):
     """
-    Check the permission_required on view against User Permissions
+    DRF permission class that checks the user has at least one of the permissions in the
+    permission_required attribute on the search app.
     """
 
     def has_permission(self, request, view):
         """
         Return `True` if permission is granted `False` otherwise.
-        Raises ImproperlyConfigured if permission_required is not set on view
         """
-        user = request.user
-        permissions = view.search_app.permission_required
+        return has_permissions_for_app(request, view.search_app)
 
-        return user and any(user.has_perm(permission) for permission in permissions)
+
+def has_permissions_for_app(request, search_app):
+    """
+    Checks if the user has permission to search for records related to a search app.
+
+    This is done by checking if the user has at least one of the permissions in the
+    permission_required attribute on the search app.
+    """
+    user = request.user
+    permissions = search_app.permission_required
+
+    return user and any(user.has_perm(permission) for permission in permissions)

--- a/datahub/search/permissions.py
+++ b/datahub/search/permissions.py
@@ -1,0 +1,17 @@
+from rest_framework.permissions import BasePermission
+
+
+class SearchAppPermissions(BasePermission):
+    """
+    Check the permission_required on view against User Permissions
+    """
+
+    def has_permission(self, request, view):
+        """
+        Return `True` if permission is granted `False` otherwise.
+        Raises ImproperlyConfigured if permission_required is not set on view
+        """
+        user = request.user
+        permissions = view.search_app.permission_required
+
+        return user and any(user.has_perm(permission) for permission in permissions)

--- a/datahub/search/urls.py
+++ b/datahub/search/urls.py
@@ -13,13 +13,13 @@ for search_app in get_search_apps():
     if search_app.view:
         urlpatterns.append(url(
             rf'^search/{search_app.name}$',
-            search_app.view.as_view(),
+            search_app.view.as_view(search_app=search_app),
             name=search_app.name
         ))
 
     if search_app.export_view:
         urlpatterns.append(url(
             rf'^search/{search_app.name}/export$',
-            search_app.export_view.as_view(),
+            search_app.export_view.as_view(search_app=search_app),
             name=f'{search_app.name}-export'
         ))

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -11,10 +11,10 @@ from rest_framework.fields import empty
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from datahub.core.permissions import UserHasPermissions
 from datahub.oauth.scopes import Scope
 from . import elasticsearch
 from .apps import get_search_apps
+from .permissions import SearchAppPermissions
 from .serializers import SearchSerializer
 from .utils import Echo
 
@@ -110,7 +110,7 @@ class SearchAPIView(APIView):
     """Filtered search view."""
 
     search_app = None
-    permission_classes = (IsAuthenticatedOrTokenHasScope, UserHasPermissions)
+    permission_classes = (IsAuthenticatedOrTokenHasScope, SearchAppPermissions)
     FILTER_FIELDS = []
     REMAP_FIELDS = {}
 

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -119,6 +119,14 @@ class SearchAPIView(APIView):
         }
         return filters
 
+    def get_permission_filter_args(self) -> dict:
+        """
+        Gets filter arguments used to enforce permissions.
+
+        Results much match at least one of the rules in the dict returned.
+        """
+        return {}
+
     def validate_data(self, data):
         """Validate and clean data."""
         serializer = self.serializer_class(data=data)
@@ -152,6 +160,7 @@ class SearchAPIView(APIView):
 
         validated_data = self.validate_data(data)
         filter_data = self._get_filter_data(validated_data)
+        permission_filters = self.get_permission_filter_args()
 
         aggregations = (self.REMAP_FIELDS.get(field, field) for field in self.FILTER_FIELDS) \
             if self.include_aggregations else None
@@ -161,6 +170,7 @@ class SearchAPIView(APIView):
             term=validated_data['original_query'],
             filter_data=filter_data,
             composite_filters=self.COMPOSITE_FILTERS,
+            permission_filters=permission_filters,
             field_order=validated_data['sortby'],
             aggregations=aggregations,
         )


### PR DESCRIPTION
This makes various changes to get permissions fully working with search:

* Enforces read permissions in global search
* Enforces investment association permissions in global and investment project entity search
* Updates ES models so that created_by and various investment project fields include the adviser's team
* Adds signal receivers for investment project team member changes

The datahub.search.elasticsearch module really needs splitting up into multiple modules, hopefully we can look at that soon.