### PR TITLE
Update various dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -18,11 +18,11 @@ pyyaml==3.12
 python-dateutil==2.6.1
 
 # Persistency layer
-psycopg2==2.7.3.2
+psycopg2==2.7.4
 
-boto3==1.5.22
+boto3==1.5.30
 
-notifications-python-client==4.7.1
+notifications-python-client==4.7.2
 
 # ES
 elasticsearch==5.5.2
@@ -32,10 +32,10 @@ aws-requests-auth==0.4.1
 # Testing and dev
 pytest==3.3.2
 pytest-django==3.1.2
-pytest-sugar==0.9.0
+pytest-sugar==0.9.1
 pytest-cov==2.5.1
 ipython==6.2.1
-ipdb==0.10.3
+ipdb==0.11
 factory-boy==2.10.0
 freezegun==0.3.9
 requests-mock==1.4.0
@@ -46,10 +46,10 @@ pip-tools==1.11.0
 # Code static analysis
 flake8==3.5.0
 flake8-blind-except==0.1.1
-flake8-debugger==3.0.0
+flake8-debugger==3.1.0
 flake8-import-order==0.14.3
 flake8-docstrings==1.3.0
-flake8-print==3.0.1
+flake8-print==3.1.0
 flake8-quotes==0.13.0
 flake8-string-format==0.2.3
 pep8-naming==0.5.0

--- a/requirements.in
+++ b/requirements.in
@@ -30,7 +30,7 @@ elasticsearch-dsl==5.4.0
 aws-requests-auth==0.4.1
 
 # Testing and dev
-pytest==3.3.2
+pytest==3.4.0
 pytest-django==3.1.2
 pytest-sugar==0.9.1
 pytest-cov==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,15 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-asttokens==1.1.8          # via flake8-import-order
+asttokens==1.1.9          # via flake8-import-order
 attrs==17.4.0             # via pytest
 aws-requests-auth==0.4.1
-boto3==1.5.22
-botocore==1.8.36          # via boto3, s3transfer
+boto3==1.5.30
+botocore==1.8.44          # via boto3, s3transfer
 certifi==2018.1.18        # via requests
 chardet==3.0.4            # via chardet, requests
 click==6.7                # via click, pip-tools
-coverage==4.4.2           # via pytest-cov
+coverage==4.5.1           # via pytest-cov
 cssselect==1.0.3
 decorator==4.2.1          # via ipython, traitlets
 django-debug-toolbar==1.9.1
@@ -30,14 +30,14 @@ docutils==0.14            # via botocore, docutils
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.2
 factory-boy==2.10.0
-faker==0.8.10             # via factory-boy
+faker==0.8.11             # via factory-boy
 first==2.0.1              # via first, pip-tools
 flake8-blind-except==0.1.1
-flake8-debugger==3.0.0
+flake8-debugger==3.1.0
 flake8-docstrings==1.3.0
 flake8-import-order==0.14.3
 flake8-polyfill==1.0.2    # via flake8-docstrings, pep8-naming
-flake8-print==3.0.1
+flake8-print==3.1.0
 flake8-quotes==0.13.0
 flake8-string-format==0.2.3
 flake8==3.5.0
@@ -47,7 +47,7 @@ gevent==1.2.2
 greenlet==0.4.13          # via gevent
 gunicorn==19.7.1
 idna==2.6                 # via idna, requests
-ipdb==0.10.3
+ipdb==0.11
 ipython-genutils==0.2.0   # via ipython-genutils, traitlets
 ipython==6.2.1
 jedi==0.11.1              # via ipython
@@ -55,16 +55,16 @@ jmespath==0.9.3           # via boto3, botocore, jmespath
 lxml==4.1.1
 mccabe==0.6.1             # via flake8, mccabe
 monotonic==1.4            # via notifications-python-client
-notifications-python-client==4.7.1
+notifications-python-client==4.7.2
 oauthlib==2.0.6           # via django-oauth-toolkit
 parso==0.1.1              # via jedi
 pep8-naming==0.5.0
-pexpect==4.3.1            # via ipython
+pexpect==4.4.0            # via ipython
 pickleshare==0.7.4        # via ipython, pickleshare
 pip-tools==1.11.0
 pluggy==0.6.0             # via pytest
 prompt-toolkit==1.0.15    # via ipython, prompt-toolkit
-psycopg2==2.7.3.2
+psycopg2==2.7.4
 ptyprocess==0.5.2         # via pexpect, ptyprocess
 py==1.5.2                 # via pytest
 pycodestyle==2.3.1        # via flake8, flake8-debugger, flake8-import-order, flake8-print, pycodestyle
@@ -74,16 +74,16 @@ pygments==2.2.0           # via ipython, pygments
 pyjwt==1.5.3              # via notifications-python-client, pyjwt
 pytest-cov==2.5.1
 pytest-django==3.1.2
-pytest-sugar==0.9.0
+pytest-sugar==0.9.1
 pytest==3.3.2
 python-dateutil==2.6.1
-pytz==2017.3              # via django
+pytz==2018.3              # via django
 pyyaml==3.12
 raven==6.5.0
 requests-mock==1.4.0
 requests==2.18.4
 requests_toolbelt==0.8.0
-s3transfer==0.1.12        # via boto3
+s3transfer==0.1.13        # via boto3
 simplegeneric==0.8.1      # via ipython, simplegeneric
 six==1.11.0               # via asttokens, django-environ, django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, pip-tools, prompt-toolkit, pydocstyle, pytest, python-dateutil, requests-mock, six, traitlets
 snowballstemmer==1.2.1    # via pydocstyle, snowballstemmer

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ pyjwt==1.5.3              # via notifications-python-client, pyjwt
 pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-sugar==0.9.1
-pytest==3.3.2
+pytest==3.4.0
 python-dateutil==2.6.1
 pytz==2018.3              # via django
 pyyaml==3.12


### PR DESCRIPTION
Issue number: N/A

### Description of change

Various dependency updates, including pytest 3.4.0.

https://docs.pytest.org/en/latest/changelog.html
http://initd.org/psycopg/docs/news.html
https://github.com/boto/boto3/blob/develop/CHANGELOG.rst
https://github.com/Frozenball/pytest-sugar/blob/master/CHANGES.rst
https://github.com/gotcha/ipdb/blob/master/HISTORY.txt
https://github.com/JBKahn/flake8-debugger/releases
https://github.com/JBKahn/flake8-print/releases

There's nothing [in the change log for notifications-python-client](https://github.com/alphagov/notifications-python-client/blob/master/CHANGELOG.md), it looks like just Flake8 fixes.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
