### PR TITLE
Make billing postcode optional for OMIS orders

### DIFF
--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -143,7 +143,7 @@ class OrderSerializer(serializers.ModelSerializer):
                     'billing_address_2': {'required': False},
                     'billing_address_town': {'required': True},
                     'billing_address_county': {'required': False},
-                    'billing_address_postcode': {'required': True},
+                    'billing_address_postcode': {'required': False},
                     'billing_address_country': {'required': True},
                 }
             )

--- a/datahub/omis/order/test/test_validators.py
+++ b/datahub/omis/order/test/test_validators.py
@@ -704,7 +704,7 @@ class TestAddressValidator:
         address_fields = {
             'address1': None,
             'address2': None,
-            'postcode': None,
+            'town': None,
         }
 
         instance = mock.Mock(**address_fields) if with_instance else None
@@ -715,7 +715,7 @@ class TestAddressValidator:
             fields_mapping={
                 'address1': {'required': True},
                 'address2': {'required': False},
-                'postcode': {'required': True},
+                'town': {'required': True},
             }
         )
 
@@ -725,7 +725,7 @@ class TestAddressValidator:
             validator(data)
         assert exc.value.detail == {
             'address1': ['This field is required.'],
-            'postcode': ['This field is required.']
+            'town': ['This field is required.']
         }
 
     @pytest.mark.parametrize('values_as_data', (True, False))
@@ -744,7 +744,7 @@ class TestAddressValidator:
         address_fields = {
             'address1': None,
             'address2': None,
-            'postcode': None,
+            'town': None,
         }
 
         instance = mock.Mock(**address_fields) if with_instance else None
@@ -755,7 +755,7 @@ class TestAddressValidator:
             fields_mapping={
                 'address1': {'required': True},
                 'address2': {'required': False},
-                'postcode': {'required': True},
+                'town': {'required': True},
             }
         )
 
@@ -782,7 +782,7 @@ class TestAddressValidator:
         address_fields = {
             'address1': None,
             'address2': 'lorem ipsum',
-            'postcode': None,
+            'town': None,
         }
 
         instance = mock.Mock(**address_fields)
@@ -793,7 +793,7 @@ class TestAddressValidator:
             fields_mapping={
                 'address1': {'required': True},
                 'address2': {'required': False},
-                'postcode': {'required': True},
+                'town': {'required': True},
             }
         )
 
@@ -803,7 +803,7 @@ class TestAddressValidator:
             validator(data)
         assert exc.value.detail == {
             'address1': ['This field is required.'],
-            'postcode': ['This field is required.']
+            'town': ['This field is required.']
         }
 
     def test_defaults(self):

--- a/datahub/omis/order/test/views/test_order_details.py
+++ b/datahub/omis/order/test/views/test_order_details.py
@@ -394,7 +394,6 @@ class TestAddOrderDetails(APITestMixin):
         assert response.json() == {
             'billing_address_1': ['This field is required.'],
             'billing_address_town': ['This field is required.'],
-            'billing_address_postcode': ['This field is required.'],
             'billing_address_country': ['This field is required.'],
         }
 
@@ -885,7 +884,6 @@ class TestChangeOrderDetails(APITestMixin):
         assert response.json() == {
             'billing_address_1': ['This field is required.'],
             'billing_address_town': ['This field is required.'],
-            'billing_address_postcode': ['This field is required.'],
             'billing_address_country': ['This field is required.'],
         }
 

--- a/datahub/omis/order/validators.py
+++ b/datahub/omis/order/validators.py
@@ -357,7 +357,7 @@ class AddressValidator:
         'address_2': {'required': False},
         'address_town': {'required': True},
         'address_county': {'required': False},
-        'address_postcode': {'required': True},
+        'address_postcode': {'required': False},
         'address_country': {'required': True},
     }
 


### PR DESCRIPTION
`postcode` in CRM is optional.
We copy the address and store it on the order on quote creation so this makes sure postcode is optional in OMIS as well.