### PR TITLE
DH-1399 Acceptance tests add users with other permissions

### DIFF
--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -xe
-# This file is used as a cmd script with an automatically built backend docker to run User Acceptance Tests against on circleCI.
-# For more information about how this is used please see https://github.com/uktrade/data-hub-frontend
+# This file is used as a cmd script with an automatically built backend docker to run User Acceptance Tests against
+# on circleCI. For more information about how this is used please see
+# https://github.com/uktrade/data-hub-frontend#continuous-integration
 
 dockerize -wait ${POSTGRES_URL} -wait ${ES5_URL} -timeout 60s
 python /app/manage.py migrate

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -16,19 +16,52 @@ from datahub.company.models import Advisor
 
 dit_east_midlands_id = '9010dd28-9798-e211-a939-e4115bead28a'
 
-user = Advisor.objects.create_user(
-    email='${QA_USER_EMAIL}',
-    first_name='Circle',
-    last_name='Ci',
+dit_staff_user = Advisor.objects.create_user(
+    email='dit_staff@datahub.com',
+    first_name='DIT',
+    last_name='Staff',
     dit_team_id=dit_east_midlands_id,
 )
 
 AccessToken.objects.create(
-    user=user,
-    token='${OAUTH2_DEV_TOKEN}',
+    user=dit_staff_user,
+    token='ditStaffToken',
     expires=now() + datetime.timedelta(days=1),
     scope='data-hub:internal-front-end',
-)" | /app/manage.py shell
+)
+
+da_scottish_council_id = 'b23ade1c-9798-e211-a939-e4115bead28a'
+
+da_staff_user = Advisor.objects.create_user(
+    email='da_staff@datahub.com',
+    first_name='DA',
+    last_name='Staff',
+    dit_team_id=da_scottish_council_id,
+)
+
+AccessToken.objects.create(
+    user=da_staff_user,
+    token='daStaffToken',
+    expires=now() + datetime.timedelta(days=1),
+    scope='data-hub:internal-front-end',
+)
+
+heart_of_the_south_west_lep_id = '08d987f8-6525-e511-b6bc-e4115bead28a'
+
+lep_staff_user = Advisor.objects.create_user(
+    email='lep_staff@datahub.com',
+    first_name='LEP',
+    last_name='Staff',
+    dit_team_id=heart_of_the_south_west_lep_id,
+)
+
+AccessToken.objects.create(
+    user=lep_staff_user,
+    token='lepStaffToken',
+    expires=now() + datetime.timedelta(days=1),
+    scope='data-hub:internal-front-end',
+)
+" | /app/manage.py shell
 
 python /app/manage.py loaddata /app/fixtures/test_ch_data.yaml
 python /app/manage.py loaddata /app/fixtures/test_data.yaml

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -8,6 +8,7 @@ python /app/manage.py migrate
 python /app/manage.py loadmetadata
 python /app/manage.py load_omis_metadata
 
+# TODO abstract this into a method in ./manage.py
 echo "import datetime
 from django.utils.timezone import now
 from oauth2_provider.models import AccessToken


### PR DESCRIPTION
This work adds the following `users` and relevant `access tokens` to be used in [circleCi](https://circleci.com/workflow-run/cce8bff0-613f-4905-9b7c-78d5b9294794)

- `dit_staff@datahub.com`: `ditStaffToken`
- `lep_staff@datahub.com`: `lepStaffToken`
- `da_staff@datahub.com`: `daStaffToken`