### PR TITLE
Add sector descends filters to search

### DIFF
--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -28,6 +28,8 @@ class CompanySearchApp(SearchApp):
         'global_headquarters',
         'registered_address_country',
         'sector',
+        'sector__parent',
+        'sector__parent__parent',
         'trading_address_country',
         'turnover_range',
         'uk_region',

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -132,7 +132,6 @@ class Company(DocType, MapDBModelToDict):
         'reference_code',
         'registered_address_country.name_trigram',
         'registered_address_postcode_trigram',
-        'sector.name_trigram',
         'trading_address_country.name_trigram',
         'trading_address_postcode_trigram',
         'uk_region.name_trigram'

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -56,7 +56,7 @@ class Company(DocType, MapDBModelToDict):
     )
     registered_address_postcode_trigram = dsl_utils.TrigramText()
     registered_address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
-    sector = dsl_utils.id_name_partial_mapping('sector')
+    sector = dsl_utils.sector_mapping()
     trading_address_1 = Text()
     trading_address_2 = Text()
     trading_address_country = dsl_utils.id_name_partial_mapping(
@@ -92,7 +92,7 @@ class Company(DocType, MapDBModelToDict):
         'parent': dict_utils.id_name_dict,
         'global_headquarters': dict_utils.id_name_dict,
         'registered_address_country': dict_utils.id_name_dict,
-        'sector': dict_utils.id_name_dict,
+        'sector': dict_utils.sector_dict,
         'trading_address_country': dict_utils.id_name_dict,
         'turnover_range': dict_utils.id_name_dict,
         'uk_region': dict_utils.id_name_dict,

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -20,6 +20,7 @@ class SearchCompanySerializer(SearchSerializer):
     headquarter_type = SingleOrListField(child=NullStringUUIDField(), required=False)
     name = serializers.CharField(required=False)
     sector = SingleOrListField(child=StringUUIDField(), required=False)
+    sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     trading_address_country = SingleOrListField(child=StringUUIDField(), required=False)
     country = SingleOrListField(child=StringUUIDField(), required=False)
     uk_based = serializers.BooleanField(required=False)

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -52,7 +52,6 @@ def test_get_basic_search_query():
                                 'registered_address_postcode_trigram',
                                 'related_programmes.name',
                                 'related_programmes.name_trigram',
-                                'sector.name_trigram',
                                 'subject_english',
                                 'subtotal_cost_string',
                                 'teams.name',
@@ -150,7 +149,6 @@ def test_limited_get_search_by_entity_query():
                                             'reference_code',
                                             'registered_address_country.name_trigram',
                                             'registered_address_postcode_trigram',
-                                            'sector.name_trigram',
                                             'trading_address_country.name_trigram',
                                             'trading_address_postcode_trigram',
                                             'uk_region.name_trigram'

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -20,6 +20,7 @@ class SearchCompanyParams:
         'headquarter_type',
         'name',
         'sector',
+        'sector_descends',
         'country',
         'trading_address_country',
         'trading_address_postcode',
@@ -43,6 +44,7 @@ class SearchCompanyParams:
     COMPOSITE_FILTERS = {
         'name': ['name', 'name_trigram', 'trading_name_trigram'],
         'country': ['trading_address_country.id', 'registered_address_country.id'],
+        'sector_descends': ['sector.id', 'sector.ancestors.id'],
     }
 
 

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -3,6 +3,7 @@ from elasticsearch.helpers.test import get_test_client
 from pytest import fixture
 
 from datahub.core.test_utils import synchronous_executor_submit, synchronous_transaction_on_commit
+from datahub.metadata.test.factories import SectorFactory
 from datahub.search import elasticsearch
 from .apps import get_search_apps
 
@@ -65,3 +66,17 @@ def _create_test_index(client, index):
         client.indices.delete(index)
 
     elasticsearch.configure_index(index, settings.ES_INDEX_SETTINGS)
+
+
+@fixture
+def hierarchical_sectors():
+    """Creates three test sectors in a hierarchy."""
+    parent = None
+    sectors = []
+
+    for _ in range(3):
+        sector = SectorFactory(parent=parent)
+        sectors.append(sector)
+        parent = sector
+
+    yield sectors

--- a/datahub/search/contact/apps.py
+++ b/datahub/search/contact/apps.py
@@ -19,6 +19,8 @@ class ContactSearchApp(SearchApp):
         'address_country',
         'archived_by',
         'company__sector',
+        'company__sector__parent',
+        'company__sector__parent__parent',
         'company__uk_region',
         'company__registered_address_country',
         'company__trading_address_country',

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -57,7 +57,7 @@ class Contact(DocType, MapDBModelToDict):
     adviser = dsl_utils.contact_or_adviser_mapping('adviser')
     archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
     company = dsl_utils.id_name_partial_mapping('company')
-    company_sector = dsl_utils.id_name_mapping()
+    company_sector = dsl_utils.sector_mapping()
     company_uk_region = dsl_utils.id_name_mapping()
     created_by = dsl_utils.contact_or_adviser_mapping('created_by', include_dit_team=True)
 
@@ -71,7 +71,7 @@ class Contact(DocType, MapDBModelToDict):
     }
 
     COMPUTED_MAPPINGS = {
-        'company_sector': dict_utils.computed_nested_id_name_dict('company.sector'),
+        'company_sector': dict_utils.computed_nested_sector_dict('company.sector'),
         'company_uk_region': dict_utils.computed_nested_id_name_dict('company.uk_region'),
         'address_1': contact_dict_utils.computed_address_field('address_1'),
         'address_2': contact_dict_utils.computed_address_field('address_2'),

--- a/datahub/search/contact/serializers.py
+++ b/datahub/search/contact/serializers.py
@@ -15,6 +15,7 @@ class SearchContactSerializer(SearchSerializer):
     company = SingleOrListField(child=StringUUIDField(), required=False)
     company_name = serializers.CharField(required=False)
     company_sector = SingleOrListField(child=StringUUIDField(), required=False)
+    company_sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     company_uk_region = SingleOrListField(child=StringUUIDField(), required=False)
     address_country = SingleOrListField(child=StringUUIDField(), required=False)
     created_by = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -52,7 +52,6 @@ def test_get_basic_search_query():
                                 'registered_address_postcode_trigram',
                                 'related_programmes.name',
                                 'related_programmes.name_trigram',
-                                'sector.name_trigram',
                                 'subject_english',
                                 'subtotal_cost_string',
                                 'teams.name',

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -16,6 +16,7 @@ class SearchContactParams:
         'company',
         'company_name',
         'company_sector',
+        'company_sector_descends',
         'company_uk_region',
         'created_by',
         'created_on_exists',
@@ -41,6 +42,10 @@ class SearchContactParams:
             'company.name_trigram',
             'company.trading_name',
             'company.trading_name_trigram',
+        ],
+        'company_sector_descends': [
+            'company_sector.id',
+            'company_sector.ancestors.id',
         ],
     }
 

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -56,8 +56,8 @@ def adviser_dict_with_team(obj):
     return contact_or_adviser_dict(obj, include_dit_team=True)
 
 
