### PR TITLE
Add OMIS get payment session endpoint

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -230,4 +230,4 @@ GOVUK_PAY_URL = env('GOVUK_PAY_URL', default='')
 GOVUK_PAY_AUTH_TOKEN = env('GOVUK_PAY_AUTH_TOKEN', default='')
 GOVUK_PAY_TIMEOUT = 15  # in seconds
 GOVUK_PAY_PAYMENT_DESCRIPTION = 'Overseas Market Introduction Service'
-GOVUK_PAY_RETURN_URL = f'{OMIS_PUBLIC_ORDER_URL}/card-payment/{{session_id}}'
+GOVUK_PAY_RETURN_URL = f'{OMIS_PUBLIC_ORDER_URL}/payment/card/{{session_id}}'

--- a/datahub/omis/payment/models.py
+++ b/datahub/omis/payment/models.py
@@ -56,6 +56,9 @@ class PaymentGatewaySession(BaseModel):
 
         :raises GOVUKPayAPIException: if there is a problem with GOV.UK Pay
         """
+        if self.is_finished():
+            return ''
+
         next_url = self._get_payment_from_govuk_pay()['_links']['next_url'] or {}
         return next_url.get('href', '')
 

--- a/datahub/omis/payment/urls.py
+++ b/datahub/omis/payment/urls.py
@@ -30,4 +30,12 @@ payment_gateway_session_public_urls = [
         PublicPaymentGatewaySessionViewSet.as_view({'post': 'create'}),
         name='collection'
     ),
+    re_path(
+        (
+            r'^order/(?P<public_token>[0-9A-Za-z_\-]{50})/'
+            r'payment-gateway-session/(?P<pk>[0-9a-z-]{36})$'
+        ),
+        PublicPaymentGatewaySessionViewSet.as_view({'get': 'retrieve'}),
+        name='detail'
+    ),
 ]

--- a/datahub/omis/payment/views.py
+++ b/datahub/omis/payment/views.py
@@ -79,6 +79,16 @@ class PublicPaymentGatewaySessionViewSet(BaseNestedOrderViewSet):
         """
         return super().get_queryset().filter(order=self.get_order())
 
+    def get_object(self):
+        """
+        :returns: the PaymentGatewaySession instance or 404 if it doesn't exist.
+            It refreshes the data from the related GOV.UK payment record if
+            necessary
+        """
+        obj = super().get_object()
+        obj.refresh_from_govuk_payment()
+        return obj
+
     def create(self, request, *args, **kwargs):
         """
         Same as the DRF create but it catches the Conflict exception and


### PR DESCRIPTION
This adds a new endpoint to get a payment gateway session for an OMIS order.
Behind the scenes, it calls GOV.UK Pay to refresh the related metadata in django.