### PR TITLE
Make thread pool more robust

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `AWS_DEFAULT_REGION` | No | [Default region used by boto3.](http://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variable-configuration) |
 | `AWS_SECRET_ACCESS_KEY` | No | Used as part of [boto3 auto-configuration](http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials). |
 | `BULK_INSERT_BATCH_SIZE`  | No | Used when loading Companies House records (default=5000). |
+| `DATABASE_CONN_MAX_AGE`  | No | [Maximum database connection age (in seconds).](https://docs.djangoproject.com/en/2.0/ref/databases/) |
 | `DATABASE_URL`  | Yes | PostgreSQL server URL (with embedded credentials). |
 | `DATAHUB_FRONTEND_BASE_URL`  | Yes | |
 | `DATAHUB_SECRET`  | Yes | |

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -111,9 +111,12 @@ WSGI_APPLICATION = 'config.wsgi.application'
 
 
 DATABASES = {
-    'default': env.db('DATABASE_URL')
+    'default': {
+        **env.db('DATABASE_URL'),
+        'ATOMIC_REQUESTS': True,
+        'CONN_MAX_AGE': env.int('DATABASE_CONN_MAX_AGE', 0),
+    }
 }
-DATABASES['default']['ATOMIC_REQUESTS'] = True
 
 FIXTURE_DIRS = [
     str(ROOT_DIR('fixtures'))

--- a/conftest.py
+++ b/conftest.py
@@ -69,3 +69,26 @@ def local_memory_cache(monkeypatch):
         {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
     )
     monkeypatch.setattr('django.core.cache.caches', CacheHandler())
+
+
+@pytest.fixture
+def synchronous_thread_pool(monkeypatch):
+    """Run everything submitted to thread pools executor in sync."""
+    monkeypatch.setattr(
+        'datahub.core.utils._submit_to_thread_pool',
+        _synchronous_submit_to_thread_pool
+    )
+
+
+@pytest.fixture
+def synchronous_on_commit(monkeypatch):
+    """During a test run a transaction is never committed, so we have to improvise."""
+    monkeypatch.setattr('django.db.transaction.on_commit', _synchronous_on_commit)
+
+
+def _synchronous_submit_to_thread_pool(fn, *args, **kwargs):
+    fn(*args, **kwargs)
+
+
+def _synchronous_on_commit(fn):
+    fn()

--- a/conftest.py
+++ b/conftest.py
@@ -75,7 +75,7 @@ def local_memory_cache(monkeypatch):
 def synchronous_thread_pool(monkeypatch):
     """Run everything submitted to thread pools executor in sync."""
     monkeypatch.setattr(
-        'datahub.core.utils._submit_to_thread_pool',
+        'datahub.core.thread_pool._submit_to_thread_pool',
         _synchronous_submit_to_thread_pool
     )
 

--- a/datahub/core/apps.py
+++ b/datahub/core/apps.py
@@ -2,7 +2,7 @@ import atexit
 
 from django.apps import AppConfig
 
-from datahub.core.utils import shut_down_thread_pool
+from datahub.core.thread_pool import shut_down_thread_pool
 
 
 class CoreConfig(AppConfig):

--- a/datahub/core/test/test_thread_pool.py
+++ b/datahub/core/test/test_thread_pool.py
@@ -1,0 +1,26 @@
+from unittest import mock
+
+import pytest
+
+from datahub.core.thread_pool import submit_to_thread_pool
+
+pytestmark = pytest.mark.django_db
+
+
+def _synchronous_executor_submit(fn, *args, **kwargs):
+    fn(*args, **kwargs)
+
+
+@mock.patch('datahub.core.thread_pool._executor.submit', _synchronous_executor_submit)
+@mock.patch('datahub.core.thread_pool.client')
+def test_error_raises_exception(mock_raven_client):
+    """
+    Test that if an error occurs whilst executing a thread pool task,
+    the exception is raised and sent to sentry.
+    """
+    mock_task = mock.Mock(__name__='mock_task', side_effect=ValueError())
+
+    with pytest.raises(ValueError):
+        submit_to_thread_pool(mock_task)
+
+    assert mock_raven_client.captureException.called

--- a/datahub/core/test/test_utils.py
+++ b/datahub/core/test/test_utils.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from unittest import mock
 from uuid import UUID
 
 import pytest
@@ -7,8 +6,7 @@ import pytest
 from datahub.core.constants import Constant
 from datahub.core.test.support.models import MetadataModel
 from datahub.core.utils import (
-    join_truthy_strings, load_constants_to_database, slice_iterable_into_chunks,
-    submit_to_thread_pool
+    join_truthy_strings, load_constants_to_database, slice_iterable_into_chunks
 )
 
 pytestmark = pytest.mark.django_db
@@ -83,22 +81,3 @@ def test_load_constants_to_database():
     }
     actual_items = {(obj.id, obj.name) for obj in MetadataModel.objects.all()}
     assert actual_items == expected_items
-
-
-def _synchronous_executor_submit(fn, *args, **kwargs):
-    fn(*args, **kwargs)
-
-
-@mock.patch('datahub.core.utils._executor.submit', _synchronous_executor_submit)
-@mock.patch('datahub.core.utils.client')
-def test_error_raises_exception(mock_raven_client):
-    """
-    Test that if an error occurs whilst executing a thread pool task,
-    the exception is raised and sent to sentry.
-    """
-    mock_task = mock.Mock(__name__='mock_task', side_effect=ValueError())
-
-    with pytest.raises(ValueError):
-        submit_to_thread_pool(mock_task)
-
-    assert mock_raven_client.captureException.called

--- a/datahub/core/test/test_utils.py
+++ b/datahub/core/test/test_utils.py
@@ -6,7 +6,6 @@ import pytest
 
 from datahub.core.constants import Constant
 from datahub.core.test.support.models import MetadataModel
-from datahub.core.test_utils import synchronous_executor_submit
 from datahub.core.utils import (
     join_truthy_strings, load_constants_to_database, slice_iterable_into_chunks,
     submit_to_thread_pool
@@ -86,7 +85,11 @@ def test_load_constants_to_database():
     assert actual_items == expected_items
 
 
-@mock.patch('datahub.core.utils._executor.submit', synchronous_executor_submit)
+def _synchronous_executor_submit(fn, *args, **kwargs):
+    fn(*args, **kwargs)
+
+
+@mock.patch('datahub.core.utils._executor.submit', _synchronous_executor_submit)
 @mock.patch('datahub.core.utils.client')
 def test_error_raises_exception(mock_raven_client):
     """

--- a/datahub/core/test/test_utils.py
+++ b/datahub/core/test/test_utils.py
@@ -1,12 +1,15 @@
 from enum import Enum
+from unittest import mock
 from uuid import UUID
 
 import pytest
 
 from datahub.core.constants import Constant
 from datahub.core.test.support.models import MetadataModel
+from datahub.core.test_utils import synchronous_executor_submit
 from datahub.core.utils import (
-    join_truthy_strings, load_constants_to_database, slice_iterable_into_chunks
+    join_truthy_strings, load_constants_to_database, slice_iterable_into_chunks,
+    submit_to_thread_pool
 )
 
 pytestmark = pytest.mark.django_db
@@ -81,3 +84,18 @@ def test_load_constants_to_database():
     }
     actual_items = {(obj.id, obj.name) for obj in MetadataModel.objects.all()}
     assert actual_items == expected_items
+
+
+@mock.patch('datahub.core.utils._executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils.client')
+def test_error_raises_exception(mock_raven_client):
+    """
+    Test that if an error occurs whilst executing a thread pool task,
+    the exception is raised and sent to sentry.
+    """
+    mock_task = mock.Mock(__name__='mock_task', side_effect=ValueError())
+
+    with pytest.raises(ValueError):
+        submit_to_thread_pool(mock_task)
+
+    assert mock_raven_client.captureException.called

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -157,16 +157,6 @@ class APITestMixin:
         return self._applications[grant_type]
 
 
-def synchronous_executor_submit(fn, *args, **kwargs):
-    """Run everything submitted to thread pools executor in sync."""
-    fn(*args, **kwargs)
-
-
-def synchronous_transaction_on_commit(fn):
-    """During a test run a transaction is never committed, so we have to improvise."""
-    fn()
-
-
 def format_date_or_datetime(value):
     """
     Formats a date or datetime using DRF fields.

--- a/datahub/core/thread_pool.py
+++ b/datahub/core/thread_pool.py
@@ -1,0 +1,49 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from django.db import close_old_connections
+from raven.contrib.django.models import client
+
+from datahub.core.utils import logger
+
+_executor = ThreadPoolExecutor()
+
+
+def submit_to_thread_pool(fn, *args, **kwargs):
+    """Submits a function to be run in the thread pool."""
+    return _submit_to_thread_pool(fn, *args, **kwargs)
+
+
+def shut_down_thread_pool():
+    """Shuts down the thread pool."""
+    logger.info('Shutting down thread pool...')
+    _executor.shutdown()
+
+
+def _submit_to_thread_pool(fn, *args, **kwargs):
+    """
+    Implementation of submit_to_thread_pool().
+
+    Gives tests a centralised place to patch task submission for synchronous execution.
+    """
+    return _executor.submit(_make_thread_pool_task(fn, *args, **kwargs))
+
+
+def _make_thread_pool_task(fn, *args, **kwargs):
+    """
+    Wraps a task with exception handling and old- and broken-connection clean-up.
+
+    close_old_connections() is called both before and after the execution of the task to mimic
+    what Django does with requests.
+    """
+    def _task():
+        try:
+            close_old_connections()
+            fn(*args, **kwargs)
+        except Exception:
+            msg = f'Error running thread pool task {fn.__name__}'
+            logger.exception(msg)
+            client.captureException(msg)
+            raise
+        finally:
+            close_old_connections()
+    return _task

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -5,6 +5,7 @@ from logging import getLogger
 
 import boto3
 import requests
+from django.db import close_old_connections
 from raven.contrib.django.raven_compat.models import client
 
 logger = getLogger(__name__)
@@ -67,14 +68,23 @@ def _submit_to_thread_pool(fn, *args, **kwargs):
 
 
 def _make_thread_pool_task(fn, *args, **kwargs):
+    """
+    Wraps a task with exception handling and old- and broken-connection clean-up.
+
+    close_old_connections() is called both before and after the execution of the task to mimic
+    what Django does with requests.
+    """
     def _task():
         try:
+            close_old_connections()
             fn(*args, **kwargs)
         except Exception:
             msg = f'Error running thread pool task {fn.__name__}'
             logger.exception(msg)
             client.captureException(msg)
             raise
+        finally:
+            close_old_connections()
     return _task
 
 

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -5,6 +5,7 @@ from logging import getLogger
 
 import boto3
 import requests
+from raven.contrib.django.raven_compat.models import client
 
 logger = getLogger(__name__)
 _executor = ThreadPoolExecutor()
@@ -62,7 +63,19 @@ def _submit_to_thread_pool(fn, *args, **kwargs):
 
     Gives tests a centralised place to patch task submission for synchronous execution.
     """
-    return _executor.submit(fn, *args, **kwargs)
+    return _executor.submit(_make_thread_pool_task(fn, *args, **kwargs))
+
+
+def _make_thread_pool_task(fn, *args, **kwargs):
+    def _task():
+        try:
+            fn(*args, **kwargs)
+        except Exception:
+            msg = f'Error running thread pool task {fn.__name__}'
+            logger.exception(msg)
+            client.captureException(msg)
+            raise
+    return _task
 
 
 def shut_down_thread_pool():

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -1,15 +1,11 @@
-from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 from itertools import islice
 from logging import getLogger
 
 import boto3
 import requests
-from django.db import close_old_connections
-from raven.contrib.django.raven_compat.models import client
 
 logger = getLogger(__name__)
-_executor = ThreadPoolExecutor()
 
 
 class StrEnum(str, Enum):
@@ -51,47 +47,6 @@ def slice_iterable_into_chunks(iterable, batch_size, obj_creator):
         if not objects:
             break
         yield objects
-
-
-def submit_to_thread_pool(fn, *args, **kwargs):
-    """Submits a function to be run in the thread pool."""
-    return _submit_to_thread_pool(fn, *args, **kwargs)
-
-
-def _submit_to_thread_pool(fn, *args, **kwargs):
-    """
-    Implementation of submit_to_thread_pool().
-
-    Gives tests a centralised place to patch task submission for synchronous execution.
-    """
-    return _executor.submit(_make_thread_pool_task(fn, *args, **kwargs))
-
-
-def _make_thread_pool_task(fn, *args, **kwargs):
-    """
-    Wraps a task with exception handling and old- and broken-connection clean-up.
-
-    close_old_connections() is called both before and after the execution of the task to mimic
-    what Django does with requests.
-    """
-    def _task():
-        try:
-            close_old_connections()
-            fn(*args, **kwargs)
-        except Exception:
-            msg = f'Error running thread pool task {fn.__name__}'
-            logger.exception(msg)
-            client.captureException(msg)
-            raise
-        finally:
-            close_old_connections()
-    return _task
-
-
-def shut_down_thread_pool():
-    """Shuts down the thread pool."""
-    logger.info('Shutting down thread pool...')
-    _executor.shutdown()
 
 
 def get_s3_client():

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -6,8 +6,8 @@ from logging import getLogger
 import boto3
 import requests
 
-executor = ThreadPoolExecutor()
 logger = getLogger(__name__)
+_executor = ThreadPoolExecutor()
 
 
 class StrEnum(str, Enum):
@@ -51,10 +51,24 @@ def slice_iterable_into_chunks(iterable, batch_size, obj_creator):
         yield objects
 
 
+def submit_to_thread_pool(fn, *args, **kwargs):
+    """Submits a function to be run in the thread pool."""
+    return _submit_to_thread_pool(fn, *args, **kwargs)
+
+
+def _submit_to_thread_pool(fn, *args, **kwargs):
+    """
+    Implementation of submit_to_thread_pool().
+
+    Gives tests a centralised place to patch task submission for synchronous execution.
+    """
+    return _executor.submit(fn, *args, **kwargs)
+
+
 def shut_down_thread_pool():
     """Shuts down the thread pool."""
     logger.info('Shutting down thread pool...')
-    executor.shutdown()
+    _executor.shutdown()
 
 
 def get_s3_client():

--- a/datahub/documents/av_scan.py
+++ b/datahub/documents/av_scan.py
@@ -48,12 +48,8 @@ def virus_scan_document(document_pk: str):
 
     Any errors are logged and sent to Sentry.
     """
-    try:
-        with advisory_lock(f'av-scan-{document_pk}'):
-            _process_document(document_pk)
-    except Exception:
-        logger.exception('Error scanning document for viruses')
-        client.captureException()
+    with advisory_lock(f'av-scan-{document_pk}'):
+        _process_document(document_pk)
 
 
 def _process_document(document_pk: str):

--- a/datahub/documents/models.py
+++ b/datahub/documents/models.py
@@ -9,7 +9,7 @@ from django.dispatch import receiver
 from raven.contrib.django.raven_compat.models import client
 
 from datahub.core.models import ArchivableModel, BaseModel
-from datahub.core.utils import delete_s3_obj, executor, sign_s3_url
+from datahub.core.utils import delete_s3_obj, sign_s3_url, submit_to_thread_pool
 
 logger = getLogger(__name__)
 
@@ -89,5 +89,5 @@ def document_post_delete(sender, **kwargs):
             client.captureException(msg)
 
     transaction.on_commit(
-        lambda: executor.submit(delete_document)
+        lambda: submit_to_thread_pool(delete_document)
     )

--- a/datahub/documents/models.py
+++ b/datahub/documents/models.py
@@ -8,7 +8,8 @@ from django.db.models.signals import post_delete
 from django.dispatch import receiver
 
 from datahub.core.models import ArchivableModel, BaseModel
-from datahub.core.utils import delete_s3_obj, sign_s3_url, submit_to_thread_pool
+from datahub.core.thread_pool import submit_to_thread_pool
+from datahub.core.utils import delete_s3_obj, sign_s3_url
 
 logger = getLogger(__name__)
 

--- a/datahub/documents/models.py
+++ b/datahub/documents/models.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.db import models, transaction
 from django.db.models.signals import post_delete
 from django.dispatch import receiver
-from raven.contrib.django.raven_compat.models import client
 
 from datahub.core.models import ArchivableModel, BaseModel
 from datahub.core.utils import delete_s3_obj, sign_s3_url, submit_to_thread_pool
@@ -81,12 +80,7 @@ def document_post_delete(sender, **kwargs):
     key = instance.s3_key
 
     def delete_document():
-        try:
-            delete_s3_obj(bucket, key)
-        except Exception:
-            msg = 'Exception during s3 object removal.'
-            logger.exception(msg)
-            client.captureException(msg)
+        delete_s3_obj(bucket, key)
 
     transaction.on_commit(
         lambda: submit_to_thread_pool(delete_document)

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -3021,7 +3021,7 @@ class TestDocumentViews(APITestMixin):
         assert response.data['filename'] == 'test.txt'
         assert 'signed_url' in response.data
 
-    @patch('datahub.core.utils._submit_to_thread_pool')
+    @patch('datahub.core.thread_pool._submit_to_thread_pool')
     def test_document_upload_status(self, mock_submit):
         """Tests setting of document upload status to complete.
 
@@ -3042,7 +3042,7 @@ class TestDocumentViews(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         mock_submit.assert_called_once_with(virus_scan_document, str(doc.pk))
 
-    @patch('datahub.core.utils._submit_to_thread_pool')
+    @patch('datahub.core.thread_pool._submit_to_thread_pool')
     @pytest.mark.usefixtures('synchronous_on_commit')
     def test_document_delete_of_not_uploaded_doc_does_not_trigger_s3_delete(self, mock_submit):
         """Tests document deletion."""

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -21,7 +21,6 @@ from datahub.core import constants
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
 from datahub.core.test_utils import (
     APITestMixin, create_test_user, format_date_or_datetime, random_obj_for_model,
-    synchronous_executor_submit, synchronous_transaction_on_commit
 )
 from datahub.documents.av_scan import virus_scan_document
 from datahub.investment import views
@@ -3044,7 +3043,7 @@ class TestDocumentViews(APITestMixin):
         mock_submit.assert_called_once_with(virus_scan_document, str(doc.pk))
 
     @patch('datahub.core.utils._submit_to_thread_pool')
-    @patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+    @pytest.mark.usefixtures('synchronous_on_commit')
     def test_document_delete_of_not_uploaded_doc_does_not_trigger_s3_delete(self, mock_submit):
         """Tests document deletion."""
         project = InvestmentProjectFactory()
@@ -3059,8 +3058,7 @@ class TestDocumentViews(APITestMixin):
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert mock_submit.called is False
 
-    @patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-    @patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+    @pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
     def test_document_delete(self, s3_stubber):
         """Tests document deletion."""
         project = InvestmentProjectFactory()

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 
 from datahub.core.audit import AuditViewSet
 from datahub.core.mixins import ArchivableViewSetMixin
-from datahub.core.utils import submit_to_thread_pool
+from datahub.core.thread_pool import submit_to_thread_pool
 from datahub.core.viewsets import CoreViewSetV3
 from datahub.documents.av_scan import virus_scan_document
 from datahub.investment.models import (

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -13,7 +13,7 @@ from rest_framework.response import Response
 
 from datahub.core.audit import AuditViewSet
 from datahub.core.mixins import ArchivableViewSetMixin
-from datahub.core.utils import executor
+from datahub.core.utils import submit_to_thread_pool
 from datahub.core.viewsets import CoreViewSetV3
 from datahub.documents.av_scan import virus_scan_document
 from datahub.investment.models import (
@@ -268,7 +268,7 @@ class IProjectDocumentViewSet(CoreViewSetV3):
         serializer = UploadStatusSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        executor.submit(virus_scan_document, str(doc.pk))
+        submit_to_thread_pool(virus_scan_document, str(doc.pk))
 
         return Response(
             status=status.HTTP_200_OK,

--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from notifications_python_client.notifications import NotificationsAPIClient
 from raven.contrib.django.raven_compat.models import client as raven_client
 
-from datahub.core.utils import executor
+from datahub.core.utils import submit_to_thread_pool
 from datahub.omis.market.models import Market
 from datahub.omis.region.models import UKRegionalSettings
 from .constants import Template
@@ -63,7 +63,7 @@ class Notify:
 
     def _send_email(self, **kwargs):
         """Send email in a separate thread."""
-        executor.submit(send_email, self.client, **kwargs)
+        submit_to_thread_pool(send_email, self.client, **kwargs)
 
     def _prepare_personalisation(self, order, data=None):
         """Prepare the personalisation data with common values."""

--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -6,7 +6,7 @@ from unittest import mock
 from django.conf import settings
 from notifications_python_client.notifications import NotificationsAPIClient
 
-from datahub.core.utils import submit_to_thread_pool
+from datahub.core.thread_pool import submit_to_thread_pool
 from datahub.omis.market.models import Market
 from datahub.omis.region.models import UKRegionalSettings
 from .constants import Template

--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -5,7 +5,6 @@ from unittest import mock
 
 from django.conf import settings
 from notifications_python_client.notifications import NotificationsAPIClient
-from raven.contrib.django.raven_compat.models import client as raven_client
 
 from datahub.core.utils import submit_to_thread_pool
 from datahub.omis.market.models import Market
@@ -24,12 +23,7 @@ def send_email(client, **kwargs):
     if settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL:
         data['email_address'] = settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL
 
-    try:
-        client.send_email_notification(**data)
-    except:  # noqa: B901
-        logger.exception('Error while sending a notification email.')
-        raven_client.captureException()
-        raise
+    client.send_email_notification(**data)
 
 
 class Notify:

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
-from notifications_python_client.errors import APIError
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import UKRegion
@@ -23,20 +22,6 @@ pytestmark = pytest.mark.django_db
 
 class TestSendEmail:
     """Tests for errors with the internal send_email function."""
-
-    @mock.patch('datahub.omis.notification.client.raven_client')
-    def test_error_raises_exception(self, mock_raven_client):
-        """
-        Test that if an error occurs whilst sending an email,
-        the exception is raised and sent to sentry.
-        """
-        notify_client = mock.Mock()
-        notify_client.send_email_notification.side_effect = APIError()
-
-        with pytest.raises(APIError):
-            send_email(notify_client)
-
-        assert mock_raven_client.captureException.called
 
     def test_override_recipient_email(self, settings):
         """

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -67,7 +67,7 @@ class TestSendEmail:
         )
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyOrderInfo:
     """Tests for generic notifications related to an order."""
 
@@ -154,7 +154,7 @@ class TestNotifyOrderInfo:
         assert call_args['personalisation']['recipient name'] == 'example name'
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyOrderCreated:
     """Tests for notifications sent when an order is created."""
 
@@ -288,7 +288,7 @@ class TestNotifyOrderCreated:
         assert call_args['template_id'] != Template.order_created_for_regional_manager.value
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyAdviserAdded:
     """Tests for the adviser_added logic."""
 
@@ -320,7 +320,7 @@ class TestNotifyAdviserAdded:
         assert call_args['personalisation']['creation date'] == '18/05/2017'
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyAdviserRemoved:
     """Tests for the adviser_removed logic."""
 
@@ -344,7 +344,7 @@ class TestNotifyAdviserRemoved:
         assert call_args['personalisation']['recipient name'] == adviser.name
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyOrderPaid:
     """Tests for the order_paid logic."""
 
@@ -397,7 +397,7 @@ class TestNotifyOrderPaid:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyOrderCompleted:
     """Tests for the order_completed logic."""
 
@@ -432,7 +432,7 @@ class TestNotifyOrderCompleted:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyOrderCancelled:
     """Tests for the order_cancelled logic."""
 
@@ -485,7 +485,7 @@ class TestNotifyOrderCancelled:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyQuoteGenerated:
     """Tests for the quote_generated logic."""
 
@@ -538,7 +538,7 @@ class TestNotifyQuoteGenerated:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyQuoteAccepted:
     """Tests for the quote_accepted logic."""
 
@@ -591,7 +591,7 @@ class TestNotifyQuoteAccepted:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestNotifyQuoteCancelled:
     """Tests for the quote_cancelled logic."""
 

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -7,7 +7,6 @@ from django.conf import settings
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import UKRegion
-from datahub.core.test_utils import synchronous_executor_submit
 from datahub.omis.market.models import Market
 from datahub.omis.order.test.factories import (
     OrderAssigneeCompleteFactory, OrderAssigneeFactory, OrderCompleteFactory,
@@ -52,7 +51,7 @@ class TestSendEmail:
         )
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyOrderInfo:
     """Tests for generic notifications related to an order."""
 
@@ -139,7 +138,7 @@ class TestNotifyOrderInfo:
         assert call_args['personalisation']['recipient name'] == 'example name'
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyOrderCreated:
     """Tests for notifications sent when an order is created."""
 
@@ -273,7 +272,7 @@ class TestNotifyOrderCreated:
         assert call_args['template_id'] != Template.order_created_for_regional_manager.value
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyAdviserAdded:
     """Tests for the adviser_added logic."""
 
@@ -305,7 +304,7 @@ class TestNotifyAdviserAdded:
         assert call_args['personalisation']['creation date'] == '18/05/2017'
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyAdviserRemoved:
     """Tests for the adviser_removed logic."""
 
@@ -329,7 +328,7 @@ class TestNotifyAdviserRemoved:
         assert call_args['personalisation']['recipient name'] == adviser.name
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyOrderPaid:
     """Tests for the order_paid logic."""
 
@@ -382,7 +381,7 @@ class TestNotifyOrderPaid:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyOrderCompleted:
     """Tests for the order_completed logic."""
 
@@ -417,7 +416,7 @@ class TestNotifyOrderCompleted:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyOrderCancelled:
     """Tests for the order_cancelled logic."""
 
@@ -470,7 +469,7 @@ class TestNotifyOrderCancelled:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyQuoteGenerated:
     """Tests for the quote_generated logic."""
 
@@ -523,7 +522,7 @@ class TestNotifyQuoteGenerated:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyQuoteAccepted:
     """Tests for the quote_accepted logic."""
 
@@ -576,7 +575,7 @@ class TestNotifyQuoteAccepted:
             assert call['personalisation']['embedded link'] == order.get_datahub_frontend_url()
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestNotifyQuoteCancelled:
     """Tests for the quote_cancelled logic."""
 

--- a/datahub/omis/notification/test/test_signal_receivers.py
+++ b/datahub/omis/notification/test/test_signal_receivers.py
@@ -19,7 +19,7 @@ from ..constants import Template
 pytestmark = pytest.mark.django_db
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNotifyPostSaveOrder:
     """Tests for notifications sent when an order is saved/updated."""
@@ -44,7 +44,7 @@ class TestNotifyPostSaveOrder:
         assert not notify.client.send_email_notification.called
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNofityPostSaveOrderAdviser:
     """Tests for notifications sent when an adviser is added to an order."""
@@ -78,7 +78,7 @@ class TestNofityPostSaveOrderAdviser:
         assert call_args['template_id'] == Template.you_have_been_added_for_adviser.value
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNofityPostDeleteOrderAdviser:
     """Tests for notifications sent when an adviser is removed from an order."""
@@ -116,7 +116,7 @@ class TestNofityPostDeleteOrderAdviser:
         assert call_args['template_id'] == Template.you_have_been_removed_for_adviser.value
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNofityPostOrderPaid:
     """Tests for notifications sent when an order is marked as paid."""
@@ -154,7 +154,7 @@ class TestNofityPostOrderPaid:
         ]
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNotifyPostOrderCompleted:
     """Tests for notifications sent when an order marked as completed."""
@@ -183,7 +183,7 @@ class TestNotifyPostOrderCompleted:
         ]
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNofityPostOrderCancelled:
     """Tests for notifications sent when an order is cancelled."""
@@ -213,7 +213,7 @@ class TestNofityPostOrderCancelled:
         ]
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNotifyPostQuoteGenerated:
     """Tests for notifications sent when a quote is generated."""
