### PR TITLE
Omis change contact

### DIFF
--- a/datahub/omis/order/test/test_validators.py
+++ b/datahub/omis/order/test/test_validators.py
@@ -24,7 +24,6 @@ from ..validators import (
     OrderEditableFieldsValidator,
     OrderInStatusRule,
     OrderInStatusValidator,
-    ReadonlyAfterCreationValidator,
     VATValidator,
 )
 
@@ -88,66 +87,6 @@ class TestContactWorksAtCompanyValidator:
             validator({
                 'main_contact': new_main_contact,
                 'main_company': company
-            })
-        except Exception:
-            pytest.fail('Should not raise a validator error.')
-
-
-class TestReadonlyAfterCreationValidator:
-    """Tests for ReadonlyAfterCreationValidator."""
-
-    def test_can_change_when_creating(self):
-        """Test that if we are creating the instance, the validation passes."""
-        serializer = mock.Mock(instance=None)
-
-        validator = ReadonlyAfterCreationValidator(
-            fields=('field1', 'field2')
-        )
-        validator.set_context(serializer)
-
-        try:
-            validator({
-                'field1': 'some value',
-                'field2': 'some value',
-            })
-        except Exception:
-            pytest.fail('Should not raise a validator error.')
-
-    def test_cannot_change_after_creation(self):
-        """
-        Test that if we are updating the instance and we try to update the fields,
-        the validation fails.
-        """
-        serializer = mock.Mock()  # serializer.instance is != None
-
-        validator = ReadonlyAfterCreationValidator(
-            fields=('field1', 'field2')
-        )
-        validator.set_context(serializer)
-
-        with pytest.raises(ValidationError):
-            validator({
-                'field1': 'some value',
-                'field2': 'some value',
-            })
-
-    def test_ok_if_the_values_dont_change_after_creation(self):
-        """
-        Test that if we are updating the instance and we don't update the fields,
-        the validation passes.
-        """
-        serializer = mock.Mock()
-        instance = serializer.instance
-
-        validator = ReadonlyAfterCreationValidator(
-            fields=('field1', 'field2')
-        )
-        validator.set_context(serializer)
-
-        try:
-            validator({
-                'field1': instance.field1,
-                'field2': instance.field2,
             })
         except Exception:
             pytest.fail('Should not raise a validator error.')
@@ -718,29 +657,49 @@ class TestOrderEditableFieldsValidator:
     @pytest.mark.parametrize(
         'order_status,mapping,data,should_pass',
         (
+            # allowed field => OK
             (
                 OrderStatus.draft,
                 {OrderStatus.draft: {'description'}},
                 {'description': 'lorem ipsum'},
                 True
             ),
+            # disallowed field => Fail
             (
                 OrderStatus.draft,
                 {OrderStatus.draft: {'contact'}},
                 {'description': 'lorem ipsum'},
                 False
             ),
+            # status not in mapping => OK
             (
                 OrderStatus.draft,
                 {OrderStatus.paid: {'contact'}},
                 {'description': 'lorem ipsum'},
                 True
             ),
+            # disallowed field didn't change => OK
+            (
+                OrderStatus.draft,
+                {OrderStatus.draft: {'contact'}},
+                {'description': 'original description'},
+                True
+            ),
+            # nothing allowed => Fail
+            (
+                OrderStatus.draft,
+                {OrderStatus.draft: {}},
+                {'description': 'lorem ipsum'},
+                False
+            ),
         )
     )
     def test_validation_with_order(self, order_status, mapping, data, should_pass):
         """Test the validator with different order status, mapping and data."""
-        order = Order(status=order_status)
+        order = Order(
+            status=order_status,
+            description='original description'
+        )
         serializer = mock.Mock(instance=order)
 
         validator = OrderEditableFieldsValidator(mapping)


### PR DESCRIPTION
This allows the contact on an order to be changed if the order is in status != complete or cancelled.

This also refactors the order validators trying to simplify things. 
Instead of several, sometimes abstract validators, now the view only uses one `OrderEditableFieldsValidator` which defines clearly what can be edited and what can't at any particular stage.