### PR TITLE
Remove Meta class from Sector

### DIFF
--- a/datahub/metadata/models.py
+++ b/datahub/metadata/models.py
@@ -57,9 +57,6 @@ class Sector(MPTTModel, DisableableModel):
             ancestors.append(obj)
         return reversed(ancestors)
 
-    class Meta(MPTTModel.Meta, BaseConstantModel.Meta):
-        ordering = ('lft', )
-
     class MPTTMeta:
         order_insertion_by = ('segment',)
 


### PR DESCRIPTION
Issue number: N/A

### Description of change

It was wrong for multiple reasons:

- the value of the ordering attribute was wrong, though this was not noticed as MPTT ordered query sets correctly anyway
- it inherited from BaseConstantModel.Meta when the class didn't inherit from BaseConstantModel

This removes the Meta class completely as it's not required here for anything.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
