### PR TITLE
Add post delete signal to interactions.

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -506,3 +506,9 @@ def _split_date_range_fields(fields):
 
 def _clip_limit(offset, limit):
     return max(min(limit, MAX_RESULTS - offset), 0)
+
+
+def delete_document(model, document_id):
+    """Deletes specified model's document."""
+    doc = model.get(id=document_id)
+    doc.delete()

--- a/datahub/search/interaction/signals.py
+++ b/datahub/search/interaction/signals.py
@@ -1,18 +1,25 @@
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_delete, post_save
 
 from datahub.company.models import Company as DBCompany, Contact as DBContact
 from datahub.interaction.models import Interaction as DBInteraction
 from datahub.investment.models import InvestmentProject as DBInvestmentProject
-
+from datahub.search.elasticsearch import delete_document
 from datahub.search.signals import sync_es
 from .models import Interaction as ESInteraction
 
 
 def sync_interaction_to_es(sender, instance, **kwargs):
-    """Sync contact to the Elasticsearch."""
+    """Sync interaction to the Elasticsearch."""
     transaction.on_commit(
         lambda: sync_es(ESInteraction, DBInteraction, str(instance.pk))
+    )
+
+
+def remove_interaction_from_es(sender, instance, **kwargs):
+    """Remove interaction from es."""
+    transaction.on_commit(
+        lambda: delete_document(ESInteraction, str(instance.pk))
     )
 
 
@@ -46,6 +53,12 @@ def connect_signals():
         sync_related_interactions_to_es,
         sender=DBInvestmentProject,
         dispatch_uid='iproject_sync_related_interactions_to_es'
+    )
+
+    post_delete.connect(
+        remove_interaction_from_es,
+        sender=DBInteraction,
+        dispatch_uid='remove_interaction_from_es',
     )
 
 


### PR DESCRIPTION
This adds post_delete signal for Interactions, so that when interaction is deleted, it is also deleted from Elasticsearch.