### PR TITLE
Add dbmaintenance command to update adviser contact email addresses

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_adviser_contact_email.py
+++ b/datahub/dbmaintenance/management/commands/update_adviser_contact_email.py
@@ -1,0 +1,37 @@
+import reversion
+
+from datahub.company.models import Advisor
+from datahub.dbmaintenance.utils import parse_email, parse_uuid
+from ..base import CSVBaseCommand
+
+
+class Command(CSVBaseCommand):
+    """Command to update the contact_email for advisers."""
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        super().add_arguments(parser)
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            default=False,
+            help='If True it only simulates the command without saving the changes.',
+        )
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        pk = parse_uuid(row['id'])
+        contact_email = parse_email(row['contact_email'])
+        adviser = Advisor.objects.get(pk=pk)
+
+        if adviser.contact_email == contact_email:
+            return
+
+        adviser.contact_email = contact_email
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            adviser.save(update_fields=('contact_email',))
+            reversion.set_comment('Loaded contact email from spreadsheet.')

--- a/datahub/dbmaintenance/test/commands/test_update_adviser_contact_email.py
+++ b/datahub/dbmaintenance/test/commands/test_update_adviser_contact_email.py
@@ -1,0 +1,152 @@
+from io import BytesIO
+
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.company.test.factories import AdviserFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('ERROR')
+
+    advisers = [
+        AdviserFactory(contact_email='adviser0@test.com'),
+        AdviserFactory(contact_email='adviser1@test.com'),
+        AdviserFactory(contact_email='adviser2@test.com'),
+        AdviserFactory(contact_email=''),
+        AdviserFactory(contact_email='adviser4@test.com'),
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,contact_email
+00000000-0000-0000-0000-000000000000,adviser9@test.com
+{advisers[0].id},invalid_email
+{advisers[1].id},adviser1changed@test.com
+{advisers[2].id},adviser2@test.com
+{advisers[3].id},adviser3changed@test.com
+{advisers[4].id},
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_adviser_contact_email', bucket, object_key)
+
+    assert len(caplog.records) == 2
+    assert 'Advisor matching query does not exist' in caplog.text
+    assert 'Enter a valid email address' in caplog.text
+
+    for adviser in advisers:
+        adviser.refresh_from_db()
+
+    expected_emails = [
+        'adviser0@test.com', 'adviser1changed@test.com', 'adviser2@test.com',
+        'adviser3changed@test.com', '',
+    ]
+    assert [adviser.contact_email for adviser in advisers] == expected_emails
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+
+    advisers = [
+        AdviserFactory(contact_email='adviser0@test.com'),
+        AdviserFactory(contact_email='adviser1@test.com'),
+        AdviserFactory(contact_email='adviser2@test.com'),
+        AdviserFactory(contact_email=''),
+        AdviserFactory(contact_email='adviser4@test.com'),
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,contact_email
+00000000-0000-0000-0000-000000000000,adviser9@test.com
+{advisers[0].id},invalid_email
+{advisers[1].id},adviser1changed@test.com
+{advisers[2].id},adviser2@test.com
+{advisers[3].id},adviser3changed@test.com
+{advisers[4].id},
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_adviser_contact_email', bucket, object_key, simulate=True)
+
+    assert len(caplog.records) == 2
+    assert 'Advisor matching query does not exist' in caplog.text
+    assert 'Enter a valid email address' in caplog.text
+
+    for adviser in advisers:
+        adviser.refresh_from_db()
+
+    expected_emails = [
+        'adviser0@test.com', 'adviser1@test.com', 'adviser2@test.com', '', 'adviser4@test.com',
+
+    ]
+    assert [adviser.contact_email for adviser in advisers] == expected_emails
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    advisers = [
+        AdviserFactory(contact_email='adviser0@test.com'),
+        AdviserFactory(contact_email='adviser1@test.com'),
+        AdviserFactory(contact_email='adviser2@test.com'),
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,contact_email
+{advisers[0].id},invalid_email
+{advisers[1].id},adviser1changed@test.com
+{advisers[2].id},adviser2@test.com
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_adviser_contact_email', bucket, object_key)
+
+    for adviser in advisers:
+        adviser.refresh_from_db()
+
+    versions = Version.objects.get_for_object(advisers[0])
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(advisers[1])
+    assert versions.count() == 1
+    assert versions[0].revision.comment == 'Loaded contact email from spreadsheet.'
+
+    versions = Version.objects.get_for_object(advisers[2])
+    assert versions.count() == 0

--- a/datahub/dbmaintenance/utils.py
+++ b/datahub/dbmaintenance/utils.py
@@ -1,4 +1,4 @@
-from rest_framework.fields import BooleanField, DateField, UUIDField
+from rest_framework.fields import BooleanField, DateField, EmailField, UUIDField
 
 
 def parse_bool(value):
@@ -9,6 +9,11 @@ def parse_bool(value):
 def parse_date(value):
     """Parses a date from a string."""
     return _parse_value(value, DateField())
+
+
+def parse_email(value):
+    """Parses an email address from a string."""
+    return _parse_value(value, EmailField(), blank_value='')
 
 
 def parse_uuid(value):
@@ -26,8 +31,9 @@ def parse_uuid_list(value):
     return [field.to_internal_value(item) for item in value.split(',')]
 
 
-def _parse_value(value, field):
+def _parse_value(value, field, blank_value=None):
     if not value or value.lower().strip() == 'null':
-        return None
+        return blank_value
 
+    field.run_validation(value)
     return field.to_internal_value(value)


### PR DESCRIPTION
Issue number: N/A

### Description of change

Adds a command to update the contact_email field for advisers.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