-def computed_nested_id_name_dict(nested_field):
-    """Creates dictionary with selected fields from nested_field."""
+def _computed_nested_dict(nested_field, dict_func):
+    """Creates a dictionary from a nested field using dict_func."""
     def get_dict(obj):
         fields = nested_field.split('.', maxsplit=1)
         if len(fields) != 2:
@@ -71,9 +71,19 @@ def computed_nested_id_name_dict(nested_field):
         if field is None:
             return None
 
-        return id_name_dict(field)
+        return dict_func(field)
 
     return get_dict
+
+
+def computed_nested_id_name_dict(nested_field):
+    """Creates a dictionary with id and name from a nested field."""
+    return _computed_nested_dict(nested_field, id_name_dict)
+
+
+def computed_nested_sector_dict(nested_field):
+    """Creates a dictionary for a sector from from a nested field."""
+    return _computed_nested_dict(nested_field, sector_dict)
 
 
 def company_dict(obj):
@@ -96,4 +106,22 @@ def investment_project_dict(obj):
         'id': str(obj.id),
         'name': obj.name,
         'project_code': obj.project_code,
+    }
+
+
+def sector_dict(obj):
+    """Creates a dictionary for a sector."""
+    if obj is None:
+        return None
+
+    return {
+        'id': str(obj.id),
+        'name': obj.name,
+        'ancestors': [_format_ancestor_sector(ancestor) for ancestor in obj.get_ancestors()],
+    }
+
+
+def _format_ancestor_sector(obj):
+    return {
+        'id': str(obj.id),
     }

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -117,11 +117,7 @@ def sector_dict(obj):
     return {
         'id': str(obj.id),
         'name': obj.name,
-        'ancestors': [_format_ancestor_sector(ancestor) for ancestor in obj.get_ancestors()],
-    }
-
-
-def _format_ancestor_sector(obj):
-    return {
-        'id': str(obj.id),
+        'ancestors': [{
+            'id': str(ancestor.id),
+        } for ancestor in obj.get_ancestors()],
     }

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -92,3 +92,25 @@ def investment_project_mapping():
         'name': SortableCaseInsensitiveKeywordText(),
         'project_code': SortableCaseInsensitiveKeywordText(),
     })
