### PR TITLE
Rename Interaction.KIND 'policy' to 'policy_feedback'

### DIFF
--- a/datahub/interaction/migrations/0001_squashed_0019_rename_default_permissions.py
+++ b/datahub/interaction/migrations/0001_squashed_0019_rename_default_permissions.py
@@ -51,7 +51,7 @@ class Migration(migrations.Migration):
                 ('investment_project', models.ForeignKey(blank=True, help_text='For interactions only.', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='interactions', to='investment.InvestmentProject')),
                 ('created_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
                 ('modified_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
-                ('kind', models.CharField(choices=[('interaction', 'Interaction'), ('service_delivery', 'Service delivery'), ('policy', 'Policy interaction')], max_length=255)),
+                ('kind', models.CharField(choices=[('interaction', 'Interaction'), ('service_delivery', 'Service delivery'), ('policy_feedback', 'Policy feedback')], max_length=255)),
                 ('event', models.ForeignKey(blank=True, help_text='For service deliveries only.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='interactions', to='event.Event')),
                 ('archived_documents_url_path', models.CharField(blank=True, help_text='Legacy field. File browser path to the archived documents for this interaction.', max_length=255)),
 

--- a/datahub/interaction/migrations/0008_add_interaction_kind.py
+++ b/datahub/interaction/migrations/0008_add_interaction_kind.py
@@ -18,7 +18,7 @@ class Migration(migrations.Migration):
             field=models.CharField(choices=[
                 ('interaction', 'Interaction'),
                 ('service_delivery', 'Service delivery'),
-                ('policy', 'Policy interaction'),
+                ('policy_feedback', 'Policy feedback'),
             ], default='interaction', max_length=255),
             preserve_default=False,
         ),

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -74,7 +74,7 @@ class Interaction(BaseModel):
     KINDS = Choices(
         ('interaction', 'Interaction'),
         ('service_delivery', 'Service delivery'),
-        ('policy', 'Policy interaction'),
+        ('policy_feedback', 'Policy feedback'),
     )
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -109,7 +109,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('communication_channel', bool),
                     when=InRule('kind', [
                         Interaction.KINDS.interaction,
-                        Interaction.KINDS.policy
+                        Interaction.KINDS.policy_feedback
                     ]),
                 ),
                 ValidationRule(
@@ -125,7 +125,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('net_company_receipt', is_blank),
                     when=InRule('kind', [
                         Interaction.KINDS.interaction,
-                        Interaction.KINDS.policy
+                        Interaction.KINDS.policy_feedback
                     ]),
                 ),
                 ValidationRule(

--- a/datahub/interaction/test/test_views.py
+++ b/datahub/interaction/test/test_views.py
@@ -296,7 +296,9 @@ class TestGetInteractionView(APITestMixin):
 class TestAddInteractionView(APITestMixin):
     """Tests for the add interaction view."""
 
-    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    @pytest.mark.parametrize(
+        'kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy_feedback,)
+    )
     @freeze_time('2017-04-18 13:25:30.986208')
     def test_add_interaction(self, kind):
         """Test add new interaction."""
@@ -691,7 +693,10 @@ class TestAddInteractionView(APITestMixin):
             'subject': ['This field is required.'],
         }
 
-    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    @pytest.mark.parametrize(
+        'kind',
+        (Interaction.KINDS.interaction, Interaction.KINDS.policy_feedback,)
+    )
     def test_add_interaction_missing_interaction_only_fields(self, kind):
         """Test add new interaction without required interaction-only fields."""
         adviser = AdviserFactory()
@@ -716,7 +721,10 @@ class TestAddInteractionView(APITestMixin):
             'communication_channel': ['This field is required.'],
         }
 
-    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    @pytest.mark.parametrize(
+        'kind',
+        (Interaction.KINDS.interaction, Interaction.KINDS.policy_feedback,)
+    )
     def test_add_interaction_with_service_delivery_fields(self, kind):
         """Tests that adding an interaction with an event fails."""
         adviser = AdviserFactory()
@@ -779,7 +787,10 @@ class TestAddInteractionView(APITestMixin):
         }
 
     @freeze_time('2017-04-18 13:25:30.986208')
