### PR TITLE
Throttle OMIS create gateway session endpoint

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -175,6 +175,9 @@ REST_FRAMEWORK = {
         'oauth2_provider.contrib.rest_framework.IsAuthenticatedOrTokenHasScope',
         'datahub.core.permissions.DjangoCrudPermission',
     ],
+    'DEFAULT_THROTTLE_RATES': {
+        'payment_gateway_session.create': None,  # disabled for now
+    },
     'ORDERING_PARAM': 'sortby'
 }
 

--- a/conftest.py
+++ b/conftest.py
@@ -2,6 +2,8 @@ import factory
 import pytest
 import requests_mock
 from botocore.stub import Stubber
+from django.conf import settings
+from django.core.cache import CacheHandler
 from django.core.management import call_command
 from pytest_django.lazy_django import skip_if_no_django
 
@@ -56,3 +58,14 @@ def requests_stubber():
     """Requests stubber based on requests-mock"""
     with requests_mock.mock() as requests_stubber:
         yield requests_stubber
+
+
+@pytest.fixture()
+def local_memory_cache(monkeypatch):
+    """Configure settings.CACHES to use LocMemCache."""
+    monkeypatch.setitem(
+        settings.CACHES,
+        'default',
+        {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
+    )
+    monkeypatch.setattr('django.core.cache.caches', CacheHandler())

--- a/datahub/core/test/test_throttling.py
+++ b/datahub/core/test/test_throttling.py
@@ -1,0 +1,99 @@
+import time
+
+import pytest
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+from ..throttling import PathRateThrottle
+
+
+class Path3SecRateThrottle(PathRateThrottle):
+    """PathRateThrottle with a specific rate."""
+
+    scope = 'path'
+    rate = '3/sec'
+
+    def __init__(self, *args, **kwargs):
+        """
+        Re-define self.timer to allow classes to mock time.time if needed.
+        This is because DRF sets this property on the class and it doesn't give
+        opportunities for tests to override it.
+        """
+        super(Path3SecRateThrottle, self).__init__(*args, **kwargs)
+        self.timer = time.time
+
+
+class MockView(APIView):
+    """Simple APIView to test PathRateThrottle."""
+
+    authentication_classes = ()
+    permission_classes = ()
+    throttle_classes = (Path3SecRateThrottle,)
+
+    def get(self, request):
+        """Simple implementatin of the GET method."""
+        return Response('foo')
+
+
+@pytest.mark.usefixtures('local_memory_cache')
+class TestPathRateThrottle:
+    """Tests for the PathRateThrottle class."""
+
+    @freeze_time('2018-03-01 00:00:00')
+    def test_requests_are_throttled(self):
+        """Test that the requests are throttled."""
+        factory = APIRequestFactory()
+
+        for dummy in range(4):
+            request = factory.get('/some-path/')
+            response = MockView.as_view()(request)
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    @freeze_time('2018-03-01 00:00:00')
+    def test_query_params_do_not_count(self):
+        """
+        Test that query params are ignored.
+        Eg. GET /some-path/ and GET /some-path/?param=value
+        are treated as the same.
+        """
+        factory = APIRequestFactory()
+
+        for index in range(4):
+            request = factory.get(f'/some-path/?param={index}')
+            response = MockView.as_view()(request)
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    @freeze_time('2018-03-01 00:00:00')
+    def test_case_does_not_count(self):
+        """
+        Test that the match is case insensitive..
+        Eg. GET /some-path/ and GET /some-Path/
+        are treated as the same.
+        """
+        factory = APIRequestFactory()
+
+        for path in ['path', 'Path', 'pAth', 'paTh']:
+            request = factory.get(f'/some-{path}/')
+            response = MockView.as_view()(request)
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+    @freeze_time('2018-03-01 00:00:00')
+    def test_throttling_is_per_path(self):
+        """
+        Test that throttling is per path.
+        Eg. GET /some-path-1/ and POST /some-path-2/
+        are not treated as the same.
+        """
+        factory = APIRequestFactory()
+
+        for dummy in range(4):
+            request = factory.get('/some-path/')
+            response = MockView.as_view()(request)
+        assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
+
+        request = factory.get('/some-path2/')
+        response = MockView.as_view()(request)
+        assert response.status_code == status.HTTP_200_OK

--- a/datahub/core/throttling.py
+++ b/datahub/core/throttling.py
@@ -1,0 +1,29 @@
+import hashlib
+
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class PathRateThrottle(SimpleRateThrottle):
+    """
+    Limits the rate of API calls based on the path used
+    instead of the user logged-in or the client IP.
+
+    This is useful with views without user authentication where
+    the path includes user-related resources.
+
+    E.g. /user/<user-token>/forgot-password/
+
+    Note: query params are ignored.
+    """
+
+    def get_cache_key(self, request, view):
+        """
+        :returns: cache key constructed from the request path
+        """
+        # we hash the path to have a deterministic length (64 chars)
+        ident_hash = hashlib.sha256(request.path.lower().encode('utf-8'))
+
+        return self.cache_format % {
+            'scope': self.scope,
+            'ident': ident_hash.hexdigest()
+        }


### PR DESCRIPTION
As the create gateway session endpoint can be triggered by a user action (e.g. user clicks on a pay button), we want to disallow clients from hitting the API often enough to create issues so we limit the number to max x per minute.