### PR TITLE
Notify OMIS regional managers when an order is created

### DIFF
--- a/datahub/omis/notification/constants.py
+++ b/datahub/omis/notification/constants.py
@@ -7,6 +7,7 @@ class Template(Enum):
     generic_order_info = '53055338-6acd-4dd6-b315-d1bd74015eb2'
 
     order_created_for_post_manager = '335f5402-f610-43ef-bfcf-e196215b3cf1'
+    order_created_for_regional_manager = '15a7824a-b179-4ffb-a8a1-74ba89285e20'
     you_have_been_added_for_adviser = '1c631f72-4d33-41f5-ba9b-12862b5b273a'
     you_have_been_removed_for_adviser = '07668530-2dc1-4dde-9a12-9144fc303eb7'
 

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -5,12 +5,14 @@ from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
 
 from datahub.company.test.factories import AdviserFactory
+from datahub.core.constants import UKRegion
 from datahub.core.test_utils import synchronous_executor_submit
 from datahub.omis.market.models import Market
 from datahub.omis.order.test.factories import (
     OrderCompleteFactory, OrderFactory,
     OrderPaidFactory, OrderWithOpenQuoteFactory
 )
+from datahub.omis.region.models import UKRegionalSettings
 
 from ..client import Notify
 
@@ -57,7 +59,15 @@ class TestTemplates:
         market.manager_email = 'test@test.com'
         market.save()
 
-        order = OrderFactory(primary_market_id=market.country.pk)
+        UKRegionalSettings.objects.create(
+            uk_region_id=UKRegion.london.value.id,
+            manager_emails=['reg_test@test.com']
+        )
+
+        order = OrderFactory(
+            primary_market_id=market.country.pk,
+            uk_region_id=UKRegion.london.value.id
+        )
 
         notify.order_created(order)
 


### PR DESCRIPTION
This sends an email to the regional managers of the UK region related to an order when this gets created.