### PR TITLE
Update build pack and Python version

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,3 +1,3 @@
 ---
 applications:
-- buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.0
+- buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.6

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.1
+python-3.6.3


### PR DESCRIPTION
3.6.3 is the latest 3.6 version supported by the build pack. 3.6.4 is not yet available.

Have deployed this to UAT as a test.