### PR TITLE
Enhance references in OMIS payments

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -245,5 +245,5 @@ OMIS_PUBLIC_ORDER_URL = f'{OMIS_PUBLIC_BASE_URL}/{{public_token}}'
 GOVUK_PAY_URL = env('GOVUK_PAY_URL', default='')
 GOVUK_PAY_AUTH_TOKEN = env('GOVUK_PAY_AUTH_TOKEN', default='')
 GOVUK_PAY_TIMEOUT = 15  # in seconds
-GOVUK_PAY_PAYMENT_DESCRIPTION = 'Overseas Market Introduction Service'
+GOVUK_PAY_PAYMENT_DESCRIPTION = 'Overseas Market Introduction Service order {reference}'
 GOVUK_PAY_RETURN_URL = f'{OMIS_PUBLIC_ORDER_URL}/payment/card/{{session_id}}'

--- a/datahub/omis/payment/managers.py
+++ b/datahub/omis/payment/managers.py
@@ -45,8 +45,10 @@ class BasePaymentGatewaySessionManager(models.Manager):
         pay = PayClient()
         govuk_payment = pay.create_payment(
             amount=order.total_cost,
-            reference=str(session_id),
-            description=settings.GOVUK_PAY_PAYMENT_DESCRIPTION,
+            reference=f'{order.reference}-{str(session_id)[:8].upper()}',
+            description=settings.GOVUK_PAY_PAYMENT_DESCRIPTION.format(
+                reference=order.reference
+            ),
             return_url=settings.GOVUK_PAY_RETURN_URL.format(
                 public_token=order.public_token,
                 session_id=session_id

--- a/datahub/omis/payment/test/test_models.py
+++ b/datahub/omis/payment/test/test_models.py
@@ -204,6 +204,7 @@ class TestPaymentGatewaySessionRefresh:
             'state': {'status': 'success'},
             'email': 'email@example.com',
             'created_date': '2018-02-13T14:56:56.734Z',
+            'reference': '12345',
             'card_details': {
                 'last_digits_card_number': '1111',
                 'cardholder_name': 'John Doe',
@@ -237,6 +238,7 @@ class TestPaymentGatewaySessionRefresh:
         assert payment.amount == response_json['amount']
         assert payment.method == PaymentMethod.card
         assert payment.received_on == dateutil_parse('2018-02-13').date()
+        assert payment.transaction_reference == '12345'
 
         assert payment.cardholder_name == 'John Doe'
         assert payment.card_brand == 'Visa'

--- a/datahub/omis/payment/test/test_utils.py
+++ b/datahub/omis/payment/test/test_utils.py
@@ -28,6 +28,7 @@ class TestGetOmisPaymentDataFromGovukPayment:
             'state': {'status': 'success'},
             'email': 'email@example.com',
             'created_date': '2018-02-13T14:56:56.734Z',
+            'reference': '12345',
             'card_details': {
                 'last_digits_card_number': '1111',
                 'cardholder_name': 'John Doe',
@@ -49,6 +50,7 @@ class TestGetOmisPaymentDataFromGovukPayment:
             'amount': 1234,
             'method': PaymentMethod.card,
             'received_on': dateutil_parse('2018-02-13').date(),
+            'transaction_reference': '12345',
             'cardholder_name': 'John Doe',
             'card_brand': 'Visa',
             'billing_email': 'email@example.com',

--- a/datahub/omis/payment/test/views/test_public_payment_gateway_sessions.py
+++ b/datahub/omis/payment/test/views/test_public_payment_gateway_sessions.py
@@ -347,6 +347,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
                 'amount': order.total_cost,
                 'state': {'status': 'success'},
                 'email': 'email@example.com',
+                'reference': '12345',
                 'created_date': '2018-02-13T14:56:56.734Z',
                 'card_details': {
                     'last_digits_card_number': '1111',
@@ -700,6 +701,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
                 'amount': order.total_cost,
                 'state': {'status': 'success'},
                 'email': 'email@example.com',
+                'reference': '12345',
                 'created_date': '2018-02-13T14:56:56.734Z',
                 '_links': {
                     'next_url': None,

--- a/datahub/omis/payment/utils.py
+++ b/datahub/omis/payment/utils.py
@@ -20,8 +20,9 @@ def trasform_govuk_payment_to_omis_payment_data(govuk_payment):
     return {
         'amount': govuk_payment['amount'],
         'method': PaymentMethod.card,
+        'transaction_reference': govuk_payment['reference'],
 
-        # unfortunatelly GOV.UK Pay doesn't tell us when the payment actually happened
+        # unfortunately GOV.UK Pay doesn't tell us when the payment actually happened
         'received_on': dateutil_parse(govuk_payment['created_date']).date(),
 
         # card details


### PR DESCRIPTION
This:
- adds the order reference to the description of a GOV.UK payment
- uses the order reference and the first 8 chars of the payment gateway session id as GOV.UK payment reference. This is because it's shown to the user at the end of the transaction and it could be used to get to the record either from the GOV.UK Pay admin area and/or in our system
- stores the GOV.UK payment reference on the OMIS payment record as `transaction_reference`