@@ -243,7 +243,7 @@ class TestNotifyPostQuoteGenerated:
         ]
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNotifyPostQuoteAccepted:
     """Tests for notifications sent when a quote is accepted."""
@@ -273,7 +273,7 @@ class TestNotifyPostQuoteAccepted:
         ]
 
 
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 @mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
 class TestNotifyPostQuoteCancelled:
     """Tests for notifications sent when a quote is cancelled."""

--- a/datahub/omis/notification/test/test_signal_receivers.py
+++ b/datahub/omis/notification/test/test_signal_receivers.py
@@ -1,12 +1,7 @@
-from unittest import mock
-
 import pytest
 from dateutil.parser import parse as dateutil_parse
 
 from datahub.company.test.factories import AdviserFactory
-from datahub.core.test_utils import (
-    synchronous_executor_submit, synchronous_transaction_on_commit
-)
 from datahub.omis.order.models import CancellationReason
 from datahub.omis.order.test.factories import (
     OrderAssigneeCompleteFactory, OrderAssigneeFactory, OrderFactory,
@@ -19,8 +14,7 @@ from ..constants import Template
 pytestmark = pytest.mark.django_db
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNotifyPostSaveOrder:
     """Tests for notifications sent when an order is saved/updated."""
 
@@ -44,8 +38,7 @@ class TestNotifyPostSaveOrder:
         assert not notify.client.send_email_notification.called
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNofityPostSaveOrderAdviser:
     """Tests for notifications sent when an adviser is added to an order."""
 
@@ -78,8 +71,7 @@ class TestNofityPostSaveOrderAdviser:
         assert call_args['template_id'] == Template.you_have_been_added_for_adviser.value
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNofityPostDeleteOrderAdviser:
     """Tests for notifications sent when an adviser is removed from an order."""
 
@@ -116,8 +108,7 @@ class TestNofityPostDeleteOrderAdviser:
         assert call_args['template_id'] == Template.you_have_been_removed_for_adviser.value
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNofityPostOrderPaid:
     """Tests for notifications sent when an order is marked as paid."""
 
@@ -154,8 +145,7 @@ class TestNofityPostOrderPaid:
         ]
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNotifyPostOrderCompleted:
     """Tests for notifications sent when an order marked as completed."""
 
