### PR TITLE
Add sector descends filter to interactions search

### DIFF
--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -15,11 +15,17 @@ class InteractionSearchApp(SearchApp):
     permission_required = (f'interaction.{InteractionPermission.read_all}',)
     queryset = DBInteraction.objects.prefetch_related(
         'company',
+        'company__sector',
+        'company__sector__parent',
+        'company__sector__parent__parent',
         'contact',
         'dit_adviser',
         'dit_team',
         'communication_channel',
         'investment_project',
+        'investment_project__sector',
+        'investment_project__sector__parent',
+        'investment_project__sector__parent__parent',
         'service',
         'service_delivery_status',
         'event',

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -13,6 +13,7 @@ class Interaction(DocType, MapDBModelToDict):
     kind = Keyword()
     date = Date()
     company = dsl_utils.id_name_partial_mapping('company')
+    company_sector = dsl_utils.sector_mapping()
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
     is_event = Boolean()
     event = dsl_utils.id_name_partial_mapping('event')
@@ -26,6 +27,7 @@ class Interaction(DocType, MapDBModelToDict):
     dit_team = dsl_utils.id_name_partial_mapping('dit_team')
     communication_channel = dsl_utils.id_name_mapping()
     investment_project = dsl_utils.id_name_mapping()
+    investment_project_sector = dsl_utils.sector_mapping()
     service_delivery_status = dsl_utils.id_name_mapping()
     grant_amount_offered = Double()
     net_company_receipt = Double()
@@ -46,7 +48,11 @@ class Interaction(DocType, MapDBModelToDict):
     }
 
     COMPUTED_MAPPINGS = {
-        'is_event': attrgetter('is_event')
+        'is_event': attrgetter('is_event'),
+        'company_sector': dict_utils.computed_nested_sector_dict('company.sector'),
+        'investment_project_sector': dict_utils.computed_nested_sector_dict(
+            'investment_project.sector'
+        ),
     }
 
     IGNORED_FIELDS = (

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -25,6 +25,7 @@ class SearchInteractionSerializer(SearchSerializer):
     communication_channel = SingleOrListField(child=StringUUIDField(), required=False)
     investment_project = SingleOrListField(child=StringUUIDField(), required=False)
     service = SingleOrListField(child=StringUUIDField(), required=False)
+    sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
 
     DEFAULT_ORDERING = 'date:desc'
 

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -204,6 +204,13 @@ class TestViews(APITestMixin):
                 'id': str(interaction.company.pk),
                 'name': interaction.company.name,
             },
+            'company_sector': {
+                'id': str(interaction.company.sector.pk),
+                'name': interaction.company.sector.name,
+                'ancestors': [{
+                    'id': str(ancestor.pk),
+                } for ancestor in interaction.company.sector.get_ancestors()],
+            },
             'contact': {
                 'id': str(interaction.contact.pk),
                 'first_name': interaction.contact.first_name,
@@ -233,6 +240,7 @@ class TestViews(APITestMixin):
                 'name': interaction.communication_channel.name,
             },
             'investment_project': None,
+            'investment_project_sector': None,
             'service_delivery_status': None,
             'grant_amount_offered': None,
             'net_company_receipt': None,

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -1,5 +1,6 @@
 from collections import Counter
 from datetime import datetime
+from uuid import UUID
 
 import factory
 import pytest
@@ -11,10 +12,14 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
-from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user, random_obj_for_queryset
 from datahub.interaction.constants import CommunicationChannel
 from datahub.interaction.models import Interaction
-from datahub.interaction.test.factories import CompanyInteractionFactory, ServiceDeliveryFactory
+from datahub.interaction.test.factories import (
+    CompanyInteractionFactory, InvestmentProjectInteractionFactory, ServiceDeliveryFactory,
+)
+from datahub.investment.test.factories import ActiveInvestmentProjectFactory
+from datahub.metadata.models import Sector
 from datahub.metadata.test.factories import TeamFactory
 
 pytestmark = pytest.mark.django_db
