### PR TITLE
Remove ignore 409 flag from ES tests

### DIFF
--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -54,8 +54,7 @@ def setup_es(_setup_es_indexes, monkeypatch):
     _setup_es_indexes.indices.refresh()
     _setup_es_indexes.delete_by_query(
         settings.ES_INDEX,
-        body={'query': {'match_all': {}}},
-        ignore=(409,)
+        body={'query': {'match_all': {}}}
     )
     _setup_es_indexes.indices.refresh()
 

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -20,10 +20,9 @@ pytestmark = pytest.mark.django_db
         OrderWithAcceptedQuoteFactory
     )
 )
-def test_order_to_dict(Factory, setup_es):
+def test_order_to_dict(Factory):
     """Test converting an order to dict."""
     order = Factory()
-    setup_es.indices.refresh()
 
     invoice = order.invoice
     OrderSubscriberFactory.create_batch(2, order=order)
@@ -154,7 +153,7 @@ def test_order_to_dict(Factory, setup_es):
     }
 
 
-def test_orders_to_es_documents(setup_es):
+def test_orders_to_es_documents():
     """Test converting 2 orders to Elasticsearch documents."""
     orders = OrderFactory.create_batch(2)
 


### PR DESCRIPTION
This removes the flag to ignore conflict errors when deleting docs as we are refreshing the indexes before.

It also removes the ES fixture from a couple of tests that didn't need ES at all.
