### PR TITLE
Register models with reversion via decorator

### DIFF
--- a/datahub/company/admin.py
+++ b/datahub/company/admin.py
@@ -1,7 +1,8 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from reversion.admin import VersionAdmin
 
-from datahub.core.admin import BaseModelVersionAdmin, DisabledOnFilter, ReadOnlyAdmin
+from datahub.core.admin import DisabledOnFilter, ReadOnlyAdmin
 from .models import Advisor, CompaniesHouseCompany, Company, Contact, ExportExperienceCategory
 
 
@@ -17,7 +18,7 @@ class MetadataAdmin(admin.ModelAdmin):
 
 
 @admin.register(Company)
-class CompanyAdmin(BaseModelVersionAdmin):
+class CompanyAdmin(VersionAdmin):
     """Company admin."""
 
     search_fields = (
@@ -45,7 +46,7 @@ class CompanyAdmin(BaseModelVersionAdmin):
 
 
 @admin.register(Contact)
-class ContactAdmin(BaseModelVersionAdmin):
+class ContactAdmin(VersionAdmin):
     """Contact admin."""
 
     search_fields = (
@@ -79,10 +80,9 @@ class CHCompany(ReadOnlyAdmin):
 
 
 @admin.register(Advisor)
-class AdviserAdmin(BaseModelVersionAdmin, UserAdmin):
+class AdviserAdmin(VersionAdmin, UserAdmin):
     """Adviser admin."""
 
-    reversion_excluded_fields = BaseModelVersionAdmin.reversion_excluded_fields + ('last_login',)
     fieldsets = (
         (None, {
             'fields': (

--- a/datahub/company/models/adviser.py
+++ b/datahub/company/models/adviser.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from django.utils.timezone import now
 
+from datahub.core import reversion
 from datahub.core.utils import join_truthy_strings
 from datahub.metadata import models as metadata_models
 
@@ -47,6 +48,7 @@ class AdviserManager(BaseUserManager):
         return self._create_user(email, password, **extra_fields)
 
 
+@reversion.register_base_model(extra_exclude=('last_login',))
 class Advisor(AbstractBaseUser, PermissionsMixin):
     """Adviser model.
 

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.functional import cached_property
 
-from datahub.core import constants
+from datahub.core import constants, reversion
 from datahub.core.models import ArchivableModel, BaseConstantModel, BaseModel
 from datahub.core.utils import StrEnum
 from datahub.metadata import models as metadata_models
@@ -51,6 +51,7 @@ class CompanyAbstract(models.Model):
         return self.name
 
 
+@reversion.register_base_model()
 class Company(ArchivableModel, BaseModel, CompanyAbstract):
     """Representation of the company as per CDMS."""
 

--- a/datahub/company/models/contact.py
+++ b/datahub/company/models/contact.py
@@ -3,6 +3,7 @@ import uuid
 from django.conf import settings
 from django.db import models
 
+from datahub.core import reversion
 from datahub.core.models import ArchivableModel, BaseModel
 from datahub.core.utils import StrEnum
 from datahub.metadata import models as metadata_models
@@ -17,6 +18,7 @@ class ContactPermission(StrEnum):
     read_contact_document = 'read_contact_document'
 
 
+@reversion.register_base_model()
 class Contact(ArchivableModel, BaseModel):
     """Contact from CDMS."""
 

--- a/datahub/core/admin.py
+++ b/datahub/core/admin.py
@@ -1,7 +1,6 @@
 from collections import OrderedDict
 
 from django.contrib import admin
-from reversion.admin import VersionAdmin
 
 
 class DisabledOnFilter(admin.SimpleListFilter):
@@ -24,41 +23,6 @@ class DisabledOnFilter(admin.SimpleListFilter):
             is_disabled = True if value == 'yes' else False
             return queryset.filter(disabled_on__isnull=(not is_disabled))
         return queryset
-
-
-class ConfigurableVersionAdmin(VersionAdmin):
-    """
-    Subclass of VersionAdmin that allows the excluded model fields for django-reversion
-    to be easily set.
-
-    This is in line with the example on:
-    https://django-reversion.readthedocs.io/en/stable/admin.html#reversion-admin-versionadmin
-
-    Excluded fields are not saved in django-reversion versions.
-
-    This is set in the admin class because we're using django-reversion auto-registration
-    via VersionAdmin.
-    """
-
-    reversion_excluded_fields = None
-
-    def reversion_register(self, model, **options):
-        """Used the the django-reversion model auto-registration mechanism."""
-        if self.reversion_excluded_fields:
-            options['exclude'] = self.reversion_excluded_fields
-        super().reversion_register(model, **options)
-
-
-class BaseModelVersionAdmin(ConfigurableVersionAdmin):
-    """
-    VersionAdmin subclass that excludes fields defined on BaseModel.
-
-    These aren't particularly useful to save in django-reversion versions because
-    created_by/created_on will not change between versions, and modified_on/modified_by
-    is tracked by django-reversion separately in revisions.
-    """
-
-    reversion_excluded_fields = ('created_on', 'created_by', 'modified_on', 'modified_by')
 
 
 class ReadOnlyAdmin(admin.ModelAdmin):

--- a/datahub/core/reversion.py
+++ b/datahub/core/reversion.py
@@ -1,0 +1,34 @@
+import reversion
+
+EXCLUDED_BASE_MODEL_FIELDS = ('created_on', 'created_by', 'modified_on', 'modified_by')
+
+
+def register_base_model(extra_exclude=None, **kwargs):
+    """
+    Shortcut to reversion.register() which excludes some fields defined on BaseModel
+    by default.
+
+    These aren't particularly useful to save in django-reversion versions because
+    created_by/created_on will not change between versions, and modified_on/modified_by
+    is tracked by django-reversion separately in revisions.
+
+    :param extra_exclude: list of "extra" fields to exclude along with the default ones
+    :param kwargs: same as the reversion.register ones
+
+    Note: if you pass `exclude` you override the default excluded fields. You cannot use
+        exclude and extra_exclude at the same time as they are mutual exclusive.
+
+    Note: if you remove this decorator from a model, VersionAdmin must be removed
+    as well otherwise the model will be auto-registered automatically.
+    """
+    assert 'exclude' not in kwargs or not extra_exclude, (
+        "You can't pass in extra_exclude and exclude at the same time."
+    )
+
+    if 'exclude' not in kwargs:
+        kwargs['exclude'] = (
+            *EXCLUDED_BASE_MODEL_FIELDS,
+            *(extra_exclude or ())
+        )
+
+    return reversion.register(**kwargs)

--- a/datahub/core/test/test_reversion.py
+++ b/datahub/core/test/test_reversion.py
@@ -1,0 +1,49 @@
+from unittest import mock
+import pytest
+
+from ..reversion import EXCLUDED_BASE_MODEL_FIELDS, register_base_model
+
+
+class TestRegisterBaseModel:
+    """Tests for the `register_base_model` decorator."""
+
+    @mock.patch('datahub.core.reversion.reversion')
+    def test_without_args(self, mocked_reversion):
+        """Test that the default exclude is used if no argument is passed in."""
+        register_base_model()
+        assert mocked_reversion.register.call_args_list == [
+            mock.call(exclude=EXCLUDED_BASE_MODEL_FIELDS)
+        ]
+
+    @mock.patch('datahub.core.reversion.reversion')
+    def test_with_extra_exclude(self, mocked_reversion):
+        """Test that if extra_exclude is passed in, it is appended to the default exclude list."""
+        register_base_model(extra_exclude=('other',))
+        assert mocked_reversion.register.call_args_list == [
+            mock.call(exclude=(*EXCLUDED_BASE_MODEL_FIELDS, 'other'))
+        ]
+
+    @mock.patch('datahub.core.reversion.reversion')
+    def test_with_explicit_exclude(self, mocked_reversion):
+        """Test that if exclude is passed in, it overrides the default one."""
+        register_base_model(exclude=('other',))
+        assert mocked_reversion.register.call_args_list == [
+            mock.call(exclude=('other',))
+        ]
+
+    @mock.patch('datahub.core.reversion.reversion')
+    def test_fails_with_extra_exclude_and_exclude(self, mocked_reversion):
+        """Test that extra_exclude and exclude cannot be passed in at the same time."""
+        with pytest.raises(AssertionError):
+            register_base_model(exclude=('other',), extra_exclude=('other',))
+
+    @mock.patch('datahub.core.reversion.reversion')
+    def test_with_other_args(self, mocked_reversion):
+        """Test passing any other argument forwards it untouched."""
+        register_base_model(ignore_duplicates=False)
+        assert mocked_reversion.register.call_args_list == [
+            mock.call(
+                exclude=EXCLUDED_BASE_MODEL_FIELDS,
+                ignore_duplicates=False
+            )
+        ]

--- a/datahub/event/admin.py
+++ b/datahub/event/admin.py
@@ -4,8 +4,9 @@ from django.contrib import admin
 from django.contrib.admin import DateFieldListFilter, helpers
 from django.template.response import TemplateResponse
 from django.utils.timezone import now
+from reversion.admin import VersionAdmin
 
-from datahub.core.admin import BaseModelVersionAdmin, DisabledOnFilter
+from datahub.core.admin import DisabledOnFilter
 from datahub.event.models import Event, EventType, LocationType, Programme
 
 
@@ -38,7 +39,7 @@ def confirm_action(title, action_message):
 
 
 @admin.register(Event)
-class EventAdmin(BaseModelVersionAdmin):
+class EventAdmin(VersionAdmin):
     """Admin for Events."""
 
     fields = (

--- a/datahub/event/models.py
+++ b/datahub/event/models.py
@@ -3,11 +3,13 @@ import uuid
 from django.conf import settings
 from django.db import models
 
+from datahub.core import reversion
 from datahub.core.models import BaseConstantModel, BaseModel, DisableableModel
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
 
+@reversion.register_base_model()
 class Event(BaseModel, DisableableModel):
     """An event (exhibition etc.)"""
 

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -1,8 +1,7 @@
 from django.contrib import admin
+from reversion.admin import VersionAdmin
 
-from datahub.core.admin import (
-    BaseModelVersionAdmin, custom_add_permission, custom_change_permission, DisabledOnFilter
-)
+from datahub.core.admin import custom_add_permission, custom_change_permission, DisabledOnFilter
 from datahub.interaction.models import InteractionPermission
 from .models import CommunicationChannel, Interaction
 
@@ -21,7 +20,7 @@ class MetadataAdmin(admin.ModelAdmin):
 @admin.register(Interaction)
 @custom_add_permission(InteractionPermission.add_all)
 @custom_change_permission(InteractionPermission.change_all)
-class InteractionAdmin(BaseModelVersionAdmin):
+class InteractionAdmin(VersionAdmin):
     """Interaction admin."""
 
     search_fields = (

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.db import models
 from model_utils import Choices
 
+from datahub.core import reversion
 from datahub.core.models import BaseConstantModel, BaseModel, BaseOrderedConstantModel
 from datahub.core.utils import StrEnum
 
@@ -66,6 +67,7 @@ class ServiceDeliveryStatus(BaseOrderedConstantModel):
     """
 
 
+@reversion.register_base_model()
 class Interaction(BaseModel):
     """Interaction."""
 

--- a/datahub/investment/admin.py
+++ b/datahub/investment/admin.py
@@ -1,9 +1,10 @@
 """Admin registration for investment models."""
 
 from django.contrib import admin
+from reversion.admin import VersionAdmin
 
 from datahub.core.admin import (
-    BaseModelVersionAdmin, custom_add_permission, custom_change_permission,
+    custom_add_permission, custom_change_permission,
     custom_delete_permission, DisabledOnFilter,
 )
 from datahub.investment.models import (
@@ -20,7 +21,7 @@ from datahub.investment.models import (
 
 @admin.register(InvestmentProject)
 @custom_change_permission(InvestmentProjectPermission.change_all)
-class InvestmentProjectAdmin(BaseModelVersionAdmin):
+class InvestmentProjectAdmin(VersionAdmin):
     """Investment project admin."""
 
     search_fields = (
@@ -58,7 +59,7 @@ class InvestmentProjectAdmin(BaseModelVersionAdmin):
 @custom_add_permission(InvestmentProjectPermission.change_all)
 @custom_change_permission(InvestmentProjectPermission.change_all)
 @custom_delete_permission(InvestmentProjectPermission.change_all)
-class InvestmentProjectTeamMemberAdmin(BaseModelVersionAdmin):
+class InvestmentProjectTeamMemberAdmin(VersionAdmin):
     """Investment project team member admin."""
 
     raw_id_fields = (

--- a/datahub/investment/models.py
+++ b/datahub/investment/models.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models, transaction
 from model_utils import Choices
 
+from datahub.core import reversion
 from datahub.core.constants import InvestmentProjectStage
 from datahub.core.models import (
     ArchivableModel,
@@ -341,6 +342,7 @@ _AssociatedToManyField = namedtuple(
 )
 
 
+@reversion.register_base_model()
 class InvestmentProject(ArchivableModel, IProjectAbstract,
                         IProjectValueAbstract, IProjectRequirementsAbstract,
                         IProjectTeamAbstract, BaseModel):
@@ -421,6 +423,7 @@ class InvestmentProject(ArchivableModel, IProjectAbstract,
                     yield adviser
 
 
+@reversion.register_base_model()
 class InvestmentProjectTeamMember(models.Model):
     """Intermediary M2M model for investment project team members.
 


### PR DESCRIPTION
Before we were relying on the `reversion.admin.VersionAdmin` logic which auto-registers models automatically.
This was not very safe as we are using reversion not only in the admin but in many other places (e.g. endpoints) as well.

This removes the registration via admin and replaces it with explicitly registering the models with reversion.

As a result, `BaseModelVersionAdmin` and `ConfigurableVersionAdmin` are not needed any more.