### PR TITLE
Deprecate OMIS billing phone/email/contact name

### DIFF
--- a/datahub/omis/order/migrations/0001_squashed_0030_cancellation.py
+++ b/datahub/omis/order/migrations/0001_squashed_0030_cancellation.py
@@ -328,17 +328,17 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='order',
             name='billing_contact_name',
-            field=models.CharField(blank=True, max_length=255),
+            field=models.CharField(blank=True, max_length=255, editable=False, help_text='Legacy field. Billing contact name.'),
         ),
         migrations.AddField(
             model_name='order',
             name='billing_email',
-            field=models.EmailField(blank=True, max_length=255),
+            field=models.EmailField(blank=True, max_length=255, editable=False, help_text='Legacy field. Billing email address.'),
         ),
         migrations.AddField(
             model_name='order',
             name='billing_phone',
-            field=models.CharField(blank=True, max_length=150),
+            field=models.CharField(blank=True, max_length=150, editable=False, help_text='Legacy field. Billing phone number.'),
         ),
         migrations.AddField(
             model_name='order',
@@ -353,7 +353,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='order',
             name='archived_documents_url_path',
-            field=models.CharField(blank=True, help_text='Legacy field. Link to the archived documents for this order.', max_length=255),
+            field=models.CharField(blank=True, editable=False, help_text='Legacy field. Link to the archived documents for this order.', max_length=255),
         ),
         migrations.AddField(
             model_name='order',

--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -209,9 +209,6 @@ class Order(BaseModel):
     )
 
     billing_company_name = models.CharField(max_length=MAX_LENGTH, blank=True)
-    billing_contact_name = models.CharField(max_length=MAX_LENGTH, blank=True)
-    billing_email = models.EmailField(max_length=MAX_LENGTH, blank=True)
-    billing_phone = models.CharField(max_length=150, blank=True)
     billing_address_1 = models.CharField(max_length=MAX_LENGTH, blank=True)
     billing_address_2 = models.CharField(max_length=MAX_LENGTH, blank=True)
     billing_address_town = models.CharField(max_length=MAX_LENGTH, blank=True)
@@ -259,8 +256,20 @@ class Order(BaseModel):
         help_text='Legacy field. Can DIT speak to the contacts?'
     )
     archived_documents_url_path = models.CharField(
-        max_length=MAX_LENGTH, blank=True,
+        max_length=MAX_LENGTH, blank=True, editable=False,
         help_text='Legacy field. Link to the archived documents for this order.'
+    )
+    billing_contact_name = models.CharField(
+        max_length=MAX_LENGTH, blank=True, editable=False,
+        help_text='Legacy field. Billing contact name.'
+    )
+    billing_email = models.EmailField(
+        max_length=MAX_LENGTH, blank=True, editable=False,
+        help_text='Legacy field. Billing email address.'
+    )
+    billing_phone = models.CharField(
+        max_length=150, blank=True, editable=False,
+        help_text='Legacy field. Billing phone number.'
     )
 
     objects = OrderQuerySet.as_manager()

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -128,6 +128,9 @@ class OrderSerializer(serializers.ModelSerializer):
             'cancelled_on',
             'cancellation_reason',
             'billing_company_name',
