### PR TITLE
Add a command to update company numbers

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_company_company_number.py
+++ b/datahub/dbmaintenance/management/commands/update_company_company_number.py
@@ -1,0 +1,42 @@
+from logging import getLogger
+
+import reversion
+
+from datahub.company.models import Company
+from datahub.dbmaintenance.utils import parse_limited_string, parse_uuid
+from ..base import CSVBaseCommand
+
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """Command to update Company.company_number."""
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        super().add_arguments(parser)
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            default=False,
+            help='If True it only simulates the command without saving changes.',
+        )
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        pk = parse_uuid(row['id'])
+        company = Company.objects.get(pk=pk)
+        company_number = parse_limited_string(row['company_number'])
+
+        if company.company_number == company_number:
+            return
+
+        company.company_number = company_number
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            company.save(update_fields=('company_number',))
+            reversion.set_comment('Company number updated.')

--- a/datahub/dbmaintenance/test/commands/test_update_company_company_number.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_company_number.py
@@ -1,0 +1,142 @@
+from datetime import datetime, timezone
+from io import BytesIO
+
+import factory
+import pytest
+from django.core.management import call_command
+from freezegun import freeze_time
+from reversion.models import Version
+
+from datahub.company.test.factories import CompanyFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('ERROR')
+
+    original_datetime = datetime(2017, 1, 1, tzinfo=timezone.utc)
+
+    with freeze_time(original_datetime):
+        company_numbers = ['123', '456', '466879', '', None]
+        companies = CompanyFactory.create_batch(
+            5,
+            company_number=factory.Iterator(company_numbers),
+        )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,company_number
+00000000-0000-0000-0000-000000000000,123456
+{companies[0].pk},012345
+{companies[1].pk},456
+{companies[2].pk},null
+{companies[3].pk},087891
+{companies[4].pk},087892
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    with freeze_time('2018-11-11 00:00:00'):
+        call_command('update_company_company_number', bucket, object_key)
+
+    for company in companies:
+        company.refresh_from_db()
+
+    assert 'Company matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+    assert [company.company_number for company in companies] == [
+        '012345', '456', '', '087891', '087892'
+    ]
+    assert all(company.modified_on == original_datetime for company in companies)
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+
+    company_numbers = ['123', '456', '466879', '', None]
+    companies = CompanyFactory.create_batch(
+        5,
+        company_number=factory.Iterator(company_numbers),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,company_number
+00000000-0000-0000-0000-000000000000,123456
+{companies[0].pk},012345
+{companies[1].pk},456
+{companies[2].pk},null
+{companies[3].pk},087891
+{companies[4].pk},087892
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_company_company_number', bucket, object_key, simulate=True)
+
+    for company in companies:
+        company.refresh_from_db()
+
+    assert 'Company matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+    assert [company.company_number for company in companies] == company_numbers
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    company_without_change = CompanyFactory(
+        company_number='132589',
+    )
+    company_with_change = CompanyFactory(
+        company_number='566489',
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,company_number
+{company_without_change.pk},132589
+{company_with_change.pk},0566489
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_company_company_number', bucket, object_key)
+
+    versions = Version.objects.get_for_object(company_without_change)
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(company_with_change)
+    assert versions.count() == 1
+    assert versions[0].revision.comment == 'Company number updated.'

--- a/datahub/dbmaintenance/utils.py
+++ b/datahub/dbmaintenance/utils.py
@@ -1,4 +1,7 @@
-from rest_framework.fields import BooleanField, DateField, DecimalField, EmailField, UUIDField
+from django.conf import settings
+from rest_framework.fields import (
+    BooleanField, CharField, DateField, DecimalField, EmailField, UUIDField,
+)
 
 
 def parse_bool(value):
@@ -34,6 +37,11 @@ def parse_uuid_list(value):
     field = UUIDField()
 
     return [field.to_internal_value(item) for item in value.split(',')]
+
+
+def parse_limited_string(value, max_length=settings.CHAR_FIELD_MAX_LENGTH):
+    """Parses/validates a string."""
+    return _parse_value(value, CharField(max_length=max_length), blank_value='')
 
 
 def _parse_value(value, field, blank_value=None):


### PR DESCRIPTION
Issue number: DH-1393

### Description of change

Add a dbmaintenance command to update Company.company_numbers using a CSV file.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
