### PR TITLE
Remove interaction type metadata endpoint

### DIFF
--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -288,17 +288,6 @@ class Country(Enum):
     zimbabwe = Constant('Zimbabwe', '39afd8d0-5d95-e211-a939-e4115bead28a')
 
 
-class CommunicationChannel(Enum):
-    """Communication channels."""
-
-    email_website = Constant('Email/Website', '70c226d7-5d95-e211-a939-e4115bead28a')
-    face_to_face = Constant('Face to Face', 'a5d71fdd-5d95-e211-a939-e4115bead28a')
-    letter_fax = Constant('Letter/Fax', '74c226d7-5d95-e211-a939-e4115bead28a')
-    social_media = Constant('Social Media', 'a8d71fdd-5d95-e211-a939-e4115bead28a')
-    telephone = Constant('Telephone', '72c226d7-5d95-e211-a939-e4115bead28a')
-    video_teleconf = Constant('Video/Teleconf.', 'a7d71fdd-5d95-e211-a939-e4115bead28a')
-
-
 class Role(Enum):
     """Roles."""
 

--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -288,8 +288,8 @@ class Country(Enum):
     zimbabwe = Constant('Zimbabwe', '39afd8d0-5d95-e211-a939-e4115bead28a')
 
 
-class InteractionType(Enum):
-    """Interaction types."""
+class CommunicationChannel(Enum):
+    """Communication channels."""
 
     email_website = Constant('Email/Website', '70c226d7-5d95-e211-a939-e4115bead28a')
     face_to_face = Constant('Face to Face', 'a5d71fdd-5d95-e211-a939-e4115bead28a')

--- a/datahub/interaction/constants.py
+++ b/datahub/interaction/constants.py
@@ -1,0 +1,14 @@
+from enum import Enum
+
+from datahub.core.constants import Constant
+
+
+class CommunicationChannel(Enum):
+    """Communication channels."""
+
+    email_website = Constant('Email/Website', '70c226d7-5d95-e211-a939-e4115bead28a')
+    face_to_face = Constant('Face to Face', 'a5d71fdd-5d95-e211-a939-e4115bead28a')
+    letter_fax = Constant('Letter/Fax', '74c226d7-5d95-e211-a939-e4115bead28a')
+    social_media = Constant('Social Media', 'a8d71fdd-5d95-e211-a939-e4115bead28a')
+    telephone = Constant('Telephone', '72c226d7-5d95-e211-a939-e4115bead28a')
+    video_teleconf = Constant('Video/Teleconf.', 'a7d71fdd-5d95-e211-a939-e4115bead28a')

--- a/datahub/interaction/metadata.py
+++ b/datahub/interaction/metadata.py
@@ -20,9 +20,3 @@ registry.register(
     metadata_id='service-delivery-status',
     model=models.ServiceDeliveryStatus,
 )
-
-# For backwards compatibility. Will be removed once front end updated.
-registry.register(
-    metadata_id='interaction-type',
-    model=models.CommunicationChannel,
-)

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -5,7 +5,7 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory, Conta
 from datahub.core import constants
 from datahub.core.test_utils import random_obj_for_model
 from datahub.event.test.factories import EventFactory
-from datahub.interaction.models import Interaction, ServiceDeliveryStatus
+from datahub.interaction.models import CommunicationChannel, Interaction, ServiceDeliveryStatus
 from datahub.investment.test.factories import InvestmentProjectFactory
 
 
@@ -32,7 +32,9 @@ class CompanyInteractionFactory(InteractionFactoryBase):
 
     kind = Interaction.KINDS.interaction
     company = factory.SubFactory(CompanyFactory)
-    communication_channel_id = constants.CommunicationChannel.face_to_face.value.id
+    communication_channel = factory.LazyFunction(
+        lambda: random_obj_for_model(CommunicationChannel)
+    )
 
 
 class InvestmentProjectInteractionFactory(InteractionFactoryBase):
@@ -40,7 +42,9 @@ class InvestmentProjectInteractionFactory(InteractionFactoryBase):
 
     kind = Interaction.KINDS.interaction
     investment_project = factory.SubFactory(InvestmentProjectFactory)