+
+
+def sector_mapping():
+    """Mapping for sector fields."""
+    return Nested(
+        properties={
+            'id': Keyword(),
+            'name': SortableCaseInsensitiveKeywordText(),
+            'ancestors': _ancestor_sector_mapping(),
+        },
+        include_in_parent=True,
+    )
+
+
+def _ancestor_sector_mapping():
+    """Mapping for ancestral sector fields."""
+    return Nested(
+        properties={
+            'id': Keyword(),
+        },
+        include_in_parent=True,
+    )

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -47,6 +47,8 @@ class InvestmentSearchApp(SearchApp):
         'referral_source_activity_website',
         'referral_source_adviser',
         'sector',
+        'sector__parent',
+        'sector__parent__parent',
         'specific_programme',
         'strategic_drivers',
         'stage',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -80,7 +80,7 @@ class InvestmentProject(DocType, MapDBModelToDict):
     referral_source_activity_website = dsl_utils.id_name_mapping()
     referral_source_activity_event = dsl_utils.SortableCaseInsensitiveKeywordText()
     referral_source_advisor = dsl_utils.contact_or_adviser_mapping('referral_source_advisor')
-    sector = dsl_utils.id_name_partial_mapping('sector')
+    sector = dsl_utils.sector_mapping()
     status = dsl_utils.SortableCaseInsensitiveKeywordText()
     average_salary = dsl_utils.id_name_mapping()
     date_lost = Date()
@@ -123,7 +123,7 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'referral_source_activity_marketing': dict_utils.id_name_dict,
         'referral_source_activity_website': dict_utils.id_name_dict,
         'referral_source_adviser': dict_utils.contact_or_adviser_dict,
-        'sector': dict_utils.id_name_dict,
+        'sector': dict_utils.sector_dict,
         'project_code': str,
         'average_salary': dict_utils.id_name_dict,
         'archived_by': dict_utils.contact_or_adviser_dict,

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -159,7 +159,6 @@ class InvestmentProject(DocType, MapDBModelToDict):
         'investor_company.name',
         'investor_company.name_trigram',
         'project_code_trigram',
-        'sector.name_trigram',
     )
 
     class Meta:

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -23,6 +23,7 @@ class SearchInvestmentProjectSerializer(SearchSerializer):
     investor_company = SingleOrListField(child=StringUUIDField(), required=False)
     investor_company_country = SingleOrListField(child=StringUUIDField(), required=False)
     sector = SingleOrListField(child=StringUUIDField(), required=False)
