### PR TITLE
Return business type in Companies House view

### DIFF
--- a/datahub/company/ch_constants.py
+++ b/datahub/company/ch_constants.py
@@ -1,0 +1,51 @@
+from datahub.company.constants import BusinessTypeConstant
+
+# This mapping determines which Companies House company categories we are interested in,
+# and what their corresponding business type should be in Data Hub.
+#
+# Any company categories that are mapped to a falsey value are not loaded to the database by the
+# sync_ch command.
+#
+# Additionally, the Companies House company view returns a business type using this mapping. That
+# business type is then used by the front end when POSTing to /v3/company.
+COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPING = {
+    # Address not available/main registration not with Companies House
+    'charitable incorporated organisation': None,
+    'community interest company': BusinessTypeConstant.community_interest_company,
+    'european public limited-liability company (se)': BusinessTypeConstant.public_limited_company,
+    # Address not available/main registration with FCA
+    'industrial and provident society': None,
+    # Address not available/main registration with FCA
+    'investment company with variable capital': None,
+    # Address not available/main registration with FCA
+    'investment company with variable capital (securities)': None,
+    # Address not available/main registration with FCA
+    'investment company with variable capital(umbrella)': None,
+    'limited liability partnership': BusinessTypeConstant.limited_liability_partnership,
+    'limited partnership': BusinessTypeConstant.limited_partnership,
+    # Historical
+    'old public company': BusinessTypeConstant.company,
+    # Foreign and other irrelevant companies
+    'other company type': None,
+    "pri/lbg/nsc (private, limited by guarantee, no share capital, use of 'limited' exemption)":
+        BusinessTypeConstant.private_limited_company,
+    'pri/ltd by guar/nsc (private, limited by guarantee, no share capital)':
+        BusinessTypeConstant.private_limited_company,
+    # Section 30 is the limited exemption
+    'priv ltd sect. 30 (private limited company, section 30 of the companies act)':
+        BusinessTypeConstant.private_limited_company,
+    'private limited company': BusinessTypeConstant.private_limited_company,
+    'private unlimited': BusinessTypeConstant.company,
+    'private unlimited company': BusinessTypeConstant.company,
+    # Address not available/main registration with FCA
+    'protected cell company': None,
+    'public limited company': BusinessTypeConstant.public_limited_company,
+    # Address not available/main registration with FCA
+    'registered society': None,
+    # Address not available
+    'royal charter company': None,
+    # Address not available/main registration not with Companies House
+    'scottish charitable incorporated organisation': None,
+    # Scottish qualifying partnership, generally have a foreign address
+    'scottish partnership': None,
+}

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -6,10 +6,12 @@ from django.db import models
 from django.utils.functional import cached_property
 from mptt.fields import TreeForeignKey
 
+from datahub.company.ch_constants import COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPING
 from datahub.core import constants, reversion
 from datahub.core.models import ArchivableModel, BaseConstantModel, BaseModel
 from datahub.core.utils import StrEnum
 from datahub.metadata import models as metadata_models
+from datahub.metadata.models import BusinessType
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -200,6 +202,16 @@ class CompaniesHouseCompany(CompanyAbstract):
     def __str__(self):
         """Admin displayed human readable name."""
         return self.name
+
+    @cached_property
+    def business_type(self):
+        """The business type associated with the company category provided by Companies House."""
+        business_type = COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPING.get(
+            self.company_category.lower()
+        )
+        if business_type:
+            return BusinessType.objects.get(pk=business_type.value.id)
+        return None
 
     class Meta:
         verbose_name_plural = 'Companies House companies'

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -58,13 +58,46 @@ class AdviserSerializer(serializers.ModelSerializer):
         depth = 1
 
 
-class CompaniesHouseCompanySerializer(serializers.ModelSerializer):
-    """Companies House company serializer."""
+class NestedCompaniesHouseCompanySerializer(serializers.ModelSerializer):
+    """Nested Companies House company serializer."""
+
+    registered_address_country = NestedRelatedField('metadata.Country')
 
     class Meta:
         model = CompaniesHouseCompany
