### PR TITLE
Re-group imports

### DIFF
--- a/datahub/core/test/support/serializers.py
+++ b/datahub/core/test/support/serializers.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+
 from datahub.core.test.support.models import PermissionModel
 from .models import MyDisableableModel
 

--- a/datahub/core/test/test_reversion.py
+++ b/datahub/core/test/test_reversion.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import pytest
 
 from ..reversion import EXCLUDED_BASE_MODEL_FIELDS, register_base_model

--- a/datahub/core/test/test_viewsets.py
+++ b/datahub/core/test/test_viewsets.py
@@ -1,10 +1,8 @@
 from django.contrib.auth import get_user_model
-
 from rest_framework import serializers, status
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 from .support.models import EmptyModel, InheritedModel
-
 from ..test_utils import APITestMixin
 from ..viewsets import CoreViewSetV1, CoreViewSetV3
 

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from secrets import token_hex
-import factory
 
+import factory
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission

--- a/datahub/dbmaintenance/management/base.py
+++ b/datahub/dbmaintenance/management/base.py
@@ -2,6 +2,7 @@ import codecs
 import csv
 from contextlib import closing
 from logging import getLogger
+
 from django.core.management.base import BaseCommand
 
 from datahub.core.utils import get_s3_client

--- a/datahub/dbmaintenance/management/commands/update_omis_uk_regions.py
+++ b/datahub/dbmaintenance/management/commands/update_omis_uk_regions.py
@@ -2,7 +2,6 @@ from functools import lru_cache
 
 from datahub.metadata.models import UKRegion
 from datahub.omis.order.models import Order
-
 from ..base import CSVBaseCommand
 
 

--- a/datahub/dbmaintenance/test/commands/test_update_omis_uk_regions.py
+++ b/datahub/dbmaintenance/test/commands/test_update_omis_uk_regions.py
@@ -1,6 +1,6 @@
 from io import BytesIO
-import pytest
 
+import pytest
 from django.core.management import call_command
 
 from datahub.core import constants

--- a/datahub/metadata/serializers.py
+++ b/datahub/metadata/serializers.py
@@ -1,5 +1,4 @@
 from datahub.core.serializers import ConstantModelSerializer, NestedRelatedField
-
 from .models import Country, TeamRole, UKRegion
 
 

--- a/datahub/metadata/test/test_registry.py
+++ b/datahub/metadata/test/test_registry.py
@@ -1,10 +1,8 @@
 import pytest
 from django.core.exceptions import ImproperlyConfigured
-
 from rest_framework import serializers
 
 from datahub.core.serializers import ConstantModelSerializer
-
 from ..models import Sector, UKRegion
 from ..registry import MetadataRegistry
 

--- a/datahub/omis/core/exceptions.py
+++ b/datahub/omis/core/exceptions.py
@@ -1,5 +1,4 @@
 from django.utils.translation import ugettext_lazy as _
-
 from rest_framework import status
 from rest_framework.exceptions import APIException
 

--- a/datahub/omis/core/test/test_utils.py
+++ b/datahub/omis/core/test/test_utils.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import pytest
 from freezegun import freeze_time
 

--- a/datahub/omis/invoice/managers.py
+++ b/datahub/omis/invoice/managers.py
@@ -1,7 +1,6 @@
 from django.db import models
 
 from datahub.omis.core.utils import generate_datetime_based_reference
-
 from . import constants
 from .utils import calculate_payment_due_date
 

--- a/datahub/omis/invoice/models.py
+++ b/datahub/omis/invoice/models.py
@@ -5,7 +5,6 @@ from django.db import models
 
 from datahub.core.models import BaseModel
 from datahub.metadata.models import Country
-
 from .managers import InvoiceManager
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH

--- a/datahub/omis/invoice/serializers.py
+++ b/datahub/omis/invoice/serializers.py
@@ -2,7 +2,6 @@ from rest_framework import serializers
 
 from datahub.core.serializers import NestedRelatedField
 from datahub.metadata.models import Country
-
 from .models import Invoice
 
 

--- a/datahub/omis/invoice/test/test_managers.py
+++ b/datahub/omis/invoice/test/test_managers.py
@@ -1,9 +1,9 @@
 from unittest import mock
+
 import pytest
 from dateutil.parser import parse as dateutil_parse
 
 from datahub.omis.order.test.factories import OrderFactory
-
 from .. import constants
 from ..models import Invoice
 

--- a/datahub/omis/invoice/test/test_utils.py
+++ b/datahub/omis/invoice/test/test_utils.py
@@ -1,12 +1,11 @@
 from unittest import mock
