### PR TITLE
Investment Project search created_on filter.

### DIFF
--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -12,6 +12,8 @@ class SearchInvestmentProjectSerializer(SearchSerializer):
     """Serialiser used to validate investment project search POST bodies."""
 
     client_relationship_manager = SingleOrListField(child=StringUUIDField(), required=False)
+    created_on_after = RelaxedDateTimeField(required=False)
+    created_on_before = RelaxedDateTimeField(required=False)
     estimated_land_date_after = RelaxedDateTimeField(required=False)
     estimated_land_date_before = RelaxedDateTimeField(required=False)
     investment_type = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -1,5 +1,7 @@
 import datetime
+
 import pytest
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
@@ -68,16 +70,27 @@ def setup_data(setup_es):
     yield investment_projects
 
 
+@pytest.fixture
+def created_on_data(setup_es):
+    """Setup data for created_on date filter test."""
+    investment_projects = []
+    dates = (
+        '2015-01-01', '2016-09-12', '2017-09-12', '2048-02-04', '2048-01-24',
+    )
+
+    for date in dates:
+        with freeze_time(date):
+            investment_projects.append(
+                InvestmentProjectFactory()
+            )
+
+    setup_es.indices.refresh()
+
+    yield investment_projects
+
+
 class TestSearch(APITestMixin):
     """Tests search views."""
