### PR TITLE
Update Django to 2.0.1

### DIFF
--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -1,6 +1,6 @@
 """API URL config."""
 
-from django.conf.urls import include, url
+from django.urls import path, include
 from rest_framework import routers
 
 from datahub.company import urls as company_urls
@@ -24,17 +24,17 @@ v1_urls = router_v1.urls
 # API V3
 
 v3_urls = [
-    url(r'^', include((company_urls.contact_urls, 'contact'), namespace='contact')),
-    url(r'^', include((company_urls.company_urls, 'company'), namespace='company')),
-    url(r'^', include((company_urls.ch_company_urls, 'ch-company'), namespace='ch-company')),
-    url(r'^', include((event_urls, 'event'), namespace='event')),
-    url(r'^', include((interaction_urls, 'interaction'), namespace='interaction')),
-    url(r'^', include((investment_urls, 'investment'), namespace='investment')),
-    url(r'^', include((leads_urls, 'business-leads'), namespace='business-leads')),
-    url(r'^', include((search_urls, 'search'), namespace='search')),
-    url(r'^omis/', include((omis_urls.internal_frontend_urls, 'omis'), namespace='omis')),
-    url(
-        r'^omis/public/',
+    path('', include((company_urls.contact_urls, 'contact'), namespace='contact')),
+    path('', include((company_urls.company_urls, 'company'), namespace='company')),
+    path('', include((company_urls.ch_company_urls, 'ch-company'), namespace='ch-company')),
+    path('', include((event_urls, 'event'), namespace='event')),
+    path('', include((interaction_urls, 'interaction'), namespace='interaction')),
+    path('', include((investment_urls, 'investment'), namespace='investment')),
+    path('', include((leads_urls, 'business-leads'), namespace='business-leads')),
+    path('', include((search_urls, 'search'), namespace='search')),
+    path('omis/', include((omis_urls.internal_frontend_urls, 'omis'), namespace='omis')),
+    path(
+        'omis/public/',
         include((omis_urls.public_urls, 'omis-public'), namespace='omis-public')
     ),
 ]

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,6 +1,6 @@
 from django.conf import settings
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, path
 from oauth2_provider.views import TokenView
 
 from datahub.ping.views import ping
@@ -10,21 +10,22 @@ from . import api_urls
 
 
 unversioned_urls = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^ping.xml$', ping, name='ping'),
-    url(r'^metadata/', include('datahub.metadata.urls')),
-    url(r'^token/$', TokenView.as_view(), name='token'),
-    url(r'^whoami/$', who_am_i, name='who_am_i'),
-    url(r'^dashboard/', include(('datahub.search.dashboard.urls', 'dashboard'), namespace='dashboard'))
+    path('admin/', admin.site.urls),
+    path('ping.xml', ping, name='ping'),
+    path('metadata/', include('datahub.metadata.urls')),
+    path('token/', TokenView.as_view(), name='token'),
+    path('whoami/', who_am_i, name='who_am_i'),
+    path('dashboard/', include(('datahub.search.dashboard.urls', 'dashboard'), namespace='dashboard'))
 ]
 
 urlpatterns = [
-    url(r'^', include((api_urls.v1_urls, 'api'), namespace='api-v1')),  # V1 has actually no version in the URL
-    url(r'^v3/', include((api_urls.v3_urls, 'api'), namespace='api-v3')),
+    # V1 has actually no version in the URL
+    path('', include((api_urls.v1_urls, 'api'), namespace='api-v1')),
+    path('v3/', include((api_urls.v3_urls, 'api'), namespace='api-v3')),
 ] + unversioned_urls
 
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns += [
-        url(r'^__debug__/', include(debug_toolbar.urls)),
+        path('__debug__/', include(debug_toolbar.urls)),
     ]

--- a/datahub/company/urls.py
+++ b/datahub/company/urls.py
@@ -1,6 +1,6 @@
 """Company views URL config."""
 
