### PR TITLE
Switch to datahub.core.reversion.NonAtomicRevisionMiddleware

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -83,7 +83,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'reversion.middleware.RevisionMiddleware',
+    'datahub.core.reversion.NonAtomicRevisionMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware'
 ]
 

--- a/datahub/core/reversion.py
+++ b/datahub/core/reversion.py
@@ -1,4 +1,5 @@
 import reversion
+from reversion.middleware import RevisionMiddleware
 
 EXCLUDED_BASE_MODEL_FIELDS = ('created_on', 'created_by', 'modified_on', 'modified_by')
 
@@ -32,3 +33,15 @@ def register_base_model(extra_exclude=None, **kwargs):
         )
 
     return reversion.register(**kwargs)
+
+
+class NonAtomicRevisionMiddleware(RevisionMiddleware):
+    """
+    Same as reversion.middleware.RevisionMiddleware but with atomic == False.
+    Therefore the resulting atomic value depends on:
+    - the `ATOMIC_REQUESTS` settings
+    - whether `transaction.atomic()` is used
+    - whether `transaction.non_atomic_requests()` is used
+    """
+
+    atomic = False


### PR DESCRIPTION
This replaces `reversion.middleware.RevisionMiddleware` with `datahub.core.reversion.NonAtomicRevisionMiddleware` which sets `atomic = False` and lets the atomicity of the transaction be determined by the django logic instead.