### PR TITLE
Reuse metadata admin classes across apps

### DIFF
--- a/datahub/company/admin.py
+++ b/datahub/company/admin.py
@@ -2,19 +2,12 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
 from reversion.admin import VersionAdmin
 
-from datahub.core.admin import DisabledOnFilter, ReadOnlyAdmin
+from datahub.core.admin import ReadOnlyAdmin
+from datahub.metadata.admin import DisableableMetadataAdmin
 from .models import Advisor, CompaniesHouseCompany, Company, Contact, ExportExperienceCategory
 
 
-@admin.register(ExportExperienceCategory)
-class MetadataAdmin(admin.ModelAdmin):
-    """Export experience category admin."""
-
-    fields = ('id', 'name', 'disabled_on', )
-    list_display = ('name', 'disabled_on', )
-    readonly_fields = ('id',)
-    search_fields = ('name', 'pk')
-    list_filter = (DisabledOnFilter,)
+admin.site.register(ExportExperienceCategory, DisableableMetadataAdmin)
 
 
 @admin.register(Company)

--- a/datahub/event/admin.py
+++ b/datahub/event/admin.py
@@ -8,6 +8,7 @@ from reversion.admin import VersionAdmin
 
 from datahub.core.admin import DisabledOnFilter
 from datahub.event.models import Event, EventType, LocationType, Programme
+from datahub.metadata.admin import DisableableMetadataAdmin
 
 
 def confirm_action(title, action_message):
@@ -121,12 +122,4 @@ class EventAdmin(VersionAdmin):
     enable_selected.short_description = 'Enable selected events'
 
 
-@admin.register(EventType, LocationType, Programme)
-class DisableableMetadataAdmin(admin.ModelAdmin):
-    """Custom Disableable Metadata Admin."""
-
-    fields = ('id', 'name', 'disabled_on',)
-    list_display = ('name', 'disabled_on',)
-    readonly_fields = ('id',)
-    search_fields = ('name', 'pk')
-    list_filter = (DisabledOnFilter,)
+admin.site.register((EventType, LocationType, Programme), DisableableMetadataAdmin)

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -1,31 +1,14 @@
 from django.contrib import admin
 from reversion.admin import VersionAdmin
 
-from datahub.core.admin import custom_add_permission, custom_change_permission, DisabledOnFilter
+from datahub.core.admin import custom_add_permission, custom_change_permission
 from datahub.interaction.models import InteractionPermission, PolicyArea, PolicyIssueType
+from datahub.metadata.admin import DisableableMetadataAdmin, OrderedMetadataAdmin
 from .models import CommunicationChannel, Interaction
 
 
-@admin.register(CommunicationChannel)
-class MetadataAdmin(admin.ModelAdmin):
-    """Communication channel admin."""
-
-    fields = ('id', 'name', 'disabled_on', )
-    list_display = ('name', 'disabled_on', )
-    readonly_fields = ('id',)
-    search_fields = ('name', 'pk')
-    list_filter = (DisabledOnFilter,)
-
-
-@admin.register(
-    PolicyArea,
-    PolicyIssueType
-)
-class OrderedMetadataAdmin(MetadataAdmin):
-    """Ordered Metadata model admin."""
-
-    fields = ('id', 'name', 'disabled_on', 'order')
-    list_display = ('name', 'disabled_on', 'order')
+admin.site.register(CommunicationChannel, DisableableMetadataAdmin)
+admin.site.register((PolicyArea, PolicyIssueType), OrderedMetadataAdmin)
 
 
 @admin.register(Interaction)

--- a/datahub/investment/admin.py
+++ b/datahub/investment/admin.py
@@ -4,8 +4,9 @@ from django.contrib import admin
 from reversion.admin import VersionAdmin
 
 from datahub.core.admin import (
-    custom_add_permission, custom_change_permission,
-    custom_delete_permission, DisabledOnFilter,
+    custom_add_permission,
+    custom_change_permission,
+    custom_delete_permission,
 )
 from datahub.investment.models import (
     InvestmentDeliveryPartner,
@@ -17,6 +18,7 @@ from datahub.investment.models import (
     IProjectDocument,
     SpecificProgramme,
 )
+from datahub.metadata.admin import DisableableMetadataAdmin
 
 
 @admin.register(InvestmentProject)
@@ -88,17 +90,9 @@ class IProjectDocumentAdmin(admin.ModelAdmin):
     date_hierarchy = 'created_on'
 
 
-@admin.register(
+admin.site.register((
     InvestmentDeliveryPartner,
     InvestorType,
     Involvement,
     SpecificProgramme,
-)
-class DisableableMetadataAdmin(admin.ModelAdmin):
-    """Custom Disableable Metadata Admin."""
-
-    fields = ('id', 'name', 'disabled_on',)
-    list_display = ('name', 'disabled_on',)
-    readonly_fields = ('id',)
-    search_fields = ('name', 'pk')
-    list_filter = (DisabledOnFilter,)
+), DisableableMetadataAdmin)

--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -35,9 +35,12 @@ MODELS_TO_REGISTER_READ_ONLY = (
 )
 
 
-@admin.register(*MODELS_TO_REGISTER_DISABLEABLE)
 class DisableableMetadataAdmin(admin.ModelAdmin):
-    """Custom Disableable Metadata Admin."""
+    """
+    Generic admin for disableable metadata models.
+
+    Intended to be used across apps.
+    """
 
     fields = ('id', 'name', 'disabled_on',)
     list_display = ('name', 'disabled_on',)
@@ -46,24 +49,35 @@ class DisableableMetadataAdmin(admin.ModelAdmin):
     list_filter = (DisabledOnFilter,)
 
 
-@admin.register(*MODELS_TO_REGISTER_READ_ONLY)
 class ReadOnlyMetadataAdmin(ReadOnlyAdmin):
-    """Admin for metadata models that shouldn't be edited."""
+    """
+    Generic admin for metadata models that shouldn't be edited.
+
+    Intended to be used across apps.
+    """
 
     list_display = ('name', 'disabled_on',)
     search_fields = ('name', 'pk')
     list_filter = (DisabledOnFilter,)
 
 
-@admin.register(*MODELS_TO_REGISTER_WITH_ORDER)
 class OrderedMetadataAdmin(admin.ModelAdmin):
-    """Admin for ordered metadata models."""
+    """
+    Generic admin for ordered metadata models.
+
+    Intended to be used across apps.
+    """
 
     fields = ('id', 'name', 'order', 'disabled_on',)
     list_display = ('name', 'order', 'disabled_on',)
     readonly_fields = ('id',)
     search_fields = ('name', 'pk')
     list_filter = (DisabledOnFilter,)
+
+
+admin.site.register(MODELS_TO_REGISTER_DISABLEABLE, DisableableMetadataAdmin)
+admin.site.register(MODELS_TO_REGISTER_READ_ONLY, ReadOnlyMetadataAdmin)
+admin.site.register(MODELS_TO_REGISTER_WITH_ORDER, OrderedMetadataAdmin)
 
 
 @admin.register(models.Team)


### PR DESCRIPTION
Issue number: N/A

### Description of change

Cuts down on repetition of model admin classes by reusing metadata ones across apps.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
