### PR TITLE
Fix incorrect monkey patching during tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ coverage.xml
 .hypothesis/
 /codecov.sh
 /test-reports/
+/.pytest_cache/
 
 # Translations
 *.mo

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 from django.conf import settings
 from elasticsearch.helpers.test import get_test_client
 from pytest import fixture
@@ -10,56 +8,59 @@ from .apps import get_search_apps
 
 
 @fixture(scope='session')
-def client(worker_id):
+def _es_client(worker_id):
     """
     Makes the ES test helper client available.
 
     Also patches settings.ES_INDEX using the xdist worker ID so that each process gets a unique
     index when running tests using multiple processes using pytest -n.
     """
-    with mock.patch.object(settings, 'ES_INDEX', new=f'test_{worker_id}'):
-        from elasticsearch_dsl.connections import connections
-        client = get_test_client(nowait=False)
-        connections.add_connection('default', client)
-        yield client
+    # pytest's monkeypatch does not work in session fixtures, but there is no need to restore
+    # the value so we just overwrite it normally
+    settings.ES_INDEX = f'test_{worker_id}'
+
+    from elasticsearch_dsl.connections import connections
+    client = get_test_client(nowait=False)
+    connections.add_connection('default', client)
+    yield client
 
 
 @fixture(scope='session')
-def setup_es_indexes(client):
+def _setup_es_indexes(_es_client):
     """Sets up ES and makes the client available."""
-    create_test_index(client, settings.ES_INDEX)
+    _create_test_index(_es_client, settings.ES_INDEX)
 
     # Create models in the test index
     for search_app in get_search_apps():
         search_app.init_es()
         search_app.connect_signals()
 
-    with mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit), \
-            mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit):
+    yield _es_client
 
-        yield client
-
-    client.indices.delete(settings.ES_INDEX)
+    _es_client.indices.delete(settings.ES_INDEX)
 
     for search_app in get_search_apps():
         search_app.disconnect_signals()
 
 
 @fixture
-def setup_es(setup_es_indexes):
+def setup_es(_setup_es_indexes, monkeypatch):
     """Sets up ES and deletes all the records after each run."""
-    yield setup_es_indexes
+    monkeypatch.setattr('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+    monkeypatch.setattr('datahub.core.utils.executor.submit', synchronous_executor_submit)
 
-    setup_es_indexes.indices.refresh()
-    setup_es_indexes.delete_by_query(
+    yield _setup_es_indexes
+
+    _setup_es_indexes.indices.refresh()
+    _setup_es_indexes.delete_by_query(
         settings.ES_INDEX,
         body={'query': {'match_all': {}}},
         ignore=(409,)
     )
-    setup_es_indexes.indices.refresh()
+    _setup_es_indexes.indices.refresh()
 
 
-def create_test_index(client, index):
+def _create_test_index(client, index):
     """Creates/configures the test index."""
     if client.indices.exists(index=index):
         client.indices.delete(index)


### PR DESCRIPTION
Issue number: N/A

### Description of change

This makes a small change to move the monkey patching of `django.db.transaction.on_commit` and `datahub.core.utils.executor.submit` outside of a session-scoped pytest fixture, so that the patching doesn't leak into tests that it's not meant to affect.

Before, `pytest datahub/search/company/test/test_views.py datahub/omis/notification/test/test_client.py` would fail. Now, it passes.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
