### PR TITLE
Update dependencies and fix remainder of imports not conforming to import style

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_company_headquarter_type.py
+++ b/datahub/dbmaintenance/management/commands/update_company_headquarter_type.py
@@ -1,4 +1,5 @@
 import uuid
+
 import reversion
 
 from datahub.company.models import Company

--- a/datahub/dbmaintenance/management/commands/update_investment_project_comments.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_comments.py
@@ -1,7 +1,6 @@
 import reversion
 
 from datahub.investment.models import InvestmentProject
-
 from ..base import CSVBaseCommand
 
 

--- a/datahub/dbmaintenance/management/commands/update_investment_project_company.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_company.py
@@ -1,4 +1,5 @@
 import uuid
+
 import reversion
 
 from datahub.investment.models import InvestmentProject

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -12,7 +12,6 @@ from datahub.core.test_utils import APITestMixin, create_test_user, random_obj_f
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.constants import CommunicationChannel
 from datahub.interaction.models import InteractionPermission, ServiceDeliveryStatus
-
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory, EventServiceDeliveryFactory, InvestmentProjectInteractionFactory,
     ServiceDeliveryFactory,

--- a/datahub/investment/test/test_models.py
+++ b/datahub/investment/test/test_models.py
@@ -1,7 +1,6 @@
 """Tests for investment models."""
 
 import pytest
-
 from django.core.exceptions import ObjectDoesNotExist
 
 from datahub.company.test.factories import AdviserFactory

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -1,8 +1,6 @@
 from datahub.company.models import Company as DBCompany
-
 from .models import Company
 from .views import SearchCompanyAPIView, SearchCompanyExportAPIView
-
 from ..apps import SearchApp
 
 

--- a/datahub/search/company/signals.py
+++ b/datahub/search/company/signals.py
@@ -2,7 +2,6 @@ from django.db import transaction
 from django.db.models.signals import post_save
 
 from datahub.company.models import Company as DBCompany
-
 from .models import Company as ESCompany
 from ..signals import sync_es
 

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -1,5 +1,4 @@
 from ..models import Company as ESCompany
-
 from ... import elasticsearch
 
 

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -1,7 +1,6 @@
 import pytest
 
 from datahub.company.test.factories import CompanyFactory
-
 from ..models import Company as ESCompany
 
 pytestmark = pytest.mark.django_db

--- a/datahub/search/company/test/test_signals.py
+++ b/datahub/search/company/test/test_signals.py
@@ -2,7 +2,6 @@ import pytest
 
 from datahub.company.test.factories import CompanyFactory
 from datahub.search import elasticsearch
-
 from ..models import Company
 
 pytestmark = pytest.mark.django_db

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -6,7 +6,6 @@ from pytest import fixture
 
 from datahub.core.test_utils import synchronous_executor_submit, synchronous_transaction_on_commit
 from datahub.search import elasticsearch
-
 from .apps import get_search_apps
 
 

--- a/datahub/search/contact/apps.py
+++ b/datahub/search/contact/apps.py
@@ -1,8 +1,6 @@
 from datahub.company.models import Contact as DBContact
-
 from .models import Contact
 from .views import SearchContactAPIView, SearchContactExportAPIView
-
 from ..apps import SearchApp
 
 

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from elasticsearch_dsl import Boolean, Date, DocType, Keyword, Text
+
 from . import dict_utils as contact_dict_utils
 from .. import dict_utils
 from .. import dsl_utils

--- a/datahub/search/contact/signals.py
+++ b/datahub/search/contact/signals.py
@@ -2,7 +2,6 @@ from django.db import transaction
 from django.db.models.signals import post_save
 
 from datahub.company.models import Company as DBCompany, Contact as DBContact
-
 from .models import Contact as ESContact
 from ..signals import sync_es
 

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -1,5 +1,4 @@
 from ..models import Contact as ESContact
-
 from ... import elasticsearch
 
 

--- a/datahub/search/contact/test/test_signals.py
+++ b/datahub/search/contact/test/test_signals.py
@@ -2,7 +2,6 @@ import pytest
 
 from datahub.company.test.factories import ContactFactory
 from datahub.search import elasticsearch
-
 from ..models import Contact
 
 pytestmark = pytest.mark.django_db

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -1,4 +1,5 @@
 import uuid
+
 import pytest
 from rest_framework import status
 from rest_framework.reverse import reverse

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -1,4 +1,5 @@
 from functools import partial
