### PR TITLE
Remove CoreViewSetV1

### DIFF
--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -7,7 +7,7 @@ from rest_framework.filters import OrderingFilter
 
 from datahub.core.audit import AuditViewSet
 from datahub.core.mixins import ArchivableViewSetMixin
-from datahub.core.viewsets import CoreViewSetV3
+from datahub.core.viewsets import CoreViewSet
 from datahub.investment.queryset import get_slim_investment_project_queryset
 from datahub.oauth.scopes import Scope
 from .models import (
@@ -25,7 +25,7 @@ from .serializers import (
 )
 
 
-class CompanyViewSet(ArchivableViewSetMixin, CoreViewSetV3):
+class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
     """Company view set V3."""
 
     required_scopes = (Scope.internal_front_end,)
@@ -72,7 +72,7 @@ class CompaniesHouseCompanyViewSet(
     lookup_field = 'company_number'
 
 
-class ContactViewSet(ArchivableViewSetMixin, CoreViewSetV3):
+class ContactViewSet(ArchivableViewSetMixin, CoreViewSet):
     """Contact ViewSet v3."""
 
     required_scopes = (Scope.internal_front_end,)

--- a/datahub/core/test/support/views.py
+++ b/datahub/core/test/support/views.py
@@ -2,13 +2,13 @@ from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOr
 
 from datahub.core.test.support.models import PermissionModel
 from datahub.core.test.support.serializers import PermissionModelSerializer
-from datahub.core.viewsets import CoreViewSetV3
+from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.test.scopes import TestScope
 from .models import MyDisableableModel
 from .serializers import MyDisableableModelSerializer
 
 
-class MyDisableableModelViewset(CoreViewSetV3):
+class MyDisableableModelViewset(CoreViewSet):
     """MyDisableableModel view set."""
 
     permission_classes = (IsAuthenticatedOrTokenHasScope,)
@@ -17,7 +17,7 @@ class MyDisableableModelViewset(CoreViewSetV3):
     queryset = MyDisableableModel.objects.all()
 
 
-class PermissionModelViewset(CoreViewSetV3):
+class PermissionModelViewset(CoreViewSet):
     """PermissionModel view set."""
 
     serializer_class = PermissionModelSerializer

--- a/datahub/core/viewsets.py
+++ b/datahub/core/viewsets.py
@@ -15,22 +15,13 @@ def has_fields(model, *fields):
     return True
 
 
-class CoreViewSetV1(mixins.CreateModelMixin,
-                    mixins.RetrieveModelMixin,
-                    mixins.UpdateModelMixin,
-                    mixins.ListModelMixin,
-                    GenericViewSet):
-    """Handle custom validation errors in a DRF friendly way."""
-
-    read_serializer_class = None
-    write_serializer_class = None
-
-    def get_serializer_class(self):
-        """Return a different serializer class for reading or writing, if defined."""
-        if self.action in ('list', 'retrieve', 'archive', 'unarchive'):
-            return self.read_serializer_class
-        elif self.action in ('create', 'update', 'partial_update'):
-            return self.write_serializer_class
+class CoreViewSet(mixins.CreateModelMixin,
+                  mixins.RetrieveModelMixin,
+                  mixins.UpdateModelMixin,
+                  mixins.DestroyModelMixin,
+                  mixins.ListModelMixin,
+                  GenericViewSet):
+    """Base class for view sets."""
 
     def perform_create(self, serializer):
         """Custom logic for creating the model instance."""
@@ -39,53 +30,6 @@ class CoreViewSetV1(mixins.CreateModelMixin,
 
     def perform_update(self, serializer):
         """Custom logic for updating the model instance."""
-        extra_data = self.get_additional_data(False)
-        serializer.save(**extra_data)
-
-    def get_additional_data(self, create):
-        """Returns additional data to be saved in the model instance.
-
-        Intended to be overridden by subclasses.
-
-        :param create:  True for is a model instance is being created; False
-                        for updates
-        :return:        dict of additional data to be saved
-        """
-        additional_data = {}
-        if has_fields(self.get_queryset().model, 'created_by', 'modified_by'):
-            additional_data['modified_by'] = self.request.user
-
-            if create:
-                additional_data['created_by'] = self.request.user
-
-        return additional_data
-
-
-class CoreViewSetV3(mixins.CreateModelMixin,
-                    mixins.RetrieveModelMixin,
-                    mixins.UpdateModelMixin,
-                    mixins.DestroyModelMixin,
-                    mixins.ListModelMixin,
-                    GenericViewSet):
-    """Base class for v3 view sets."""
-
-    def perform_create(self, serializer):
-        """Custom logic for creating the model instance.
-
-        At the moment some models are raising Django validation errors;
-        these are converted to DRF validation errors so a proper error
-        response is generated.
-        """
-        extra_data = self.get_additional_data(True)
-        serializer.save(**extra_data)
-
-    def perform_update(self, serializer):
-        """Custom logic for updating the model instance.
-
-        At the moment some models are raising Django validation errors;
-        these are converted to DRF validation errors so a proper error
-        response is generated.
-        """
         extra_data = self.get_additional_data(False)
         serializer.save(**extra_data)
 

--- a/datahub/event/views.py
+++ b/datahub/event/views.py
@@ -1,10 +1,10 @@
-from datahub.core.viewsets import CoreViewSetV3
+from datahub.core.viewsets import CoreViewSet
 from datahub.event.models import Event
 from datahub.event.serializers import EventSerializer
 from datahub.oauth.scopes import Scope
 
 
-class EventViewSet(CoreViewSetV3):
+class EventViewSet(CoreViewSet):
     """Views for events."""
 
     required_scopes = (Scope.internal_front_end,)

--- a/datahub/feature_flag/views.py
+++ b/datahub/feature_flag/views.py
@@ -1,11 +1,11 @@
 from rest_framework.permissions import IsAuthenticated
 
-from datahub.core.viewsets import CoreViewSetV3
+from datahub.core.viewsets import CoreViewSet
 from datahub.feature_flag.models import FeatureFlag
 from datahub.feature_flag.serializers import FeatureFlagSerializer
 
 
-class FeatureFlagViewSet(CoreViewSetV3):
+class FeatureFlagViewSet(CoreViewSet):
     """Feature flag ViewSet v3."""
 
     pagination_class = None

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -2,7 +2,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework.filters import OrderingFilter
 
-from datahub.core.viewsets import CoreViewSetV3
+from datahub.core.viewsets import CoreViewSet
 from datahub.interaction.permissions import (
     InteractionModelPermissions,
     IsAssociatedToInvestmentProjectInteractionFilter,
@@ -13,7 +13,7 @@ from datahub.interaction.serializers import InteractionSerializer
 from datahub.oauth.scopes import Scope
 
 
-class InteractionViewSet(CoreViewSetV3):
+class InteractionViewSet(CoreViewSet):
     """Interaction ViewSet v3."""
 
     required_scopes = (Scope.internal_front_end,)

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -14,7 +14,7 @@ from rest_framework.response import Response
 from datahub.core.audit import AuditViewSet
 from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.thread_pool import submit_to_thread_pool
-from datahub.core.viewsets import CoreViewSetV3
+from datahub.core.viewsets import CoreViewSet
 from datahub.documents.av_scan import virus_scan_document
 from datahub.investment.models import (
     InvestmentProject, InvestmentProjectTeamMember, IProjectDocument
@@ -49,7 +49,7 @@ class IProjectAuditViewSet(AuditViewSet):
         return 'Investment project audit log'
 
 
-class IProjectViewSet(ArchivableViewSetMixin, CoreViewSetV3):
+class IProjectViewSet(ArchivableViewSetMixin, CoreViewSet):
     """Unified investment project views.
 
     This replaces the previous project, value, team and requirements endpoints.
@@ -148,7 +148,7 @@ class IProjectModifiedSinceViewSet(IProjectViewSet):
     filter_class = _ModifiedOnFilter
 
 
-class IProjectTeamMembersViewSet(CoreViewSetV3):
+class IProjectTeamMembersViewSet(CoreViewSet):
     """Investment project team member views."""
 
     non_existent_project_error_message = 'Specified investment project does not exist'
@@ -229,7 +229,7 @@ class IProjectTeamMembersViewSet(CoreViewSetV3):
             raise Http404(self.non_existent_project_error_message)
 
 
-class IProjectDocumentViewSet(CoreViewSetV3):
+class IProjectDocumentViewSet(CoreViewSet):
     """Investment Project Documents ViewSet."""
 
     required_scopes = (Scope.internal_front_end,)

--- a/datahub/leads/views.py
+++ b/datahub/leads/views.py
@@ -3,13 +3,13 @@
 from django_filters.rest_framework import DjangoFilterBackend
 
 from datahub.core.mixins import ArchivableViewSetMixin
-from datahub.core.viewsets import CoreViewSetV3
+from datahub.core.viewsets import CoreViewSet
 from datahub.leads.models import BusinessLead
 from datahub.leads.serializers import BusinessLeadSerializer
 from datahub.oauth.scopes import Scope
 
 
-class BusinessLeadViewSet(ArchivableViewSetMixin, CoreViewSetV3):
+class BusinessLeadViewSet(ArchivableViewSetMixin, CoreViewSet):
     """
     Business lead views.
 

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -4,7 +4,7 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from datahub.core.viewsets import CoreViewSetV3
+from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
 from .models import Order
 from .serializers import (
@@ -17,7 +17,7 @@ from .serializers import (
 )
 
 
-class OrderViewSet(CoreViewSetV3):
+class OrderViewSet(CoreViewSet):
     """Order ViewSet"""
 
     required_scopes = (Scope.internal_front_end,)
@@ -66,7 +66,7 @@ class OrderViewSet(CoreViewSetV3):
         }
 
 
-class PublicOrderViewSet(CoreViewSetV3):
+class PublicOrderViewSet(CoreViewSet):
     """ViewSet for public facing order endpoint."""
 
     lookup_field = 'public_token'
@@ -192,7 +192,7 @@ class AssigneeView(APIView):
         return self.get_list_response(order)
 
 
-class BaseNestedOrderViewSet(CoreViewSetV3):
+class BaseNestedOrderViewSet(CoreViewSet):
     """
     Base class for nested viewsets with order as parent
     E.g. /order/<order-id>/<child>


### PR DESCRIPTION
Issue number: N/A

### Description of change

Removes CoreViewSetV1 as it was not being used anywhere.

Also renames CoreViewSetV3 to just CoreViewSet.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