-    communication_channel_id = constants.CommunicationChannel.face_to_face.value.id
+    communication_channel = factory.LazyFunction(
+        lambda: random_obj_for_model(CommunicationChannel)
+    )
 
 
 class ServiceDeliveryFactory(InteractionFactoryBase):

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -32,7 +32,7 @@ class CompanyInteractionFactory(InteractionFactoryBase):
 
     kind = Interaction.KINDS.interaction
     company = factory.SubFactory(CompanyFactory)
-    communication_channel_id = constants.InteractionType.face_to_face.value.id
+    communication_channel_id = constants.CommunicationChannel.face_to_face.value.id
 
 
 class InvestmentProjectInteractionFactory(InteractionFactoryBase):
@@ -40,7 +40,7 @@ class InvestmentProjectInteractionFactory(InteractionFactoryBase):
 
     kind = Interaction.KINDS.interaction
     investment_project = factory.SubFactory(InvestmentProjectFactory)
-    communication_channel_id = constants.InteractionType.face_to_face.value.id
+    communication_channel_id = constants.CommunicationChannel.face_to_face.value.id
 
 
 class ServiceDeliveryFactory(InteractionFactoryBase):

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -7,7 +7,7 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
-from datahub.core.constants import InteractionType, Service, Team
+from datahub.core.constants import CommunicationChannel, Service, Team
 from datahub.core.test_utils import APITestMixin, create_test_user, random_obj_for_model
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.models import InteractionPermission, ServiceDeliveryStatus
@@ -71,8 +71,8 @@ class TestGetInteractionView(APITestMixin):
             'is_event': None,
             'service_delivery_status': None,
             'communication_channel': {
-                'id': InteractionType.face_to_face.value.id,
-                'name': InteractionType.face_to_face.value.name
+                'id': CommunicationChannel.face_to_face.value.id,
+                'name': CommunicationChannel.face_to_face.value.name
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),
@@ -136,8 +136,8 @@ class TestGetInteractionView(APITestMixin):
             'is_event': None,
             'service_delivery_status': None,
             'communication_channel': {
-                'id': InteractionType.face_to_face.value.id,
-                'name': InteractionType.face_to_face.value.name
+                'id': CommunicationChannel.face_to_face.value.id,
+                'name': CommunicationChannel.face_to_face.value.name
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),
@@ -206,8 +206,8 @@ class TestGetInteractionView(APITestMixin):
             'is_event': None,
             'service_delivery_status': None,
             'communication_channel': {
-                'id': InteractionType.face_to_face.value.id,
-                'name': InteractionType.face_to_face.value.name
+                'id': CommunicationChannel.face_to_face.value.id,
+                'name': CommunicationChannel.face_to_face.value.name
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),
@@ -296,7 +296,7 @@ class TestAddInteractionView(APITestMixin):
         url = reverse('api-v3:interaction:collection')
         request_data = {
             'kind': 'interaction',
-            'communication_channel': InteractionType.face_to_face.value.id,
+            'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
@@ -316,8 +316,8 @@ class TestAddInteractionView(APITestMixin):
             'is_event': None,
             'service_delivery_status': None,
             'communication_channel': {
-                'id': InteractionType.face_to_face.value.id,
-                'name': InteractionType.face_to_face.value.name
+                'id': CommunicationChannel.face_to_face.value.id,
+                'name': CommunicationChannel.face_to_face.value.name
             },
             'subject': 'whatever',
             'date': '2017-04-18',
@@ -625,7 +625,7 @@ class TestAddInteractionView(APITestMixin):
         request_data = {
             'kind': 'interaction',
             'is_event': False,
-            'communication_channel': InteractionType.face_to_face.value.id,
+            'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
@@ -655,7 +655,7 @@ class TestAddInteractionView(APITestMixin):
         request_data = {
             'kind': 'service_delivery',
             'is_event': True,
-            'communication_channel': InteractionType.face_to_face.value.id,
+            'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
@@ -683,7 +683,7 @@ class TestAddInteractionView(APITestMixin):
         response = self.api_client.post(url, {
             'kind': 'interaction',
             'contact': contact.pk,
-            'communication_channel': InteractionType.face_to_face.value.id,
+            'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
@@ -709,7 +709,7 @@ class TestAddInteractionView(APITestMixin):
         response = self.api_client.post(url, {
             'kind': 'interaction',
             'contact': contact.pk,
-            'communication_channel': InteractionType.face_to_face.value.id,
+            'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': AdviserFactory().pk,
@@ -741,7 +741,7 @@ class TestAddInteractionView(APITestMixin):
         response = self.api_client.post(url, {
             'kind': 'interaction',
             'contact': contact.pk,
-            'communication_channel': InteractionType.face_to_face.value.id,
+            'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': requester.pk,
@@ -773,7 +773,7 @@ class TestAddInteractionView(APITestMixin):
         response = api_client.post(url, {
             'kind': 'interaction',
             'contact': contact.pk,
-            'communication_channel': InteractionType.face_to_face.value.id,
+            'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': requester.pk,
@@ -803,7 +803,7 @@ class TestAddInteractionView(APITestMixin):
             'kind': 'interaction',
             'company': company.pk,
             'contact': contact.pk,
-            'communication_channel': InteractionType.face_to_face.value.id,
+            'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': requester.pk,

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -7,10 +7,12 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
-from datahub.core.constants import CommunicationChannel, Service, Team
+from datahub.core.constants import Service, Team
 from datahub.core.test_utils import APITestMixin, create_test_user, random_obj_for_model
 from datahub.event.test.factories import EventFactory
+from datahub.interaction.constants import CommunicationChannel
 from datahub.interaction.models import InteractionPermission, ServiceDeliveryStatus
+
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory, EventServiceDeliveryFactory, InvestmentProjectInteractionFactory,
     ServiceDeliveryFactory,
@@ -71,8 +73,8 @@ class TestGetInteractionView(APITestMixin):
             'is_event': None,
             'service_delivery_status': None,
             'communication_channel': {
-                'id': CommunicationChannel.face_to_face.value.id,
-                'name': CommunicationChannel.face_to_face.value.name
+                'id': str(interaction.communication_channel.pk),
+                'name': interaction.communication_channel.name
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),
@@ -136,8 +138,8 @@ class TestGetInteractionView(APITestMixin):
             'is_event': None,
             'service_delivery_status': None,
             'communication_channel': {
-                'id': CommunicationChannel.face_to_face.value.id,
-                'name': CommunicationChannel.face_to_face.value.name
+                'id': str(interaction.communication_channel.pk),
+                'name': interaction.communication_channel.name
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),
@@ -206,8 +208,8 @@ class TestGetInteractionView(APITestMixin):
             'is_event': None,
             'service_delivery_status': None,
             'communication_channel': {
-                'id': CommunicationChannel.face_to_face.value.id,
-                'name': CommunicationChannel.face_to_face.value.name
+                'id': str(interaction.communication_channel.pk),
+                'name': interaction.communication_channel.name
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -471,9 +471,9 @@ class TestViews(APITestMixin):
         """Tests filtering interaction by interaction type."""
         CompanyInteractionFactory.create_batch(
             5,
-            communication_channel_id=constants.InteractionType.email_website.value.id
+            communication_channel_id=constants.CommunicationChannel.email_website.value.id
         )
-        communication_channel_id = constants.InteractionType.social_media.value.id
+        communication_channel_id = constants.CommunicationChannel.social_media.value.id
         CompanyInteractionFactory.create_batch(
             5,
             communication_channel_id=communication_channel_id

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -12,6 +12,7 @@ from rest_framework.reverse import reverse
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
 from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.interaction.constants import CommunicationChannel
 from datahub.interaction.models import Interaction
 from datahub.interaction.test.factories import CompanyInteractionFactory, ServiceDeliveryFactory
 from datahub.metadata.test.factories import TeamFactory
@@ -471,9 +472,9 @@ class TestViews(APITestMixin):
         """Tests filtering interaction by interaction type."""
         CompanyInteractionFactory.create_batch(
             5,
-            communication_channel_id=constants.CommunicationChannel.email_website.value.id
+            communication_channel_id=CommunicationChannel.email_website.value.id
         )
-        communication_channel_id = constants.CommunicationChannel.social_media.value.id
+        communication_channel_id = CommunicationChannel.social_media.value.id
         CompanyInteractionFactory.create_batch(
             5,
             communication_channel_id=communication_channel_id


### PR DESCRIPTION
Issue number: N/A

### Description of change

I noticed that the interaction type metadata endpoint was still there. It was replaced by the communication channel endpoint, so this removes the old interaction type one. It also moves the related constants to the same app as the model, and reduces usage of them a bit.

Note: This is a breaking change. The FE was updated some time ago to use the new endpoint, so no further updates should be needed there.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