-
-    def test_investment_project_no_permissions(self):
-        """Should return 403"""
-        user = create_test_user(dit_team=TeamFactory())
-        api_client = self.create_api_client(user=user)
-        url = reverse('api-v3:search:investment_project')
-        response = api_client.get(url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_search_investment_project_json(self, setup_data):
         """Tests detailed investment project search."""
@@ -92,17 +105,47 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['name'] == 'abc defg'
 
-    def test_search_investment_project_date_json(self, setup_data):
+    @pytest.mark.parametrize('filter,results', (
+        ({'estimated_land_date_before': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)}, 1, ),
+        ({'estimated_land_date_after': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)}, 2,),
+        (
+            {
+                'estimated_land_date_after': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870),
+                'estimated_land_date_before': datetime.datetime(2030, 6, 13, 9, 44, 31, 62870),
+            },
+            1,
+        ),
+    ))
+    def test_search_investment_project_estimated_land_date_json(self, setup_data, filter, results):
         """Tests detailed investment project search."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, {
-            'estimated_land_date_before': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870),
-        }, format='json')
+        response = self.api_client.post(url, filter, format='json')
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 1
-        assert len(response.data['results']) == 1
+        assert response.data['count'] == results
+        assert len(response.data['results']) == results
+
+    @pytest.mark.parametrize('filter,results', (
+        ({'created_on_before': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)}, 2, ),
+        ({'created_on_after': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)}, 3,),
+        (
+            {
+                'created_on_after': datetime.datetime(2017, 6, 13, 9, 44, 31, 62870),
+                'created_on_before': datetime.datetime(2048, 2, 1, 5, 44, 31, 62870),
+            },
+            2,
+        ),
+    ))
+    def test_search_investment_project_created_on_json(self, created_on_data, filter, results):
+        """Tests detailed investment project search."""
+        url = reverse('api-v3:search:investment_project')
+
+        response = self.api_client.post(url, filter, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == results
+        assert len(response.data['results']) == results
 
     def test_search_investment_project_invalid_date_json(self, setup_data):
         """Tests detailed investment project search."""
@@ -235,103 +278,6 @@ class TestSearch(APITestMixin):
             for investment_project in response.data['results']
         }
 
-    @pytest.mark.parametrize('permissions', (
-        (InvestmentProjectPermission.read_all,),
-        (InvestmentProjectPermission.read_associated, InvestmentProjectPermission.read_all),
-    ))
-    def test_non_restricted_user_can_see_all_projects(self, setup_es, permissions):
-        """Test that normal users can see all projects."""
-        team = TeamFactory()
-        team_others = TeamFactory()
-        adviser_1 = AdviserFactory(dit_team_id=team.id)
-        adviser_2 = AdviserFactory(dit_team_id=team_others.id)
-
-        request_user = create_test_user(
-            permission_codenames=permissions,
-            dit_team=team
-        )
-        api_client = self.create_api_client(user=request_user)
-
-        iproject_1 = InvestmentProjectFactory()
-        iproject_2 = InvestmentProjectFactory()
-
-        InvestmentProjectTeamMemberFactory(adviser=adviser_1, investment_project=iproject_1)
-        InvestmentProjectTeamMemberFactory(adviser=adviser_2, investment_project=iproject_2)
-
-        setup_es.indices.refresh()
-
-        url = reverse('api-v3:search:investment_project')
-        response = api_client.post(url, {}, format='json')
-
-        assert response.status_code == status.HTTP_200_OK
-        response_data = response.json()
-        assert response_data['count'] == 2
-        assert {str(iproject_1.pk), str(iproject_2.pk)} == {
-            result['id'] for result in response_data['results']
-        }
-
-    def test_restricted_users_cannot_see_other_teams_projects(self, setup_es):
-        """Test that restricted users cannot see other teams' projects."""
-        url = reverse('api-v3:search:investment_project')
-
-        team = TeamFactory()
-        team_other = TeamFactory()
-        adviser_other = AdviserFactory(dit_team_id=team_other.id)
-        adviser_same_team = AdviserFactory(dit_team_id=team.id)
-        request_user = create_test_user(
-            permission_codenames=['read_associated_investmentproject'],
-            dit_team=team
-        )
-        api_client = self.create_api_client(user=request_user)
-
-        project_other = InvestmentProjectFactory()
-        project_1 = InvestmentProjectFactory()
-        project_2 = InvestmentProjectFactory(created_by=adviser_same_team)
-        project_3 = InvestmentProjectFactory(client_relationship_manager=adviser_same_team)
-        project_4 = InvestmentProjectFactory(project_manager=adviser_same_team)
-        project_5 = InvestmentProjectFactory(project_assurance_adviser=adviser_same_team)
-
-        InvestmentProjectTeamMemberFactory(adviser=adviser_other, investment_project=project_other)
-        InvestmentProjectTeamMemberFactory(adviser=adviser_same_team, investment_project=project_1)
-
-        setup_es.indices.refresh()
-
-        response = api_client.post(url, {}, format='json')
-
-        assert response.status_code == status.HTTP_200_OK
-        response_data = response.json()
-        assert response_data['count'] == 5
-
-        results = response_data['results']
-        expected_ids = {str(project_1.id), str(project_2.id), str(project_3.id),
-                        str(project_4.id), str(project_5.id)}
-
-        assert {result['id'] for result in results} == expected_ids
-
-    def test_restricted_user_with_no_team_cannot_see_projects(self, setup_es):
-        """
-        Checks that a restricted user that doesn't have a team cannot view any projects (in
-        particular projects associated with other advisers that don't have teams).
-        """
-        url = reverse('api-v3:search:investment_project')
-
-        adviser_other = AdviserFactory(dit_team_id=None)
-        request_user = create_test_user(
-            permission_codenames=['read_associated_investmentproject']
-        )
-        api_client = self.create_api_client(user=request_user)
-
-        InvestmentProjectFactory()
-        InvestmentProjectFactory(created_by=adviser_other)
-
-        setup_es.indices.refresh()
-
-        response = api_client.post(url, {}, format='json')
-
-        assert response.status_code == status.HTTP_200_OK
-        response_data = response.json()
-        assert response_data['count'] == 0
-
     def test_search_investment_project_aggregates(self, setup_es):
         """Tests aggregates in investment project search."""
         url = reverse('api-v3:search:investment_project')
