### PR TITLE
Only allow explcitly defined fields in Elasticsearch

### DIFF
--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -1,10 +1,10 @@
-from elasticsearch_dsl import Date, DocType, Keyword, Text
+from elasticsearch_dsl import Date, Keyword, Text
 
 from datahub.search import dict_utils, dsl_utils
-from datahub.search.models import MapDBModelToDict
+from datahub.search.models import BaseESModel
 
 
-class CompaniesHouseCompany(DocType, MapDBModelToDict):
+class CompaniesHouseCompany(BaseESModel):
     """Elasticsearch representation of CompaniesHouseCompany model."""
 
     id = Keyword()

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -19,6 +19,7 @@ def test_mapping(setup_es):
 
     assert mapping.to_dict() == {
         'companieshousecompany': {
+            'dynamic': 'strict',
             'properties': {
                 'company_category': {
                     'analyzer': 'lowercase_keyword_analyzer',

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -104,24 +104,6 @@ class Company(DocType, MapDBModelToDict):
         'export_experience_category': dict_utils.id_name_dict,
     }
 
-    IGNORED_FIELDS = (
-        'alias',
-        'business_leads',
-        'children',
-        'subsidiaries',
-        'created_by',
-        'interactions',
-        'intermediate_investment_projects',
-        'investee_projects',
-        'investor_investment_projects',
-        'lft',
-        'modified_by',
-        'orders',
-        'rght',
-        'tree_id',
-        'archived_documents_url_path',
-    )
-
     SEARCH_FIELDS = (
         'name',
         'name_trigram',

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -1,14 +1,13 @@
 from operator import attrgetter
 
-from django.conf import settings
-from elasticsearch_dsl import Boolean, Date, DocType, Keyword, Text
+from elasticsearch_dsl import Boolean, Date, Keyword, Text
 
 from .. import dict_utils
 from .. import dsl_utils
-from ..models import MapDBModelToDict
+from ..models import BaseESModel
 
 
-class Company(DocType, MapDBModelToDict):
+class Company(BaseESModel):
     """Elasticsearch representation of Company model."""
 
     id = Keyword()
@@ -121,5 +120,4 @@ class Company(DocType, MapDBModelToDict):
     class Meta:
         """Default document meta data."""
 
-        index = settings.ES_INDEX
         doc_type = 'company'

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -20,6 +20,7 @@ def test_company_dbmodel_to_dict(setup_es):
         'archived_reason',
         'business_type',
         'classification',
+        'companies_house_data',
         'company_number',
         'contacts',
         'created_on',

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -81,14 +81,6 @@ class Contact(DocType, MapDBModelToDict):
         'address_country': contact_dict_utils.computed_address_field('address_country'),
     }
 
-    IGNORED_FIELDS = (
-        'interactions',
-        'investment_projects',
-        'modified_by',
-        'orders',
-        'archived_documents_url_path',
-    )
-
     SEARCH_FIELDS = (
         'name',
         'name_trigram',

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -1,12 +1,12 @@
-from elasticsearch_dsl import Boolean, Date, DocType, Keyword, Text
+from elasticsearch_dsl import Boolean, Date, Keyword, Text
 
 from . import dict_utils as contact_dict_utils
 from .. import dict_utils
 from .. import dsl_utils
-from ..models import MapDBModelToDict
+from ..models import BaseESModel
 
 
-class Contact(DocType, MapDBModelToDict):
+class Contact(BaseESModel):
     """Elasticsearch representation of Contact model."""
 
     id = Keyword()

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -13,6 +13,21 @@ EnglishText = partial(Text, analyzer='english_analyzer')
 SortableText = partial(Text, fielddata=True)
 
 
+class TextWithKeyword(Text):
+    """
+    Text field with keyword sub-field.
+
+    This definition is in line with the data type Elasticsearch uses for dynamically mapped text
+    fields.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Initialises the field, creating a keyword sub-field."""
+        super().__init__(*args, **kwargs, fields={
+            'keyword': Keyword(ignore_above=256)
+        })
+
+
 def contact_or_adviser_mapping(field, include_dit_team=False):
     """Mapping for Adviser/Contact fields."""
     props = {
@@ -109,11 +124,7 @@ def sector_mapping():
 def object_mapping(*fields):
     """This is a mapping that reflects how Elasticsearch auto-creates mappings for objects."""
     return Object(
-        properties={
-            field: Text(fields={
-                'keyword': Keyword(ignore_above=256)
-            }) for field in fields
-        }
+        properties={field: TextWithKeyword() for field in fields}
     )
 
 

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -18,13 +18,17 @@ class TextWithKeyword(Text):
     Text field with keyword sub-field.
 
     This definition is in line with the data type Elasticsearch uses for dynamically mapped text
-    fields.
+    fields, and is intended to be used to explicitly define fields that were previously
+    implicitly added to the ES mapping.
     """
+
+    # The default value Elasticsearch uses for ignore_above when dynamically mapping text fields
+    ES_DEFAULT_IGNORE_ABOVE = 256
 
     def __init__(self, *args, **kwargs):
         """Initialises the field, creating a keyword sub-field."""
         super().__init__(*args, **kwargs, fields={
-            'keyword': Keyword(ignore_above=256)
+            'keyword': Keyword(ignore_above=self.ES_DEFAULT_IGNORE_ABOVE)
         })
 
 

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -1,10 +1,10 @@
-from elasticsearch_dsl import Date, DocType, Keyword, Text
+from elasticsearch_dsl import Date, Keyword, Text
 
 from datahub.search import dict_utils, dsl_utils
-from datahub.search.models import MapDBModelToDict
+from datahub.search.models import BaseESModel
 
 
-class Event(DocType, MapDBModelToDict):
+class Event(BaseESModel):
     """Elasticsearch representation of Event model."""
 
     id = Keyword()

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -48,13 +48,6 @@ class Event(DocType, MapDBModelToDict):
 
     COMPUTED_MAPPINGS = {}
 
-    IGNORED_FIELDS = (
-        'created_by',
-        'modified_by',
-        'interactions',
-        'archived_documents_url_path',
-    )
-
     SEARCH_FIELDS = (
         'name',
         'name_trigram',

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -29,6 +29,8 @@ class Event(DocType, MapDBModelToDict):
     teams = dsl_utils.id_name_partial_mapping('teams')
     related_programmes = dsl_utils.id_name_partial_mapping('related_programmes')
     service = dsl_utils.id_name_mapping()
+    created_on = Date()
+    modified_on = Date()
     disabled_on = Date()
 
     MAPPINGS = {

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -1,12 +1,12 @@
 from operator import attrgetter
 
-from elasticsearch_dsl import Boolean, Date, DocType, Double, Keyword
+from elasticsearch_dsl import Boolean, Date, Double, Keyword
 
 from datahub.search import dict_utils, dsl_utils
-from datahub.search.models import MapDBModelToDict
+from datahub.search.models import BaseESModel
 
 
-class Interaction(DocType, MapDBModelToDict):
+class Interaction(BaseESModel):
     """Elasticsearch representation of Interaction model."""
 
     id = Keyword()

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -55,14 +55,6 @@ class Interaction(DocType, MapDBModelToDict):
         ),
     }
 
-    IGNORED_FIELDS = (
-        'created_by',
-        'modified_by',
-        'archived_documents_url_path',
-        'policy_area',
-        'policy_issue_type',
-    )
-
     SEARCH_FIELDS = (
         'company.name',
         'company.name_trigram',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Boolean, Date, DocType, Double, Integer, Keyword, Text
+from elasticsearch_dsl import Boolean, Date, DocType, Double, Integer, Keyword, Long, Text
 
 from .. import dict_utils
 from .. import dsl_utils
@@ -108,6 +108,23 @@ class InvestmentProject(DocType, MapDBModelToDict):
     date_abandoned = Date()
     project_arrived_in_triage_on = Date()
     proposal_deadline = Date()
+    address_1 = Text()
+    address_2 = Text()
+    address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
+    address_postcode = Text()
+    archived_on = Date()
+    client_cannot_provide_foreign_investment = Boolean()
+    client_requirements = dsl_utils.TextWithKeyword()
+    likelihood_of_landing = Long()
+    number_safeguarded_jobs = Long()
+    other_business_activity = dsl_utils.TextWithKeyword()
+    quotable_as_public_case_study = Boolean()
+    reason_abandoned = dsl_utils.TextWithKeyword()
+    reason_delayed = dsl_utils.TextWithKeyword()
+    reason_lost = dsl_utils.TextWithKeyword()
+    some_new_jobs = Boolean()
+    will_new_jobs_last_two_years = Boolean()
+    uk_company_decided = Boolean()
 
     MAPPINGS = {
         'id': str,

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -174,19 +174,6 @@ class InvestmentProject(DocType, MapDBModelToDict):
         ),
     }
 
-    IGNORED_FIELDS = (
-        'cdms_project_code',
-        'client_considering_other_countries',
-        'competitor_countries',
-        'documents',
-        'interactions',
-        'investmentprojectcode',
-        'modified_by',
-        'strategic_drivers',
-        'archived_documents_url_path',
-        'stage_log',
-    )
-
     SEARCH_FIELDS = (
         'name',
         'name_trigram',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -1,8 +1,8 @@
-from elasticsearch_dsl import Boolean, Date, DocType, Double, Integer, Keyword, Long, Text
+from elasticsearch_dsl import Boolean, Date, Double, Integer, Keyword, Long, Text
 
 from .. import dict_utils
 from .. import dsl_utils
-from ..models import MapDBModelToDict
+from ..models import BaseESModel
 
 
 def _referral_source_adviser_mapping():
@@ -28,7 +28,7 @@ def _country_lost_to_mapping():
     return dsl_utils.object_mapping('id', 'name')
 
 
-class InvestmentProject(DocType, MapDBModelToDict):
+class InvestmentProject(BaseESModel):
     """Elasticsearch representation of InvestmentProject."""
 
     id = Keyword()

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -85,7 +85,6 @@ def test_investment_project_to_dict(setup_es):
         'project_assurance_adviser',
         'team_members',
         'likelihood_of_landing',
-        'priority',
         'project_arrived_in_triage_on',
         'quotable_as_public_case_study',
         'other_business_activity',

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -1,13 +1,14 @@
 from collections import namedtuple
 
 from django.conf import settings
+from elasticsearch_dsl import DocType, MetaField
 
 from datahub.search.utils import get_model_non_mapped_field_names
 
 DataSet = namedtuple('DataSet', ('queryset', 'es_model',))
 
 
-class MapDBModelToDict:
+class BaseESModel(DocType):
     """Helps convert Django models to dictionaries."""
 
     MAPPINGS = {}
@@ -15,6 +16,9 @@ class MapDBModelToDict:
     COMPUTED_MAPPINGS = {}
 
     SEARCH_FIELDS = ()
+
+    class Meta:
+        dynamic = MetaField('strict')
 
     @classmethod
     def es_document(cls, dbmodel):

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -2,13 +2,13 @@ from collections import namedtuple
 
 from django.conf import settings
 
+from datahub.search.utils import get_model_non_mapped_field_names
+
 DataSet = namedtuple('DataSet', ('queryset', 'es_model',))
 
 
 class MapDBModelToDict:
     """Helps convert Django models to dictionaries."""
-
-    IGNORED_FIELDS = ()
 
     MAPPINGS = {}
 
@@ -32,18 +32,16 @@ class MapDBModelToDict:
     @classmethod
     def dbmodel_to_dict(cls, dbmodel):
         """Converts dbmodel instance to a dictionary suitable for ElasticSearch."""
-        result = {col: fn(getattr(dbmodel, col)) for col, fn in cls.MAPPINGS.items()
-                  if getattr(dbmodel, col) is not None}
+        mapped_values = (
+            (col, fn, getattr(dbmodel, col)) for col, fn in cls.MAPPINGS.items()
+        )
+        fields = get_model_non_mapped_field_names(cls)
 
-        result.update({
-            col: fn(dbmodel) for col, fn in cls.COMPUTED_MAPPINGS.items()
-        })
-
-        fields = [field for field in dbmodel._meta.get_fields()
-                  if field.name not in cls.IGNORED_FIELDS]
-
-        obj = {f.name: getattr(dbmodel, f.name) for f in fields if f.name not in result}
-        result.update(obj.items())
+        result = {
+            **{col: fn(val) if val is not None else None for col, fn, val in mapped_values},
+            **{col: fn(dbmodel) for col, fn in cls.COMPUTED_MAPPINGS.items()},
+            **{field: getattr(dbmodel, field) for field in fields},
+        }
 
         return result
 

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -85,21 +85,6 @@ class Order(DocType, MapDBModelToDict):
         'payment_due_date': lambda x: x.invoice.payment_due_date if x.invoice else None,
     }
 
-    IGNORED_FIELDS = (
-        'modified_by',
-        'product_info',
-        'permission_to_approach_contacts',
-        'quote',
-        'hourly_rate',
-        'discount_label',
-        'public_token',
-        'invoice',
-        'payments',
-        'refunds',
-        'archived_documents_url_path',
-        'payment_gateway_sessions'
-    )
-
     SEARCH_FIELDS = (
         'reference_trigram',
         'company.name',

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -1,11 +1,11 @@
-from elasticsearch_dsl import Boolean, Date, DocType, Integer, Keyword, Text
+from elasticsearch_dsl import Boolean, Date, Integer, Keyword, Text
 
 from .. import dict_utils
 from .. import dsl_utils
-from ..models import MapDBModelToDict
+from ..models import BaseESModel
 
 
-class Order(DocType, MapDBModelToDict):
+class Order(BaseESModel):
     """Elasticsearch representation of Order model."""
 
     id = Keyword()

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -20,6 +20,7 @@ def test_mapping(setup_es):
 
     assert mapping.to_dict() == {
         'order': {
+            'dynamic': 'strict',
             'properties': {
                 'assignees': {
                     'include_in_parent': True,

--- a/datahub/search/test/test_models.py
+++ b/datahub/search/test/test_models.py
@@ -55,6 +55,14 @@ def test_validate_model_computed_mapping_fields(search_app):
     assert not invalid_fields
 
 
+def test_validate_model_no_mapping_and_computed_intersection(search_app):
+    """Test that MAPPINGS and COMPUTED_MAPPINGS on ES models don't overlap."""
+    es_model = search_app.es_model
+    intersection = es_model.MAPPINGS.keys() & es_model.COMPUTED_MAPPINGS.keys()
+
+    assert not intersection
+
+
 def _get_db_model_fields(db_model):
     return {field.name for field in db_model._meta.get_fields()}
 

--- a/datahub/search/test/test_models.py
+++ b/datahub/search/test/test_models.py
@@ -3,6 +3,7 @@ import inspect
 from django.utils.functional import cached_property
 
 from datahub.search.apps import get_search_apps
+from datahub.search.utils import get_model_copied_to_field_names, get_model_field_names
 
 
 def pytest_generate_tests(metafunc):
@@ -21,9 +22,9 @@ def test_validate_model_fields(search_app):
     es_model = search_app.es_model
     db_model = search_app.queryset.model
 
-    fields = _get_es_model_fields(es_model)
+    fields = get_model_field_names(es_model)
 
-    copy_to_fields = _get_es_model_copy_to_fields(es_model)
+    copy_to_fields = get_model_copied_to_field_names(es_model)
     computed_fields = es_model.COMPUTED_MAPPINGS.keys()
     db_model_properties = _get_object_properties(db_model)
     db_model_fields = _get_db_model_fields(db_model)
@@ -37,7 +38,7 @@ def test_validate_model_fields(search_app):
 def test_validate_model_mapping_fields(search_app):
     """Test that all fields defined in MAPPINGS exist on the ES model."""
     es_model = search_app.es_model
-    valid_fields = _get_es_model_fields(es_model)
+    valid_fields = get_model_field_names(es_model)
     fields = es_model.MAPPINGS.keys()
     invalid_fields = fields - valid_fields
 
@@ -47,31 +48,11 @@ def test_validate_model_mapping_fields(search_app):
 def test_validate_model_computed_mapping_fields(search_app):
     """Test that all fields defined in COMPUTED_MAPPINGS exist on the ES model."""
     es_model = search_app.es_model
-    valid_fields = _get_es_model_fields(es_model)
+    valid_fields = get_model_field_names(es_model)
     fields = es_model.COMPUTED_MAPPINGS.keys()
     invalid_fields = fields - valid_fields
 
     assert not invalid_fields
-
-
-def _get_es_model_es_properties(es_model):
-    return es_model._doc_type.mapping.properties._params['properties']
-
-
-def _get_es_model_fields(es_model):
-    return _get_es_model_es_properties(es_model).keys()
-
-
-def _get_es_model_copy_to_fields(es_model):
-    props = _get_es_model_es_properties(es_model)
-
-    copy_to_field_lists = [
-        [prop.copy_to] if isinstance(prop.copy_to, str) else prop.copy_to
-        for prop in props.values()
-        if hasattr(prop, 'copy_to')
-    ]
-
-    return {field for fields in copy_to_field_lists for field in fields}
 
 
 def _get_db_model_fields(db_model):

--- a/datahub/search/test/test_models.py
+++ b/datahub/search/test/test_models.py
@@ -3,7 +3,7 @@ import inspect
 from django.utils.functional import cached_property
 
 from datahub.search.apps import get_search_apps
-from datahub.search.utils import get_model_copied_to_field_names, get_model_field_names
+from datahub.search.utils import get_model_copy_to_target_field_names, get_model_field_names
 
 
 def pytest_generate_tests(metafunc):
@@ -24,7 +24,7 @@ def test_validate_model_fields(search_app):
 
     fields = get_model_field_names(es_model)
 
-    copy_to_fields = get_model_copied_to_field_names(es_model)
+    copy_to_fields = get_model_copy_to_target_field_names(es_model)
     computed_fields = es_model.COMPUTED_MAPPINGS.keys()
     db_model_properties = _get_object_properties(db_model)
     db_model_fields = _get_db_model_fields(db_model)

--- a/datahub/search/test/test_utils.py
+++ b/datahub/search/test/test_utils.py
@@ -1,0 +1,19 @@
+from unittest.mock import Mock
+
+from datahub.search.utils import get_model_copied_to_field_names
+
+
+def test_get_model_copy_to_field_names(monkeypatch):
+    """Test that get_model_copy_to_field_names handles() handles various copy_to forms."""
+    monkeypatch.setattr('datahub.search.utils.get_model_fields', Mock(
+        return_value={
+            'field1': Mock(spec_set=()),
+            'field2': Mock(spec_set=('copy_to',), copy_to='copy_to_str'),
+            'field3': Mock(spec_set=('copy_to',), copy_to=['copy_to_list1', 'copy_to_list2']),
+        }
+    ))
+    assert get_model_copied_to_field_names(Mock()) == {
+        'copy_to_str',
+        'copy_to_list1',
+        'copy_to_list2',
+    }

--- a/datahub/search/test/test_utils.py
+++ b/datahub/search/test/test_utils.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock
 
-from datahub.search.utils import get_model_copied_to_field_names
+from datahub.search.utils import get_model_copy_to_target_field_names
 
 
 def test_get_model_copy_to_field_names(monkeypatch):
@@ -12,7 +12,7 @@ def test_get_model_copy_to_field_names(monkeypatch):
             'field3': Mock(spec_set=('copy_to',), copy_to=['copy_to_list1', 'copy_to_list2']),
         }
     ))
-    assert get_model_copied_to_field_names(Mock()) == {
+    assert get_model_copy_to_target_field_names(Mock()) == {
         'copy_to_str',
         'copy_to_list1',
         'copy_to_list2',

--- a/datahub/search/utils.py
+++ b/datahub/search/utils.py
@@ -4,3 +4,36 @@ class Echo:
     def write(self, value):
         """Returns value that is being "written"."""
         return value
+
+
+def get_model_fields(es_model):
+    """Gets the field objects for an ES model."""
+    return es_model._doc_type.mapping.properties._params['properties']
+
+
+def get_model_field_names(es_model):
+    """Gets the field names for an ES model."""
+    return get_model_fields(es_model).keys()
+
+
+def get_model_copied_to_field_names(es_model):
+    """Gets the names of fields that are copied to in an ES model."""
+    fields = get_model_fields(es_model)
+
+    copy_to_field_lists = [
+        [prop.copy_to] if isinstance(prop.copy_to, str) else prop.copy_to
+        for prop in fields.values()
+        if hasattr(prop, 'copy_to')
+    ]
+
+    return {field for fields in copy_to_field_lists for field in fields}
+
+
+def get_model_non_mapped_field_names(es_model):
+    """Gets the names of fields that are not copied to, mapped or computed."""
+    return (
+        get_model_field_names(es_model)
+        - get_model_copied_to_field_names(es_model)
+        - es_model.MAPPINGS.keys()
+        - es_model.COMPUTED_MAPPINGS.keys()
+    )

--- a/datahub/search/utils.py
+++ b/datahub/search/utils.py
@@ -16,8 +16,8 @@ def get_model_field_names(es_model):
     return get_model_fields(es_model).keys()
 
 
-def get_model_copied_to_field_names(es_model):
-    """Gets the names of fields that are copied to in an ES model."""
+def get_model_copy_to_target_field_names(es_model):
+    """Gets the names of fields (for an ES model) that are copy-to targets."""
     fields = get_model_fields(es_model)
 
     copy_to_field_lists = [
@@ -33,7 +33,7 @@ def get_model_non_mapped_field_names(es_model):
     """Gets the names of fields that are not copied to, mapped or computed."""
     return (
         get_model_field_names(es_model)
-        - get_model_copied_to_field_names(es_model)
+        - get_model_copy_to_target_field_names(es_model)
         - es_model.MAPPINGS.keys()
         - es_model.COMPUTED_MAPPINGS.keys()
     )

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -20,7 +20,7 @@ from .query_builder import (
     limit_search_query,
 )
 from .serializers import SearchSerializer
-from .utils import Echo
+from .utils import Echo, get_model_field_names
 
 EntitySearch = namedtuple('EntitySearch', ['model', 'name'])
 
@@ -265,9 +265,8 @@ class SearchExportAPIView(SearchAPIView):
 
     def _get_fieldnames(self):
         """Gets cleaned list of entity field names."""
-        return self._clean_fieldnames(
-            self.entity._doc_type.mapping.properties._params['properties'].keys()
-        )
+        field_names = get_model_field_names(self.entity)
+        return self._clean_fieldnames(field_names)
 
     def post(self, request, format=None):
         """Performs search and returns CSV file."""


### PR DESCRIPTION
Issue number: DH-1658

### Description of change

This:

* explicitly defines all fields that were previously dynamically mapped by ES
* removes IGNORED_FIELDS from the ES models so that we have a whitelist of fields to include instead of a blacklist of fields to exclude
* sets the `dynamic` parameter to `strict` for all mapping types, so that it's impossible for fields to be added to the mapping implicitly

If we're concerned about forgetting to add new fields to the ES models we could add tests for each model to assert on {fields in DB} - {fields in ES}. But we have the checklist below as well, so that should be a reminder in itself to think about that.

I'll raise a separate PR to sort some of these attributes and dict keys alphabetically as they seem to have lost any meaningful order.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
