### PR TITLE
Additional validation of headquarter_type field.

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -213,7 +213,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'Subsidiaries have to be unlinked before changing headquarter type.',
         ),
         'subsidiary_cannot_be_a_global_headquarters': ugettext_lazy(
-            'Global headquarters cannot have assigned global headquarters.',
+            'A company cannot both be and have a global headquarters.',
         )
     }
 
@@ -281,7 +281,10 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         """Ensure that global headquarters doesn't have any subsidiaries before changing
         headquarter type.
         """
-        if self.instance and self.instance.headquarter_type != headquarter_type:
+        if (
+            self.instance
+            and self.instance.headquarter_type_id != getattr(headquarter_type, 'id', None)
+        ):
             if (
                 self.instance.headquarter_type_id == UUID(HeadquarterType.ghq.value.id)
                 and self.instance.subsidiaries.count() > 0
@@ -290,7 +293,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
                     self.error_messages['global_headquarters_has_subsidiaries']
                 )
             if (
-                str(headquarter_type) == HeadquarterType.ghq.value.name
+                getattr(headquarter_type, 'id', None) == UUID(HeadquarterType.ghq.value.id)
                 and self.instance.global_headquarters is not None
             ):
                 raise serializers.ValidationError(

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -211,6 +211,9 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         ),
         'global_headquarters_has_subsidiaries': ugettext_lazy(
             'Subsidiaries have to be unlinked before changing headquarter type.',
+        ),
+        'subsidiary_cannot_be_a_global_headquarters': ugettext_lazy(
+            'Global headquarters cannot have assigned global headquarters.',
         )
     }
 
@@ -285,6 +288,13 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             ):
                 raise serializers.ValidationError(
                     self.error_messages['global_headquarters_has_subsidiaries']
+                )
+            if (
+                str(headquarter_type) == HeadquarterType.ghq.value.name
+                and self.instance.global_headquarters is not None
+            ):
+                raise serializers.ValidationError(
+                    self.error_messages['subsidiary_cannot_be_a_global_headquarters']
                 )
 
         return headquarter_type

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -281,26 +281,39 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         """Ensure that global headquarters doesn't have any subsidiaries before changing
         headquarter type.
         """
+        headquarter_type_id = getattr(headquarter_type, 'id', None)
+
         if (
             self.instance
-            and self.instance.headquarter_type_id != getattr(headquarter_type, 'id', None)
+            and self.instance.headquarter_type_id != headquarter_type_id
         ):
-            if (
-                self.instance.headquarter_type_id == UUID(HeadquarterType.ghq.value.id)
-                and self.instance.subsidiaries.count() > 0
-            ):
-                raise serializers.ValidationError(
-                    self.error_messages['global_headquarters_has_subsidiaries']
-                )
-            if (
-                getattr(headquarter_type, 'id', None) == UUID(HeadquarterType.ghq.value.id)
-                and self.instance.global_headquarters is not None
-            ):
-                raise serializers.ValidationError(
-                    self.error_messages['subsidiary_cannot_be_a_global_headquarters']
-                )
+            self._validate_cannot_remove_ghq_if_it_has_subsidiaries()
+            self._validate_cannot_become_ghq_if_linked_to_another_ghq(headquarter_type_id)
 
         return headquarter_type