-        depth = 1
-        fields = '__all__'
+        fields = (
+            'id',
+            'company_category',
+            'company_number',
+            'company_status',
+            'incorporation_date',
+            'name',
+            'registered_address_1',
+            'registered_address_2',
+            'registered_address_county',
+            'registered_address_country',
+            'registered_address_town',
+            'registered_address_postcode',
+            'sic_code_1',
+            'sic_code_2',
+            'sic_code_3',
+            'sic_code_4',
+            'uri',
+        )
+        read_only_fields = fields
+
+
+class CompaniesHouseCompanySerializer(NestedCompaniesHouseCompanySerializer):
+    """Full Companies House company serializer."""
+
+    business_type = NestedRelatedField('metadata.BusinessType')
+
+    class Meta(NestedCompaniesHouseCompanySerializer.Meta):
+        fields = (
+            *NestedCompaniesHouseCompanySerializer.Meta.fields,
+            'business_type',
+        )
+        read_only_fields = fields
 
 
 NestedAdviserField = partial(
@@ -232,7 +265,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
     classification = NestedRelatedField(
         meta_models.CompanyClassification, required=False, allow_null=True
     )
-    companies_house_data = CompaniesHouseCompanySerializer(read_only=True)
+    companies_house_data = NestedCompaniesHouseCompanySerializer(read_only=True)
     contacts = ContactSerializer(many=True, read_only=True)
     employee_range = NestedRelatedField(
         meta_models.EmployeeRange, required=False, allow_null=True

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -1,8 +1,10 @@
 import uuid
+from random import choice
 
 import factory
 from django.utils.timezone import now
 
+from datahub.company.ch_constants import COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPING
 from datahub.company.constants import BusinessTypeConstant
 from datahub.company.models import ExportExperienceCategory
 from datahub.core import constants
@@ -53,11 +55,17 @@ class CompanyFactory(factory.django.DjangoModelFactory):
         model = 'company.Company'
 
 
+def _get_random_company_category():
+    categories = ([key for key, val in COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPING.items() if val])
+    return choice(categories).capitalize()
+
+
 class CompaniesHouseCompanyFactory(factory.django.DjangoModelFactory):
     """Companies house company factory."""
 
     name = factory.Sequence(lambda n: f'name{n}')
     company_number = factory.Sequence(str)
+    company_category = factory.LazyFunction(_get_random_company_category)
     registered_address_1 = factory.Sequence(lambda n: f'{n} Bar st.')
     registered_address_town = 'Rome'
     registered_address_country_id = constants.Country.italy.value.id

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -137,7 +137,7 @@ class TestGetCompany(APITestMixin):
             'companies_house_data': {
                 'id': ch_company.id,
                 'company_number': '123',
-                'company_category': '',
+                'company_category': ch_company.company_category,
                 'company_status': '',
                 'incorporation_date': format_date_or_datetime(ch_company.incorporation_date),
                 'name': 'Foo Ltd',
@@ -148,7 +148,6 @@ class TestGetCompany(APITestMixin):
                 'registered_address_postcode': None,
                 'registered_address_country': {
                     'id': str(ch_company.registered_address_country.id),
-                    'disabled_on': None,
                     'name': ch_company.registered_address_country.name,
                 },
                 'sic_code_1': '',
@@ -1312,7 +1311,32 @@ class TestCHCompany(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
-        assert response_data['company_number'] == ch_company.company_number
+        assert response_data == {
+            'id': ch_company.id,
+            'business_type': {
+                'id': str(ch_company.business_type.id),
+                'name': ch_company.business_type.name,
+            },
+            'company_number': ch_company.company_number,
+            'company_category': ch_company.company_category,
+            'company_status': ch_company.company_status,
+            'incorporation_date': format_date_or_datetime(ch_company.incorporation_date),
+            'name': ch_company.name,
+            'registered_address_1': ch_company.registered_address_1,
+            'registered_address_2': ch_company.registered_address_2,
+            'registered_address_town': ch_company.registered_address_town,
+            'registered_address_county': ch_company.registered_address_county,
+            'registered_address_postcode': ch_company.registered_address_postcode,
+            'registered_address_country': {
+                'id': str(ch_company.registered_address_country.id),
+                'name': ch_company.registered_address_country.name,
+            },
+            'sic_code_1': ch_company.sic_code_1,
+            'sic_code_2': ch_company.sic_code_2,
+            'sic_code_3': ch_company.sic_code_3,
+            'sic_code_4': ch_company.sic_code_4,
+            'uri': ch_company.uri,
+        }
 
     def test_get_ch_company_alphanumeric(self):
         """Test retrieving a single CH company where the company number contains letters."""


### PR DESCRIPTION
Issue number: DH-1607

### Description of change

This is part of the work to move the company category to business type mapping from the front-end code base to the back end.

This is so that there does not need to be a one-to-one mapping between company categories and business types, and to allow companies limited by guarantee to be added to the system.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
