### PR TITLE
Add limited liability partnership as a business type

### DIFF
--- a/datahub/company/constants.py
+++ b/datahub/company/constants.py
@@ -21,6 +21,9 @@ class BusinessTypeConstant(Enum):
     limited_partnership = Constant(
         'Limited partnership', '8b6eaf7e-03e7-e611-bca1-e4115bead28a'
     )
+    limited_liability_partnership = Constant(
+        'Limited liability partnership', 'b70764b9-e523-46cf-8297-4c694ecbc5ce',
+    )
     partnership = Constant('Partnership', '9ad14e94-5d95-e211-a939-e4115bead28a')
     sole_trader = Constant('Sole Trader', '99d14e94-5d95-e211-a939-e4115bead28a')
     private_limited_company = Constant(


### PR DESCRIPTION
Issue number: DH-1575

### Description of change

Adds limited liability partnerships as a business type. This is to allow limited liability partnerships to be added via their Companies House record. (Limited liability partnerships are different from limited partnerships.)

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
