### PR TITLE
Omis admin cancel order

### DIFF
--- a/datahub/company/test/test_advisor_views.py
+++ b/datahub/company/test/test_advisor_views.py
@@ -11,7 +11,7 @@ class TestAdviser(APITestMixin):
 
     def test_adviser_list_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v1:advisor-list')
         response = api_client.get(url)

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -22,7 +22,7 @@ class TestCompany(APITestMixin):
 
     def test_companies_list_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:company:collection')
         response = api_client.get(url)

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -553,7 +553,7 @@ class TestContactList(APITestMixin):
 
     def test_contact_list_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:contact:list')
         response = api_client.get(url)

--- a/datahub/core/test/test_advisor_permissions.py
+++ b/datahub/core/test/test_advisor_permissions.py
@@ -22,7 +22,7 @@ class TestPermissions(APITestMixin):
         permission_group.permissions.add(permission)
         team = TeamFactory()
         team.role.groups.add(permission_group)
-        user = create_test_user(team=team)
+        user = create_test_user(dit_team=team)
         token = self.get_token(user=user)
 
         request = factory.get('/', data={}, content_type='application/json',
@@ -38,7 +38,7 @@ class TestPermissions(APITestMixin):
         """
         Tests view returns 403
         """
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         token = self.get_token(user=user)
 
         request = factory.get('/', data={}, content_type='application/json',

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -82,7 +82,7 @@ class AdminTestMixin:
         if not user:
             user = self.user
         client = Client()
-        client.login(username=user.email, password=self.PASSWORD)
+        assert client.login(username=user.email, password=self.PASSWORD)
         return client
 
 

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 from secrets import token_hex
+import factory
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -10,7 +11,6 @@ from oauth2_provider.models import AccessToken, Application
 from rest_framework.fields import DateField, DateTimeField
 from rest_framework.test import APIClient
 
-from datahub.company.test.factories import AdviserFactory
 from datahub.metadata.models import Team
 from datahub.oauth.scopes import Scope
 
@@ -24,22 +24,33 @@ def get_default_test_user():
         team = Team.objects.filter(
             role__groups__name='DIT_staff'
         ).first()
-        test_user = user_model(
+        test_user = create_test_user(
             first_name='Testo',
             last_name='Useri',
             email='Testo@Useri.com',
-            date_joined=now(),
-            dit_team=team,
+            dit_team=team
         )
-        test_user.save()
     return test_user
 
 
-def create_test_user(team=None, permission_codenames=()):
-    """Return the test user."""
-    # Because AdviserFactory sets dit_team_id, passing dit_team to it doesn't work
-    dit_team_id = team.id if team else None
-    user = AdviserFactory(dit_team_id=dit_team_id)
+def create_test_user(permission_codenames=(), **user_attrs):
+    """
+    :returns: user
+    :param permission_codenames: list of codename permissions to be
+        applied to the user
+    :param user_attrs: any user attribute
+    """
+    user_defaults = {
+        'first_name': factory.Faker('first_name').generate({}),
+        'last_name': factory.Faker('last_name').generate({}),
+        'email': factory.Faker('email').generate({}),
+        'date_joined': now()
+    }
+    user_defaults.update(user_attrs)
+
+    user_model = get_user_model()
+    user = user_model(**user_defaults)
+    user.save()
 
     permissions = Permission.objects.filter(codename__in=permission_codenames)
     user.user_permissions.set(permissions)

--- a/datahub/event/test/test_admin.py
+++ b/datahub/event/test/test_admin.py
@@ -1,7 +1,7 @@
 from django.contrib.admin import helpers
+from django.urls import reverse
 from django.utils.timezone import now
 from rest_framework import status
-from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import AdminTestMixin
 from datahub.event.test.factories import EventFactory

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -17,7 +17,7 @@ class TestGetEventView(APITestMixin):
     def test_event_details_no_permissions(self):
         """Should return 403"""
         event = EventFactory()
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:event:item', kwargs={'pk': event.pk})
         response = api_client.get(url)
@@ -95,7 +95,7 @@ class TestListEventView(APITestMixin):
 
     def test_event_list_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:event:collection')
         response = api_client.get(url)

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -21,7 +21,7 @@ class TestInteractionV3(APITestMixin):
     def test_interaction_no_permissions(self):
         """Should return 403"""
         interaction = InteractionFactory()
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = api_client.get(url)

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -46,7 +46,7 @@ class TestListView(APITestMixin):
 
     def test_investments_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         url = reverse('api-v3:investment:investment-collection')
         api_client = self.create_api_client(user=user)
         response = api_client.get(url)
@@ -2027,6 +2027,6 @@ def test_view_set_name(view_set):
 
 
 def _create_user_and_api_client(test_instance, team, permissions):
-    user = create_test_user(team=team, permission_codenames=permissions)
+    user = create_test_user(dit_team=team, permission_codenames=permissions)
     api_client = test_instance.create_api_client(user=user)
     return user, api_client

--- a/datahub/leads/test/test_views.py
+++ b/datahub/leads/test/test_views.py
@@ -19,7 +19,7 @@ class TestBusinessLeadViews(APITestMixin):
 
     def test_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:business-leads:lead-collection')
         response = api_client.get(url)

--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -498,21 +498,16 @@ class Order(BaseModel):
         order_completed.send(sender=self.__class__, order=self)
 
     @transaction.atomic
-    def cancel(self, by, reason):
+    def cancel(self, by, reason, force=False):
         """
         Cancel an order.
 
         :param by: the adviser who cancelled the order
         :param reason: CancellationReason
+        :param force: if True, cancelling an order in quote accepted or paid
+            is allowed.
         """
-        for order_validator in [
-            validators.OrderInStatusValidator(
-                allowed_statuses=(
-                    OrderStatus.draft,
-                    OrderStatus.quote_awaiting_acceptance,
-                )
-            )
-        ]:
+        for order_validator in [validators.CancellableOrderValidator(force=force)]:
             order_validator.set_instance(self)
             order_validator()
 

--- a/datahub/omis/order/templates/admin/order/cancel_confirmation.html
+++ b/datahub/omis/order/templates/admin/order/cancel_confirmation.html
@@ -1,0 +1,32 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+    <script type="text/javascript" src="{% static 'admin/js/cancel.js' %}"></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} delete-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst|escape }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a>
+&rsaquo; {% trans 'Cancel' %}
+</div>
+{% endblock %}
+
+{% block content %}
+    <p>{% blocktrans with escaped_object=object %}Are you sure you want to cancel the {{ object_name }} "{{ escaped_object }}"?{% endblocktrans %}</p>
+    <form method="post">{% csrf_token %}
+        <div>{{ form }}</div>
+        <div>
+            <input type="submit" value="{% trans "Yes, I'm sure" %}" />
+            <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{% trans "No, take me back" %}</a>
+        </div>
+    </form>
+{% endblock %}
+

--- a/datahub/omis/order/templates/admin/order/change_form.html
+++ b/datahub/omis/order/templates/admin/order/change_form.html
@@ -1,0 +1,5 @@
+{% extends "admin/change_form.html" %}{% load order_admin_tags %}
+
+
+{% block submit_buttons_top %}{% order_submit_row %}{% endblock %}
+{% block submit_buttons_bottom %}{% order_submit_row %}{% endblock %}

--- a/datahub/omis/order/templates/admin/order/submit_line.html
+++ b/datahub/omis/order/templates/admin/order/submit_line.html
@@ -1,0 +1,15 @@
+{% load i18n admin_urls %}
+<div class="submit-row">
+{% if show_save %}<input type="submit" value="{% trans 'Save' %}" class="default" name="_save" />{% endif %}
+{% if show_cancel %}
+    {% url opts|admin_urlname:'cancel' original.pk|admin_urlquote as cancel_url %}
+    <p class="deletelink-box"><a href="{% add_preserved_filters cancel_url %}" class="deletelink">{% trans "Cancel order" %}</a></p>
+{% endif %}
+{% if show_delete_link %}
+    {% url opts|admin_urlname:'delete' original.pk|admin_urlquote as delete_url %}
+    <p class="deletelink-box"><a href="{% add_preserved_filters delete_url %}" class="deletelink">{% trans "Delete" %}</a></p>
+{% endif %}
+{% if show_save_as_new %}<input type="submit" value="{% trans 'Save as new' %}" name="_saveasnew" />{% endif %}
+{% if show_save_and_add_another %}<input type="submit" value="{% trans 'Save and add another' %}" name="_addanother" />{% endif %}
+{% if show_save_and_continue %}<input type="submit" value="{% trans 'Save and continue editing' %}" name="_continue" />{% endif %}
+</div>

--- a/datahub/omis/order/templatetags/order_admin_tags.py
+++ b/datahub/omis/order/templatetags/order_admin_tags.py
@@ -1,0 +1,15 @@
+from django import template
+from django.contrib.admin.templatetags.admin_modify import submit_row
+
+register = template.Library()
+
+
+@register.inclusion_tag('admin/order/submit_line.html', takes_context=True)
+def order_submit_row(context):
+    """
+    Extend the default `submit_row` by adding an extra flag to show the cancel
+    button.
+    """
+    context = submit_row(context)
+    context['show_cancel'] = context['show_save'] and context['change']
+    return context

--- a/datahub/omis/order/test/test_admin.py
+++ b/datahub/omis/order/test/test_admin.py
@@ -1,0 +1,182 @@
+import pytest
+from django.contrib.admin.models import LogEntry
+from django.contrib.admin.options import IS_POPUP_VAR
+from django.contrib.auth import REDIRECT_FIELD_NAME
+from django.core.exceptions import NON_FIELD_ERRORS
+from django.test.client import Client
+from django.urls import reverse
+
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+
+from .factories import (
+    OrderCancelledFactory, OrderCompleteFactory,
+    OrderFactory, OrderPaidFactory,
+    OrderWithAcceptedQuoteFactory, OrderWithOpenQuoteFactory
+)
+from ..constants import OrderStatus
+from ..models import CancellationReason, Order
+
+
+class TestCancelOrderAdmin(AdminTestMixin):
+    """Tests for cancelling an order via the django admin."""
+
+    def test_403_if_not_logged_in(self):
+        """Test redirect to login if the user isn't authenticated."""
+        url = reverse('admin:order_order_cancel', args=(OrderFactory().pk,))
+
+        client = Client()
+        response = client.post(url, data={}, follow=True)
+
+        assert response.status_code == 200
+        assert len(response.redirect_chain) == 1
+        login_url = f'{reverse("admin:login")}?{REDIRECT_FIELD_NAME}={url}'
+        assert response.redirect_chain[0][0] == login_url
+
+    def test_403_if_no_permissions(self):
+        """Test 403 if user doesn't have enough permissions."""
+        order = OrderFactory()
+        url = reverse('admin:order_order_cancel', args=(order.pk,))
+
+        # create user with all order permissions apart from change
+        user = create_test_user(permission_codenames=('add_order', 'delete_order', 'read_order'))
+        user.set_password(self.PASSWORD)
+        user.is_staff = True
+        user.save()
+
+        client = self.create_client(user=user)
+        response = client.post(url, data={})
+        assert response.status_code == 403
+
+    def test_404(self):
+        """Test 404 if order doesn't exist."""
+        order_id = '00000000-0000-0000-0000-000000000000'
+        url = reverse('admin:order_order_cancel', args=(order_id,))
+
+        response = self.client.get(url, follow=True)
+        assert response.status_code == 200
+        assert [msg.message for msg in response.context['messages']] == [
+            f'order with ID "{order_id}" doesn\'t exist. Perhaps it was deleted?'
+        ]
+
+    def test_400_popup_not_allowed(self):
+        """Test popup not allowed."""
+        order = OrderFactory()
+        url = reverse('admin:order_order_cancel', args=(order.pk,))
+
+        response = self.client.get(f'{url}?{IS_POPUP_VAR}=1')
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize(
+        'data,errors',
+        (
+            (
+                {'reason': ''},
+                {'reason': ['This field is required.']}
+            ),
+            (
+                {'reason': '00000000-0000-0000-0000-000000000000'},
+                {'reason': [
+                    'Select a valid choice. That choice is not one of the available choices.'
+                ]}
+            ),
+        )
+    )
+    def test_400_validaton_error(self, data, errors):
+        """Test validation errors."""
+        order = OrderFactory()
+        url = reverse('admin:order_order_cancel', args=(order.pk,))
+
+        response = self.client.post(url, data=data)
+        assert response.status_code == 200
+        assert response.request['PATH_INFO'] == url
+
+        assert 'form' in response.context
+        assert not response.context['form'].is_valid()
+        assert response.context['form'].errors == errors
+
+    @pytest.mark.parametrize(
+        'order_factory',
+        (
+            OrderCompleteFactory,
+            OrderCancelledFactory,
+        )
+    )
+    def test_400_if_in_disallowed_status(self, order_factory):
+        """
+        Test that the action fails if the order is not in one of the allowed statuses.
+        """
+        order = order_factory()
+        url = reverse('admin:order_order_cancel', args=(order.pk,))
+
+        response = self.client.get(url)
+        assert response.status_code == 200
+
+        reason = CancellationReason.objects.filter(
+            disabled_on__isnull=True
+        ).order_by('?').first()
+
+        response = self.client.post(url, data={'reason': reason.pk})
+        assert response.status_code == 200
+        assert response.request['PATH_INFO'] == url
+
+        # check form in error
+        assert 'form' in response.context
+        assert not response.context['form'].is_valid()
+        err_msg = (
+            'The action cannot be performed '
+            f'in the current status {order.get_status_display()}.'
+        )
+        assert response.context['form'].errors == {
+            NON_FIELD_ERRORS: [err_msg]
+        }
+
+        # check that nothing has changed in the db
+        order_from_db = Order.objects.get(pk=order.pk)
+        assert order.status == order_from_db.status
+        assert order.cancelled_on == order_from_db.cancelled_on
+        assert order.cancelled_by == order_from_db.cancelled_by
+        assert order.cancellation_reason == order_from_db.cancellation_reason
+
+        # check no logs created
+        assert not LogEntry.objects.count()
+
+    @pytest.mark.parametrize(
+        'order_factory',
+        (
+            OrderFactory,
+            OrderWithOpenQuoteFactory,
+            OrderWithAcceptedQuoteFactory,
+            OrderPaidFactory,
+        )
+    )
+    def test_200_if_in_allowed_status(self, order_factory):
+        """
+        Test that the order gets cancelled if it's in one of the allowed statuses.
+        """
+        order = order_factory()
+        url = reverse('admin:order_order_cancel', args=(order.pk,))
+
+        response = self.client.get(url)
+        assert response.status_code == 200
+
+        reason = CancellationReason.objects.filter(
+            disabled_on__isnull=True
+        ).order_by('?').first()
+
+        response = self.client.post(url, data={'reason': reason.pk}, follow=True)
+        assert response.status_code == 200
+        change_url = reverse('admin:order_order_change', args=(order.pk,))
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == change_url
+
+        order.refresh_from_db()
+        assert order.status == OrderStatus.cancelled
+        assert order.cancelled_on
+        assert order.cancelled_by == self.user
+        assert order.cancellation_reason == reason
+
+        log_entry = LogEntry.objects.last()
+        assert log_entry.user == self.user
+        assert log_entry.is_change()
+        assert log_entry.object_id == str(order.pk)
+        assert log_entry.get_change_message() == f'Cancelled because {reason}.'

--- a/datahub/omis/order/validators.py
+++ b/datahub/omis/order/validators.py
@@ -8,7 +8,7 @@ from datahub.core.validate_utils import DataCombiner
 from datahub.core.validators import AbstractRule, BaseRule
 from datahub.omis.core.exceptions import Conflict
 
-from .constants import VATStatus
+from .constants import OrderStatus, VATStatus
 
 
 class ContactWorksAtCompanyValidator:
@@ -325,6 +325,26 @@ class CompletableOrderValidator:
             raise ValidationError({
                 api_settings.NON_FIELD_ERRORS_KEY: self.message
             })
+
+
+class CancellableOrderValidator(OrderInStatusValidator):
+    """Validator which checks that the order can be cancelled."""
+
+    def __init__(self, force=False):
+        """
+        :param force: if True, cancelling an order in quote accepted or paid
+            is allowed.
+        """
+        allowed_statuses = [
+            OrderStatus.draft,
+            OrderStatus.quote_awaiting_acceptance,
+        ]
+        if force:
+            allowed_statuses += [
+                OrderStatus.quote_accepted,
+                OrderStatus.paid,
+            ]
+        super().__init__(allowed_statuses, order_required=True)
 
 
 class AddressValidator:

--- a/datahub/search/companieshousecompany/tests/test_views.py
+++ b/datahub/search/companieshousecompany/tests/test_views.py
@@ -50,7 +50,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
 
     def test_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:companieshousecompany')
         response = api_client.get(url)

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -48,7 +48,7 @@ class TestSearch(APITestMixin):
 
     def test_company_search_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:company')
         response = api_client.get(url)

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -26,7 +26,7 @@ class TestSearch(APITestMixin):
 
     def test_company_search_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:contact')
         response = api_client.get(url)

--- a/datahub/search/event/tests/test_views.py
+++ b/datahub/search/event/tests/test_views.py
@@ -26,7 +26,7 @@ class TestSearch(APITestMixin):
 
     def test_event_search_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:event')
         response = api_client.get(url)

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -57,7 +57,7 @@ class TestViews(APITestMixin):
 
     def test_interaction_search_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:interaction')
         response = api_client.get(url)

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -73,7 +73,7 @@ class TestSearch(APITestMixin):
 
     def test_investment_project_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:investment_project')
         response = api_client.get(url)
@@ -247,8 +247,8 @@ class TestSearch(APITestMixin):
         adviser_2 = AdviserFactory(dit_team_id=team_others.id)
 
         request_user = create_test_user(
-            team=team,
             permission_codenames=permissions,
+            dit_team=team
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -279,8 +279,8 @@ class TestSearch(APITestMixin):
         adviser_other = AdviserFactory(dit_team_id=team_other.id)
         adviser_same_team = AdviserFactory(dit_team_id=team.id)
         request_user = create_test_user(
-            team=team,
-            permission_codenames=['read_associated_investmentproject']
+            permission_codenames=['read_associated_investmentproject'],
+            dit_team=team
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -418,8 +418,8 @@ class TestBasicSearch(APITestMixin):
         adviser_2 = AdviserFactory(dit_team_id=team_others.id)
 
         request_user = create_test_user(
-            team=team,
             permission_codenames=permissions,
+            dit_team=team
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -453,8 +453,8 @@ class TestBasicSearch(APITestMixin):
         adviser_other = AdviserFactory(dit_team_id=team_other.id)
         adviser_same_team = AdviserFactory(dit_team_id=team.id)
         request_user = create_test_user(
-            team=team,
-            permission_codenames=['read_associated_investmentproject']
+            permission_codenames=['read_associated_investmentproject'],
+            dit_team=team
         )
         api_client = self.create_api_client(user=request_user)
 

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -80,7 +80,7 @@ class TestSearchOrder(APITestMixin):
 
     def test_no_permissions(self):
         """Should return 403"""
-        user = create_test_user(team=TeamFactory())
+        user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:search:order')
         response = api_client.get(url)

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -394,7 +394,7 @@ class TestSearch(APITestMixin):
     ))
     def test_basic_search_permissions(self, setup_es, permission, permission_entity, entity):
         """Tests model permissions enforcement in basic search."""
-        user = create_test_user(team=TeamFactory(), permission_codenames=[permission])
+        user = create_test_user(permission_codenames=[permission], dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
 
         InvestmentProjectFactory(created_by=user)

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -34,7 +34,7 @@ class TestUserView(APITestMixin):
         team = TeamFactory(name='Test Team', role=role)
         team.role.groups.add(group)
 
-        user_test = create_test_user(team=team)
+        user_test = create_test_user(dit_team=team)
         user_test.user_permissions.set(permissions[1:])
         api_client = self.create_api_client(user=user_test)
 


### PR DESCRIPTION
At the moment, advisers can only cancel an order if in status `draft` or `quote_awaiting_acceptance` using the datahub-frontend.

This adds the ability for DIT staff to cancel orders in status `quote_accepted` or `paid` as well. 
It belongs to the admin area as it should be considered an exceptional case.

It also refactors datahub.core.test_utils as there were a couple of functions which were confusingly similar.