@@ -183,8 +173,7 @@ class TestNotifyPostOrderCompleted:
         ]
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNofityPostOrderCancelled:
     """Tests for notifications sent when an order is cancelled."""
 
@@ -213,8 +202,7 @@ class TestNofityPostOrderCancelled:
         ]
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNotifyPostQuoteGenerated:
     """Tests for notifications sent when a quote is generated."""
 
@@ -243,8 +231,7 @@ class TestNotifyPostQuoteGenerated:
         ]
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNotifyPostQuoteAccepted:
     """Tests for notifications sent when a quote is accepted."""
 
@@ -273,8 +260,7 @@ class TestNotifyPostQuoteAccepted:
         ]
 
 
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-@mock.patch('django.db.transaction.on_commit', synchronous_transaction_on_commit)
+@pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNotifyPostQuoteCancelled:
     """Tests for notifications sent when a quote is cancelled."""
 

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.django_db
     not settings.OMIS_NOTIFICATION_TEST_API_KEY,
     reason='`settings.OMIS_NOTIFICATION_TEST_API_KEY` not set (optional).'
 )
-@mock.patch('datahub.core.utils.executor.submit', synchronous_executor_submit)
+@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 class TestTemplates:
     """
     These tests are going to be run only if `OMIS_NOTIFICATION_TEST_API_KEY` is set

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -1,12 +1,9 @@
-from unittest import mock
-
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import UKRegion
-from datahub.core.test_utils import synchronous_executor_submit
 from datahub.omis.market.models import Market
 from datahub.omis.order.test.factories import (
     OrderCompleteFactory, OrderFactory,
@@ -23,7 +20,7 @@ pytestmark = pytest.mark.django_db
     not settings.OMIS_NOTIFICATION_TEST_API_KEY,
     reason='`settings.OMIS_NOTIFICATION_TEST_API_KEY` not set (optional).'
 )
-@mock.patch('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestTemplates:
     """
     These tests are going to be run only if `OMIS_NOTIFICATION_TEST_API_KEY` is set

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from elasticsearch.helpers.test import get_test_client
 from pytest import fixture
 
