### PR TITLE
Add validation for investment project actual land date

### DIFF
--- a/datahub/investment/test/factories.py
+++ b/datahub/investment/test/factories.py
@@ -121,6 +121,7 @@ class WonInvestmentProjectFactory(VerifyWinInvestmentProjectFactory):
 
     stage_id = InvestmentProjectStage.won.value.id
     status = InvestmentProject.STATUSES.won
+    actual_land_date = factory.Faker('past_date')
 
 
 class InvestmentProjectTeamMemberFactory(factory.django.DjangoModelFactory):

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -1109,13 +1109,17 @@ class TestPartialUpdateView(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
 
     def test_change_stage_to_won(self):
-        """Tests moving a complete project to the 'Won' stage."""
+        """
+        Tests moving a complete project to the 'Won' stage, when all required fields are
+        complete.
+        """
         project = VerifyWinInvestmentProjectFactory()
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
         request_data = {
             'stage': {
                 'id': constants.InvestmentProjectStage.won.value.id
-            }
+            },
+            'actual_land_date': '2016-01-31',
         }
         response = self.api_client.patch(url, data=request_data, format='json')
         assert response.status_code == status.HTTP_200_OK
@@ -1125,6 +1129,25 @@ class TestPartialUpdateView(APITestMixin):
             'name': constants.InvestmentProjectStage.won.value.name,
         }
         assert response_data['status'] == 'won'
+
+    def test_change_stage_to_won_failure(self):
+        """
+        Tests moving a project to the 'Won' stage, when required field for that transition
+        are missing.
+        """
+        project = VerifyWinInvestmentProjectFactory()
+        url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
+        request_data = {
+            'stage': {
+                'id': constants.InvestmentProjectStage.won.value.id
+            },
+        }
+        response = self.api_client.patch(url, data=request_data, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data == {
+            'actual_land_date': ['This field is required.'],
+        }
 
     def test_revert_stage_to_verify_win(self):
         """Tests moving a complete project from the 'Won' stage to 'Verify win'."""

--- a/datahub/investment/validate.py
+++ b/datahub/investment/validate.py
@@ -38,6 +38,7 @@ VALIDATION_MAPPING = {
     'address_1': Stage.verify_win.value,
     'address_town': Stage.verify_win.value,
     'address_postcode': Stage.verify_win.value,
+    'actual_land_date': Stage.won.value,
 }
 
 CondValRule = namedtuple('CondValRule', ('field', 'condition', 'stage'))


### PR DESCRIPTION
DH-1357
This makes actual land date required in order to advance a project to the Won stage.