### PR TITLE
Set throttling value for OMIS create payment session

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -176,7 +176,7 @@ REST_FRAMEWORK = {
         'datahub.core.permissions.DjangoCrudPermission',
     ],
     'DEFAULT_THROTTLE_RATES': {
-        'payment_gateway_session.create': None,  # disabled for now
+        'payment_gateway_session.create': '5/min',
     },
     'ORDERING_PARAM': 'sortby'
 }


### PR DESCRIPTION
This sets the throttling value for the create payment session endpoint to **5 a minute** for now.