+    sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     stage = SingleOrListField(child=StringUUIDField(), required=False)
     status = SingleOrListField(child=serializers.CharField(), required=False)
     uk_region_location = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -54,7 +54,6 @@ def test_get_basic_search_query():
                                 'registered_address_postcode_trigram',
                                 'related_programmes.name',
                                 'related_programmes.name_trigram',
-                                'sector.name_trigram',
                                 'subject_english',
                                 'subtotal_cost_string',
                                 'teams.name',
@@ -151,7 +150,6 @@ def test_limited_get_search_by_entity_query():
                                             'investor_company.name',
                                             'investor_company.name_trigram',
                                             'project_code_trigram',
-                                            'sector.name_trigram'
                                         ),
                                         'type': 'cross_fields',
                                         'operator': 'and'

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -26,6 +26,7 @@ class SearchInvestmentProjectParams:
         'investor_company',
         'investor_company_country',
         'sector',
+        'sector_descends',
         'stage',
         'status',
         'uk_region_location',
@@ -48,6 +49,10 @@ class SearchInvestmentProjectParams:
             'project_assurance_adviser.id',
             'project_manager.id',
             'team_members.id',
+        ],
+        'sector_descends': [
+            'sector.id',
+            'sector.ancestors.id'
         ],
     }
 

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -18,7 +18,7 @@ class Order(DocType, MapDBModelToDict):
     created_on = Date()
     modified_on = Date()
     primary_market = dsl_utils.id_name_mapping()
-    sector = dsl_utils.id_name_mapping()
+    sector = dsl_utils.sector_mapping()
     uk_region = dsl_utils.id_name_mapping()
     description = dsl_utils.EnglishText()
     contacts_not_to_approach = Text()
@@ -66,7 +66,7 @@ class Order(DocType, MapDBModelToDict):
         'contact': dict_utils.contact_or_adviser_dict,
         'created_by': dict_utils.adviser_dict_with_team,
         'primary_market': dict_utils.id_name_dict,
-        'sector': dict_utils.id_name_dict,
+        'sector': dict_utils.sector_dict,
         'uk_region': dict_utils.id_name_dict,
         'service_types': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'subscribers': lambda col: [

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -368,6 +368,15 @@ def test_mapping(setup_es):
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
                             'type': 'text'
+                        },
+                        'ancestors': {
+                            'include_in_parent': True,
+                            'properties': {
+                                'id': {
+                                    'type': 'keyword'
+                                }
+                            },
+                            'type': 'nested'
                         }
                     },
                     'type': 'nested'
@@ -543,7 +552,10 @@ def test_indexed_doc(Factory, setup_es):
             },
             'sector': {
                 'id': str(order.sector.pk),
-                'name': order.sector.name
+                'name': order.sector.name,
+                'ancestors': [{
+                    'id': str(ancestor.pk),
+                } for ancestor in order.sector.get_ancestors()]
             },
             'uk_region': {
                 'id': str(order.uk_region.pk),

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -48,7 +48,10 @@ def test_order_to_dict(Factory):
         },
         'sector': {
             'id': str(order.sector.pk),
-            'name': order.sector.name
+            'name': order.sector.name,
+            'ancestors': [{
+                'id': str(ancestor.pk),
+            } for ancestor in order.sector.get_ancestors()]
         },
         'uk_region': {
             'id': str(order.uk_region.pk),


### PR DESCRIPTION
Issue number: DH-1585

### Description of change

This makes a few changes to search:

* Removes `sector.name_trigram` from the global search fields (as per DH-1585)
* Standardises how sectors are stored in Elasticsearch and includes the sector's ancestors in the search document
* Adds a new filter to company, contact and investment project search that matches on a sector or any of its descendants

Will amend the base branch once the other PR has been merged.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