-from datahub.core.test_utils import synchronous_executor_submit, synchronous_transaction_on_commit
 from datahub.metadata.test.factories import SectorFactory
 from datahub.search import elasticsearch
 from .apps import get_search_apps
@@ -45,11 +44,8 @@ def _setup_es_indexes(_es_client):
 
 
 @fixture
-def setup_es(_setup_es_indexes, monkeypatch):
+def setup_es(_setup_es_indexes, synchronous_on_commit, synchronous_thread_pool):
     """Sets up ES and deletes all the records after each run."""
-    monkeypatch.setattr('django.db.transaction.on_commit', synchronous_transaction_on_commit)
-    monkeypatch.setattr('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
-
     yield _setup_es_indexes
 
     _setup_es_indexes.indices.refresh()

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -48,7 +48,7 @@ def _setup_es_indexes(_es_client):
 def setup_es(_setup_es_indexes, monkeypatch):
     """Sets up ES and deletes all the records after each run."""
     monkeypatch.setattr('django.db.transaction.on_commit', synchronous_transaction_on_commit)
-    monkeypatch.setattr('datahub.core.utils.executor.submit', synchronous_executor_submit)
+    monkeypatch.setattr('datahub.core.utils._submit_to_thread_pool', synchronous_executor_submit)
 
     yield _setup_es_indexes
 

--- a/datahub/search/signals.py
+++ b/datahub/search/signals.py
@@ -1,6 +1,6 @@
 from logging import getLogger
 
-from datahub.core.utils import submit_to_thread_pool
+from datahub.core.thread_pool import submit_to_thread_pool
 from datahub.search import elasticsearch
 
 logger = getLogger(__name__)

--- a/datahub/search/signals.py
+++ b/datahub/search/signals.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from raven.contrib.django.raven_compat.models import client
 
-from datahub.core.utils import executor
+from datahub.core.utils import submit_to_thread_pool
 from datahub.search import elasticsearch
 
 logger = getLogger(__name__)
@@ -22,4 +22,4 @@ def _sync_es(search_model, db_model, pk):
 
 def sync_es(search_model, db_model, pk):
     """Sync to ES by instance pk and type."""
-    return executor.submit(_sync_es, search_model, db_model, pk)
+    return submit_to_thread_pool(_sync_es, search_model, db_model, pk)

--- a/datahub/search/signals.py
+++ b/datahub/search/signals.py
@@ -1,7 +1,5 @@
 from logging import getLogger
 
-from raven.contrib.django.raven_compat.models import client
-
 from datahub.core.utils import submit_to_thread_pool
 from datahub.search import elasticsearch
 
@@ -10,14 +8,9 @@ logger = getLogger(__name__)
 
 def _sync_es(search_model, db_model, pk):
     """Sync to ES by instance pk and type."""
-    try:
-        instance = db_model.objects.get(pk=pk)
-        doc = search_model.es_document(instance)
-        elasticsearch.bulk(actions=(doc, ), chunk_size=1)
-    except:  # noqa: B901
-        logger.exception('Error while saving entity to ES')
-        client.captureException()
-        raise
+    instance = db_model.objects.get(pk=pk)
+    doc = search_model.es_document(instance)
+    elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
 
 def sync_es(search_model, db_model, pk):


### PR DESCRIPTION
Issue number: N/A

### Description of change

This makes the thread pool more robust by:

* Centralising exception handling of thread pool tasks
* Calling django.db.close_old_connections() at the start and end of tasks to clean-up old and broken database connections (mimicking what Django does with requests)

Django stores connections using thread-local storage, so previously when a connection was broken (e.g. due to database restart) all future tasks run in a thread with a broken connection would fail. This change lowers the risk of failures, and enables recovery from them.

[`CONN_MAX_AGE`](https://docs.djangoproject.com/en/2.0/ref/databases/) is also made configurable so that we can configure that if we need to.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
