### PR TITLE
Make Elasticsearch paging consistent.

### DIFF
--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -91,7 +91,11 @@ def test_get_basic_search_query():
             }
         },
         'from': 5,
-        'size': 5
+        'size': 5,
+        'sort': [
+            '_score',
+            'id'
+        ]
     }
 
 
@@ -207,5 +211,9 @@ def test_limited_get_search_by_entity_query():
             }
         },
         'from': 5,
-        'size': 5
+        'size': 5,
+        'sort': [
+            '_score',
+            'id'
+        ]
     }

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -369,7 +369,12 @@ class TestSearch(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'uk_region': ['This field may not be null.']}
 
-    def test_company_search_paging(self, setup_es):
+    @pytest.mark.parametrize('sortby', (
+        {},
+        {'sortby': 'name:asc'},
+        {'sortby': 'created_on:asc'},
+    ))
+    def test_company_search_paging(self, sortby, setup_es):
         """Tests if content placement is consistent between pages."""
         ids = [
             UUID('05ab924a-903e-4dd0-9a36-958091bcf41b'),
@@ -395,6 +400,7 @@ class TestSearch(APITestMixin):
             'entity': 'company',
             'offset': 0,
             'limit': 2,
+            **sortby,
         })
 
         assert response.status_code == status.HTTP_200_OK

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -374,7 +374,7 @@ class TestSearch(APITestMixin):
         {'sortby': 'name:asc'},
         {'sortby': 'created_on:asc'},
     ))
-    def test_company_search_paging(self, sortby, setup_es):
+    def test_company_search_paging(self, setup_es, sortby):
         """Tests if content placement is consistent between pages."""
         ids = [
             UUID('05ab924a-903e-4dd0-9a36-958091bcf41b'),

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -91,7 +91,11 @@ def test_get_basic_search_query():
             }
         },
         'from': 5,
-        'size': 5
+        'size': 5,
+        'sort': [
+            '_score',
+            'id'
+        ]
     }
 
 
@@ -202,5 +206,9 @@ def test_get_limited_search_by_entity_query():
             }
         },
         'from': 5,
-        'size': 5
+        'size': 5,
+        'sort': [
+            '_score',
+            'id'
+        ]
     }

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -170,7 +170,7 @@ def _remap_sort_field(field):
 def _get_sort_query(qs, field_order=None):
     """Attaches sort query."""
     if field_order is None:
-        return qs
+        return qs.sort('_score', 'id')
 
     tokens = field_order.rsplit(':', maxsplit=1)
     order = tokens[1] if len(tokens) > 1 else 'asc'
@@ -187,7 +187,7 @@ def _get_sort_query(qs, field_order=None):
 
     qs = qs.sort({
         _remap_sort_field(tokens[0]): sort_params
-    })
+    }, 'id')
     return qs
 
 

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -93,7 +93,11 @@ def test_get_basic_search_query():
             }
         },
         'from': 5,
-        'size': 5
+        'size': 5,
+        'sort': [
+            '_score',
+            'id'
+        ],
     }
 
 
@@ -207,5 +211,9 @@ def test_limited_get_search_by_entity_query():
             }
         },
         'from': 5,
-        'size': 5
+        'size': 5,
+        'sort': [
+            '_score',
+            'id'
+        ]
     }

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -91,7 +91,12 @@ class TestSearch(APITestMixin):
         assert response.data['count'] == 2
         assert len(response.data['results']) == 1
 
-    def test_basic_search_consistent_paging(self, setup_es):
+    @pytest.mark.parametrize('sortby', (
+        {},
+        {'sortby': 'name:asc'},
+        {'sortby': 'created_on:asc'},
+    ))
+    def test_basic_search_consistent_paging(self, setup_es, sortby):
         """Tests if content placement is consistent between pages."""
         ids = [
             UUID('05ab924a-903e-4dd0-9a36-958091bcf41b'),
@@ -117,6 +122,7 @@ class TestSearch(APITestMixin):
             'entity': 'company',
             'offset': 0,
             'limit': 2,
+            **sortby
         })
 
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Issue number: DH-1389

### Description of change

This adds `id` as additional sort field besides of default `_score` or chosen field. `id` is in every entity and is unique. Additional sorting by this field acts as a tiebreaker in case search result score (or primary sort field) is equal and makes search results deterministic and consistent between the pages 

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
