### PR TITLE
Add level__lte filter to sector view

### DIFF
--- a/datahub/metadata/metadata.py
+++ b/datahub/metadata/metadata.py
@@ -7,6 +7,9 @@ registry.register(metadata_id='country', model=models.Country)
 registry.register(metadata_id='employee-range', model=models.EmployeeRange)
 registry.register(metadata_id='role', model=models.Role)
 registry.register(
+    filter_fields={
+        'level': ['lte'],
+    },
     metadata_id='sector',
     model=models.Sector,
     queryset=models.Sector.objects.select_related(

--- a/datahub/metadata/registry.py
+++ b/datahub/metadata/registry.py
@@ -4,7 +4,10 @@ from django.core.exceptions import ImproperlyConfigured
 
 from datahub.core.serializers import ConstantModelSerializer
 
-MetadataMapping = namedtuple('MetadataMapping', ['model', 'queryset', 'serializer'])
+MetadataMapping = namedtuple(
+    'MetadataMapping',
+    ['model', 'queryset', 'serializer', 'filter_fields'],
+)
 
 
 class MetadataRegistry:
@@ -36,13 +39,14 @@ class MetadataRegistry:
         """Keeps a local copy of the metadata registered."""
         self.metadata = {}
 
-    def register(self, metadata_id, model, queryset=None, serializer=ConstantModelSerializer):
+    def register(self, metadata_id, model, queryset=None, serializer=ConstantModelSerializer,
+                 filter_fields=None):
         """Registers a new metadata."""
         if metadata_id in self.metadata:
             raise ImproperlyConfigured(f'Metadata {metadata_id} already registered.')
 
         queryset = queryset if queryset is not None else model.objects.all()
-        self.metadata[metadata_id] = MetadataMapping(model, queryset, serializer)
+        self.metadata[metadata_id] = MetadataMapping(model, queryset, serializer, filter_fields)
 
     @property
     def mappings(self):

--- a/datahub/metadata/urls.py
+++ b/datahub/metadata/urls.py
@@ -2,5 +2,4 @@ from django.urls import path
 
 from . import views
 
-
 urlpatterns = [path(*args, **kwargs) for args, kwargs in views.urls_args]


### PR DESCRIPTION
Issue number: DH-1585

### Description of change

Add the ability to filter sectors to those with a level less than or equal to a value . Will be used by the front end to get sectors up to a certain level (e.g. only root sectors).

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