+
 from elasticsearch_dsl import Keyword, Nested, Text
 
 SortableCaseInsensitiveKeywordText = partial(

--- a/datahub/search/event/signals.py
+++ b/datahub/search/event/signals.py
@@ -2,7 +2,6 @@ from django.db import transaction
 from django.db.models.signals import post_save
 
 from datahub.event.models import Event as DBEvent
-
 from datahub.search.signals import sync_es
 from .models import Event as ESEvent
 

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -1,6 +1,5 @@
 from django.db.models import Prefetch
 
-
 from datahub.investment.models import (
     InvestmentProject as DBInvestmentProject,
     InvestmentProjectPermission,
@@ -9,10 +8,8 @@ from datahub.investment.models import (
 from datahub.investment.permissions import (
     get_association_filters, InvestmentProjectAssociationChecker
 )
-
 from .models import InvestmentProject
 from .views import SearchInvestmentProjectAPIView, SearchInvestmentProjectExportAPIView
-
 from ..apps import EXCLUDE_ALL, SearchApp
 
 

--- a/datahub/search/investment/signals.py
+++ b/datahub/search/investment/signals.py
@@ -7,7 +7,6 @@ from datahub.investment.models import (
     InvestmentProject as DBInvestmentProject,
     InvestmentProjectTeamMember
 )
-
 from .models import InvestmentProject as ESInvestmentProject
 from ..signals import sync_es
 

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -1,5 +1,4 @@
 from ..models import InvestmentProject as ESInvestmentProject
-
 from ... import elasticsearch
 
 

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -1,7 +1,6 @@
 import pytest
 
 from datahub.investment.test.factories import InvestmentProjectFactory
-
 from ..models import InvestmentProject as ESInvestmentProject
 
 pytestmark = pytest.mark.django_db

--- a/datahub/search/investment/test/test_signals.py
+++ b/datahub/search/investment/test/test_signals.py
@@ -6,7 +6,6 @@ from datahub.investment.test.factories import (
 )
 from datahub.metadata.test.factories import TeamFactory
 from datahub.search import elasticsearch
-
 from ..models import InvestmentProject
 
 pytestmark = pytest.mark.django_db

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -5,7 +5,6 @@ from django.core.paginator import Paginator
 from django.db import models
 
 from datahub.search.elasticsearch import bulk
-
 from ...apps import get_search_apps
 
 

--- a/datahub/search/signals.py
+++ b/datahub/search/signals.py
@@ -1,8 +1,8 @@
 from logging import getLogger
 
 from raven.contrib.django.raven_compat.models import client
-from datahub.core.utils import executor
 
+from datahub.core.utils import executor
 from datahub.search import elasticsearch
 
 logger = getLogger(__name__)

--- a/datahub/search/test/commands/test_sync_es.py
+++ b/datahub/search/test/commands/test_sync_es.py
@@ -3,11 +3,9 @@ from unittest import mock
 import pytest
 from django.core import management
 
-
 from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.search.management.commands import sync_es
-
 from ...apps import get_search_apps
 from ...company.models import Company as ESCompany
 from ...contact.models import Contact as ESContact

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -1,4 +1,5 @@
 from unittest import mock
+
 from pytest import raises
 
 from .. import dict_utils

--- a/requirements.in
+++ b/requirements.in
@@ -47,7 +47,7 @@ pip-tools==1.11.0
 flake8==3.5.0
 flake8-blind-except==0.1.1
 flake8-debugger==3.1.0
-flake8-import-order==0.14.3
+flake8-import-order==0.17
 flake8-docstrings==1.3.0
 flake8-print==3.1.0
 flake8-quotes==0.14.0

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ cssselect==1.0.3
 Django==2.0.2
 djangorestframework==3.7.7
 django-environ==0.4.4
-django-extensions==1.9.9
+django-extensions==2.0.0
 django-filter==1.1.0
 django-reversion==2.0.13
 django-pglocks==1.0.2
@@ -20,7 +20,7 @@ python-dateutil==2.6.1
 # Persistency layer
 psycopg2==2.7.4
 
-boto3==1.5.30
+boto3==1.5.36
 
 notifications-python-client==4.7.2
 
@@ -30,7 +30,7 @@ elasticsearch-dsl==5.4.0
 aws-requests-auth==0.4.1
 
 # Testing and dev
-pytest==3.4.0
+pytest==3.4.1
 pytest-django==3.1.2
 pytest-sugar==0.9.1
 pytest-cov==2.5.1
@@ -50,7 +50,7 @@ flake8-debugger==3.1.0
 flake8-import-order==0.14.3
 flake8-docstrings==1.3.0
 flake8-print==3.1.0
-flake8-quotes==0.13.0
+flake8-quotes==0.14.0
 flake8-string-format==0.2.3
 pep8-naming==0.5.0
 pydocstyle==2.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-asttokens==1.1.9          # via flake8-import-order
+asttokens==1.1.10         # via flake8-import-order
 attrs==17.4.0             # via pytest
 aws-requests-auth==0.4.1
-boto3==1.5.30
-botocore==1.8.44          # via boto3, s3transfer
+boto3==1.5.36
+botocore==1.8.50          # via boto3, s3transfer
 certifi==2018.1.18        # via requests
 chardet==3.0.4            # via chardet, requests
 click==6.7                # via click, pip-tools
@@ -17,7 +17,7 @@ cssselect==1.0.3
 decorator==4.2.1          # via ipython, traitlets
 django-debug-toolbar==1.9.1
 django-environ==0.4.4
-django-extensions==1.9.9
+django-extensions==2.0.0
 django-filter==1.1.0
 django-model-utils==3.1.1
 django-oauth-toolkit==1.0.0
@@ -38,7 +38,7 @@ flake8-docstrings==1.3.0
 flake8-import-order==0.14.3
 flake8-polyfill==1.0.2    # via flake8-docstrings, pep8-naming
 flake8-print==3.1.0
-flake8-quotes==0.13.0
+flake8-quotes==0.14.0
 flake8-string-format==0.2.3
 flake8==3.5.0
 freezegun==0.3.9
@@ -75,7 +75,7 @@ pyjwt==1.5.3              # via notifications-python-client, pyjwt
 pytest-cov==2.5.1
 pytest-django==3.1.2
 pytest-sugar==0.9.1
-pytest==3.4.0
+pytest==3.4.1
 python-dateutil==2.6.1
 pytz==2018.3              # via django
 pyyaml==3.12
@@ -89,7 +89,7 @@ six==1.11.0               # via asttokens, django-environ, django-extensions, el
 snowballstemmer==1.2.1    # via pydocstyle, snowballstemmer
 sqlparse==0.2.4           # via django-debug-toolbar, sqlparse
 termcolor==1.1.0          # via pytest-sugar, termcolor
-text-unidecode==1.1       # via faker
+text-unidecode==1.2       # via faker
 traitlets==4.3.2          # via ipython, traitlets
 typing==3.6.4             # via django-extensions
 urllib3==1.22             # via elasticsearch, requests, urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-asttokens==1.1.10         # via flake8-import-order
 attrs==17.4.0             # via pytest
 aws-requests-auth==0.4.1
 boto3==1.5.36
@@ -29,13 +28,14 @@ docopt==0.6.2             # via docopt, notifications-python-client
 docutils==0.14            # via botocore, docutils
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.2
+enum34==1.1.6             # via flake8-import-order
 factory-boy==2.10.0
 faker==0.8.11             # via factory-boy
 first==2.0.1              # via first, pip-tools
 flake8-blind-except==0.1.1
 flake8-debugger==3.1.0
 flake8-docstrings==1.3.0
-flake8-import-order==0.14.3
+flake8-import-order==0.17
 flake8-polyfill==1.0.2    # via flake8-docstrings, pep8-naming
 flake8-print==3.1.0
 flake8-quotes==0.14.0
@@ -85,7 +85,7 @@ requests==2.18.4
 requests_toolbelt==0.8.0
 s3transfer==0.1.13        # via boto3
 simplegeneric==0.8.1      # via ipython, simplegeneric
-six==1.11.0               # via asttokens, django-environ, django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, pip-tools, prompt-toolkit, pydocstyle, pytest, python-dateutil, requests-mock, six, traitlets
+six==1.11.0               # via django-environ, django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, pip-tools, prompt-toolkit, pydocstyle, pytest, python-dateutil, requests-mock, six, traitlets
 snowballstemmer==1.2.1    # via pydocstyle, snowballstemmer
 sqlparse==0.2.4           # via django-debug-toolbar, sqlparse
 termcolor==1.1.0          # via pytest-sugar, termcolor


### PR DESCRIPTION
Issue number: #770

### Description of change

Updates various dependencies, and gets the remainder of the imports conforming to the more stricter checks in the current version of flake8-import-order.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
