### PR TITLE
Avoid double-escaping in OMIS quotes

### DIFF
--- a/datahub/omis/quote/test/test_utils.py
+++ b/datahub/omis/quote/test/test_utils.py
@@ -198,9 +198,7 @@ class TestCalculateQuoteExpiryDate:
 class TestEscapeMarkdown:
     """Tests for the escape_markdown logic."""
 
-    def test_escape(self):
-        """Test that all markdown syntax is escaped."""
-        content = """# noqa: E501
+    CONTENT = """# noqa: E501
 from https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet
 
     Headers
@@ -370,7 +368,9 @@ alt="IMAGE ALT TEXT HERE" width="240" height="180" border="10" /></a>
 [![IMAGE ALT TEXT HERE](http://img.youtube.com/vi/YOUTUBE_VIDEO_ID_HERE/0.jpg)](http://www.youtube.com/watch?v=YOUTUBE_VIDEO_ID_HERE)
 """
 
-        escaped_content = escape_markdown(content)
+    def test_escape_including_html(self):
+        """Test that all markdown syntax is escaped including html chars."""
+        escaped_content = escape_markdown(self.CONTENT)
         expected_content = (
             """\# noqa: E501 """
             """from https://github.com/adam\-p/markdown\-here/wiki/Markdown\-Cheatsheet """
@@ -441,6 +441,88 @@ alt="IMAGE ALT TEXT HERE" width="240" height="180" border="10" /></a>
             """src=&quot;http://img.youtube.com/vi/YOUTUBE\_VIDEO\_ID\_HERE/0.jpg&quot; """
             """alt=&quot;IMAGE ALT TEXT HERE&quot; width=&quot;240&quot; height=&quot;"""
             """180&quot; border=&quot;10&quot; /&gt;&lt;/a&gt; \[!\[IMAGE ALT TEXT HERE\]"""
+            """\(http://img.youtube.com/vi/YOUTUBE\_VIDEO\_ID\_HERE/0.jpg\)\]"""
+            """\(http://www.youtube.com/watch?v=YOUTUBE\_VIDEO\_ID\_HERE\) """
+        )
+        assert escaped_content == expected_content
+
+    def test_escape_excluding_html(self):
+        """
+        Test that all markdown syntax is escaped excluding html characters.
+        This is useful when using templates as Django already escapes html
+        when rendering variables so it would result in escaping them twice.
+        """
+        escaped_content = escape_markdown(self.CONTENT, escape_html=False)
+        expected_content = (
+            """\# noqa: E501 """
+            """from https://github.com/adam\-p/markdown\-here/wiki/Markdown\-Cheatsheet """
+            """Headers \# H1 \#\# H2 \#\#\# H3 \#\#\#\# H4 \#\#\#\#\# H5 \#\#\#\#\#\# H6 """
+            """Alternatively, for H1 and H2, an underline\-ish style: Alt\-H1 """
+            """====== Alt\-H2 \-\-\-\-\-\- Emphasis Emphasis, aka italics, """
+            """with \*asterisks\* or \_underscores\_. Strong emphasis, aka bold, """
+            """with \*\*asterisks\*\* or \_\_underscores\_\_. Combined emphasis with """
+            """\*\*asterisks and \_underscores\_\*\*. Strikethrough uses two tildes. """
+            """\~\~Scratch this.\~\~ Lists 1. First ordered list item 2. Another item """
+            """⋅⋅\* Unordered sub\-list. 1. Actual numbers don't matter, """
+            """just that it's a number ⋅⋅1. Ordered sub\-list 4. And another item. """
+            """⋅⋅⋅You can have properly indented paragraphs within list items. """
+            """Notice the blank line above, and the leading spaces """
+            """\(at least one, but we'll use three here to also align the raw Markdown\). """
+            """⋅⋅⋅To have a line break without a paragraph, you will need to use """
+            """two trailing spaces.⋅⋅ ⋅⋅⋅\(This is contrary to the typical """
+            """GFM line break behaviour, where trailing spaces are not required.\) """
+            """\* Unordered list can use asterisks \- Or minuses \+ Or pluses Links """
+            """\[I'm an inline\-style link\]\(https://www.google.com\) """
+            """\[I'm an inline\-style link with title\]"""
+            """\(https://www.google.com "Google's Homepage"\) """
+            """\[I'm a reference\-style link\]\[Arbitrary case\-insensitive """
+            """reference text\] \[I'm a relative reference to a repository """
+            """file\]\(../blob/master/LICENSE\) \[You can use numbers for reference\-style """
+            """link definitions\]\[1\] Or leave it empty and use the \[link text itself\]. """
+            """URLs and URLs in angle brackets will automatically get turned into links. """
+            """http://www.example.com or <http://www.example.com> and sometimes """
+            """example.com \(but not on Github, for example\). Some text to show that """
+            """the reference links can follow later. \[arbitrary case\-insensitive """
+            """reference text\]: https://www.mozilla.org \[1\]: http://slashdot.org """
+            """\[link text itself\]: http://www.reddit.com Images Here's our """
+            """logo \(hover to see the title text\): Inline\-style: !\[alt text\]"""
+            """\(https://github.com/adam\-p/markdown\-here/raw/master/"""
+            """src/common/images/icon48.png "Logo Title Text 1"\) """
+            """Reference\-style: !\[alt text\]\[logo\] \[logo\]: """
+            """https://github.com/adam\-p/markdown\-here/raw/master/"""
+            """src/common/images/icon48.png "Logo Title Text 2" """
+            """Code and Syntax Highlighting Inline \`code\` has \`back\-ticks around\` """
+            """it. \`\`\`javascript var s = "JavaScript syntax highlighting"; """
+            """alert\(s\); \`\`\` \`\`\`python s = "Python syntax highlighting" """
+            """print s \`\`\` \`\`\` No language indicated, so no syntax highlighting. """
+            """But let's throw in a <b>tag</b>. \`\`\` Tables Colons """
+            """can be used to align columns. | Tables | Are | Cool | """
+            """| \-\-\-\-\-\-\-\-\-\-\-\-\- |:\-\-\-\-\-\-\-\-\-\-\-\-\-:| \-\-\-\-\-:| | """
+            """col 3 is | right\-aligned | $1600 | | col 2 is | centered | $12 | | """
+            """zebra stripes | are neat | $1 | There must be at least 3 """
+            """dashes separating each header cell. The outer pipes \(|\) are optional, """
+            """and you don't need to make the raw Markdown line up prettily. """
+            """You can also use inline Markdown. Markdown | Less | Pretty \-\-\- """
+            """| \-\-\- | \-\-\- \*Still\* | \`renders\` | \*\*nicely\*\* 1 | 2 | 3 """
+            """Blockquotes > This is a very long line that will still be quoted """
+            """properly when it wraps. Oh boy let's keep writing to make sure """
+            """this is long enough to actually wrap for everyone. Oh, you """
+            """can \*put\* \*\*Markdown\*\* into a blockquote. Inline HTML <dl> """
+            """<dt>Definition list</dt> <dd>Is something people """
+            """use sometimes.</dd> <dt>Markdown in HTML</dt> """
+            """<dd>Does \*not\* work \*\*very\*\* well. Use HTML """
+            """<em>tags</em>.</dd> </dl> Horizontal """
+            """Rule Three or more... \-\-\- Hyphens \*\*\* Asterisks \_\_\_ """
+            """Underscores Line Breaks Here's a line for us to start with. """
+            """This line is separated from the one above by two newlines, so it will be """
+            """a \*separate paragraph\*. This line is also a separate paragraph, but... """
+            """This line is only separated by a single newline, so it's a separate """
+            """line in the \*same paragraph\*. YouTube Videos <a """
+            """href="http://www.youtube.com/watch?feature=player\_embedded&"""
+            """v=YOUTUBE\_VIDEO\_ID\_HERE " target="\_blank"><img """
+            """src="http://img.youtube.com/vi/YOUTUBE\_VIDEO\_ID\_HERE/0.jpg" """
+            """alt="IMAGE ALT TEXT HERE" width="240" height=\""""
+            """180" border="10" /></a> \[!\[IMAGE ALT TEXT HERE\]"""
             """\(http://img.youtube.com/vi/YOUTUBE\_VIDEO\_ID\_HERE/0.jpg\)\]"""
             """\(http://www.youtube.com/watch?v=YOUTUBE\_VIDEO\_ID\_HERE\) """
         )

--- a/datahub/omis/quote/utils.py
+++ b/datahub/omis/quote/utils.py
@@ -18,10 +18,14 @@ from .constants import QUOTE_EXPIRY_DAYS_BEFORE_DELIVERY, QUOTE_EXPIRY_DAYS_FROM
 QUOTE_TEMPLATE = PurePath(__file__).parent / 'templates/content.md'
 
 
-def escape_markdown(content):
+def escape_markdown(content, escape_html=True):
     """
     Escape markdown characters so that when it's interpreted
     the converted text is not a valid markdown text.
+
+    :param escape_html: html chars are escaped if True.
+        Django already escapes HTML chars automatically when rendering
+        templates so in those cases escape_html cam be safely set to False
     """
     # escape all markdown chars (e.g. replace * with \*)
     content = re.sub(r'([~_\*#\(\)\[\]`\-\+\\])', r'\\\1', content)
@@ -30,7 +34,8 @@ def escape_markdown(content):
     content = re.sub(r'\s+', r' ', content)
 
     # escape html
-    content = html.escape(content)
+    if escape_html:
+        content = html.escape(content)
 
     return content
 
@@ -73,17 +78,17 @@ def generate_quote_content(order, expires_on):
     return render_to_string(
         QUOTE_TEMPLATE,
         {
-            'order_reference': escape_markdown(order.reference),
-            'company_name': escape_markdown(order.company.name),
-            'order_description': escape_markdown(order.description),
+            'order_reference': escape_markdown(order.reference, escape_html=False),
+            'company_name': escape_markdown(order.company.name, escape_html=False),
+            'order_description': escape_markdown(order.description, escape_html=False),
             'order_delivery_date': order.delivery_date,
             'subtotal_cost': pricing.subtotal_cost,
             'quote_expires_on': expires_on,
-            'company_address': escape_markdown(company_address),
-            'contact_name': escape_markdown(order.contact.name),
+            'company_address': escape_markdown(company_address, escape_html=False),
+            'contact_name': escape_markdown(order.contact.name, escape_html=False),
             'contact_email': order.get_current_contact_email(),
             'generic_contact_email': settings.OMIS_GENERIC_CONTACT_EMAIL,
-            'lead_assignee_name': escape_markdown(lead_assignee.adviser.name)
+            'lead_assignee_name': escape_markdown(lead_assignee.adviser.name, escape_html=False)
         }
     )
 


### PR DESCRIPTION
When generating the content of a quote, the logic was escaping html chars along with markdown ones.

However Django already escapes those chars automatically when rendering variables in templates so this caused them to be escaped twice.

This stops escaping html chars when generating the content of a quote to take advantage of the default Django functionality.

By default the `escape_html` param is True when calling the util function `escape_markdown` so that it does not get misused by mistake.