### PR TITLE
Refactor dashboard code and rename ESModel attribute on search apps

### DIFF
--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -25,7 +25,7 @@ class SearchApp:
     """Used to configure ES search modules to be used within Data Hub."""
 
     name = None
-    ESModel = None
+    es_model = None
     view = None
     export_view = None
     queryset = None
@@ -46,7 +46,7 @@ class SearchApp:
         Makes sure mappings exist in Elasticsearch.
         This call is idempotent.
         """
-        self.ESModel.init(index=settings.ES_INDEX)
+        self.es_model.init(index=settings.ES_INDEX)
 
     def connect_signals(self):
         """
@@ -68,7 +68,7 @@ class SearchApp:
         """Returns dataset that will be synchronised with Elasticsearch."""
         queryset = self.get_queryset()
 
-        return DataSet(queryset, self.ESModel)
+        return DataSet(queryset, self.es_model)
 
     def get_permission_filters(self, request):
         """

--- a/datahub/search/companieshousecompany/apps.py
+++ b/datahub/search/companieshousecompany/apps.py
@@ -8,7 +8,7 @@ class CompaniesHouseCompanySearchApp(SearchApp):
     """SearchApp for companies house companies."""
 
     name = 'companieshousecompany'
-    ESModel = CompaniesHouseCompany
+    es_model = CompaniesHouseCompany
     view = SearchCompaniesHouseCompanyAPIView
     permission_required = ('company.read_companieshousecompany',)
     queryset = DBCompaniesHouseCompany.objects.prefetch_related(

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -8,7 +8,7 @@ class CompanySearchApp(SearchApp):
     """SearchApp for company."""
 
     name = 'company'
-    ESModel = Company
+    es_model = Company
     view = SearchCompanyAPIView
     export_view = SearchCompanyExportAPIView
     permission_required = ('company.read_company',)

--- a/datahub/search/contact/apps.py
+++ b/datahub/search/contact/apps.py
@@ -8,7 +8,7 @@ class ContactSearchApp(SearchApp):
     """SearchApp for contacts"""
 
     name = 'contact'
-    ESModel = Contact
+    es_model = Contact
     view = SearchContactAPIView
     export_view = SearchContactExportAPIView
     permission_required = ('company.read_contact',)

--- a/datahub/search/dashboard/views.py
+++ b/datahub/search/dashboard/views.py
@@ -41,7 +41,7 @@ def _get_objects(request, limit, search_app, adviser_field):
 
     query = get_search_by_entity_query(
         term='',
-        entity=search_app.ESModel,
+        entity=search_app.es_model,
         filter_data={
             adviser_field: request.user.id,
             'created_on_exists': True,

--- a/datahub/search/dashboard/views.py
+++ b/datahub/search/dashboard/views.py
@@ -4,10 +4,8 @@ from rest_framework.views import APIView
 
 from datahub.oauth.scopes import Scope
 from datahub.search.contact.apps import ContactSearchApp
-from datahub.search.contact.models import Contact
 from datahub.search.elasticsearch import get_search_by_entity_query, limit_search_query
 from datahub.search.interaction.apps import InteractionSearchApp
-from datahub.search.interaction.models import Interaction
 from datahub.search.permissions import has_permissions_for_app
 from .serializers import HomepageSerializer
 
@@ -26,8 +24,8 @@ class IntelligentHomepageView(APIView):
         serializer.is_valid(raise_exception=True)
         limit = serializer.validated_data['limit']
 
-        interactions = self._get_interactions(request, limit)
-        contacts = self._get_contacts(request, limit)
+        interactions = _get_objects(request, limit, InteractionSearchApp, 'dit_adviser.id')
+        contacts = _get_objects(request, limit, ContactSearchApp, 'created_by.id')
 
         response = {
             'interactions': interactions,
@@ -36,44 +34,24 @@ class IntelligentHomepageView(APIView):
 
         return Response(data=response)
 
-    def _get_interactions(self, request, limit):
-        if not has_permissions_for_app(request, InteractionSearchApp):
-            return []
 
-        interactions_query = get_search_by_entity_query(
-            term='',
-            entity=Interaction,
-            filter_data={
-                'dit_adviser.id': request.user.id,
-                'created_on_exists': True,
-            },
-            field_order='created_on:desc',
-        )
-        interactions = limit_search_query(
-            interactions_query,
-            offset=0,
-            limit=limit,
-        ).execute()
+def _get_objects(request, limit, search_app, adviser_field):
+    if not has_permissions_for_app(request, search_app):
+        return []
 
-        return [interaction.to_dict() for interaction in interactions.hits]
+    query = get_search_by_entity_query(
+        term='',
+        entity=search_app.ESModel,
+        filter_data={
+            adviser_field: request.user.id,
+            'created_on_exists': True,
+        },
+        field_order='created_on:desc',
+    )
+    results = limit_search_query(
+        query,
+        offset=0,
+        limit=limit,
+    ).execute()
 
-    def _get_contacts(self, request, limit):
-        if not has_permissions_for_app(request, ContactSearchApp):
-            return []
-
-        contacts_query = get_search_by_entity_query(
-            term='',
-            entity=Contact,
-            filter_data={
-                'created_by.id': request.user.id,
-                'created_on_exists': True,
-            },
-            field_order='created_on:desc',
-        )
-        contacts = limit_search_query(
-            contacts_query,
-            offset=0,
-            limit=limit,
-        ).execute()
-
-        return [contact.to_dict() for contact in contacts.hits]
+    return [result.to_dict() for result in results.hits]

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -246,7 +246,7 @@ def get_basic_search_query(
     """
     limit = _clip_limit(offset, limit)
 