+
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from freezegun import freeze_time
 
 from datahub.omis.core.utils import generate_datetime_based_reference
-
 from datahub.omis.order.test.factories import OrderWithAcceptedQuoteFactory
-
 from ..models import Invoice
 from ..utils import calculate_payment_due_date
 

--- a/datahub/omis/invoice/test/views/test_public_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_public_invoice_details.py
@@ -1,5 +1,4 @@
 import pytest
-
 from oauth2_provider.models import Application
 from rest_framework import status
 from rest_framework.reverse import reverse

--- a/datahub/omis/market/metadata.py
+++ b/datahub/omis/market/metadata.py
@@ -1,6 +1,5 @@
 from datahub.metadata.fixtures import Fixture
 from datahub.metadata.registry import registry
-
 from . import models
 from .serializers import MarketSerializer
 

--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -10,7 +10,6 @@ from raven.contrib.django.raven_compat.models import client as raven_client
 from datahub.core.utils import executor
 from datahub.omis.market.models import Market
 from datahub.omis.region.models import UKRegionalSettings
-
 from .constants import Template
 
 

--- a/datahub/omis/notification/signal_receivers.py
+++ b/datahub/omis/notification/signal_receivers.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 from django.db import transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -2,10 +2,8 @@ import itertools
 from unittest import mock
 
 import pytest
-
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
-
 from notifications_python_client.errors import APIError
 
 from datahub.company.test.factories import AdviserFactory
@@ -17,7 +15,6 @@ from datahub.omis.order.test.factories import (
     OrderFactory, OrderPaidFactory, OrderSubscriberFactory, OrderWithOpenQuoteFactory
 )
 from datahub.omis.region.models import UKRegionalSettings
-
 from ..client import notify, send_email
 from ..constants import Template
 

--- a/datahub/omis/notification/test/test_signal_receivers.py
+++ b/datahub/omis/notification/test/test_signal_receivers.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 import pytest
 from dateutil.parser import parse as dateutil_parse
 
@@ -12,7 +13,6 @@ from datahub.omis.order.test.factories import (
     OrderPaidFactory, OrderSubscriberFactory,
     OrderWithAcceptedQuoteFactory, OrderWithOpenQuoteFactory
 )
-
 from ..client import notify
 from ..constants import Template
 

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -1,6 +1,6 @@
 from unittest import mock
-import pytest
 
+import pytest
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
 
@@ -13,7 +13,6 @@ from datahub.omis.order.test.factories import (
     OrderPaidFactory, OrderWithOpenQuoteFactory
 )
 from datahub.omis.region.models import UKRegionalSettings
-
 from ..client import Notify
 
 

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -1,4 +1,5 @@
 from functools import update_wrapper
+
 from django import forms
 from django.contrib import admin
 from django.contrib import messages
@@ -22,7 +23,6 @@ from django.views.decorators.csrf import csrf_protect
 
 from datahub.core.admin import ReadOnlyAdmin
 from datahub.omis.core.exceptions import Conflict
-
 from . import validators
 from .models import CancellationReason, Order
 

--- a/datahub/omis/order/metadata.py
+++ b/datahub/omis/order/metadata.py
@@ -1,7 +1,6 @@
 from datahub.core.serializers import ConstantModelSerializer
 from datahub.metadata.fixtures import Fixture
 from datahub.metadata.registry import registry
-
 from . import models
 
 

--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -13,14 +13,12 @@ from datahub.company.models import Advisor, Company, Contact
 from datahub.core.models import (
     BaseConstantModel, BaseModel, BaseOrderedConstantModel
 )
-
 from datahub.metadata.models import Country, Sector, Team, UKRegion
 from datahub.omis.core.utils import generate_reference
 from datahub.omis.invoice.models import Invoice
 from datahub.omis.payment.models import Payment
 from datahub.omis.payment.validators import ReconcilablePaymentsValidator
 from datahub.omis.quote.models import Quote
-
 from . import validators
 from .constants import DEFAULT_HOURLY_RATE, OrderStatus, VATStatus
 from .managers import OrderQuerySet

--- a/datahub/omis/order/pricing.py
+++ b/datahub/omis/order/pricing.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
-from django.db.models import Sum
 
+from django.db.models import Sum
 from rest_framework.exceptions import ValidationError
 
 from .constants import VATStatus

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -15,7 +15,6 @@ from datahub.core.validators import (
     ValidationRule,
 )
 from datahub.metadata.models import Country, Sector, Team, UKRegion