+
+    def _validate_cannot_remove_ghq_if_it_has_subsidiaries(self):
+        """Raises an exception if company is a global hq and has subsidiaries."""
+        if (
+            self.instance.headquarter_type_id == UUID(HeadquarterType.ghq.value.id)
+            and self.instance.subsidiaries.count() > 0
+        ):
+            raise serializers.ValidationError(
+                self.error_messages['global_headquarters_has_subsidiaries']
+            )
+
+    def _validate_cannot_become_ghq_if_linked_to_another_ghq(
+        self,
+        headquarter_type_id
+    ):
+        """Raises an exception if new headquarter type is ghq and company is linked to ghq."""
+        if (
+            headquarter_type_id == UUID(HeadquarterType.ghq.value.id)
+            and self.instance.global_headquarters is not None
+        ):
+            raise serializers.ValidationError(
+                self.error_messages['subsidiary_cannot_be_a_global_headquarters']
+            )
 
     def validate_global_headquarters(self, global_headquarters):
         """Ensure that global headquarters is global headquarters and it is not pointing
@@ -313,7 +326,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
                     self.error_messages['global_headquarters_company_is_not_a_global_headquarters']
                 )
 
-            # check if global_headquarters is not pointing to an instance of the model
+            # checks if global_headquarters is not pointing to an instance of the model
             if self.instance == global_headquarters:
                 raise serializers.ValidationError(
                     self.error_messages['invalid_global_headquarters']

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -524,7 +524,7 @@ class TestUpdateCompany(APITestMixin):
             assert response.data['global_headquarters'] == error
 
     def test_remove_global_headquarters_link(self):
-        """Tests if we can remove global headquarter link."""
+        """Tests that we can remove global headquarter link."""
         global_headquarters = CompanyFactory(
             headquarter_type_id=HeadquarterType.ghq.value.id
         )
@@ -544,7 +544,7 @@ class TestUpdateCompany(APITestMixin):
         assert global_headquarters.subsidiaries.count() == 0
 
     def test_cannot_point_company_to_itself_as_global_headquarters(self):
-        """Test if you cannot point company as its own global headquarters."""
+        """Test that you cannot point company as its own global headquarters."""
         company = CompanyFactory(
             headquarter_type_id=HeadquarterType.ghq.value.id
         )
@@ -560,7 +560,7 @@ class TestUpdateCompany(APITestMixin):
         assert response.data['global_headquarters'] == error
 
     def test_subsidiary_cannot_become_a_global_headquarters(self):
-        """Tests if subsidiary cannot become a global headquarter."""
+        """Tests that subsidiary cannot become a global headquarter."""
         global_headquarters = CompanyFactory(
             headquarter_type_id=HeadquarterType.ghq.value.id
         )

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -543,8 +543,8 @@ class TestUpdateCompany(APITestMixin):
 
         assert global_headquarters.subsidiaries.count() == 0
 
-    def test_company_pointing_itself_as_global_headquarters(self):
-        """Test if you can point company as its own global headquarters."""
+    def test_cannot_point_company_to_itself_as_global_headquarters(self):
+        """Test if you cannot point company as its own global headquarters."""
         company = CompanyFactory(
             headquarter_type_id=HeadquarterType.ghq.value.id
         )
@@ -559,13 +559,13 @@ class TestUpdateCompany(APITestMixin):
         error = ['Global headquarters cannot point to itself.']
         assert response.data['global_headquarters'] == error
 
-    def test_subsidiary_becomes_a_global_headquarters(self):
-        """Tests if subsidiary can become a global headquarter."""
+    def test_subsidiary_cannot_become_a_global_headquarters(self):
+        """Tests if subsidiary cannot become a global headquarter."""
         global_headquarters = CompanyFactory(
             headquarter_type_id=HeadquarterType.ghq.value.id
         )
         company = CompanyFactory(
-            headquarter_type=None,
+            headquarter_type_id=None,
             global_headquarters=global_headquarters,
         )
 
@@ -576,9 +576,8 @@ class TestUpdateCompany(APITestMixin):
         response = self.api_client.patch(url, format='json', data={
             'headquarter_type': HeadquarterType.ghq.value.id,
         })
-
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        error = ['Global headquarters cannot have assigned global headquarters.']
+        error = ['A company cannot both be and have a global headquarters.']
         assert response.data['headquarter_type'] == error
 
     @pytest.mark.parametrize('headquarter_type_id,changed_to,has_subsidiaries,is_valid', (

--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -8,7 +8,6 @@ MODELS_TO_REGISTER_DISABLEABLE = (
     models.CompanyClassification,
     models.Country,
     models.FDIType,
-    models.HeadquarterType,
     models.InvestmentBusinessActivity,
     models.InvestmentStrategicDriver,
     models.ReferralSourceActivity,
@@ -30,6 +29,7 @@ MODELS_TO_REGISTER_WITH_ORDER = (
 
 MODELS_TO_REGISTER_READ_ONLY = (
     models.BusinessType,
+    models.HeadquarterType,
     models.InvestmentType,
     models.InvestmentProjectStage,
 )


### PR DESCRIPTION
Issue number: DH-1569

### Description of change

This adds additional validation of `headquarter_type`, so that when a company is linked to a global headquarters it can't become global headquarters itself.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