@@ -578,3 +583,105 @@ class TestViews(APITestMixin):
         response_data = response.json()
         names = {result['subject'] for result in response_data['results']}
         assert names == results
+
+    @pytest.mark.parametrize(
+        'sector_level',
+        (0, 1, 2),
+    )
+    def test_sector_descends_filter_for_company_interaction(
+            self,
+            hierarchical_sectors,
+            setup_es,
+            sector_level,
+    ):
+        """Test the sector_descends filter with company interactions."""
+        num_sectors = len(hierarchical_sectors)
+        sectors_ids = [sector.pk for sector in hierarchical_sectors]
+
+        companies = CompanyFactory.create_batch(
+            num_sectors,
+            sector_id=factory.Iterator(sectors_ids)
+        )
+        company_interactions = CompanyInteractionFactory.create_batch(
+            3,
+            company=factory.Iterator(companies)
+        )
+
+        other_companies = CompanyFactory.create_batch(
+            3,
+            sector=factory.LazyFunction(lambda: random_obj_for_queryset(
+                Sector.objects.exclude(pk__in=sectors_ids)
+            ))
+        )
+        CompanyInteractionFactory.create_batch(
+            3,
+            company=factory.Iterator(other_companies)
+        )
+
+        setup_es.indices.refresh()
+
+        url = reverse('api-v3:search:interaction')
+        body = {
+            'sector_descends': hierarchical_sectors[sector_level].pk
+        }
+        response = self.api_client.post(url, body)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == num_sectors - sector_level
+
+        actual_ids = {UUID(interaction['id']) for interaction in response_data['results']}
+        expected_ids = {interaction.pk for interaction in company_interactions[sector_level:]}
+        assert actual_ids == expected_ids
+
+    @pytest.mark.parametrize(
+        'sector_level',
+        (0, 1, 2),
+    )
+    def test_sector_descends_filter_for_investment_project_interaction(
+            self,
+            hierarchical_sectors,
+            setup_es,
+            sector_level,
+    ):
+        """Test the sector_descends filter with investment project interactions."""
+        num_sectors = len(hierarchical_sectors)
+        sectors_ids = [sector.pk for sector in hierarchical_sectors]
+
+        projects = ActiveInvestmentProjectFactory.create_batch(
+            num_sectors,
+            sector_id=factory.Iterator(sectors_ids)
+        )
+        investment_project_interactions = InvestmentProjectInteractionFactory.create_batch(
+            3,
+            investment_project=factory.Iterator(projects)
+        )
+
+        other_projects = ActiveInvestmentProjectFactory.create_batch(
+            3,
+            sector=factory.LazyFunction(lambda: random_obj_for_queryset(
+                Sector.objects.exclude(pk__in=sectors_ids)
+            ))
+        )
+        InvestmentProjectInteractionFactory.create_batch(
+            3,
+            investment_project=factory.Iterator(other_projects)
+        )
+
+        setup_es.indices.refresh()
+
+        url = reverse('api-v3:search:interaction')
+        body = {
+            'sector_descends': hierarchical_sectors[sector_level].pk
+        }
+        response = self.api_client.post(url, body)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == num_sectors - sector_level
+
+        actual_ids = {UUID(interaction['id']) for interaction in response_data['results']}
+        expected_ids = {
+            interaction.pk for interaction in investment_project_interactions[sector_level:]
+        }
+        assert actual_ids == expected_ids

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -25,6 +25,7 @@ class SearchInteractionParams:
         'date_before',
         'communication_channel',
         'investment_project',
+        'sector_descends',
         'service',
     )
 
@@ -52,6 +53,12 @@ class SearchInteractionParams:
         'dit_adviser_name': [
             'dit_adviser.name',
             'dit_adviser.name_trigram'
+        ],
+        'sector_descends': [
+            'company_sector.id',
+            'company_sector.ancestors.id',
+            'investment_project_sector.id',
+            'investment_project_sector.ancestors.id',
         ],
     }
 


### PR DESCRIPTION
Issue number: DH-1620

### Description of change

Adds the company and investment project sectors to the interaction search model. Also adds a sector_descends filter to interaction search.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