-    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    @pytest.mark.parametrize(
+        'kind',
+        (Interaction.KINDS.interaction, Interaction.KINDS.policy_feedback,)
+    )
     def test_add_interaction_project(self, kind):
         """Test add new interaction for an investment project."""
         project = InvestmentProjectFactory()
@@ -806,7 +817,10 @@ class TestAddInteractionView(APITestMixin):
         assert response_data['modified_on'] == '2017-04-18T13:25:30.986208Z'
         assert response_data['created_on'] == '2017-04-18T13:25:30.986208Z'
 
-    @pytest.mark.parametrize('kind', (Interaction.KINDS.interaction, Interaction.KINDS.policy,))
+    @pytest.mark.parametrize(
+        'kind',
+        (Interaction.KINDS.interaction, Interaction.KINDS.policy_feedback,)
+    )
     def test_add_interaction_no_entity(self, kind):
         """Test add new interaction without a contact, company or
         investment project.

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -401,7 +401,7 @@
 - model: interaction.interaction
   pk: aa162e87-06d5-423d-963e-1ecbe46c62aa
   fields:
-    kind: policy
+    kind: policy_feedback
     subject: Unhappy with tariff
     date: '2017-07-05T00:00:00Z'
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611


### PR DESCRIPTION
Issue number: 
MI-1413 & MI-1391

### Description of change

Renaming this key as the front-end heavily relies on the key rather than the
display representation of KINDS to build titles/headings and buttons when
adding/editing/viewing Interactions.

### Checklist

* [x] ~Have any relevant search models been updated?~
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] ~Have any relevant select-/prefetch-related field lists in the views and search apps been updated?~
* [x] ~Has the admin site been updated (for new models, fields etc.)?~
* [x] ~Has the README been updated (if needed)?~


### Why?
After speaking to @web-bert and @teneightfive they tell me that the FE relies heavily on the Interaction.KIND.key for messages in the interface and changing it to use the display value from the metadata would be too much work so it would be better to make the backend key "read correctly" when used in the FE templates. https://github.com/uktrade/data-hub-frontend/tree/mi-1391-policy-interactions

Things they'd have to change if we wanted the FE text to be independent of the BE key:
* https://github.com/uktrade/data-hub-frontend/blob/a67d36c5efaf588a6724a115c88a57c316292d27/src/apps/interactions/controllers/edit.js#L43
* https://github.com/uktrade/data-hub-frontend/blob/a67d36c5efaf588a6724a115c88a57c316292d27/src/apps/interactions/controllers/edit.js#L30
* https://github.com/uktrade/data-hub-frontend/blob/a67d36c5efaf588a6724a115c88a57c316292d27/src/apps/interactions/constants.js#L16
* https://github.com/uktrade/data-hub-frontend/blob/a67d36c5efaf588a6724a115c88a57c316292d27/src/apps/interactions/controllers/edit.js#L11
* https://github.com/uktrade/data-hub-frontend/blob/a67d36c5efaf588a6724a115c88a57c316292d27/src/apps/interactions/controllers/edit.js#L35
* https://github.com/uktrade/data-hub-frontend/blob/a67d36c5efaf588a6724a115c88a57c316292d27/test/acceptance/features/interactions/step_definitions/save.js#L20
* https://github.com/uktrade/data-hub-frontend/blob/a67d36c5efaf588a6724a115c88a57c316292d27/src/apps/interactions/transformers.js#L142

@jim68000 @reupen are you happy with changing BE to make FE changes easier? Now is a good time to make this change as nobody has created a policy interaction yet so we don't need to migrate legacy data