### PR TITLE
Add investment project search adviser filter

### DIFF
--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -11,6 +11,7 @@ from ..serializers import (
 class SearchInvestmentProjectSerializer(SearchSerializer):
     """Serialiser used to validate investment project search POST bodies."""
 
+    adviser = SingleOrListField(child=StringUUIDField(), required=False)
     client_relationship_manager = SingleOrListField(child=StringUUIDField(), required=False)
     created_on_after = RelaxedDateTimeField(required=False)
     created_on_before = RelaxedDateTimeField(required=False)

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -14,6 +14,7 @@ class SearchInvestmentProjectParams:
     include_aggregations = True
 
     FILTER_FIELDS = (
+        'adviser',
         'client_relationship_manager',
         'created_on_after',
         'created_on_before',
@@ -38,6 +39,16 @@ class SearchInvestmentProjectParams:
         'sector': 'sector.id',
         'stage': 'stage.id',
         'uk_region_location': 'uk_region_locations.id',
+    }
+
+    COMPOSITE_FILTERS = {
+        'adviser': [
+            'created_by.id',
+            'client_relationship_manager.id',
+            'project_assurance_adviser.id',
+            'project_manager.id',
+            'team_members.id',
+        ],
     }
 
 


### PR DESCRIPTION
Issue number: DH-1550

### Description of change

Adds a composite adviser filter to investment project search.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
