### PR TITLE
Update omission list in .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,9 +8,7 @@ omit =
     *__init__.py
     *models.py
     *apps.py
-    *core/auth.py
     *datahub/core/management/commands/distributed_migrate.py
-    *loading_scripts/etl/*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
Issue number: N/A

### Description of change

Removes the `*loading_scripts/etl/*` omission as that no longer exists, and also removes the `*core/auth.py` omission as that shouldn't be excluded from coverage.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
