### PR TITLE
Add the ability to pass multiple rules to ValidationRule

### DIFF
--- a/datahub/core/validators.py
+++ b/datahub/core/validators.py
@@ -1,7 +1,8 @@
 from abc import ABC, abstractmethod
+from collections import namedtuple
 from functools import partial
 from operator import eq
-from typing import Any, Callable
+from typing import Any, Callable, Sequence
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -316,13 +317,28 @@ class AnyIsNotBlankRule(BaseRule):
         return any(is_not_blank(combiner[field]) for field in self._fields)
 
 
-class ValidationRule(ConditionalRule):
-    """A rule that is only checked when a condition is met."""
+FieldAndError = namedtuple('FieldAndError', ('field', 'error_key'))
+
+
+class AbstractValidationRule(ABC):
+    """Abstract base class for RulesBasedValidator validation rules."""
+
+    @abstractmethod
+    def __call__(self, combiner) -> Sequence[FieldAndError]:
+        """Performs validation, returning a list of errors."""
+
+
+class ValidationRule(AbstractValidationRule):
+    """
+    A simple validation rule, taking a list of rules that must be met if a condition is also met.
+
+    Used with RulesBasedValidator.
+    """
 
     def __init__(self,
                  error_key: str,
-                 rule: OperatorRule,
-                 when: OperatorRule=None):
+                 *rules: AbstractRule,
+                 when: AbstractRule=None):
         """
         Initialises a validation rule.
 
@@ -331,25 +347,30 @@ class ValidationRule(ConditionalRule):
         :param when:      Optional conditional rule to check before applying this rule.
                           If the condition evaluates to False, validation passes.
         """
-        super().__init__(rule, when=when)
-        self.error_key = error_key
+        self._rules = [ConditionalRule(rule, when=when) for rule in rules]
+        self._error_key = error_key
+
+    def __call__(self, combiner) -> Sequence[FieldAndError]:
+        """Performs validation, returning a list of errors."""
+        errors = []
+        for rule in self._rules:
+            if not rule(combiner):
+                errors.append(FieldAndError(rule.field, self._error_key))
+        return errors
 
     def __repr__(self):
         """Returns the Python representation of this object."""
-        return (
-            f'{self.__class__.__name__}({self.error_key!r}, {self._rule!r}, '
-            f'when={self._condition!r})'
-        )
+        return f'{self.__class__.__name__}({self._error_key!r}, {self._rules!r})'
 
 
 class RulesBasedValidator:
     """
     Class-level DRF validator for cross-field validation.
 
-    Validation is performed using rules (instances of ValidationRule).
+    Validation is performed using rules (instances of AbstractValidationRule).
     """
 
-    def __init__(self, *rules: ValidationRule):
+    def __init__(self, *rules: AbstractValidationRule):
         """
         Initialises the validator with rules.
         """
@@ -370,9 +391,10 @@ class RulesBasedValidator:
             model=self._serializer.Meta.model,
         )
         for rule in self._rules:
-            if not rule(combiner):
-                fields_errors = errors.setdefault(rule.field, [])
-                fields_errors.append(self._serializer.error_messages[rule.error_key])
+            rule_errors = rule(combiner)
+            for error in rule_errors:
+                fields_errors = errors.setdefault(error.field, [])
+                fields_errors.append(self._serializer.error_messages[error.error_key])
 
         if errors:
             raise serializers.ValidationError(errors)

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -117,20 +117,8 @@ class InteractionSerializer(serializers.ModelSerializer):
                 ValidationRule(
                     'invalid_for_interaction',
                     OperatorRule('is_event', is_blank),
-                    when=EqualsRule('kind', Interaction.KINDS.interaction),
-                ),
-                ValidationRule(
-                    'invalid_for_interaction',
                     OperatorRule('service_delivery_status', is_blank),
-                    when=EqualsRule('kind', Interaction.KINDS.interaction),
-                ),
-                ValidationRule(
-                    'invalid_for_interaction',
                     OperatorRule('grant_amount_offered', is_blank),
-                    when=EqualsRule('kind', Interaction.KINDS.interaction),
-                ),
-                ValidationRule(
-                    'invalid_for_interaction',
                     OperatorRule('net_company_receipt', is_blank),
                     when=EqualsRule('kind', Interaction.KINDS.interaction),
                 ),


### PR DESCRIPTION
Issue number: 

### Description of change

This changes ValidationRule so that it's possible to return more than one error from it, and makes it possible to pass more than one rule to it. In turn that made it possible to simplify the interaction validation rules.

I think the generalisation of ValidationRule is a good step, but there might be scope to improve the design.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
