### PR TITLE
[MI-1413] Add support for Policy Interaction Kind

### DIFF
--- a/datahub/core/test/test_validators.py
+++ b/datahub/core/test/test_validators.py
@@ -12,6 +12,7 @@ from datahub.core.validators import (
     ConditionalRule,
     EqualsRule,
     FieldAndError,
+    InRule,
     OperatorRule,
     RequiredUnlessAlreadyBlankValidator,
     RulesBasedValidator,
@@ -191,6 +192,17 @@ def test_equals_rule(data, field, test_value, res):
     """Tests ValidationCondition for various cases."""
     combiner = Mock(spec_set=DataCombiner, __getitem__=lambda self, field_: data[field_])
     condition = EqualsRule(field, test_value)
+    assert condition(combiner) == res
+
+
+@pytest.mark.parametrize('data,field,test_value,res', (
+    ({'colour': 'red'}, 'colour', ['red', 'green'], True),
+    ({'colour': 'red'}, 'colour', ['blue', 'green'], False),
+))
+def test_in_rule(data, field, test_value, res):
+    """Tests InRule for various cases."""
+    combiner = Mock(spec_set=DataCombiner, __getitem__=lambda self, field_: data[field_])
+    condition = InRule(field, test_value)
     assert condition(combiner) == res
 
 

--- a/datahub/core/validators.py
+++ b/datahub/core/validators.py
@@ -1,8 +1,8 @@
 from abc import ABC, abstractmethod
 from collections import namedtuple
 from functools import partial
-from operator import eq
-from typing import Any, Callable, Sequence
+from operator import contains, eq
+from typing import Any, Callable, Iterable, Sequence
 
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
@@ -248,6 +248,19 @@ class EqualsRule(OperatorRule):
         :param value: Value to test equality with.
         """
         super().__init__(field, partial(eq, value))
+
+
+class InRule(OperatorRule):
+    """Contains operator-based rule for a field. Checks that field value is in values"""
+
+    def __init__(self, field: str, value: Iterable[Any]):
+        """
+        Initialises the rule.
+
+        :param field: The name of the field the rule applies to.
+        :param value: a list of Values to test equality with.
+        """
+        super().__init__(field, partial(contains, value))
 
 
 class ConditionalRule:

--- a/datahub/interaction/migrations/0001_squashed_0019_rename_default_permissions.py
+++ b/datahub/interaction/migrations/0001_squashed_0019_rename_default_permissions.py
@@ -51,7 +51,7 @@ class Migration(migrations.Migration):
                 ('investment_project', models.ForeignKey(blank=True, help_text='For interactions only.', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='interactions', to='investment.InvestmentProject')),
                 ('created_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
                 ('modified_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
-                ('kind', models.CharField(choices=[('interaction', 'Interaction'), ('service_delivery', 'Service delivery')], max_length=255)),
+                ('kind', models.CharField(choices=[('interaction', 'Interaction'), ('service_delivery', 'Service delivery'), ('policy', 'Policy interaction')], max_length=255)),
                 ('event', models.ForeignKey(blank=True, help_text='For service deliveries only.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='interactions', to='event.Event')),
                 ('archived_documents_url_path', models.CharField(blank=True, help_text='Legacy field. File browser path to the archived documents for this interaction.', max_length=255)),
 

--- a/datahub/interaction/migrations/0008_add_interaction_kind.py
+++ b/datahub/interaction/migrations/0008_add_interaction_kind.py
@@ -15,7 +15,11 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='interaction',
             name='kind',
-            field=models.CharField(choices=[('interaction', 'Interaction'), ('service_delivery', 'Service delivery')], default='interaction', max_length=255),
+            field=models.CharField(choices=[
+                ('interaction', 'Interaction'),
+                ('service_delivery', 'Service delivery'),
+                ('policy', 'Policy interaction'),
+            ], default='interaction', max_length=255),
             preserve_default=False,
         ),
     ]

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -74,6 +74,7 @@ class Interaction(BaseModel):
     KINDS = Choices(
         ('interaction', 'Interaction'),
         ('service_delivery', 'Service delivery'),
+        ('policy', 'Policy interaction'),
     )
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -8,7 +8,7 @@ from datahub.company.serializers import NestedAdviserField
 from datahub.core.serializers import NestedRelatedField
 from datahub.core.validate_utils import is_blank, is_not_blank
 from datahub.core.validators import (
-    AnyOfValidator, EqualsRule, OperatorRule, RulesBasedValidator, ValidationRule
+    AnyOfValidator, EqualsRule, InRule, OperatorRule, RulesBasedValidator, ValidationRule
 )
 from datahub.event.models import Event
 from datahub.investment.models import InvestmentProject
@@ -107,7 +107,10 @@ class InteractionSerializer(serializers.ModelSerializer):
                 ValidationRule(
                     'required',
                     OperatorRule('communication_channel', bool),
-                    when=EqualsRule('kind', Interaction.KINDS.interaction),
+                    when=InRule('kind', [
+                        Interaction.KINDS.interaction,
+                        Interaction.KINDS.policy
+                    ]),
                 ),
                 ValidationRule(
                     'invalid_for_service_delivery',
@@ -120,7 +123,10 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('service_delivery_status', is_blank),
                     OperatorRule('grant_amount_offered', is_blank),
                     OperatorRule('net_company_receipt', is_blank),
-                    when=EqualsRule('kind', Interaction.KINDS.interaction),
+                    when=InRule('kind', [
+                        Interaction.KINDS.interaction,
+                        Interaction.KINDS.policy
+                    ]),
                 ),
                 ValidationRule(
                     'required',

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -296,15 +296,16 @@ class TestGetInteractionView(APITestMixin):
 class TestAddInteractionView(APITestMixin):
     """Tests for the add interaction view."""
 
+    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
     @freeze_time('2017-04-18 13:25:30.986208')
-    def test_add_interaction(self):
+    def test_add_interaction(self, kind):
         """Test add new interaction."""
         adviser = AdviserFactory()
         company = CompanyFactory()
         contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': 'interaction',
+            'kind': kind,
             'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
             'date': date.today().isoformat(),
@@ -321,7 +322,7 @@ class TestAddInteractionView(APITestMixin):
         response_data = response.json()
         assert response_data == {
             'id': response_data['id'],
-            'kind': 'interaction',
+            'kind': kind,
             'is_event': None,
             'service_delivery_status': None,
             'grant_amount_offered': None,
@@ -690,14 +691,15 @@ class TestAddInteractionView(APITestMixin):
             'subject': ['This field is required.'],
         }
 
-    def test_add_interaction_missing_interaction_only_fields(self):
+    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    def test_add_interaction_missing_interaction_only_fields(self, kind):
         """Test add new interaction without required interaction-only fields."""
         adviser = AdviserFactory()
         company = CompanyFactory()
         contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': 'interaction',
+            'kind': kind,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
@@ -714,14 +716,15 @@ class TestAddInteractionView(APITestMixin):
             'communication_channel': ['This field is required.'],
         }
 
-    def test_add_interaction_with_service_delivery_fields(self):
+    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    def test_add_interaction_with_service_delivery_fields(self, kind):
         """Tests that adding an interaction with an event fails."""
         adviser = AdviserFactory()
         company = CompanyFactory()
         contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         request_data = {
-            'kind': 'interaction',
+            'kind': kind,
             'is_event': False,
             'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
@@ -776,14 +779,15 @@ class TestAddInteractionView(APITestMixin):
         }
 
     @freeze_time('2017-04-18 13:25:30.986208')
-    def test_add_interaction_project(self):
+    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    def test_add_interaction_project(self, kind):
         """Test add new interaction for an investment project."""
         project = InvestmentProjectFactory()
         adviser = AdviserFactory()
         contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         response = self.api_client.post(url, {
-            'kind': 'interaction',
+            'kind': kind,
             'contact': contact.pk,
             'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',
@@ -802,14 +806,15 @@ class TestAddInteractionView(APITestMixin):
         assert response_data['modified_on'] == '2017-04-18T13:25:30.986208Z'
         assert response_data['created_on'] == '2017-04-18T13:25:30.986208Z'
 
-    def test_add_interaction_no_entity(self):
+    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    def test_add_interaction_no_entity(self, kind):
         """Test add new interaction without a contact, company or
         investment project.
         """
         contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         response = self.api_client.post(url, {
-            'kind': 'interaction',
+            'kind': kind,
             'contact': contact.pk,
             'communication_channel': CommunicationChannel.face_to_face.value.id,
             'subject': 'whatever',

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -399,6 +399,29 @@
     modified_on: '2017-06-05T00:00:00Z'
 
 - model: interaction.interaction
+  pk: aa162e87-06d5-423d-963e-1ecbe46c62aa
+  fields:
+    kind: policy
+    subject: Unhappy with tariff
+    date: '2017-07-05T00:00:00Z'
+    company: 0f5216e0-849f-11e6-ae22-56b6b6499611
+    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
+    event: ~
+    service: f56eb92b-3499-e211-a939-e4115bead28a
+    service_delivery_status: ~
+    grant_amount_offered: ~
+    net_company_receipt: ~
+    dit_adviser: 7bad8082-4978-4fe8-a018-740257f01637
+    notes: This is a dummy interaction for testing
+    dit_team: 8248318c-9698-e211-a939-e4115bead28a
+    communication_channel: ~
+    investment_project: ~
+    created_by: 7bad8082-4978-4fe8-a018-740257f01637
+    created_on: '2017-07-05T00:00:00Z'
+    modified_by: 7bad8082-4978-4fe8-a018-740257f01637
+    modified_on: '2017-07-05T00:00:00Z'
+
+- model: interaction.interaction
   pk: ec4a46ef-6e50-4a5c-bba0-e311f0471312
   fields:
     kind: service_delivery


### PR DESCRIPTION
Issue number: MI-1413

### Description of change

Adds a new Interaction kind called 'policy', the frontend will be updated to add support for creating these policy interactions.

### Checklist

* [x] ~Have any relevant search models been updated?~
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] ~Have any relevant select-/prefetch-related field lists in the views and search apps been updated?~
* [x] ~Has the admin site been updated (for new models, fields etc.)?~
* [x] ~Has the README been updated (if needed)?~
