### PR TITLE
Allow OMIS T&Cs to be changed via admin

### DIFF
--- a/datahub/omis/quote/admin.py
+++ b/datahub/omis/quote/admin.py
@@ -1,0 +1,34 @@
+from django.contrib import admin
+
+from .models import TermsAndConditions
+
+
+@admin.register(TermsAndConditions)
+class TermsAndConditionsAdmin(admin.ModelAdmin):
+    """Admin for TermsAndConditions."""
+
+    fields = (
+        'id',
+        'name',
+        'created_on',
+        'content',
+    )
+    list_display = (
+        'name',
+        'created_on',
+    )
+    readonly_fields = (
+        'id',
+        'created_on',
+    )
+    actions = None
+
+    def has_delete_permission(self, request, obj=None):
+        """Records cannot be deleted."""
+        return False
+
+    def get_readonly_fields(self, request, obj=None):
+        """Records cannot be changed after creation."""
+        if obj and obj.pk:
+            return self.fields
+        return self.readonly_fields

--- a/datahub/omis/quote/migrations/0006_auto_20171107_1355.py
+++ b/datahub/omis/quote/migrations/0006_auto_20171107_1355.py
@@ -18,12 +18,12 @@ class Migration(migrations.Migration):
             name='TermsAndConditions',
             fields=[
                 ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
-                ('created_on', models.DateTimeField(auto_now_add=True, db_index=True)),
+                ('created_on', models.DateTimeField(auto_now_add=True, db_index=True, help_text='Set automatically.')),
                 ('name', models.CharField(help_text='Only used internally.', max_length=100)),
-                ('content', models.TextField()),
+                ('content', models.TextField(help_text='In <a href="https://daringfireball.net/projects/markdown/syntax">Markdown</a>. You can preview the formatted content using an online editor such as <a href="https://dillinger.io/">dillinger.io</a>')),
             ],
             options={
-                'ordering': ('-created_on',),
+                'ordering': ('-created_on',), 'verbose_name_plural': 'terms and conditions'
             },
         ),
         migrations.AddField(

--- a/datahub/omis/quote/models.py
+++ b/datahub/omis/quote/models.py
@@ -19,16 +19,24 @@ class TermsAndConditions(models.Model):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     created_on = models.DateTimeField(
-        db_index=True, auto_now_add=True
+        db_index=True, auto_now_add=True,
+        help_text='Set automatically.'
     )
     name = models.CharField(
         max_length=100,
         help_text='Only used internally.'
     )
-    content = models.TextField()
+    content = models.TextField(
+        help_text=(
+            'In <a href="https://daringfireball.net/projects/markdown/syntax">Markdown</a>. '
+            'You can preview the formatted content using an online editor '
+            'such as <a href="https://dillinger.io/">dillinger.io</a>'
+        )
+    )
 
     class Meta:
         ordering = ('-created_on', )
+        verbose_name_plural = 'terms and conditions'
 
     def __str__(self):
         """Human-readable representation"""

--- a/datahub/omis/quote/templates/admin/omis-quote/termsandconditions/change_form.html
+++ b/datahub/omis/quote/templates/admin/omis-quote/termsandconditions/change_form.html
@@ -1,0 +1,21 @@
+{% extends "admin/change_form.html" %}{% load i18n %}
+
+{% block content %}
+
+<p class="help">
+    {% blocktrans %}Please note that records cannot be changed or deleted after creation.
+    If you want to update the current Terms and Conditions, you need to create a new record.{% endblocktrans %}
+</p>
+<p class="help">
+    {% blocktrans %}The system uses the latest version (based on the created on field) when generating a quote which is then
+    stored against the order and kept permanently.{% endblocktrans %}
+</p>
+{{block.super}}
+{% endblock content %}
+
+
+{% block submit_buttons_bottom %}
+    {% with show_save_and_continue=False %}
+        {% if not change %}{{block.super}}{% endif %}
+    {% endwith %}
+{% endblock %}

--- a/datahub/omis/quote/test/test_admin.py
+++ b/datahub/omis/quote/test/test_admin.py
@@ -1,0 +1,45 @@
+from django.urls import reverse
+from rest_framework import status
+
+from datahub.core.test_utils import AdminTestMixin
+
+from ..models import TermsAndConditions
+
+
+class TestTermsAndConditionsAdmin(AdminTestMixin):
+    """Tests for the TermsAndConditionsAdmin."""
+
+    def test_can_add(self):
+        """Test that terms and conditions records can be added."""
+        url = reverse('admin:omis-quote_termsandconditions_add')
+        data = {'name': 'v1', 'content': 'some content'}
+        response = self.client.post(url, data, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert TermsAndConditions.objects.filter(name='v1').exists()
+
+        terms = TermsAndConditions.objects.get(name='v1')
+        assert terms.content == 'some content'
+
+    def test_cannot_delete(self):
+        """Test that terms and conditions records cannot be deleted."""
+        terms = TermsAndConditions.objects.create(name='vtest', content='lorem ipsum')
+
+        url = reverse('admin:omis-quote_termsandconditions_delete', args=(terms.id,))
+        response = self.client.post(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_cannot_change(self):
+        """Test that terms and conditions records cannot be changed."""
+        terms = TermsAndConditions.objects.create(name='vtest', content='lorem ipsum')
+
+        url = reverse('admin:omis-quote_termsandconditions_change', args=(terms.id,))
+        data = {'name': 'v2', 'content': 'new content'}
+        response = self.client.post(url, data, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        terms.refresh_from_db()
+
+        assert terms.name == 'vtest'
+        assert terms.content == 'lorem ipsum'


### PR DESCRIPTION
This allows TermsAndConditions records to be added via the django admin. 
After creation records cannot be changed or deleted as they might have been used in generated quotes.

<img width="1303" alt="t cs admin" src="https://user-images.githubusercontent.com/178865/35854674-e482d8a2-0b28-11e8-816a-3a1124fc5d17.png">