+            'billing_contact_name',
+            'billing_email',
+            'billing_phone',
         )
         validators = (
             ContactWorksAtCompanyValidator(),

--- a/datahub/omis/order/test/test_models.py
+++ b/datahub/omis/order/test/test_models.py
@@ -262,11 +262,12 @@ class TestGenerateQuote:
         # status changed
         assert order.status == OrderStatus.quote_awaiting_acceptance
 
+        assert not order.billing_contact_name
+        assert not order.billing_email
+        assert not order.billing_phone
+
         # billing fields populated
         assert order.billing_company_name == company.name
-        assert order.billing_contact_name == order.contact.name
-        assert order.billing_email == order.contact.email
-        assert order.billing_phone == order.contact.telephone_number
         assert order.billing_address_1 == company.registered_address_1
         assert order.billing_address_2 == company.registered_address_2
         assert order.billing_address_county == company.registered_address_county

--- a/datahub/omis/order/test/test_utils.py
+++ b/datahub/omis/order/test/test_utils.py
@@ -58,9 +58,9 @@ class TestPopulateBillingData:
 
         populate_billing_data(order)
 
-        assert order.billing_contact_name == contact.name
-        assert order.billing_email == contact.email
-        assert order.billing_phone == contact.telephone_number
+        assert not order.billing_contact_name
+        assert not order.billing_email
+        assert not order.billing_phone
 
         assert order.billing_company_name == company.name
         assert order.billing_address_1 == company.registered_address_1
@@ -98,41 +98,22 @@ class TestPopulateBillingData:
         assert order.billing_address_postcode == ''
         assert order.billing_address_country is None
 
-    @pytest.mark.parametrize(
-        'order_field,order_value',
-        (
-            ('billing_company_name', 'My Corp'),
-            ('billing_contact_name', 'Another John'),
-            ('billing_email', 'another-email@example.com'),
-            ('billing_phone', '99 001122'),
-        )
-    )
-    def test_with_already_populated_billing_detail(self, order_field, order_value):
+    def test_with_already_populated_billing_detail(self):
         """
         Test that if the order has an order details field already populated,
         it does not get overridden.
         """
-        billing_details = {
-            'billing_company_name': '',
-            'billing_contact_name': '',
-            'billing_email': '',
-            'billing_phone': '',
-        }
+        billing_company_name = 'My Corp'
 
         contact = ContactFactory()
         order = OrderFactory(
             contact=contact,
-            **{
-                **billing_details,
-                order_field: order_value
-            },
+            billing_company_name=billing_company_name,
         )
 
         populate_billing_data(order)
 
-        assert getattr(order, order_field) == order_value
-        for populated_field in set(billing_details.keys()) - set(order_field):
-            assert getattr(order, populated_field)
+        assert order.billing_company_name == billing_company_name
 
     @pytest.mark.parametrize(
         'billing_address',

--- a/datahub/omis/order/test/views/test_order_details.py
+++ b/datahub/omis/order/test/views/test_order_details.py
@@ -59,9 +59,6 @@ class TestAddOrderDetails(APITestMixin):
                 'vat_status': VATStatus.eu,
                 'vat_number': '01234566789',
                 'vat_verified': True,
-                'billing_contact_name': 'Billing contact name',
-                'billing_email': 'billing@example.com',
-                'billing_phone': '00112233',
                 'billing_address_1': 'Apt 1',
                 'billing_address_2': 'London Street',
                 'billing_address_town': 'London',
@@ -132,9 +129,9 @@ class TestAddOrderDetails(APITestMixin):
             'vat_cost': 0,
             'total_cost': 0,
             'billing_company_name': '',
-            'billing_contact_name': 'Billing contact name',
-            'billing_email': 'billing@example.com',
-            'billing_phone': '00112233',
+            'billing_contact_name': '',
+            'billing_email': '',
+            'billing_phone': '',
             'billing_address_1': 'Apt 1',
             'billing_address_2': 'London Street',
             'billing_address_town': 'London',
@@ -328,6 +325,9 @@ class TestAddOrderDetails(APITestMixin):
                 'product_info': 'lorem ipsum',
                 'permission_to_approach_contacts': 'lorem ipsum',
                 'archived_documents_url_path': '/documents/123',
+                'billing_contact_name': 'John Doe',
+                'billing_email': 'JohnDoe@example.com',
+                'billing_phone': '0123456789',
             },
             format='json'
         )
@@ -336,6 +336,9 @@ class TestAddOrderDetails(APITestMixin):
         assert response.json()['product_info'] == ''
         assert response.json()['permission_to_approach_contacts'] == ''
         assert response.json()['archived_documents_url_path'] == ''