-    all_models = (search_app.ESModel for search_app in get_search_apps())
+    all_models = (search_app.es_model for search_app in get_search_apps())
     fields = set(chain.from_iterable(entity.SEARCH_FIELDS for entity in all_models))
 
     # Sort the fields so that this function is deterministic

--- a/datahub/search/event/apps.py
+++ b/datahub/search/event/apps.py
@@ -8,7 +8,7 @@ class EventSearchApp(SearchApp):
     """SearchApp for events."""
 
     name = 'event'
-    ESModel = Event
+    es_model = Event
     view = SearchEventAPIView
     export_view = SearchEventExportAPIView
     permission_required = ('event.read_event',)

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -9,7 +9,7 @@ class InteractionSearchApp(SearchApp):
     """SearchApp for interactions."""
 
     name = 'interaction'
-    ESModel = Interaction
+    es_model = Interaction
     view = SearchInteractionAPIView
     export_view = SearchInteractionExportAPIView
     permission_required = (f'interaction.{InteractionPermission.read_all}',)

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -17,7 +17,7 @@ class InvestmentSearchApp(SearchApp):
     """SearchApp for investment"""
 
     name = 'investment_project'
-    ESModel = InvestmentProject
+    es_model = InvestmentProject
     view = SearchInvestmentProjectAPIView
     export_view = SearchInvestmentProjectExportAPIView
     permission_required = (

--- a/datahub/search/omis/apps.py
+++ b/datahub/search/omis/apps.py
@@ -8,7 +8,7 @@ class OrderSearchApp(SearchApp):
     """SearchApp for order"""
 
     name = 'order'
-    ESModel = Order
+    es_model = Order
     view = SearchOrderAPIView
     permission_required = ('order.read_order',)
     queryset = DBOrder.objects.prefetch_related(

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -46,7 +46,7 @@ class SearchBasicAPIView(APIView):
 
         self.entity_by_name = {
             search_app.name: EntitySearch(
-                search_app.ESModel,
+                search_app.es_model,
                 search_app.name,
             )
             for search_app in get_search_apps()
@@ -105,7 +105,7 @@ def _get_permission_filters(request):
             continue
 
         filter_args = app.get_permission_filters(request)
-        yield (app.ESModel._doc_type.name, filter_args)
+        yield (app.es_model._doc_type.name, filter_args)
 
 
 class SearchAPIView(APIView):


### PR DESCRIPTION
Issue number: N/A

### Description of change

Refactors the dashboard code to cut down on repetition, and renames the ESModel attribute on search apps to es_model to be consistent with normal naming conventions for attributes.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