-
 from datahub.omis.market.models import Market
 from .constants import OrderStatus, VATStatus
 from .models import CancellationReason, Order, OrderAssignee, OrderSubscriber, ServiceType

--- a/datahub/omis/order/signal_receivers.py
+++ b/datahub/omis/order/signal_receivers.py
@@ -2,7 +2,6 @@ from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
 from datahub.omis.order.models import Order, OrderAssignee
-
 from .pricing import update_order_pricing
 
 

--- a/datahub/omis/order/test/factories.py
+++ b/datahub/omis/order/test/factories.py
@@ -1,18 +1,16 @@
 import datetime
 import uuid
-import factory
 
+import factory
 from django.utils.timezone import now, utc
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core.constants import Country, Sector, UKRegion
 from datahub.core.test.factories import to_many_field
-
 from datahub.omis.invoice.models import Invoice
 from datahub.omis.quote.test.factories import (
     AcceptedQuoteFactory, CancelledQuoteFactory, QuoteFactory
 )
-
 from ..constants import OrderStatus, VATStatus
 from ..models import CancellationReason, ServiceType
 

--- a/datahub/omis/order/test/test_admin.py
+++ b/datahub/omis/order/test/test_admin.py
@@ -7,7 +7,6 @@ from django.test.client import Client
 from django.urls import reverse
 
 from datahub.core.test_utils import AdminTestMixin, create_test_user
