### PR TITLE
Update to Django Rest Framework 3.8.2

### DIFF
--- a/datahub/core/mixins.py
+++ b/datahub/core/mixins.py
@@ -1,7 +1,7 @@
 """General mixins."""
 from django.conf import settings
 from rest_framework import serializers
-from rest_framework.decorators import detail_route
+from rest_framework.decorators import action
 from rest_framework.response import Response
 
 
@@ -17,7 +17,7 @@ class ArchiveSerializer(serializers.Serializer):
 class ArchivableViewSetMixin:
     """To be used with archivable models."""
 
-    @detail_route(methods=['post'])
+    @action(methods=['post'], detail=True)
     def archive(self, request, pk):
         """Archive the object."""
         serializer = ArchiveSerializer(data=request.data)
@@ -29,7 +29,7 @@ class ArchivableViewSetMixin:
         serializer = self.get_serializer_class()(obj)
         return Response(data=serializer.data)
 
-    @detail_route(methods=['post'])
+    @action(methods=['post'], detail=True)
     def unarchive(self, request, pk):
         """Unarchive the object."""
         obj = self.get_object()

--- a/datahub/investment/serializers.py
+++ b/datahub/investment/serializers.py
@@ -245,6 +245,11 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
         cases, only the fields being modified are validated.  If a project ends up in an
         invalid state, this avoids the user being unable to rectify the situation.
         """
+        if not self.instance:
+            # Required for validation as DRF does not allow defaults for read-only fields
+            data['allow_blank_estimated_land_date'] = False
+            data['allow_blank_possible_uk_regions'] = False
+
         fields = None
         if self.partial and 'stage' not in data:
             fields = data.keys()
@@ -304,9 +309,6 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
         # DRF defaults to required=False even though this field is non-nullable
         extra_kwargs = {
             'likelihood_of_landing': {'min_value': 0, 'max_value': 100},
-            # Required for validation as ModelSerializer does not automatically set defaults
-            'allow_blank_estimated_land_date': {'default': False},
-            'allow_blank_possible_uk_regions': {'default': False},
         }
         permissions = {
             f'investment.{InvestmentProjectPermission.read_investmentproject_document}':

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -31,9 +31,17 @@ class SingleOrListField(serializers.ListField):
     """Field can be single instance or list."""
 
     def to_internal_value(self, data):
-        """If data is str, creates a list."""
+        """
+        If data is str, call the child serialiser's run_validation() directly.
+
+        This is to maintain an error format matching the input (if a list is provided, return an
+        error list for each item, otherwise return a single error list).
+
+        (We call self.child.run_validation() rather than self.child.to_internal_value(), because
+        ListField performs child field validation in its to_internal_value().)
+        """
         if isinstance(data, str):
-            data = [data]
+            return [self.child.run_validation(data)]
         return super().to_internal_value(data)
 
 

--- a/datahub/search/test/test_serializers.py
+++ b/datahub/search/test/test_serializers.py
@@ -1,0 +1,34 @@
+import pytest
+from rest_framework import serializers
+
+from datahub.search.serializers import SingleOrListField
+
+
+class TestSingleOrListField:
+    """Tests SingleOrListField."""
+
+    def test_single_value_validation(self):
+        """Test that a single value passes validation and is wrapped in a list."""
+        field = SingleOrListField(child=serializers.CharField())
+        assert field.run_validation('value') == ['value']
+
+    def test_multiple_values_validation(self):
+        """Test that list of values passes validation and is returned as a list."""
+        field = SingleOrListField(child=serializers.CharField())
+        assert field.run_validation(['value1', 'value2']) == ['value1', 'value2']
+
+    def test_single_value_validation_with_error(self):
+        """Test that an single invalid value returns an error in the single-item format."""
+        field = SingleOrListField(child=serializers.CharField(allow_blank=False))
+        with pytest.raises(serializers.ValidationError) as excinfo:
+            field.run_validation('')
+
+        assert excinfo.value.get_codes() == ['blank']
+
+    def test_multiple_values_validation_with_error(self):
+        """Test that multiple invalid value returns an error for each item."""
+        field = SingleOrListField(child=serializers.CharField(allow_blank=False))
+        with pytest.raises(serializers.ValidationError) as excinfo:
+            field.run_validation(['', ''])
+
+        assert excinfo.value.get_codes() == {0: ['blank'], 1: ['blank']}

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ cssselect==1.0.3
 
 # Django and django related
 Django==2.0.4
-djangorestframework==3.7.7
+djangorestframework==3.8.1
 django-environ==0.4.4
 django-extensions==2.0.6
 django-filter==1.1.0

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ cssselect==1.0.3
 
 # Django and django related
 Django==2.0.4
-djangorestframework==3.8.1
+djangorestframework==3.8.2
 django-environ==0.4.4
 django-extensions==2.0.6
 django-filter==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ aws-requests-auth==0.4.1
 backcall==0.1.0           # via ipython
 billiard==3.5.0.3         # via celery
 boto3==1.6.22
-botocore==1.9.22          # via boto3, s3transfer
+botocore==1.9.23          # via boto3, s3transfer
 celery==4.1.0
 certifi==2018.1.18        # via requests
 chardet==3.0.4            # via chardet, requests
@@ -31,7 +31,7 @@ django-pglocks==1.0.2
 django-redis==4.9.0
 django-reversion==2.0.13
 django==2.0.4
-djangorestframework==3.7.7
+djangorestframework==3.8.1
 docopt==0.6.2             # via docopt, notifications-python-client
 docutils==0.14            # via botocore, docutils
 elasticsearch-dsl==5.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ django-pglocks==1.0.2
 django-redis==4.9.0
 django-reversion==2.0.13
 django==2.0.4
-djangorestframework==3.8.1
+djangorestframework==3.8.2
 docopt==0.6.2             # via docopt, notifications-python-client
 docutils==0.14            # via botocore, docutils
 elasticsearch-dsl==5.4.0


### PR DESCRIPTION
Issue number: N/A

### Description of change

Updates to DRF 3.8.1. Release notes: http://www.django-rest-framework.org/topics/release-notes/

It has a few breaking changes in it, and a couple of them affect us:

1. It no longer uses the default value for read-only serialiser fields. This affected a couple of fields in investment projects, where defaults where being used to set the value for new records.

2. The error structure for ListField changed to something more like `{0: ['error message'], 1: ['error message']}`. 

    I'm not sure why they went for a dict of error lists rather than a list of lists (which would be more consistent with the rest of DRF).

    This affected the SingleOrListField we use in search. Since SingleOrListField is just used in search, the impact should be pretty minimal. I modified SingleOrListField so that when it is provided with a string it returns an error in the old format. (For lists, it uses the new format.)

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