+        assert response.json()['billing_contact_name'] == ''
+        assert response.json()['billing_email'] == ''
+        assert response.json()['billing_phone'] == ''
 
     @pytest.mark.parametrize(
         'vat_status',
@@ -397,38 +400,6 @@ class TestAddOrderDetails(APITestMixin):
             'billing_address_country': ['This field is required.'],
         }
 
-    @pytest.mark.parametrize(
-        'field,value',
-        (
-            ('billing_contact_name', 'lorem'),
-            ('billing_email', 'billing@example.com'),
-            ('billing_phone', '0011'),
-        )
-    )
-    def test_ok_with_non_address_billing_fields_set(self, field, value):
-        """
-        Test that if a non-address billing field is set, the validation of the
-        billing address is not triggered.
-        E.g. I can set billing email without billing address.
-        """
-        company = CompanyFactory()
-        contact = ContactFactory(company=company)
-        country = Country.france.value
-
-        url = reverse('api-v3:omis:order:list')
-        response = self.api_client.post(
-            url,
-            {
-                'company': {'id': company.pk},
-                'contact': {'id': contact.pk},
-                'primary_market': {'id': country.id},
-                field: value,
-            },
-            format='json'
-        )
-
-        assert response.status_code == status.HTTP_201_CREATED
-
 
 class TestChangeOrderDetails(APITestMixin):
     """Change Order details test case."""
@@ -464,9 +435,6 @@ class TestChangeOrderDetails(APITestMixin):
                 'vat_status': VATStatus.eu,
                 'vat_number': 'new vat number',
                 'vat_verified': False,
-                'billing_contact_name': 'Billing contact name',
-                'billing_email': 'billing@example.com',
-                'billing_phone': '00112233',
                 'billing_address_1': 'Apt 1',
                 'billing_address_2': 'London Street',
                 'billing_address_town': 'London',
@@ -538,9 +506,9 @@ class TestChangeOrderDetails(APITestMixin):
             'vat_cost': order.vat_cost,
             'total_cost': order.total_cost,
             'billing_company_name': order.billing_company_name,
-            'billing_contact_name': 'Billing contact name',
-            'billing_email': 'billing@example.com',
-            'billing_phone': '00112233',
+            'billing_contact_name': order.billing_contact_name,
+            'billing_email': order.billing_email,
+            'billing_phone': order.billing_phone,
             'billing_address_1': 'Apt 1',
             'billing_address_2': 'London Street',
             'billing_address_town': 'London',
@@ -779,6 +747,9 @@ class TestChangeOrderDetails(APITestMixin):
                     'id': uuid.uuid4()
                 },
                 'billing_company_name': 'New Corp',
+                'billing_contact_name': 'John Doe',
+                'billing_email': 'JohnDoe@example.com',
+                'billing_phone': '0123456789',
             },
             format='json'
         )
@@ -803,6 +774,9 @@ class TestChangeOrderDetails(APITestMixin):
         assert not response.json()['cancelled_on']
         assert not response.json()['cancellation_reason']
         assert response.json()['billing_company_name'] != 'New Corp'
+        assert response.json()['billing_contact_name'] != 'John Doe'
+        assert response.json()['billing_email'] != 'JohnDoe@example.com'
+        assert response.json()['billing_phone'] != '0123456789'
 
     @pytest.mark.parametrize(
         'disallowed_status', (

--- a/datahub/omis/order/utils.py
+++ b/datahub/omis/order/utils.py
@@ -5,15 +5,11 @@ def populate_billing_data(order):
     :param order: Order to change if needed
     :returns: order with billing_* fields filled in
     """
-    contact = order.contact
     company = order.company
 
     # get default and current order values of billing details
     default_billing_details = {
         'billing_company_name': company.name,
-        'billing_contact_name': contact.name,
-        'billing_email': contact.email,
-        'billing_phone': contact.telephone_number,
     }
     order_billing_details = {
         field_name: getattr(order, field_name)


### PR DESCRIPTION
This makes `billing_contact_name`, `billing_phone` and `billing_email` readonly with its values set only in previous orders.