### PR TITLE
Fix Investment Projects repeated in the results.

### DIFF
--- a/datahub/investment/permissions.py
+++ b/datahub/investment/permissions.py
@@ -150,7 +150,7 @@ class IsAssociatedToInvestmentProjectFilter(BaseFilterBackend):
             full_field_name = (f'{field_prefix}{field.field_name}__'
                                f'{field.subfield_name}__dit_team_id')
             query |= Q(**{full_field_name: value})
-        return queryset.filter(query)
+        return queryset.filter(query).distinct()
 
     def _get_filter_field_prefix(self):
         return f'{self.model_attribute}__' if self.model_attribute else ''


### PR DESCRIPTION
Issue number: DH-1547

### Description of change

If Investment Project has multiple members from the same team associated to it, listing of such investment project by the user with limited rights (`InvestmentProjectPermission.read_associated`) would result in investment projects being repeated by the number of team members associated to it.

This modifies the query in `IsAssociatedToInvestmentProjectFilter` ensuring that investment projects returned by the query are distinct.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