-from django.conf.urls import url
+from django.urls import path
 
 from datahub.company.views import (
     CompaniesHouseCompanyViewSet, CompanyAuditViewSet, CompanyViewSet,
@@ -32,14 +32,11 @@ contact_audit = ContactAuditViewSet.as_view({
 })
 
 contact_urls = [
-    url(r'^contact$', contact_collection, name='list'),
-    url(r'^contact/(?P<pk>[0-9a-z-]{36})$', contact_item, name='detail'),
-    url(r'^contact/(?P<pk>[0-9a-z-]{36})/archive$', contact_archive,
-        name='archive'),
-    url(r'^contact/(?P<pk>[0-9a-z-]{36})/unarchive$', contact_unarchive,
-        name='unarchive'),
-    url(r'^contact/(?P<pk>[0-9a-z-]{36})/audit$', contact_audit,
-        name='audit-item'),
+    path('contact', contact_collection, name='list'),
+    path('contact/<uuid:pk>', contact_item, name='detail'),
+    path('contact/<uuid:pk>/archive', contact_archive, name='archive'),
+    path('contact/<uuid:pk>/unarchive', contact_unarchive, name='unarchive'),
+    path('contact/<uuid:pk>/audit', contact_audit, name='audit-item'),
 ]
 
 # COMPANY
@@ -75,19 +72,14 @@ ch_company_item = CompaniesHouseCompanyViewSet.as_view({
 })
 
 company_urls = [
-    url(r'^company$', company_collection, name='collection'),
-    url(r'^company/(?P<pk>[0-9a-z-]{36})$', company_item, name='item'),
-    url(r'^company/(?P<pk>[0-9a-z-]{36})/archive$', company_archive,
-        name='archive'),
-    url(r'^company/(?P<pk>[0-9a-z-]{36})/unarchive$', company_unarchive,
-        name='unarchive'),
-    url(r'^company/(?P<pk>[0-9a-z-]{36})/audit$', company_audit,
-        name='audit-item'),
+    path('company', company_collection, name='collection'),
+    path('company/<uuid:pk>', company_item, name='item'),
+    path('company/<uuid:pk>/archive', company_archive, name='archive'),
+    path('company/<uuid:pk>/unarchive', company_unarchive, name='unarchive'),
+    path('company/<uuid:pk>/audit', company_audit, name='audit-item'),
 ]
 
 ch_company_urls = [
-    url(r'^ch-company$', ch_company_list,
-        name='collection'),
-    url(r'^ch-company/(?P<company_number>[\w]+)$', ch_company_item,
-        name='item'),
+    path('ch-company', ch_company_list, name='collection'),
+    path('ch-company/<company_number>', ch_company_item, name='item'),
 ]

--- a/datahub/core/test/support/urls.py
+++ b/datahub/core/test/support/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from .views import MyDisableableModelViewset
 
@@ -7,5 +7,5 @@ collection = MyDisableableModelViewset.as_view({
 })
 
 urlpatterns = [
-    url(r'^test-disableable/$', collection, name='test-disableable-collection'),
+    path('test-disableable/', collection, name='test-disableable-collection'),
 ]

--- a/datahub/event/admin.py
+++ b/datahub/event/admin.py
@@ -28,6 +28,7 @@ def confirm_action(title, action_message):
                 action_checkbox_name=helpers.ACTION_CHECKBOX_NAME,
                 opts=self.model._meta,
                 queryset=queryset,
+                media=self.media,
             )
             return TemplateResponse(request, 'admin/action_confirmation.html', context)
 

--- a/datahub/event/urls.py
+++ b/datahub/event/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from datahub.event.views import EventViewSet
 
@@ -13,6 +13,6 @@ item = EventViewSet.as_view({
 })
 
 urlpatterns = [
-    url(r'^event$', collection, name='collection'),
-    url(r'^event/(?P<pk>[0-9a-z-]{36})$', item, name='item'),
+    path('event', collection, name='collection'),
+    path('event/<uuid:pk>', item, name='item'),
 ]

--- a/datahub/interaction/urls.py
+++ b/datahub/interaction/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import path
 
 from datahub.interaction.views import InteractionViewSet
 
@@ -13,6 +13,6 @@ item = InteractionViewSet.as_view({
 })
 
 urlpatterns = [
-    url(r'^interaction$', collection, name='collection'),
-    url(r'^interaction/(?P<pk>[0-9a-z-]{36})$', item, name='item'),
+    path('interaction', collection, name='collection'),
+    path('interaction/<uuid:pk>', item, name='item'),
 ]