-
 from .factories import (
     OrderCancelledFactory, OrderCompleteFactory,
     OrderFactory, OrderPaidFactory,

--- a/datahub/omis/order/test/test_managers.py
+++ b/datahub/omis/order/test/test_managers.py
@@ -1,7 +1,6 @@
 import pytest
 
 from datahub.omis.quote.test.factories import CancelledQuoteFactory
-
 from .factories import OrderFactory
 from ..constants import OrderStatus
 from ..models import Order

--- a/datahub/omis/order/test/test_models.py
+++ b/datahub/omis/order/test/test_models.py
@@ -1,6 +1,7 @@
 import secrets
 from functools import partial
 from unittest import mock
+
 import factory
 import pytest
 from dateutil.parser import parse as dateutil_parse
@@ -16,7 +17,6 @@ from datahub.omis.core.exceptions import Conflict
 from datahub.omis.invoice.models import Invoice
 from datahub.omis.payment.models import Payment
 from datahub.omis.quote.models import Quote
-
 from .factories import (
     OrderAssigneeCompleteFactory,
     OrderAssigneeFactory,
@@ -25,7 +25,6 @@ from .factories import (
     OrderWithAcceptedQuoteFactory,
     OrderWithOpenQuoteFactory,
 )
-
 from ..constants import OrderStatus
 from ..models import CancellationReason
 

--- a/datahub/omis/order/test/test_pricing.py
+++ b/datahub/omis/order/test/test_pricing.py
@@ -1,11 +1,10 @@
 from decimal import Decimal
 from unittest import mock
-import pytest
 
+import pytest
 from rest_framework.exceptions import ValidationError
 
 from .factories import HourlyRateFactory, OrderAssigneeFactory, OrderFactory
-
 from ..constants import VATStatus
 from ..models import Order
 from ..pricing import (

--- a/datahub/omis/order/test/test_signal_receivers.py
+++ b/datahub/omis/order/test/test_signal_receivers.py
@@ -1,7 +1,6 @@
 import pytest
 
 from .factories import OrderAssigneeFactory, OrderFactory
-
 from ..constants import VATStatus
 from ..pricing import get_pricing_from_order
 

--- a/datahub/omis/order/test/test_utils.py
+++ b/datahub/omis/order/test/test_utils.py
@@ -5,7 +5,6 @@ from datahub.company.test.factories import (
     CompaniesHouseCompanyFactory, CompanyFactory, ContactFactory
 )
 from datahub.core import constants
-
 from .factories import OrderFactory
 from ..utils import populate_billing_data
 

--- a/datahub/omis/order/test/test_validators.py
+++ b/datahub/omis/order/test/test_validators.py
@@ -1,17 +1,15 @@
 from unittest import mock
+
 import pytest
 from django.db.models import Sum
-
 from rest_framework.exceptions import ValidationError
 
 from datahub.omis.core.exceptions import Conflict
-
 from .factories import (
     OrderFactory,
     OrderWithCancelledQuoteFactory,
     OrderWithOpenQuoteFactory,
 )
-
 from ..constants import OrderStatus, VATStatus
 from ..models import Order
 from ..validators import (

--- a/datahub/omis/order/test/views/test_order_assignees.py
+++ b/datahub/omis/order/test/views/test_order_assignees.py
@@ -4,7 +4,6 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import APITestMixin
-
 from ..factories import OrderAssigneeFactory, OrderFactory, OrderPaidFactory
 from ...constants import OrderStatus
 from ...models import OrderAssignee

--- a/datahub/omis/order/test/views/test_order_details.py
+++ b/datahub/omis/order/test/views/test_order_details.py
@@ -1,8 +1,8 @@
 import uuid
+
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from django.utils.timezone import now
-
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -11,14 +11,12 @@ from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core.constants import Country, Sector, UKRegion
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.omis.market.models import Market
-
 from ..factories import (
     OrderAssigneeCompleteFactory, OrderAssigneeFactory,
     OrderCancelledFactory, OrderCompleteFactory, OrderFactory,
     OrderPaidFactory, OrderWithAcceptedQuoteFactory,
     OrderWithOpenQuoteFactory,
 )
-
 from ...constants import OrderStatus, VATStatus
 from ...models import CancellationReason, ServiceType
 

--- a/datahub/omis/order/test/views/test_public_order_details.py
+++ b/datahub/omis/order/test/views/test_public_order_details.py
@@ -1,5 +1,4 @@
 import pytest
-
 from oauth2_provider.models import Application
 from rest_framework import status
 from rest_framework.reverse import reverse
@@ -7,7 +6,6 @@ from rest_framework.reverse import reverse
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.oauth.scopes import Scope
 from datahub.omis.quote.test.factories import QuoteFactory
-
 from ..factories import OrderFactory, OrderWithCancelledQuoteFactory
 from ...constants import OrderStatus
 

--- a/datahub/omis/order/test/views/test_subscriber_list.py
+++ b/datahub/omis/order/test/views/test_subscriber_list.py
@@ -4,7 +4,6 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import APITestMixin
-
 from ..factories import OrderFactory, OrderSubscriberFactory
 from ...constants import OrderStatus
 

--- a/datahub/omis/order/validators.py
+++ b/datahub/omis/order/validators.py
@@ -1,13 +1,12 @@
 from collections import defaultdict
-from django.db import models
 
+from django.db import models
 from rest_framework.exceptions import ValidationError
 from rest_framework.settings import api_settings
 
 from datahub.core.validate_utils import DataCombiner
 from datahub.core.validators import AbstractRule, BaseRule
 from datahub.omis.core.exceptions import Conflict
-
 from .constants import OrderStatus, VATStatus
 
 

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -1,6 +1,5 @@
 from django.http import Http404
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
-
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView

--- a/datahub/omis/quote/models.py
+++ b/datahub/omis/quote/models.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.utils.timezone import now
 
 from datahub.core.models import BaseModel
-
 from .managers import QuoteManager
 
 

--- a/datahub/omis/quote/serializers.py
+++ b/datahub/omis/quote/serializers.py
@@ -3,7 +3,6 @@ from rest_framework import serializers
 from datahub.company.models import Contact
 from datahub.company.serializers import NestedAdviserField
 from datahub.core.serializers import NestedRelatedField
-
 from .models import Quote
 
 

--- a/datahub/omis/quote/test/factories.py
+++ b/datahub/omis/quote/test/factories.py
@@ -1,10 +1,9 @@
 import uuid
-import factory
 
+import factory
 from django.utils.timezone import now
 
 from datahub.company.test.factories import AdviserFactory, ContactFactory
-
 from ..models import TermsAndConditions
 
 

--- a/datahub/omis/quote/test/test_admin.py
+++ b/datahub/omis/quote/test/test_admin.py
@@ -2,7 +2,6 @@ from django.urls import reverse
 from rest_framework import status
 
 from datahub.core.test_utils import AdminTestMixin
-
 from ..models import TermsAndConditions
 
 

--- a/datahub/omis/quote/test/test_managers.py
+++ b/datahub/omis/quote/test/test_managers.py
@@ -1,9 +1,9 @@
 from unittest import mock
+
 import pytest
 from dateutil.parser import parse as dateutil_parse
 
 from datahub.company.test.factories import AdviserFactory
-
 from ..models import Quote, TermsAndConditions
 
 

--- a/datahub/omis/quote/test/test_models.py
+++ b/datahub/omis/quote/test/test_models.py
@@ -4,7 +4,6 @@ from freezegun import freeze_time
 
 from datahub.company.test.factories import AdviserFactory, ContactFactory
 from datahub.omis.quote.test.factories import AcceptedQuoteFactory, CancelledQuoteFactory
-
 from .factories import QuoteFactory
 from ..models import Quote
 

--- a/datahub/omis/quote/test/test_utils.py
+++ b/datahub/omis/quote/test/test_utils.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from pathlib import PurePath
 from unittest import mock
+
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from freezegun import freeze_time
@@ -15,7 +16,6 @@ from datahub.omis.order.constants import VATStatus
 from datahub.omis.order.test.factories import (
     HourlyRateFactory, OrderAssigneeFactory, OrderFactory
 )
-
 from ..utils import (
     calculate_quote_expiry_date,
     escape_markdown,

--- a/datahub/omis/quote/test/views/test_public_quote_details.py
+++ b/datahub/omis/quote/test/views/test_public_quote_details.py
@@ -1,5 +1,4 @@
 import pytest
-
 from django.utils.timezone import now
 from freezegun import freeze_time
 from oauth2_provider.models import Application
@@ -10,7 +9,6 @@ from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import OrderFactory, OrderWithOpenQuoteFactory
-
 from ..factories import QuoteFactory
 from ...models import TermsAndConditions
 

--- a/datahub/omis/quote/test/views/test_quote_details.py
+++ b/datahub/omis/quote/test/views/test_quote_details.py
@@ -1,7 +1,7 @@
 import uuid
 from unittest import mock
-import pytest
 
+import pytest
 from dateutil.parser import parse as dateutil_parse
 from freezegun import freeze_time
 from rest_framework import status
@@ -13,7 +13,6 @@ from datahub.omis.order.models import Order
 from datahub.omis.order.test.factories import (
     OrderFactory, OrderWithCancelledQuoteFactory, OrderWithOpenQuoteFactory
 )
-
 from ..factories import QuoteFactory
 from ...models import Quote, TermsAndConditions
 

--- a/datahub/omis/quote/utils.py
+++ b/datahub/omis/quote/utils.py
@@ -11,7 +11,6 @@ from rest_framework.exceptions import ValidationError
 
 from datahub.omis.core.utils import generate_reference
 from datahub.omis.order.pricing import get_pricing_from_order
-
 from .constants import QUOTE_EXPIRY_DAYS_BEFORE_DELIVERY, QUOTE_EXPIRY_DAYS_FROM_NOW
 
 

--- a/datahub/omis/quote/views.py
+++ b/datahub/omis/quote/views.py
@@ -1,13 +1,11 @@
 from django.http import Http404
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
-
 from rest_framework import status
 from rest_framework.response import Response
 
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.models import Order
 from datahub.omis.order.views import BaseNestedOrderViewSet
-
 from .models import Quote
 from .serializers import PublicQuoteSerializer, QuoteSerializer
 

--- a/datahub/search/omis/apps.py
+++ b/datahub/search/omis/apps.py
@@ -1,8 +1,6 @@
 from datahub.omis.order.models import Order as DBOrder
-
 from .models import Order
 from .views import SearchOrderAPIView
-
 from ..apps import SearchApp
 
 

--- a/datahub/search/omis/signals.py
+++ b/datahub/search/omis/signals.py
@@ -6,7 +6,6 @@ from datahub.omis.order.models import (
     OrderAssignee as DBOrderAssignee,
     OrderSubscriber as DBOrderSubscriber
 )
-
 from .models import Order as ESOrder
 from ..signals import sync_es
 

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -7,7 +7,6 @@ from datahub.omis.order.test.factories import (
     OrderFactory, OrderPaidFactory,
     OrderWithAcceptedQuoteFactory
 )
-
 from .. import OrderSearchApp
 from ..models import Order as ESOrder
 from ... import elasticsearch

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -5,7 +5,6 @@ from datahub.omis.order.test.factories import (
     OrderFactory, OrderPaidFactory, OrderSubscriberFactory,
     OrderWithAcceptedQuoteFactory
 )
-
 from ..models import Order as ESOrder
 
 pytestmark = pytest.mark.django_db

--- a/datahub/search/omis/test/test_signals.py
+++ b/datahub/search/omis/test/test_signals.py
@@ -1,12 +1,10 @@
 import pytest
-
 from django.conf import settings
 
 from datahub.omis.order.test.factories import (
     OrderAssigneeFactory, OrderFactory,
     OrderSubscriberFactory, OrderWithOpenQuoteFactory
 )
-
 from .. import OrderSearchApp
 
 pytestmark = pytest.mark.django_db


### PR DESCRIPTION
This re-groups imports for OMIS modules to make them conform to the cryptography style.

Issue number: #770 