### PR TITLE
Enforce model permissions in dashboard endpoint

### DIFF
--- a/datahub/search/dashboard/views.py
+++ b/datahub/search/dashboard/views.py
@@ -3,9 +3,12 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from datahub.oauth.scopes import Scope
+from datahub.search.contact.apps import ContactSearchApp
 from datahub.search.contact.models import Contact
 from datahub.search.elasticsearch import get_search_by_entity_query, limit_search_query
+from datahub.search.interaction.apps import InteractionSearchApp
 from datahub.search.interaction.models import Interaction
+from datahub.search.permissions import has_permissions_for_app
 from .serializers import HomepageSerializer
 
 
@@ -19,16 +22,29 @@ class IntelligentHomepageView(APIView):
 
     def get(self, request, format=None):
         """Implement GET method."""
-        user = request.user
         serializer = HomepageSerializer(data=request.GET)
         serializer.is_valid(raise_exception=True)
         limit = serializer.validated_data['limit']
+
+        interactions = self._get_interactions(request, limit)
+        contacts = self._get_contacts(request, limit)
+
+        response = {
+            'interactions': interactions,
+            'contacts': contacts,
+        }
+
+        return Response(data=response)
+
+    def _get_interactions(self, request, limit):
+        if not has_permissions_for_app(request, InteractionSearchApp):
+            return []
 
         interactions_query = get_search_by_entity_query(
             term='',
             entity=Interaction,
             filter_data={
-                'dit_adviser.id': user.id,
+                'dit_adviser.id': request.user.id,
                 'created_on_exists': True,
             },
             field_order='created_on:desc',
@@ -39,11 +55,17 @@ class IntelligentHomepageView(APIView):
             limit=limit,
         ).execute()
 
+        return [interaction.to_dict() for interaction in interactions.hits]
+
+    def _get_contacts(self, request, limit):
+        if not has_permissions_for_app(request, ContactSearchApp):
+            return []
+
         contacts_query = get_search_by_entity_query(
             term='',
             entity=Contact,
             filter_data={
-                'created_by.id': user.id,
+                'created_by.id': request.user.id,
                 'created_on_exists': True,
             },
             field_order='created_on:desc',
@@ -54,8 +76,4 @@ class IntelligentHomepageView(APIView):
             limit=limit,
         ).execute()
 
-        response = {
-            'interactions': [interaction.to_dict() for interaction in interactions.hits],
-            'contacts': [contact.to_dict() for contact in contacts.hits],
-        }
-        return Response(data=response)
+        return [contact.to_dict() for contact in contacts.hits]


### PR DESCRIPTION
DH-1000

Although it would be low risk, permissions should be enforced in the dashboard endpoint for consistency with other endpoints.

This change simply makes the dashboard endpoint return an empty list of interactions and/or contacts when the user doesn't have the relevant model permission for them.