### PR TITLE
Remove landscape.io badge from README

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,5 +1,2 @@
 branch: develop
 update: security
-assignees:
-  - sdonk
-  - canni

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![image](https://circleci.com/gh/uktrade/data-hub-leeloo/tree/master.svg?style=svg)](https://circleci.com/gh/uktrade/data-hub-leeloo/tree/master)
 [![image](https://codecov.io/gh/uktrade/data-hub-leeloo/branch/master/graph/badge.svg)](https://codecov.io/gh/uktrade/data-hub-leeloo)
 [![image](https://codeclimate.com/github/uktrade/data-hub-leeloo/badges/gpa.svg)](https://codeclimate.com/github/uktrade/data-hub-leeloo)
-[![Code Health](https://landscape.io/github/uktrade/data-hub-leeloo/master/landscape.svg?style=flat)](https://landscape.io/github/uktrade/data-hub-leeloo/master)
 [![Updates](https://pyup.io/repos/github/uktrade/data-hub-leeloo/shield.svg)](https://pyup.io/repos/github/uktrade/data-hub-leeloo/)
 
 Leeloo provides an API into Data Hub for Data Hub clients. Using Leeloo you can search for entities and manage companies, contacts and interactions.


### PR DESCRIPTION
Issue number: N/A

### Description of change

Removes the landscape.io badge. It's been running in Python 2 mode, so hasn't been working correctly. Their docs are currently 404ing, and a test branch specifying Python 3 failed completely. We also already have the Code Climate badge which is working correctly.

Also removes outdated pyup assignees.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