--- a/datahub/investment/urls.py
+++ b/datahub/investment/urls.py
@@ -1,6 +1,6 @@
 """Investment views URL config."""
 
-from django.conf.urls import url
+from django.urls import path
 
 from datahub.investment.views import (
     IProjectAuditViewSet, IProjectDocumentViewSet, IProjectModifiedSinceViewSet,
@@ -59,25 +59,21 @@ project_document_callback = IProjectDocumentViewSet.as_view({
 })
 
 urlpatterns = [
-    url(r'^investment$', project_collection, name='investment-collection'),
-    url(r'^investment/from$', project_modified_since_collection,
-        name='investment-modified-since-collection'),
-    url(r'^investment/(?P<pk>[0-9a-z-]{36})$', project_item,
-        name='investment-item'),
-    url(r'^investment/(?P<pk>[0-9a-z-]{36})/archive$', archive_item,
-        name='archive-item'),
-    url(r'^investment/(?P<project_pk>[0-9a-z-]{36})/team-member$', project_team_member_collection,
-        name='team-member-collection'),
-    url(r'^investment/(?P<project_pk>[0-9a-z-]{36})/team-member/(?P<adviser_pk>[0-9a-z-]{36})$',
-        project_team_member_item, name='team-member-item'),
-    url(r'^investment/(?P<project_pk>[0-9a-z-]{36})/document$', project_document_collection,
-        name='document-collection'),
-    url(r'^investment/(?P<project_pk>[0-9a-z-]{36})/document/(?P<doc_pk>[0-9a-z-]{36})$',
-        project_document_item, name='document-item'),
-    url(r'^investment/(?P<project_pk>[0-9a-z-]{36})/document/(?P<doc_pk>[0-9a-z-]{36})/'
-        r'upload-callback$', project_document_callback, name='document-item-callback'),
-    url(r'^investment/(?P<pk>[0-9a-z-]{36})/unarchive$', unarchive_item,
-        name='unarchive-item'),
-    url(r'^investment/(?P<pk>[0-9a-z-]{36})/audit$', audit_item,
-        name='audit-item'),
+    path('investment', project_collection, name='investment-collection'),
+    path('investment/from', project_modified_since_collection,
+         name='investment-modified-since-collection'),
+    path('investment/<uuid:pk>', project_item, name='investment-item'),
+    path('investment/<uuid:pk>/archive', archive_item, name='archive-item'),
+    path('investment/<uuid:project_pk>/team-member', project_team_member_collection,
+         name='team-member-collection'),
+    path('investment/<uuid:project_pk>/team-member/<uuid:adviser_pk>',
+         project_team_member_item, name='team-member-item'),
+    path('investment/<uuid:project_pk>/document', project_document_collection,
+         name='document-collection'),
+    path('investment/<uuid:project_pk>/document/<uuid:doc_pk>',
+         project_document_item, name='document-item'),
+    path('investment/<uuid:project_pk>/document/<uuid:doc_pk>/upload-callback',
+         project_document_callback, name='document-item-callback'),
+    path('investment/<uuid:pk>/unarchive', unarchive_item, name='unarchive-item'),
+    path('investment/<uuid:pk>/audit', audit_item, name='audit-item'),
 ]

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -104,8 +104,8 @@ class IProjectViewSet(ArchivableViewSetMixin, CoreViewSetV3):
 class _ModifiedOnFilter(FilterSet):
     """Filter set for the modified-since view."""
 
-    modified_on__gte = IsoDateTimeFilter(name='modified_on', lookup_expr='gte')
-    modified_on__lte = IsoDateTimeFilter(name='modified_on', lookup_expr='lte')
+    modified_on__gte = IsoDateTimeFilter(field_name='modified_on', lookup_expr='gte')
+    modified_on__lte = IsoDateTimeFilter(field_name='modified_on', lookup_expr='lte')
 
     class Meta:
         model = InvestmentProject

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -170,7 +170,7 @@ class IProjectTeamMembersViewSet(CoreViewSetV3):
         """
         data = kwargs.get('data')
         if data is not None:
-            data['investment_project'] = self.kwargs['project_pk']
+            data['investment_project'] = str(self.kwargs['project_pk'])
         return super().get_serializer(*args, **kwargs)
 
     def create(self, request, *args, **kwargs):

--- a/datahub/leads/urls.py
+++ b/datahub/leads/urls.py
@@ -1,6 +1,6 @@
 """Investment views URL config."""
 
-from django.conf.urls import url
+from django.urls import path
 
 from datahub.leads.views import BusinessLeadViewSet
 
@@ -23,11 +23,8 @@ unarchive_lead_item = BusinessLeadViewSet.as_view({
 })
 
 urlpatterns = [
-    url(r'^business-leads$', lead_collection, name='lead-collection'),
-    url(r'^business-leads/(?P<pk>[0-9a-z-]{36})$', lead_item,
-        name='lead-item'),
-    url(r'^business-leads/(?P<pk>[0-9a-z-]{36})/archive$', archive_lead_item,
-        name='archive-lead-item'),
-    url(r'^business-leads/(?P<pk>[0-9a-z-]{36})/unarchive$',
-        unarchive_lead_item, name='unarchive-lead-item')
+    path('business-leads', lead_collection, name='lead-collection'),
+    path('business-leads/<uuid:pk>', lead_item, name='lead-item'),
+    path('business-leads/<uuid:pk>/archive', archive_lead_item, name='archive-lead-item'),
+    path('business-leads/<uuid:pk>/unarchive', unarchive_lead_item, name='unarchive-lead-item')
 ]

--- a/datahub/metadata/urls.py
+++ b/datahub/metadata/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 
-urlpatterns = [url(*args, **kwargs) for args, kwargs in views.urls_args]
+urlpatterns = [path(*args, **kwargs) for args, kwargs in views.urls_args]

--- a/datahub/metadata/views.py
+++ b/datahub/metadata/views.py
@@ -21,5 +21,5 @@ urls_args = []
 # programmatically generate metadata views
 for name, mapping in registry.mappings.items():
     fn = partial(metadata_view, mapping=mapping)
-    path = fr'^{name}/$'
+    path = f'{name}/'
     urls_args.append(((path, fn), {'name': name}))

--- a/datahub/omis/invoice/urls.py
+++ b/datahub/omis/invoice/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from .views import InvoiceViewSet, PublicInvoiceViewSet
 
 
 # internal frontend API
 internal_frontend_urls = [
-    url(
-        r'^order/(?P<order_pk>[0-9a-z-]{36})/invoice$',
+    path(
+        'order/<uuid:order_pk>/invoice',
         InvoiceViewSet.as_view({'get': 'retrieve'}),
         name='detail'
     ),
@@ -14,7 +14,7 @@ internal_frontend_urls = [
 
 # public facing API
 public_urls = [
-    url(
+    re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/invoice$',
         PublicInvoiceViewSet.as_view({'get': 'retrieve'}),
         name='detail'

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -1,6 +1,5 @@
 from functools import update_wrapper
 from django import forms
-from django.conf.urls import url
 from django.contrib import admin
 from django.contrib import messages
 from django.contrib.admin.exceptions import SuspiciousOperation
@@ -12,7 +11,7 @@ from django.db import router, transaction
 from django.http import HttpResponseRedirect
 from django.template.defaultfilters import date as date_filter, time as time_filter
 from django.template.response import TemplateResponse
-from django.urls import reverse
+from django.urls import path, reverse
 from django.utils.decorators import method_decorator
 from django.utils.encoding import force_text
 from django.utils.html import format_html, format_html_join
@@ -176,7 +175,8 @@ class OrderAdmin(ReadOnlyAdmin):
 
         info = self.model._meta.app_label, self.model._meta.model_name
         return [
-            url(r'^(.+)/cancel/$', wrap(self.cancel_order_view), name='%s_%s_cancel' % info),
+            path('<path:object_id>/cancel/', wrap(self.cancel_order_view),
+                 name='%s_%s_cancel' % info),
         ] + urls
 
     @csrf_protect_m

--- a/datahub/omis/order/templates/admin/order/cancel_confirmation.html
+++ b/datahub/omis/order/templates/admin/order/cancel_confirmation.html
@@ -13,7 +13,7 @@
 <div class="breadcrumbs">
 <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
 &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
-&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst|escape }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
 &rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a>
 &rsaquo; {% trans 'Cancel' %}
 </div>

--- a/datahub/omis/order/urls.py
+++ b/datahub/omis/order/urls.py
@@ -1,39 +1,39 @@
 """Company views URL config."""
 
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from .views import AssigneeView, OrderViewSet, PublicOrderViewSet, SubscriberListView
 
 # internal frontend API
 internal_frontend_urls = [
-    url(r'^order$', OrderViewSet.as_view({'post': 'create'}), name='list'),
-    url(
-        r'^order/(?P<pk>[0-9a-z-]{36})$',
+    path('order', OrderViewSet.as_view({'post': 'create'}), name='list'),
+    path(
+        'order/<uuid:pk>',
         OrderViewSet.as_view({
             'get': 'retrieve',
             'patch': 'partial_update'
         }),
         name='detail'
     ),
-    url(
-        r'^order/(?P<pk>[0-9a-z-]{36})/complete$',
+    path(
+        'order/<uuid:pk>/complete',
         OrderViewSet.as_view({'post': 'complete'}),
         name='complete'
     ),
-    url(
-        r'^order/(?P<pk>[0-9a-z-]{36})/cancel$',
+    path(
+        'order/<uuid:pk>/cancel',
         OrderViewSet.as_view({'post': 'cancel'}),
         name='cancel'
     ),
 
-    url(
-        r'^order/(?P<order_pk>[0-9a-z-]{36})/subscriber-list$',
+    path(
+        'order/<uuid:order_pk>/subscriber-list',
         SubscriberListView.as_view(),
         name='subscriber-list'
     ),
 
-    url(
-        r'^order/(?P<order_pk>[0-9a-z-]{36})/assignee$',
+    path(
+        'order/<uuid:order_pk>/assignee',
         AssigneeView.as_view(),
         name='assignee'
     ),
@@ -42,7 +42,7 @@ internal_frontend_urls = [
 
 # public facing API
 public_urls = [
-    url(
+    re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})$',
         PublicOrderViewSet.as_view({'get': 'retrieve'}),
         name='detail'

--- a/datahub/omis/payment/urls.py
+++ b/datahub/omis/payment/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from .views import PaymentViewSet, PublicPaymentViewSet
 
 
 # internal frontend API
 internal_frontend_urls = [
-    url(
-        r'^order/(?P<order_pk>[0-9a-z-]{36})/payment$',
+    path(
+        'order/<uuid:order_pk>/payment',
         PaymentViewSet.as_view({
             'get': 'list',
             'post': 'create_list'
@@ -17,7 +17,7 @@ internal_frontend_urls = [
 
 # public facing API
 public_urls = [
-    url(
+    re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/payment$',
         PublicPaymentViewSet.as_view({'get': 'list'}),
         name='collection'

--- a/datahub/omis/quote/urls.py
+++ b/datahub/omis/quote/urls.py
@@ -1,25 +1,25 @@
-from django.conf.urls import url
+from django.urls import path, re_path
 
 from .views import PublicQuoteViewSet, QuoteViewSet
 
 
 # internal frontend API
 internal_frontend_urls = [
-    url(
-        r'^order/(?P<order_pk>[0-9a-z-]{36})/quote$',
+    path(
+        'order/<uuid:order_pk>/quote',
         QuoteViewSet.as_view({
             'post': 'create',
             'get': 'retrieve',
         }),
         name='detail'
     ),
-    url(
-        r'^order/(?P<order_pk>[0-9a-z-]{36})/quote/preview$',
+    path(
+        'order/<uuid:order_pk>/quote/preview',
         QuoteViewSet.as_view({'post': 'preview'}),
         name='preview'
     ),
-    url(
-        r'^order/(?P<order_pk>[0-9a-z-]{36})/quote/cancel$',
+    path(
+        'order/<uuid:order_pk>/quote/cancel',
         QuoteViewSet.as_view({'post': 'cancel'}),
         name='cancel'
     ),
@@ -27,12 +27,12 @@ internal_frontend_urls = [
 
 # public facing API
 public_urls = [
-    url(
+    re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/quote$',
         PublicQuoteViewSet.as_view({'get': 'retrieve'}),
         name='detail'
     ),
-    url(
+    re_path(
         r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/quote/accept$',
         PublicQuoteViewSet.as_view({'post': 'accept'}),
         name='accept'

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 
 from .invoice import urls as invoice_urls
 from .order import urls as order_urls
@@ -6,15 +6,15 @@ from .payment import urls as payment_urls
 from .quote import urls as quote_urls
 
 internal_frontend_urls = [
-    url(r'^', include((order_urls.internal_frontend_urls, 'order'), namespace='order')),
-    url(r'^', include((quote_urls.internal_frontend_urls, 'quote'), namespace='quote')),
-    url(r'^', include((invoice_urls.internal_frontend_urls, 'invoice'), namespace='invoice')),
-    url(r'^', include((payment_urls.internal_frontend_urls, 'payment'), namespace='payment')),
+    path('', include((order_urls.internal_frontend_urls, 'order'), namespace='order')),
+    path('', include((quote_urls.internal_frontend_urls, 'quote'), namespace='quote')),
+    path('', include((invoice_urls.internal_frontend_urls, 'invoice'), namespace='invoice')),
+    path('', include((payment_urls.internal_frontend_urls, 'payment'), namespace='payment')),
 ]
 
 public_urls = [
-    url(r'^', include((order_urls.public_urls, 'order'), namespace='order')),
-    url(r'^', include((quote_urls.public_urls, 'quote'), namespace='quote')),
-    url(r'^', include((invoice_urls.public_urls, 'invoice'), namespace='invoice')),
-    url(r'^', include((payment_urls.public_urls, 'payment'), namespace='payment')),
+    path('', include((order_urls.public_urls, 'order'), namespace='order')),
+    path('', include((quote_urls.public_urls, 'quote'), namespace='quote')),
+    path('', include((invoice_urls.public_urls, 'invoice'), namespace='invoice')),
+    path('', include((payment_urls.public_urls, 'payment'), namespace='payment')),
 ]

--- a/datahub/search/dashboard/urls.py
+++ b/datahub/search/dashboard/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path
 
 from .views import IntelligentHomepageView
 
 urlpatterns = [
-    url(r'^homepage/$', IntelligentHomepageView.as_view(), name='intelligent-homepage')
+    path('homepage/', IntelligentHomepageView.as_view(), name='intelligent-homepage')
 ]

--- a/datahub/search/urls.py
+++ b/datahub/search/urls.py
@@ -1,25 +1,25 @@
 """Search views URL config."""
 
-from django.conf.urls import url
+from django.urls import path
 
 from .apps import get_search_apps
 from .views import SearchBasicAPIView
 
 urlpatterns = [
-    url(r'^search$', SearchBasicAPIView.as_view(), name='basic'),
+    path('search', SearchBasicAPIView.as_view(), name='basic'),
 ]
 
 for search_app in get_search_apps():
     if search_app.view:
-        urlpatterns.append(url(
-            rf'^search/{search_app.name}$',
+        urlpatterns.append(path(
+            f'search/{search_app.name}',
             search_app.view.as_view(search_app=search_app),
             name=search_app.name
         ))
 
     if search_app.export_view:
-        urlpatterns.append(url(
-            rf'^search/{search_app.name}/export$',
+        urlpatterns.append(path(
+            f'search/{search_app.name}/export',
             search_app.export_view.as_view(search_app=search_app),
             name=f'{search_app.name}-export'
         ))

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ lxml==4.1.1
 cssselect==1.0.1
 
 # Django and django related
-Django==1.11.8
+Django==2.0.1
 djangorestframework==3.7.7
 django-environ==0.4.4
 django-extensions==1.9.8

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ cssselect==1.0.1
 
 # Django and django related
 Django==1.11.8
-djangorestframework==3.7.3
+djangorestframework==3.7.7
 django-environ==0.4.4
 django-extensions==1.9.8
 django-filter==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 asttokens==1.1.7          # via flake8-import-order
 boto3==1.4.8
-botocore==1.8.8           # via boto3, s3transfer
+botocore==1.8.21          # via boto3, s3transfer
 certifi==2017.11.5        # via requests
 chardet==3.0.4            # via chardet, requests
 click==6.7                # via click, pip-tools
@@ -22,19 +22,19 @@ django-oauth-toolkit==1.0.0
 django-pglocks==1.0.2
 django-reversion==2.0.12
 django==1.11.8            # via django-debug-toolbar, django-environ, django-model-utils, django-oauth-toolkit, django-reversion
-djangorestframework==3.7.3
+djangorestframework==3.7.7
 docopt==0.6.2             # via docopt, notifications-python-client
 docutils==0.14            # via botocore, docutils
 elasticsearch-dsl==5.3.0
 elasticsearch==5.4.0
 factory-boy==2.9.2
-faker==0.8.7              # via factory-boy
+faker==0.8.8              # via factory-boy
 first==2.0.1              # via first, pip-tools
 flake8-blind-except==0.1.1
 flake8-debugger==3.0.0
 flake8-docstrings==1.1.0
 flake8-import-order==0.14.3
-flake8-polyfill==1.0.1    # via flake8-docstrings, flake8-polyfill
+flake8-polyfill==1.0.2    # via flake8-docstrings
 flake8-print==3.0.1
 flake8-quotes==0.9.0
 flake8-string-format==0.2.3
@@ -48,16 +48,16 @@ idna==2.6                 # via idna, requests
 ipdb==0.10.3
 ipython-genutils==0.2.0   # via ipython-genutils, traitlets
 ipython==6.2.1
-jedi==0.11.0              # via ipython, jedi
+jedi==0.11.1              # via ipython
 jmespath==0.9.3           # via boto3, botocore, jmespath
 lxml==4.1.1
 mccabe==0.6.1             # via flake8, mccabe
 monotonic==1.4            # via notifications-python-client
 notifications-python-client==4.6.0
 oauthlib==2.0.6           # via django-oauth-toolkit
-parso==0.1.0              # via jedi, parso
+parso==0.1.1              # via jedi
 pep8-naming==0.4.1
-pexpect==4.3.0            # via ipython
+pexpect==4.3.1            # via ipython
 pickleshare==0.7.4        # via ipython, pickleshare
 pip-tools==1.9.0
 prompt-toolkit==1.0.15    # via ipython, prompt-toolkit

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ django-model-utils==3.0.0
 django-oauth-toolkit==1.0.0
 django-pglocks==1.0.2
 django-reversion==2.0.12
-django==1.11.8            # via django-debug-toolbar, django-environ, django-model-utils, django-oauth-toolkit, django-reversion
+django==2.0.1             # via django-debug-toolbar, django-environ, django-model-utils, django-oauth-toolkit, django-reversion
 djangorestframework==3.7.7
 docopt==0.6.2             # via docopt, notifications-python-client
 docutils==0.14            # via botocore, docutils

--- a/templates/admin/action_confirmation.html
+++ b/templates/admin/action_confirmation.html
@@ -5,6 +5,7 @@
 {% block extrahead %}
     {{ block.super }}
     {{ media }}
+    <script type="text/javascript" src="{% static 'admin/js/cancel.js' %}"></script>
 {% endblock %}
 
 {% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}
@@ -40,8 +41,7 @@
             {{ form }}
             <input type="hidden" name="action" value="{{ action }}"/>
             <input type="submit" value="{% trans "Yes, I'm sure" %}"/>
-            <a href="#" onclick="window.history.back(); return false;"
-               class="button cancel-link">{% trans "No, take me back" %}</a>
+            <a href="#" class="button cancel-link">{% trans "No, take me back" %}</a>
         </div>
     </form>
 {% endblock %}


### PR DESCRIPTION
Uses the new path functions from django.urls for URL routing (not required for the upgrade, but seemed worth doing).

Also updates DRF to 3.7.7, and makes a couple of small changes to the admin templates so that they're more in line with the current ones built-in to Django.

Have run the acceptance tests acceptance tests against this branch, and the results are consistent with develop.

@marcofucci The OMIS public endpoints are still using regexes (via path_re()). They could use string parameters using path() instead, so depends on what you prefer there. (Unlike UUIDs, integers etc. there's no type conversion to do for the tokens.)