@@ -374,6 +320,115 @@ class TestSearch(APITestMixin):
         assert all(stage in response.data['aggregations']['stage'] for stage in stages)
 
 
+class TestSearchPermissions(APITestMixin):
+    """Tests search view permissions."""
+
+    def test_investment_project_no_permissions(self):
+        """Should return 403"""
+        user = create_test_user(dit_team=TeamFactory())
+        api_client = self.create_api_client(user=user)
+        url = reverse('api-v3:search:investment_project')
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize('permissions', (
+        (InvestmentProjectPermission.read_all,),
+        (InvestmentProjectPermission.read_associated, InvestmentProjectPermission.read_all),
+    ))
+    def test_non_restricted_user_can_see_all_projects(self, setup_es, permissions):
+        """Test that normal users can see all projects."""
+        team = TeamFactory()
+        team_others = TeamFactory()
+        adviser_1 = AdviserFactory(dit_team_id=team.id)
+        adviser_2 = AdviserFactory(dit_team_id=team_others.id)
+
+        request_user = create_test_user(
+            permission_codenames=permissions,
+            dit_team=team
+        )
+        api_client = self.create_api_client(user=request_user)
+
+        iproject_1 = InvestmentProjectFactory()
+        iproject_2 = InvestmentProjectFactory()
+
+        InvestmentProjectTeamMemberFactory(adviser=adviser_1, investment_project=iproject_1)
+        InvestmentProjectTeamMemberFactory(adviser=adviser_2, investment_project=iproject_2)
+
+        setup_es.indices.refresh()
+
+        url = reverse('api-v3:search:investment_project')
+        response = api_client.post(url, {}, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == 2
+        assert {str(iproject_1.pk), str(iproject_2.pk)} == {
+            result['id'] for result in response_data['results']
+        }
+
+    def test_restricted_user_with_no_team_cannot_see_projects(self, setup_es):
+        """
+        Checks that a restricted user that doesn't have a team cannot view any projects (in
+        particular projects associated with other advisers that don't have teams).
+        """
+        url = reverse('api-v3:search:investment_project')
+
+        adviser_other = AdviserFactory(dit_team_id=None)
+        request_user = create_test_user(
+            permission_codenames=['read_associated_investmentproject']
+        )
+        api_client = self.create_api_client(user=request_user)
+
+        InvestmentProjectFactory()
+        InvestmentProjectFactory(created_by=adviser_other)
+
+        setup_es.indices.refresh()
+
+        response = api_client.post(url, {}, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == 0
+
+    def test_restricted_users_cannot_see_other_teams_projects(self, setup_es):
+        """Test that restricted users cannot see other teams' projects."""
+        url = reverse('api-v3:search:investment_project')
+
+        team = TeamFactory()
+        team_other = TeamFactory()
+        adviser_other = AdviserFactory(dit_team_id=team_other.id)
+        adviser_same_team = AdviserFactory(dit_team_id=team.id)
+        request_user = create_test_user(
+            permission_codenames=['read_associated_investmentproject'],
+            dit_team=team
+        )
+        api_client = self.create_api_client(user=request_user)
+
+        project_other = InvestmentProjectFactory()
+        project_1 = InvestmentProjectFactory()
+        project_2 = InvestmentProjectFactory(created_by=adviser_same_team)
+        project_3 = InvestmentProjectFactory(client_relationship_manager=adviser_same_team)
+        project_4 = InvestmentProjectFactory(project_manager=adviser_same_team)
+        project_5 = InvestmentProjectFactory(project_assurance_adviser=adviser_same_team)
+
+        InvestmentProjectTeamMemberFactory(adviser=adviser_other, investment_project=project_other)
+        InvestmentProjectTeamMemberFactory(adviser=adviser_same_team, investment_project=project_1)
+
+        setup_es.indices.refresh()
+
+        response = api_client.post(url, {}, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == 5
+
+        results = response_data['results']
+        expected_ids = {str(project_1.id), str(project_2.id), str(project_3.id),
+                        str(project_4.id), str(project_5.id)}
+
+        assert {result['id'] for result in results} == expected_ids
+
+
 class TestBasicSearch(APITestMixin):
     """Tests basic search view."""
 
@@ -405,6 +460,10 @@ class TestBasicSearch(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         assert response.data['results'][0]['project_code'] == investment_project.project_code
+
+
+class TestBasicSearchPermissions(APITestMixin):
+    """Tests basic search view permissions."""
 
     @pytest.mark.parametrize('permissions', (
         (InvestmentProjectPermission.read_all,),

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -112,27 +112,27 @@ class TestSearch(APITestMixin):
         (
             (
                 {
-                    'estimated_land_date_before': '2017-06-13T00:00:00.000000Z'
+                    'estimated_land_date_before': '2017-06-13'
                 },
                 1,
             ),
             (
                 {
-                    'estimated_land_date_after': '2017-06-13T09:44:31.062870Z'
+                    'estimated_land_date_after': '2017-06-13'
                 },
                 2,
             ),
             (
                 {
-                    'estimated_land_date_after': '2017-06-13T09:44:31.062870Z',
-                    'estimated_land_date_before': '2030-06-13T09:44:31.062870Z',
+                    'estimated_land_date_after': '2017-06-13',
+                    'estimated_land_date_before': '2030-06-13',
                 },
                 1,
             ),
             (
                 {
-                    'estimated_land_date_before': '2017-06-13T09:44:31.062870Z',
-                    'estimated_land_date_after': '2030-06-13T09:44:31.062870Z',
+                    'estimated_land_date_before': '2017-06-13',
+                    'estimated_land_date_after': '2030-06-13',
                 },
                 0,
             ),
@@ -155,11 +155,9 @@ class TestSearch(APITestMixin):
         assert len(results) == num_results
 
         for result in results:
-            estimated_land_date = dateutil_parse(
-                result['estimated_land_date']
-            ).replace(tzinfo=utc)
+            estimated_land_date = dateutil_parse(result['estimated_land_date'])
             for filter_key, date in query.items():
-                date = dateutil_parse(date).replace(tzinfo=utc)
+                date = dateutil_parse(date)
                 if filter_key == 'estimated_land_date_before':
                     assert estimated_land_date <= date
                 if filter_key == 'estimated_land_date_after':

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -112,7 +112,7 @@ class TestSearch(APITestMixin):
         (
             (
                 {
-                    'estimated_land_date_before': '2017-06-13T09:44:31.062870Z'
+                    'estimated_land_date_before': '2017-06-13T00:00:00.000000Z'
                 },
                 1,
             ),
@@ -169,7 +169,13 @@ class TestSearch(APITestMixin):
         'query,num_results', (
             (
                 {
-                    'created_on_before': '2017-06-13T09:44:31.062870Z'
+                    'created_on_before': '2016-09-13T09:44:31.062870Z'
+                },
+                2,
+            ),
+            (
+                {
+                    'created_on_before': '2016-09-12T00:00:00.000000Z'
                 },
                 2,
             ),
@@ -178,6 +184,12 @@ class TestSearch(APITestMixin):
                     'created_on_after': '2017-06-13T09:44:31.062870Z'
                 },
                 3,
+            ),
+            (
+                {
+                    'created_on_after': '2016-09-12T00:00:00.000000Z'
+                },
+                4,
             ),
             (
                 {

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -15,6 +15,8 @@ class SearchInvestmentProjectParams:
 
     FILTER_FIELDS = (
         'client_relationship_manager',
+        'created_on_after',
+        'created_on_before',
         'estimated_land_date_after',
         'estimated_land_date_before',
         'investment_type',


### PR DESCRIPTION
This adds `created_on_after` and `created_on_before` filter to the Investment Project search.

It also reorganises tests a little, so that permission tests are in its own place.
