### PR TITLE
Add the ability to run tests in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: pip install --cache-dir ~/cache/pip -r requirements.txt
+          command: python -m pip install --cache-dir ~/cache/pip -r requirements.txt
 
       - save_cache:
           name: Save pip cache
@@ -50,17 +50,14 @@ jobs:
             - ~/cache/pip
       - run:
           name: Run Flake8
-          command: flake8
+          command: python -m flake8
 
       - run:
           name: Run tests
-          command: |
-            set -xu
-            ./tests.sh
+          command: python -m pytest -n 4 --cov -s
 
       - run:
           name: Publish coverage
           command: |
-            set -xu
             wget -O codecov.sh https://codecov.io/bash
             bash ./codecov.sh -t ${COV_TOKEN}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,10 @@ jobs:
 
       - run:
           name: Run tests
-          command: python -m pytest -n 4 --cov -s
+          command: python -m pytest -n 4 --cov -s --junitxml=test-reports/junit.xml
+
+      - store_test_results:
+          path: test-reports
 
       - run:
           name: Publish coverage

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 *,cover
 .hypothesis/
 /codecov.sh
+/test-reports/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -136,8 +136,16 @@ If using Docker, prefix these commands with `docker-compose run leeloo`.
 To run the tests:
 
 ```shell
-bash tests.sh
+./tests.sh
 ```
+
+To run the tests in parallel, pass `-n <number of processes>` to `./tests.sh`. For example, for four processes:
+
+
+```shell
+./tests.sh -n 4
+```
+
 
 To run the linter:
 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -12,7 +12,8 @@ INSTALLED_APPS += [
     'datahub.core.test.support'
 ]
 
-ES_INDEX = 'test'
+# The index is set dynamically in datahub/search/conftest.py, so that tests can be parallelised.
+ES_INDEX = None
 ES_INDEX_SETTINGS = {
     'index.mapping.nested_fields.limit': 100,
     'number_of_shards': 1,

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from elasticsearch_dsl import Date, DocType, Keyword, Text
 
 from datahub.search import dict_utils, dsl_utils
@@ -49,5 +48,4 @@ class CompaniesHouseCompany(DocType, MapDBModelToDict):
     class Meta:
         """Default document meta data."""
 
-        index = settings.ES_INDEX
         doc_type = 'companieshousecompany'

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from elasticsearch_dsl import Boolean, Date, DocType, Keyword, Text
 
 from . import dict_utils as contact_dict_utils
@@ -102,5 +101,4 @@ class Contact(DocType, MapDBModelToDict):
     class Meta:
         """Default document meta data."""
 
-        index = settings.ES_INDEX
         doc_type = 'contact'

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -516,5 +516,5 @@ def _clip_limit(offset, limit):
 
 def delete_document(model, document_id):
     """Deletes specified model's document."""
-    doc = model.get(id=document_id)
+    doc = model.get(id=document_id, index=settings.ES_INDEX)
     doc.delete()

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from elasticsearch_dsl import Date, DocType, Keyword, Text
 
 from datahub.search import dict_utils, dsl_utils
@@ -70,5 +69,4 @@ class Event(DocType, MapDBModelToDict):
     class Meta:
         """Default document meta data."""
 
-        index = settings.ES_INDEX
         doc_type = 'event'

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -1,6 +1,5 @@
 from operator import attrgetter
 
-from django.conf import settings
 from elasticsearch_dsl import Boolean, Date, DocType, Double, Keyword
 
 from datahub.search import dict_utils, dsl_utils
@@ -73,5 +72,4 @@ class Interaction(DocType, MapDBModelToDict):
     class Meta:
         """Default document meta data."""
 
-        index = settings.ES_INDEX
         doc_type = 'interaction'

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from elasticsearch_dsl import Boolean, Date, DocType, Double, Integer, Keyword, Text
 
 from .. import dict_utils
@@ -166,5 +165,4 @@ class InvestmentProject(DocType, MapDBModelToDict):
     class Meta:
         """Default document meta data."""
 
-        index = settings.ES_INDEX
         doc_type = 'investment_project'

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from elasticsearch_dsl import Boolean, Date, DocType, Integer, Keyword, Text
 
 from .. import dict_utils
@@ -114,5 +113,4 @@ class Order(DocType, MapDBModelToDict):
     class Meta:
         """Default document meta data."""
 
-        index = settings.ES_INDEX
         doc_type = 'order'

--- a/requirements.in
+++ b/requirements.in
@@ -34,6 +34,7 @@ pytest==3.4.1
 pytest-django==3.1.2
 pytest-sugar==0.9.1
 pytest-cov==2.5.1
+pytest-xdist==1.22.2
 ipython==6.2.1
 ipdb==0.11
 factory-boy==2.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+apipkg==1.4               # via execnet
 attrs==17.4.0             # via pytest
 aws-requests-auth==0.4.1
 boto3==1.5.36
@@ -29,6 +30,7 @@ docutils==0.14            # via botocore, docutils
 elasticsearch-dsl==5.4.0
 elasticsearch==5.5.2
 enum34==1.1.6             # via flake8-import-order
+execnet==1.5.0            # via pytest-xdist
 factory-boy==2.10.0
 faker==0.8.11             # via factory-boy
 first==2.0.1              # via first, pip-tools
@@ -74,7 +76,9 @@ pygments==2.2.0           # via ipython, pygments
 pyjwt==1.5.3              # via notifications-python-client, pyjwt
 pytest-cov==2.5.1
 pytest-django==3.1.2
+pytest-forked==0.2        # via pytest-xdist
 pytest-sugar==0.9.1
+pytest-xdist==1.22.2
 pytest==3.4.1
 python-dateutil==2.6.1
 pytz==2018.3              # via django

--- a/tests.sh
+++ b/tests.sh
@@ -1,2 +1,2 @@
 #!/bin/bash -xe
-pytest --cov -s
+pytest --cov -s $@


### PR DESCRIPTION
Issue number: N/A

### Description of change

This adds the ability to run tests in parallel using pytest-xdist. Each process gets its own database and Elasticsearch index. 

This is used on CircleCI, and gets the CircleCI build time down from around 10 minutes to under 5 minutes. You can also run tests in parallel locally by passing `-n <number of workers>` to pytest.

I also tried using the parallelism feature of CircleCI, but it was a lot more complicated, and this turned out faster. (In theory both methods of parallelism can be combined, though.)

I also removed the definition of the ES index on the search models. We were inconsistent about where we were getting the index name from – the only occasion it was coming from the model was when deleting documents. So I removed it from the models to simplify things.

This doesn't run the tests out of order in the same process, so we shouldn't have the session fixture leakage problem here. (That does still need to be addressed, though.)

This also outputs a JUnit test report on CircleCI, so there's better feedback from CircleCI about what tests failed etc.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
