### PR TITLE
Add OMIS refunds to django admin

### DIFF
--- a/datahub/omis/payment/admin.py
+++ b/datahub/omis/payment/admin.py
@@ -1,0 +1,226 @@
+from django import forms
+from django.conf import settings
+from django.contrib import admin
+from django.core.exceptions import ValidationError
+from django.template.defaultfilters import date as date_formatter
+from django.utils.translation import ugettext_lazy as _
+
+from datahub.omis.order.constants import OrderStatus
+from .constants import RefundStatus
+from .models import Refund
+
+
+class RefundForm(forms.ModelForm):
+    """Form for adding/changing refund records via the django admin."""
+
+    APPROVED_MANDATORY_FIELDS = [
+        'level1_approved_on',
+        'level1_approved_by',
+        'level2_approved_on',
+        'level2_approved_by',
+        'method',
+        'net_amount',
+        'vat_amount',
+    ]
+
+    class Meta:
+        model = Refund
+        fields = (
+            'id',
+            'order',
+            'reference',
+            'status',
+            'requested_on',
+            'requested_by',
+            'requested_amount',
+            'refund_reason',
+            'level1_approved_on',
+            'level1_approved_by',
+            'level1_approval_notes',
+            'level2_approved_on',
+            'level2_approved_by',
+            'level2_approval_notes',
+            'method',
+            'net_amount',
+            'vat_amount',
+            'total_amount',
+            'rejection_reason',
+            'additional_reference'
+        )
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialise the object.
+
+        During the creation step, the value of status can only be RefundStatus.approved.
+        During the editing step, the value of status cannot be changed any longer.
+        """
+        super().__init__(*args, **kwargs)
+
+        # set up the status field
+        refund_status = self.instance.status or RefundStatus.approved
+
+        self.fields['status'].choices = (
+            (refund_status, RefundStatus[refund_status]),
+        )
+
+        # set up mandatory fields when status == approved
+        if refund_status == RefundStatus.approved:
+            for field_name in self.APPROVED_MANDATORY_FIELDS:
+                self.fields[field_name].required = True
+
+    def _clean_order_status(self):
+        """Validate the order data value from the `clean` method."""
+        order = self.cleaned_data.get('order')
+        if not order:
+            return
+        if order.status not in (OrderStatus.complete, OrderStatus.paid, OrderStatus.cancelled):
+            self.add_error(
+                'order',
+                ValidationError(_('This order has not been paid for.'), code='not_paid')
+            )
+
+    def _clean_datetime_field_gte_value(self, field, compared_value):
+        """Validate a datetime data value from the `clean` method."""
+        field_value = self.cleaned_data.get(field)
+        if not field_value or not compared_value:
+            return
+
+        if field_value < compared_value:
+            self.add_error(
+                field,
+                ValidationError(
+                    _('Please specify a value greater than or equal to %(compared_value)s.'),
+                    params={
+                        'compared_value': date_formatter(
+                            compared_value, settings.DATETIME_FORMAT
+                        )
+                    },
+                    code='invalid_date'
+                )
+            )
+
+    def _clean_amounts(self):
+        """Validate the amount values from the `clean` method."""
+        order = self.cleaned_data['order']
+        net_amount = self.cleaned_data.get('net_amount')
+        vat_amount = self.cleaned_data.get('vat_amount')
+        if net_amount is None or vat_amount is None:
+            return
+
+        total_amount = net_amount + vat_amount
+
+        qs = order.refunds
+        if self.instance.pk:
+            qs = qs.exclude(pk=self.instance.pk)
+        currently_refunded = sum(
+            amount for amount in qs.values_list('total_amount', flat=True) if amount
+        )
+
+        refund_remaining = order.total_cost - currently_refunded
+        if total_amount > refund_remaining:
+            self.add_error(
+                'net_amount',
+                ValidationError(
+                    _('Remaining amount that can be refunded: %(refund_remaining)s.'),
+                    params={
+                        'refund_remaining': refund_remaining
+                    },
+                    code='refund_limit_exceeded'
+                )
+            )
+        else:
+            self.cleaned_data['total_amount'] = total_amount
+
+    def _clean_approvals(self):
+        """Validate the approval data values from the `clean` method."""
+        level1_approved_by = self.cleaned_data.get('level1_approved_by')
+        level2_approved_by = self.cleaned_data.get('level2_approved_by')
+
+        if level1_approved_by and level1_approved_by == level2_approved_by:
+            self.add_error(
+                'level1_approved_by',
+                ValidationError(
+                    _('Approvers level1 and level2 have to be different.'),
+                    code='invalid_approvers'
+                )
+            )
+
+    def clean(self):
+        """Add some extra validation on the top of the existing one."""
+        super().clean()
+
+        self._clean_order_status()
+        order = self.cleaned_data.get('order')
+        if not order:
+            return
+
+        self._clean_datetime_field_gte_value('requested_on', order.paid_on)
+        requested_on = self.cleaned_data.get('requested_on')
+
+        self._clean_datetime_field_gte_value('level1_approved_on', order.paid_on)
+        self._clean_datetime_field_gte_value('level1_approved_on', requested_on)
+        self._clean_datetime_field_gte_value('level2_approved_on', order.paid_on)
+        self._clean_datetime_field_gte_value('level2_approved_on', requested_on)
+
+        self._clean_approvals()
+
+        self._clean_amounts()
+
+        return self.cleaned_data
+
+
+@admin.register(Refund)
+class RefundAdmin(admin.ModelAdmin):
+    """Refund admin."""
+
+    form = RefundForm
+
+    search_fields = (
+        'pk',
+        'order__reference',
+        'reference',
+    )
+    list_display = (
+        'reference',
+        'order',
+        'status',
+        'requested_on',
+    )
+    list_filter = (
+        'status',
+    )
+    raw_id_fields = (
+        'order',
+        'requested_by',
+        'created_by',
+        'modified_by',
+        'level1_approved_by',
+        'level2_approved_by',
+    )
+    readonly_fields = (
+        'id',
+        'reference',
+        'created_by',
+        'created_on',
+        'modified_by',
+        'modified_on',
+        'total_amount',
+    )
+    list_select_related = (
+        'order',
+    )
+
+    def save_model(self, request, obj, form, change):
+        """
+        Populate total_amount from other fields and
+        created_by/modified_by from the logged in user.
+        """
+        if 'total_amount' in form.cleaned_data:
+            obj.total_amount = form.cleaned_data['total_amount']
+
+        if not change:
+            obj.created_by = request.user
+        obj.modified_by = request.user
+
+        super().save_model(request, obj, form, change)

--- a/datahub/omis/payment/test/factories.py
+++ b/datahub/omis/payment/test/factories.py
@@ -1,9 +1,13 @@
+import random
 import uuid
 
 import factory
+from django.utils.timezone import utc
 
+from datahub.company.test.factories import AdviserFactory
 from datahub.omis.order.test.factories import OrderPaidFactory, OrderWithAcceptedQuoteFactory
 from .. import constants
+from ..models import RefundStatus
 
 
 class PaymentFactory(factory.django.DjangoModelFactory):
@@ -32,3 +36,58 @@ class PaymentGatewaySessionFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'omis-payment.PaymentGatewaySession'
+
+
+class RequestedRefundFactory(factory.django.DjangoModelFactory):
+    """Factory for refund requested."""
+
+    id = factory.LazyFunction(uuid.uuid4)
+    created_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SubFactory(AdviserFactory)
+    order = factory.SubFactory(OrderPaidFactory)
+    reference = factory.Faker('pystr')
+    status = RefundStatus.requested
+    requested_on = factory.Faker('date_time', tzinfo=utc)
+    requested_by = factory.SubFactory(AdviserFactory)
+    refund_reason = factory.Faker('text')
+    requested_amount = factory.LazyAttribute(
+        lambda refund: random.randint(1, refund.order.total_cost)
+    )
+
+    class Meta:
+        model = 'omis-payment.Refund'
+
+
+class ApprovedRefundFactory(RequestedRefundFactory):
+    """Factory for refund requested, approved and paid."""
+
+    status = RefundStatus.approved
+
+    level1_approved_on = factory.Faker('date_time', tzinfo=utc)
+    level1_approved_by = factory.SubFactory(AdviserFactory)
+    level1_approval_notes = factory.Faker('text')
+
+    level2_approved_on = factory.Faker('date_time', tzinfo=utc)
+    level2_approved_by = factory.SubFactory(AdviserFactory)
+    level2_approval_notes = factory.Faker('text')
+
+    method = constants.PaymentMethod.bacs
+
+    vat_amount = factory.LazyAttribute(
+        lambda refund: int(refund.requested_amount * 0.2)
+    )
+    net_amount = factory.LazyAttribute(
+        lambda refund: refund.requested_amount - refund.vat_amount
+    )
+    total_amount = factory.LazyAttribute(
+        lambda refund: refund.requested_amount
+    )
+    additional_reference = factory.Faker('pystr')
+
+
+class RejectedRefundFactory(RequestedRefundFactory):
+    """Factory for refund requested and rejected."""
+
+    status = RefundStatus.rejected
+
+    rejection_reason = factory.Faker('text')

--- a/datahub/omis/payment/test/test_admin.py
+++ b/datahub/omis/payment/test/test_admin.py
@@ -1,0 +1,420 @@
+import pytest
+from dateutil.parser import parse as dateutil_parse
+from django.urls import reverse
+from django.utils.timezone import now
+from rest_framework import status
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.core.test_utils import AdminTestMixin
+from datahub.omis.order.test.factories import OrderPaidFactory, OrderWithOpenQuoteFactory
+from .factories import ApprovedRefundFactory, RejectedRefundFactory, RequestedRefundFactory
+from ..constants import PaymentMethod, RefundStatus
+from ..models import Refund
+
+
+class TestRefundAdmin(AdminTestMixin):
+    """Tests for the Refund Admin."""
+
+    def test_add(self):
+        """
+        Test adding a refund with status 'Approved'.
+        This is the only status allowed when creating a record at the moment.
+        """
+        order = OrderPaidFactory()
+        now_datetime = now()
+        now_date_str = now_datetime.date().isoformat()
+        now_time_str = now_datetime.time().isoformat()
+
+        assert Refund.objects.count() == 0
+
+        url = reverse('admin:omis-payment_refund_add')
+        data = {
+            'order': order.pk,
+            'status': RefundStatus.approved,
+            'requested_on_0': now_date_str,
+            'requested_on_1': now_time_str,
+            'requested_by': AdviserFactory().pk,
+            'requested_amount': order.total_cost,
+            'refund_reason': 'lorem ipsum refund reason',
+            'level1_approved_on_0': now_date_str,
+            'level1_approved_on_1': now_time_str,
+            'level1_approved_by': AdviserFactory().pk,
+            'level1_approval_notes': 'lorem ipsum level 1',
+            'level2_approved_on_0': now_date_str,
+            'level2_approved_on_1': now_time_str,
+            'level2_approved_by': AdviserFactory().pk,
+            'level2_approval_notes': 'lorem ipsum level 2',
+            'method': PaymentMethod.bacs,
+            'net_amount': order.total_cost - 1,
+            'vat_amount': 1,
+            'additional_reference': 'additional reference',
+            'rejection_reason': 'lorem ipsum rejection reason',
+        }
+        response = self.client.post(url, data, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        assert Refund.objects.count() == 1
+        refund = Refund.objects.first()
+
+        assert refund.order.pk == data['order']
+        assert refund.status == data['status']
+        assert refund.requested_on == now_datetime
+        assert refund.requested_by.pk == data['requested_by']
+        assert refund.requested_amount == data['requested_amount']
+        assert refund.refund_reason == data['refund_reason']
+        assert refund.level1_approved_on == now_datetime
+        assert refund.level1_approved_by.pk == data['level1_approved_by']
+        assert refund.level1_approval_notes == data['level1_approval_notes']
+        assert refund.level2_approved_on == now_datetime
+        assert refund.level2_approved_by.pk == data['level2_approved_by']
+        assert refund.level2_approval_notes == data['level2_approval_notes']
+        assert refund.method == data['method']
+        assert refund.net_amount == data['net_amount']
+        assert refund.vat_amount == data['vat_amount']
+        assert refund.additional_reference == data['additional_reference']
+        assert refund.rejection_reason == data['rejection_reason']
+
+        assert refund.total_amount == order.total_cost
+        assert refund.created_by == self.user
+        assert refund.modified_by == self.user
+        assert not refund.payment
+
+    @pytest.mark.parametrize(
+        'refund_factory',
+        (
+            RequestedRefundFactory,
+            ApprovedRefundFactory,
+            RejectedRefundFactory,
+        )
+    )
+    def test_change(self, refund_factory):
+        """Test changing a refund record, its status cannot change at this point."""
+        refund = refund_factory()
+        order = OrderPaidFactory()
+
+        now_datetime = now()
+        now_date_str = now_datetime.date().isoformat()
+        now_time_str = now_datetime.time().isoformat()
+
+        url = reverse('admin:omis-payment_refund_change', args=(refund.id,))
+        data = {
+            'order': order.pk,
+            'status': refund.status,
+            'requested_on_0': now_date_str,
+            'requested_on_1': now_time_str,
+            'requested_by': AdviserFactory().pk,
+            'requested_amount': order.total_cost,
+            'refund_reason': 'lorem ipsum refund reason',
+            'level1_approved_on_0': now_date_str,
+            'level1_approved_on_1': now_time_str,
+            'level1_approved_by': AdviserFactory().pk,
+            'level1_approval_notes': 'lorem ipsum level 1',
+            'level2_approved_on_0': now_date_str,
+            'level2_approved_on_1': now_time_str,
+            'level2_approved_by': AdviserFactory().pk,
+            'level2_approval_notes': 'lorem ipsum level 2',
+            'method': PaymentMethod.bacs,
+            'net_amount': order.total_cost - 1,
+            'vat_amount': 1,
+            'additional_reference': 'additional reference',
+            'rejection_reason': 'lorem ipsum rejection reason',
+        }
+        response = self.client.post(url, data, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        refund.refresh_from_db()
+
+        assert refund.order.pk == data['order']
+        assert refund.status == data['status']
+        assert refund.requested_on == now_datetime
+        assert refund.requested_by.pk == data['requested_by']
+        assert refund.requested_amount == data['requested_amount']
+        assert refund.refund_reason == data['refund_reason']
+        assert refund.level1_approved_on == now_datetime
+        assert refund.level1_approved_by.pk == data['level1_approved_by']
+        assert refund.level1_approval_notes == data['level1_approval_notes']
+        assert refund.level2_approved_on == now_datetime
+        assert refund.level2_approved_by.pk == data['level2_approved_by']
+        assert refund.level2_approval_notes == data['level2_approval_notes']
+        assert refund.method == data['method']
+        assert refund.net_amount == data['net_amount']
+        assert refund.vat_amount == data['vat_amount']
+        assert refund.additional_reference == data['additional_reference']
+        assert refund.rejection_reason == data['rejection_reason']
+
+        assert refund.total_amount == order.total_cost
+        assert refund.created_by != self.user
+        assert refund.modified_by == self.user
+        assert not refund.payment
+
+    @pytest.mark.parametrize(
+        'data_delta,errors',
+        (
+            # invalid status
+            (
+                {'status': RefundStatus.rejected},
+                {
+                    'status': [
+                        'Select a valid choice. rejected is not one of the available choices.'
+                    ]
+                }
+            ),
+
+            # invalid order status
+            (
+                {'order': lambda *_: OrderWithOpenQuoteFactory()},
+                {'order': ['This order has not been paid for.']}
+            ),
+
+            # requested on < order.paid_on
+            (
+                {
+                    'order': lambda *_: OrderPaidFactory(
+                        paid_on=dateutil_parse('2018-01-01T13:00Z'),
+                    ),
+                    'requested_on_0': '2018-01-01',
+                    'requested_on_1': '12:59',
+                },
+                {
+                    'requested_on': [
+                        'Please specify a value greater than or equal to Jan. 1, 2018, 1 p.m..'
+                    ]
+                }
+            ),
+
+            # level1 approved on < order.paid_on
+            (
+                {
+                    'order': lambda *_: OrderPaidFactory(
+                        paid_on=dateutil_parse('2018-01-01T13:00Z'),
+                    ),
+                    'level1_approved_on_0': '2018-01-01',
+                    'level1_approved_on_1': '12:59',
+                },
+                {
+                    'level1_approved_on': [
+                        'Please specify a value greater than or equal to Jan. 1, 2018, 1 p.m..'
+                    ]
+                }
+            ),
+
+            # level2 approved on < order.paid_on
+            (
+                {
+                    'order': lambda *_: OrderPaidFactory(
+                        paid_on=dateutil_parse('2018-01-01T13:00Z'),
+                    ),
+                    'level2_approved_on_0': '2018-01-01',
+                    'level2_approved_on_1': '12:59',
+                },
+                {
+                    'level2_approved_on': [
+                        'Please specify a value greater than or equal to Jan. 1, 2018, 1 p.m..'
+                    ]
+                }
+            ),
+
+            # same level1 and level2 approver
+            (
+                {
+                    'level1_approved_by': lambda *_: AdviserFactory().pk,
+                    'level2_approved_by': lambda _, d: d['level1_approved_by']
+                },
+                {
+                    'level1_approved_by': ['Approvers level1 and level2 have to be different.']
+                }
+            ),
+
+            # net_amount + vat_amount > order.total_cost
+            (
+                {
+                    'net_amount': lambda o, _: o.total_cost,
+                    'vat_amount': lambda *_: 1
+                },
+                {
+                    'net_amount': lambda o, _: [
+                        f'Remaining amount that can be refunded: {o.total_cost}.'
+                    ]
+                }
+            ),
+        )
+    )
+    def test_validation_error(self, data_delta, errors):
+        """Test validation errors."""
+        def resolve(value, order, data):
+            if callable(value):
+                return value(order, data)
+            return value
+
+        order = data_delta.pop('order', None) or OrderPaidFactory()
+        order = resolve(order, None, None)
+
+        now_datetime = now()
+        now_date_str = now_datetime.date().isoformat()
+        now_time_str = now_datetime.time().isoformat()
+
+        url = reverse('admin:omis-payment_refund_add')
+        data = {
+            'order': order.pk,
+            'status': RefundStatus.approved,
+            'requested_on_0': now_date_str,
+            'requested_on_1': now_time_str,
+            'requested_by': AdviserFactory().pk,
+            'requested_amount': order.total_cost,
+            'refund_reason': 'lorem ipsum refund reason',
+            'level1_approved_on_0': now_date_str,
+            'level1_approved_on_1': now_time_str,
+            'level1_approved_by': AdviserFactory().pk,
+            'level1_approval_notes': 'lorem ipsum level 1',
+            'level2_approved_on_0': now_date_str,
+            'level2_approved_on_1': now_time_str,
+            'level2_approved_by': AdviserFactory().pk,
+            'level2_approval_notes': 'lorem ipsum level 2',
+            'method': PaymentMethod.bacs,
+            'net_amount': order.total_cost - 1,
+            'vat_amount': 1,
+            'additional_reference': 'additional reference',
+        }
+
+        for data_key, data_value in data_delta.items():
+            data[data_key] = resolve(data_value, order, data)
+        response = self.client.post(url, data, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        form = response.context['adminform'].form
+        assert not form.is_valid()
+
+        for error_key, error_value in errors.items():
+            errors[error_key] = resolve(error_value, order, errors)
+        assert form.errors == errors
+
+    @pytest.mark.parametrize(
+        'refund_factory,required_fields',
+        (
+            (
+                RequestedRefundFactory,
+                (
+                    'order',
+                    'status',
+                    'requested_on',
+                    'requested_amount',
+                )
+            ),
+            (
+                ApprovedRefundFactory,
+                (
+                    'order',
+                    'status',
+                    'requested_on',
+                    'requested_amount',
+                    'level1_approved_on',
+                    'level1_approved_by',
+                    'level2_approved_on',
+                    'level2_approved_by',
+                    'method',
+                    'net_amount',
+                    'vat_amount',
+                )
+            ),
+            (
+                RejectedRefundFactory,
+                (
+                    'order',
+                    'status',
+                    'requested_on',
+                    'requested_amount',
+                )
+            ),
+        )
+    )
+    def test_required_fields(self, refund_factory, required_fields):
+        """Test required fields depending on the status of the refund."""
+        refund = refund_factory()
+
+        url = reverse('admin:omis-payment_refund_change', args=(refund.id,))
+        data = {
+            'order': '',
+            'status': '',
+            'requested_on_0': '',
+            'requested_on_1': '',
+            'requested_by': '',
+            'requested_amount': '',
+            'refund_reason': '',
+            'level1_approved_on_0': '',
+            'level1_approved_on_1': '',
+            'level1_approved_by': '',
+            'level1_approval_notes': '',
+            'level2_approved_on_0': '',
+            'level2_approved_on_1': '',
+            'level2_approved_by': '',
+            'level2_approval_notes': '',
+            'method': '',
+            'net_amount': '',
+            'vat_amount': '',
+            'additional_reference': '',
+            'rejection_reason': '',
+        }
+        response = self.client.post(url, data, follow=True)
+
+        form = response.context['adminform'].form
+        assert not form.is_valid()
+
+        assert form.errors == {
+            required_field: ['This field is required.']
+            for required_field in required_fields
+        }
+
+    @pytest.mark.parametrize(
+        'refund_factory',
+        (
+            RequestedRefundFactory,
+            ApprovedRefundFactory,
+            RejectedRefundFactory,
+        )
+    )
+    def test_cannot_change_status(self, refund_factory):
+        """Test that the status field cannot be changed at any point."""
+        refund = refund_factory()
+
+        now_datetime = now()
+        date_str = now_datetime.date().isoformat()
+        time_str = now_datetime.time().isoformat()
+
+        url = reverse('admin:omis-payment_refund_change', args=(refund.id,))
+        default_data = {
+            'order': refund.order.pk,
+            'requested_on_0': date_str,
+            'requested_on_1': time_str,
+            'requested_amount': refund.requested_amount,
+            'refund_reason': refund.refund_reason,
+            'level1_approved_on_0': date_str,
+            'level1_approved_on_1': time_str,
+            'level1_approved_by': AdviserFactory().pk,
+            'level2_approved_on_0': date_str,
+            'level2_approved_on_1': time_str,
+            'level2_approved_by': AdviserFactory().pk,
+            'method': refund.method or '',
+            'net_amount': refund.net_amount or '',
+            'vat_amount': refund.vat_amount or '',
+        }
+
+        for changed_status, _ in RefundStatus:
+            if changed_status == refund.status:
+                continue
+
+            data = {
+                **default_data,
+                'status': changed_status,
+            }
+            response = self.client.post(url, data, follow=True)
+
+            assert response.status_code == status.HTTP_200_OK
+            form = response.context['adminform'].form
+            assert not form.is_valid()
+            assert form.errors == {
+                'status': [
+                    f'Select a valid choice. {changed_status} is not one of the available choices.'
+                ]
+            }


### PR DESCRIPTION
This allows refund records to be managed via the django admin.

- Validation is kept to a minimum
- Only approved refunds can be added
- Existing refunds cannot have their status changed
- Required fields are configured depending on the refund status

Note:
- There are no refund records in status _Requested_ in production
- Things can be improved, e.g. the amounts are still in pence. This is the first iteration and others will follow if time allows.