### PR TITLE
Refresh ES indexes before deleting docs in tests

### DIFF
--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -50,6 +50,7 @@ def setup_es(setup_es_indexes):
     """Sets up ES and deletes all the records after each run."""
     yield setup_es_indexes
 
+    setup_es_indexes.indices.refresh()
     setup_es_indexes.delete_by_query(
         settings.ES_INDEX,
         body={'query': {'match_all': {}}},

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -23,6 +23,8 @@ pytestmark = pytest.mark.django_db
 def test_order_to_dict(Factory, setup_es):
     """Test converting an order to dict."""
     order = Factory()
+    setup_es.indices.refresh()
+
     invoice = order.invoice
     OrderSubscriberFactory.create_batch(2, order=order)
     OrderAssigneeFactory.create_batch(2, order=order)


### PR DESCRIPTION
There was a problem with some tests not refreshing the ES index after adding docs to ES directly or indirectly.

That's a really easy thing to forget so this just refreshes the indexes before deleting the objects after each tests to fix the problem.