### PR TITLE
Add the ability to make psycopg2 asynchronous using gevent

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `ES_VERIFY_CERTS`  | No | |
 | `GUNICORN_ACCESSLOG`  | No | File to direct Gunicorn logs to (default=stdout). |
 | `GUNICORN_ACCESS_LOG_FORMAT`  | No |  |
+| `GUNICORN_ENABLE_ASYNC_PSYCOPG2` | No | Whether to enabled asynchronous psycopg2 when the worker class is 'gevent'. |
 | `GUNICORN_WORKER_CLASS`  | No | [Type of Gunicorn worker.](http://docs.gunicorn.org/en/stable/settings.html#worker-class) Uses async workers via gevent by default. |
 | `GUNICORN_WORKER_CONNECTIONS`  | No | Maximum no. of connections for async workers (default=10). |
 | `OMIS_NOTIFICATION_ADMIN_EMAIL`  | Yes | |

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,5 +1,7 @@
 import os
 
+from psycogreen.gevent import patch_psycopg
+
 accesslog = os.environ.get('GUNICORN_ACCESSLOG', '-')
 access_log_format = os.environ.get(
     'GUNICORN_ACCESS_LOG_FORMAT',
@@ -8,3 +10,13 @@ access_log_format = os.environ.get(
 )
 worker_class = os.environ.get('GUNICORN_WORKER_CLASS', 'gevent')
 worker_connections = os.environ.get('GUNICORN_WORKER_CONNECTIONS', '10')
+
+_enable_async_psycopg2 = (
+        os.environ.get('GUNICORN_ENABLE_ASYNC_PSYCOPG2', '').lower() in ('true', '1')
+)
+
+
+def post_fork(server, worker):
+    if worker_class == 'gevent' and _enable_async_psycopg2:
+        patch_psycopg()
+        worker.log.info("Enabled async Psycopg2")

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ python-dateutil==2.6.1
 
 # Persistency layer
 psycopg2==2.7.4
+psycogreen==1.0
 
 boto3==1.6.22
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,6 +74,7 @@ pickleshare==0.7.4        # via ipython, pickleshare
 pip-tools==1.11.0
 pluggy==0.6.0             # via pytest
 prompt-toolkit==1.0.15    # via ipython, prompt-toolkit
+psycogreen==1.0
 psycopg2==2.7.4
 ptyprocess==0.5.2         # via pexpect, ptyprocess
 py==1.5.3                 # via pytest


### PR DESCRIPTION
Issue number: N/A

### Description of change

This add the ability to made psycopg2 asynchronous (when the server is run using Gunicorn) using psycogreen and the GUNICORN_ENABLE_ASYNC_PSYCOPG2 environment variable.

Although we were using gevent workers with Gunicorn, psycopg2 was not made asynchronous because it's unaffected by the patching that gevent does.

GUNICORN_ENABLE_ASYNC_PSYCOPG2 is disabled by default. We can enable it in a test environment first to make sure there are no undesired side effects.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
