### PR TITLE
Add community interest company as a business type

### DIFF
--- a/datahub/company/constants.py
+++ b/datahub/company/constants.py
@@ -34,3 +34,6 @@ class BusinessTypeConstant(Enum):
     uk_establishment = Constant(
         'UK branch of foreign company (BR)', 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98'
     )
+    community_interest_company = Constant(
+        'Community interest company', '34e4cb83-e5e1-421e-ac90-8a52edcc209c'
+    )


### PR DESCRIPTION
Issue number: DH-1532

### Description of change

Adds community interest company as a business type. This is to allow community interest companies to be added via their Companies House record.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
