### PR TITLE
Loosely sort ES model attributes alphabetically

### DIFF
--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -8,6 +8,10 @@ class CompaniesHouseCompany(BaseESModel):
     """Elasticsearch representation of CompaniesHouseCompany model."""
 
     id = Keyword()
+    company_category = dsl_utils.SortableCaseInsensitiveKeywordText()
+    company_number = dsl_utils.SortableCaseInsensitiveKeywordText()
+    company_status = dsl_utils.SortableCaseInsensitiveKeywordText()
+    incorporation_date = Date()
     name = dsl_utils.SortableText(
         copy_to=[
             'name_keyword', 'name_trigram'
@@ -22,15 +26,11 @@ class CompaniesHouseCompany(BaseESModel):
     registered_address_postcode = Text(copy_to='registered_address_postcode_trigram')
     registered_address_postcode_trigram = dsl_utils.TrigramText()
     registered_address_country = dsl_utils.id_name_mapping()
-    company_number = dsl_utils.SortableCaseInsensitiveKeywordText()
-    company_category = dsl_utils.SortableCaseInsensitiveKeywordText()
-    company_status = dsl_utils.SortableCaseInsensitiveKeywordText()
     sic_code_1 = Text()
     sic_code_2 = Text()
     sic_code_3 = Text()
     sic_code_4 = Text()
     uri = Text()
-    incorporation_date = Date()
 
     MAPPINGS = {
         'id': str,

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -12,6 +12,55 @@ class Company(BaseESModel):
 
     id = Keyword()
     account_manager = dsl_utils.contact_or_adviser_mapping('account_manager')
+    archived = Boolean()
+    archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
+    archived_on = Date()
+    archived_reason = Text()
+    business_type = dsl_utils.id_name_mapping()
+    classification = dsl_utils.id_name_mapping()
+    companies_house_data = dsl_utils.company_mapping()
+    company_number = dsl_utils.SortableCaseInsensitiveKeywordText()
+    contacts = dsl_utils.contact_or_adviser_mapping('contacts')
+    created_on = Date()
+    description = dsl_utils.EnglishText()
+    employee_range = dsl_utils.id_name_mapping()
+    export_experience_category = dsl_utils.id_name_mapping()
+    export_to_countries = dsl_utils.id_name_mapping()
+    future_interest_countries = dsl_utils.id_name_mapping()
+    global_headquarters = dsl_utils.id_name_mapping()
+    headquarter_type = dsl_utils.id_name_mapping()
+    modified_on = Date()
+    name = dsl_utils.SortableText(copy_to=['name_keyword', 'name_trigram'])
+    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
+    name_trigram = dsl_utils.TrigramText()
+    one_list_account_owner = dsl_utils.contact_or_adviser_mapping('one_list_account_owner')
+    parent = dsl_utils.id_name_mapping()
+    reference_code = dsl_utils.SortableCaseInsensitiveKeywordText()
+    registered_address_1 = Text()
+    registered_address_2 = Text()
+    registered_address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
+    registered_address_county = Text()
+    registered_address_country = dsl_utils.id_name_partial_mapping(
+        'registered_address_country'
+    )
+    registered_address_postcode = Text(
+        copy_to=[
+            'registered_address_postcode_trigram'
+        ]
+    )
+    registered_address_postcode_trigram = dsl_utils.TrigramText()
+    sector = dsl_utils.sector_mapping()
+    trading_address_1 = Text()
+    trading_address_2 = Text()
+    trading_address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
+    trading_address_county = Text()
+    trading_address_postcode = Text(
+        copy_to=['trading_address_postcode_trigram']
+    )
+    trading_address_postcode_trigram = dsl_utils.TrigramText()
+    trading_address_country = dsl_utils.id_name_partial_mapping(
+        'trading_address_country'
+    )
     trading_name = dsl_utils.SortableText(
         copy_to=[
             'trading_name_keyword',
@@ -20,87 +69,38 @@ class Company(BaseESModel):
     )
     trading_name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
     trading_name_trigram = dsl_utils.TrigramText()
-    archived = Boolean()
-    archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
-    contacts = dsl_utils.contact_or_adviser_mapping('contacts')
-    archived_on = Date()
-    archived_reason = Text()
-    business_type = dsl_utils.id_name_mapping()
-    classification = dsl_utils.id_name_mapping()
-    company_number = dsl_utils.SortableCaseInsensitiveKeywordText()
-    vat_number = Keyword(index=False)
-    companies_house_data = dsl_utils.company_mapping()
-    created_on = Date()
-    description = dsl_utils.EnglishText()
-    employee_range = dsl_utils.id_name_mapping()
-    headquarter_type = dsl_utils.id_name_mapping()
-    modified_on = Date()
-    name = dsl_utils.SortableText(copy_to=['name_keyword', 'name_trigram'])
-    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
-    name_trigram = dsl_utils.TrigramText()
-    one_list_account_owner = dsl_utils.contact_or_adviser_mapping('one_list_account_owner')
-    parent = dsl_utils.id_name_mapping()
-    global_headquarters = dsl_utils.id_name_mapping()
-    reference_code = dsl_utils.SortableCaseInsensitiveKeywordText()
-    registered_address_1 = Text()
-    registered_address_2 = Text()
-    registered_address_country = dsl_utils.id_name_partial_mapping(
-        'registered_address_country'
-    )
-    registered_address_county = Text()
-    registered_address_postcode = Text(
-        copy_to=[
-            'registered_address_postcode_trigram'
-        ]
-    )
-    registered_address_postcode_trigram = dsl_utils.TrigramText()
-    registered_address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
-    sector = dsl_utils.sector_mapping()
-    trading_address_1 = Text()
-    trading_address_2 = Text()
-    trading_address_country = dsl_utils.id_name_partial_mapping(
-        'trading_address_country'
-    )
-    trading_address_county = Text()
-    trading_address_postcode = Text(
-        copy_to=['trading_address_postcode_trigram']
-    )
-    trading_address_postcode_trigram = dsl_utils.TrigramText()
-    trading_address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
     turnover_range = dsl_utils.id_name_mapping()
     uk_region = dsl_utils.id_name_mapping()
     uk_based = Boolean()
+    vat_number = Keyword(index=False)
     website = Text()
-    export_to_countries = dsl_utils.id_name_mapping()
-    future_interest_countries = dsl_utils.id_name_mapping()
-    export_experience_category = dsl_utils.id_name_mapping()
 
     COMPUTED_MAPPINGS = {
         'trading_name': attrgetter('alias')
     }
 
     MAPPINGS = {
-        'companies_house_data': dict_utils.company_dict,
+        'id': str,
         'account_manager': dict_utils.contact_or_adviser_dict,
         'archived_by': dict_utils.contact_or_adviser_dict,
-        'one_list_account_owner': dict_utils.contact_or_adviser_dict,
         'business_type': dict_utils.id_name_dict,
         'classification': dict_utils.id_name_dict,
+        'companies_house_data': dict_utils.company_dict,
+        'contacts': lambda col: [dict_utils.contact_or_adviser_dict(c) for c in col.all()],
         'employee_range': dict_utils.id_name_dict,
-        'headquarter_type': dict_utils.id_name_dict,
-        'parent': dict_utils.id_name_dict,
+        'export_experience_category': dict_utils.id_name_dict,
+        'export_to_countries': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
+        'future_interest_countries': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'global_headquarters': dict_utils.id_name_dict,
+        'headquarter_type': dict_utils.id_name_dict,
+        'one_list_account_owner': dict_utils.contact_or_adviser_dict,
+        'parent': dict_utils.id_name_dict,
         'registered_address_country': dict_utils.id_name_dict,
         'sector': dict_utils.sector_dict,
         'trading_address_country': dict_utils.id_name_dict,
         'turnover_range': dict_utils.id_name_dict,
-        'uk_region': dict_utils.id_name_dict,
-        'contacts': lambda col: [dict_utils.contact_or_adviser_dict(c) for c in col.all()],
-        'id': str,
         'uk_based': bool,
-        'export_to_countries': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
-        'future_interest_countries': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
-        'export_experience_category': dict_utils.id_name_dict,
+        'uk_region': dict_utils.id_name_dict,
     }
 
     SEARCH_FIELDS = (

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -10,16 +10,31 @@ class Contact(BaseESModel):
     """Elasticsearch representation of Contact model."""
 
     id = Keyword()
+    accepts_dit_email_marketing = Boolean()
+    address_1 = Text()
+    address_2 = Text()
+    address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
+    address_county = dsl_utils.SortableCaseInsensitiveKeywordText()
+    address_postcode = Text()
+    address_country = dsl_utils.id_name_mapping()
+    address_same_as_company = Boolean()
+    adviser = dsl_utils.contact_or_adviser_mapping('adviser')
     archived = Boolean()
+    archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
     archived_on = Date()
     archived_reason = Text()
+    company = dsl_utils.id_name_partial_mapping('company')
+    company_sector = dsl_utils.sector_mapping()
+    company_uk_region = dsl_utils.id_name_mapping()
+    contactable_by_dit = Boolean()
+    contactable_by_email = Boolean()
+    contactable_by_overseas_dit_partners = Boolean()
+    contactable_by_phone = Boolean()
+    contactable_by_uk_dit_partners = Boolean()
+    created_by = dsl_utils.contact_or_adviser_mapping('created_by', include_dit_team=True)
     created_on = Date()
-    modified_on = Date()
-    name = dsl_utils.SortableText()
-    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
-    # field is being aggregated
-    name_trigram = dsl_utils.TrigramText()
-    title = dsl_utils.id_name_mapping()
+    email = dsl_utils.SortableCaseInsensitiveKeywordText()
+    email_alternative = Text()
     first_name = dsl_utils.SortableText(
         copy_to=[
             'name',
@@ -27,58 +42,43 @@ class Contact(BaseESModel):
             'name_trigram',
         ]
     )
+    job_title = dsl_utils.SortableCaseInsensitiveKeywordText()
     last_name = dsl_utils.SortableText(
         copy_to=[
             'name',
             'name_keyword',
             'name_trigram',
         ])
+    modified_on = Date()
+    name = dsl_utils.SortableText()
+    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
+    # field is being aggregated
+    name_trigram = dsl_utils.TrigramText()
+    notes = dsl_utils.EnglishText()
     primary = Boolean()
+    telephone_alternative = Text()
     telephone_countrycode = Keyword()
     telephone_number = Keyword()
-    email = dsl_utils.SortableCaseInsensitiveKeywordText()
-    address_same_as_company = Boolean()
-    address_1 = Text()
-    address_2 = Text()
-    address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
-    address_county = dsl_utils.SortableCaseInsensitiveKeywordText()
-    address_postcode = Text()
-    telephone_alternative = Text()
-    email_alternative = Text()
-    notes = dsl_utils.EnglishText()
-    job_title = dsl_utils.SortableCaseInsensitiveKeywordText()
-    contactable_by_dit = Boolean()
-    contactable_by_uk_dit_partners = Boolean()
-    contactable_by_overseas_dit_partners = Boolean()
-    accepts_dit_email_marketing = Boolean()
-    contactable_by_email = Boolean()
-    contactable_by_phone = Boolean()
-    address_country = dsl_utils.id_name_mapping()
-    adviser = dsl_utils.contact_or_adviser_mapping('adviser')
-    archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
-    company = dsl_utils.id_name_partial_mapping('company')
-    company_sector = dsl_utils.sector_mapping()
-    company_uk_region = dsl_utils.id_name_mapping()
-    created_by = dsl_utils.contact_or_adviser_mapping('created_by', include_dit_team=True)
+    title = dsl_utils.id_name_mapping()
 
     MAPPINGS = {
         'id': str,
-        'title': dict_utils.id_name_dict,
         'adviser': dict_utils.contact_or_adviser_dict,
-        'company': dict_utils.id_name_dict,
         'archived_by': dict_utils.contact_or_adviser_dict,
+        'company': dict_utils.id_name_dict,
         'created_by': dict_utils.adviser_dict_with_team,
+        'title': dict_utils.id_name_dict,
     }
 
     COMPUTED_MAPPINGS = {
-        'company_sector': dict_utils.computed_nested_sector_dict('company.sector'),
-        'company_uk_region': dict_utils.computed_nested_id_name_dict('company.uk_region'),
         'address_1': contact_dict_utils.computed_address_field('address_1'),
         'address_2': contact_dict_utils.computed_address_field('address_2'),
         'address_town': contact_dict_utils.computed_address_field('address_town'),
         'address_county': contact_dict_utils.computed_address_field('address_county'),
         'address_postcode': contact_dict_utils.computed_address_field('address_postcode'),
         'address_country': contact_dict_utils.computed_address_field('address_country'),
+        'company_sector': dict_utils.computed_nested_sector_dict('company.sector'),
+        'company_uk_region': dict_utils.computed_nested_id_name_dict('company.uk_region'),
     }
 
     SEARCH_FIELDS = (

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -8,13 +8,6 @@ class Event(BaseESModel):
     """Elasticsearch representation of Event model."""
 
     id = Keyword()
-    name = dsl_utils.SortableText(copy_to=['name_keyword', 'name_trigram'])
-    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
-    name_trigram = dsl_utils.TrigramText()
-    event_type = dsl_utils.id_name_mapping()
-    start_date = Date()
-    end_date = Date()
-    location_type = dsl_utils.id_name_mapping()
     address_1 = Text()
     address_2 = Text()
     address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
@@ -22,28 +15,35 @@ class Event(BaseESModel):
     address_postcode = Text(copy_to='address_postcode_trigram')
     address_postcode_trigram = dsl_utils.TrigramText()
     address_country = dsl_utils.id_name_partial_mapping('address_country')
-    uk_region = dsl_utils.id_name_partial_mapping('uk_region')
+    created_on = Date()
+    disabled_on = Date()
+    end_date = Date()
+    event_type = dsl_utils.id_name_mapping()
+    lead_team = dsl_utils.id_name_mapping()
+    location_type = dsl_utils.id_name_mapping()
+    modified_on = Date()
+    name = dsl_utils.SortableText(copy_to=['name_keyword', 'name_trigram'])
+    name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
+    name_trigram = dsl_utils.TrigramText()
     notes = dsl_utils.EnglishText()
     organiser = dsl_utils.contact_or_adviser_partial_mapping('organiser')
-    lead_team = dsl_utils.id_name_mapping()
-    teams = dsl_utils.id_name_partial_mapping('teams')
     related_programmes = dsl_utils.id_name_partial_mapping('related_programmes')
     service = dsl_utils.id_name_mapping()
-    created_on = Date()
-    modified_on = Date()
-    disabled_on = Date()
+    start_date = Date()
+    teams = dsl_utils.id_name_partial_mapping('teams')
+    uk_region = dsl_utils.id_name_partial_mapping('uk_region')
 
     MAPPINGS = {
         'id': str,
-        'event_type': dict_utils.id_name_dict,
-        'location_type': dict_utils.id_name_dict,
         'address_country': dict_utils.id_name_dict,
-        'uk_region': dict_utils.id_name_dict,
-        'organiser': dict_utils.contact_or_adviser_dict,
+        'event_type': dict_utils.id_name_dict,
         'lead_team': dict_utils.id_name_dict,
-        'teams': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
+        'location_type': dict_utils.id_name_dict,
+        'organiser': dict_utils.contact_or_adviser_dict,
         'related_programmes': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'service': dict_utils.id_name_dict,
+        'teams': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
+        'uk_region': dict_utils.id_name_dict,
     }
 
     COMPUTED_MAPPINGS = {}

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -10,49 +10,49 @@ class Interaction(BaseESModel):
     """Elasticsearch representation of Interaction model."""
 
     id = Keyword()
-    kind = Keyword()
-    date = Date()
     company = dsl_utils.id_name_partial_mapping('company')
     company_sector = dsl_utils.sector_mapping()
+    communication_channel = dsl_utils.id_name_mapping()
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
-    is_event = Boolean()
+    created_on = Date()
+    date = Date()
+    dit_adviser = dsl_utils.contact_or_adviser_partial_mapping('dit_adviser')
+    dit_team = dsl_utils.id_name_partial_mapping('dit_team')
     event = dsl_utils.id_name_partial_mapping('event')
+    investment_project = dsl_utils.id_name_mapping()
+    investment_project_sector = dsl_utils.sector_mapping()
+    is_event = Boolean()
+    grant_amount_offered = Double()
+    kind = Keyword()
+    modified_on = Date()
+    net_company_receipt = Double()
+    notes = dsl_utils.EnglishText()
     service = dsl_utils.id_name_mapping()
+    service_delivery_status = dsl_utils.id_name_mapping()
     subject = dsl_utils.SortableCaseInsensitiveKeywordText(
         copy_to=['subject_english']
     )
     subject_english = dsl_utils.EnglishText()
-    dit_adviser = dsl_utils.contact_or_adviser_partial_mapping('dit_adviser')
-    notes = dsl_utils.EnglishText()
-    dit_team = dsl_utils.id_name_partial_mapping('dit_team')
-    communication_channel = dsl_utils.id_name_mapping()
-    investment_project = dsl_utils.id_name_mapping()
-    investment_project_sector = dsl_utils.sector_mapping()
-    service_delivery_status = dsl_utils.id_name_mapping()
-    grant_amount_offered = Double()
-    net_company_receipt = Double()
-    created_on = Date()
-    modified_on = Date()
 
     MAPPINGS = {
         'id': str,
         'company': dict_utils.id_name_dict,
+        'communication_channel': dict_utils.id_name_dict,
         'contact': dict_utils.contact_or_adviser_dict,
-        'event': dict_utils.id_name_dict,
-        'service': dict_utils.id_name_dict,
         'dit_adviser': dict_utils.contact_or_adviser_dict,
         'dit_team': dict_utils.id_name_dict,
-        'communication_channel': dict_utils.id_name_dict,
+        'event': dict_utils.id_name_dict,
         'investment_project': dict_utils.id_name_dict,
+        'service': dict_utils.id_name_dict,
         'service_delivery_status': dict_utils.id_name_dict,
     }
 
     COMPUTED_MAPPINGS = {
-        'is_event': attrgetter('is_event'),
         'company_sector': dict_utils.computed_nested_sector_dict('company.sector'),
         'investment_project_sector': dict_utils.computed_nested_sector_dict(
             'investment_project.sector'
         ),
+        'is_event': attrgetter('is_event'),
     }
 
     SEARCH_FIELDS = (

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -32,140 +32,140 @@ class InvestmentProject(BaseESModel):
     """Elasticsearch representation of InvestmentProject."""
 
     id = Keyword()
-    allow_blank_estimated_land_date = Boolean(index=False)
-    allow_blank_possible_uk_regions = Boolean(index=False)
+    actual_land_date = Date()
+    actual_uk_regions = dsl_utils.id_name_mapping()
+    address_1 = Text()
+    address_2 = Text()
+    address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
+    address_postcode = Text()
     approved_commitment_to_invest = Boolean()
     approved_fdi = Boolean()
     approved_good_value = Boolean()
     approved_high_value = Boolean()
     approved_landed = Boolean()
     approved_non_fdi = Boolean()
-    actual_land_date = Date()
+    allow_blank_estimated_land_date = Boolean(index=False)
+    allow_blank_possible_uk_regions = Boolean(index=False)
+    anonymous_description = dsl_utils.EnglishText()
+    archived = Boolean()
+    archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
+    archived_on = Date()
+    archived_reason = Text()
+    associated_non_fdi_r_and_d_project = dsl_utils.investment_project_mapping()
+    average_salary = dsl_utils.id_name_mapping()
     business_activities = dsl_utils.id_name_mapping()
+    client_cannot_provide_foreign_investment = Boolean()
+    client_cannot_provide_total_investment = Boolean()
     client_contacts = dsl_utils.contact_or_adviser_mapping('client_contacts')
     client_relationship_manager = dsl_utils.contact_or_adviser_mapping(
         'client_relationship_manager', include_dit_team=True
     )
-    project_manager = dsl_utils.contact_or_adviser_mapping(
-        'project_manager', include_dit_team=True
-    )
-    project_assurance_adviser = dsl_utils.contact_or_adviser_mapping(
-        'project_assurance_adviser', include_dit_team=True
-    )
-    team_members = dsl_utils.contact_or_adviser_mapping('team_members', include_dit_team=True)
-    archived = Boolean()
-    archived_reason = Text()
-    archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
+    client_requirements = dsl_utils.TextWithKeyword()
+    comments = dsl_utils.EnglishText()
+    country_lost_to = _country_lost_to_mapping()
     created_on = Date()
     created_by = dsl_utils.contact_or_adviser_mapping(
         'created_by', include_dit_team=True
     )
-    modified_on = Date()
+    date_abandoned = Date()
+    date_lost = Date()
+    delivery_partners = dsl_utils.id_name_mapping()
     description = dsl_utils.EnglishText()
-    comments = dsl_utils.EnglishText()
-    anonymous_description = dsl_utils.EnglishText()
     estimated_land_date = Date()
+    export_revenue = Boolean()
     fdi_type = dsl_utils.id_name_mapping()
     fdi_value = dsl_utils.id_name_mapping()
+    foreign_equity_investment = Double()
+    government_assistance = Boolean()
     intermediate_company = dsl_utils.id_name_mapping()
-    uk_company = dsl_utils.id_name_partial_mapping('uk_company')
     investor_company = dsl_utils.id_name_partial_mapping('investor_company')
     investor_company_country = dsl_utils.id_name_mapping()
     investment_type = dsl_utils.id_name_mapping()
     investor_type = dsl_utils.id_name_mapping()
     level_of_involvement = dsl_utils.id_name_mapping()
-    specific_programme = dsl_utils.id_name_mapping()
+    likelihood_of_landing = Long()
+    project_assurance_adviser = dsl_utils.contact_or_adviser_mapping(
+        'project_assurance_adviser', include_dit_team=True
+    )
+    project_manager = dsl_utils.contact_or_adviser_mapping(
+        'project_manager', include_dit_team=True
+    )
     name = dsl_utils.SortableText(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = dsl_utils.SortableCaseInsensitiveKeywordText()
     name_trigram = dsl_utils.TrigramText()
-    r_and_d_budget = Boolean()
-    non_fdi_r_and_d_budget = Boolean()
-    associated_non_fdi_r_and_d_project = dsl_utils.investment_project_mapping()
     new_tech_to_uk = Boolean()
-    export_revenue = Boolean()
-    uk_region_locations = dsl_utils.id_name_mapping()
-    actual_uk_regions = dsl_utils.id_name_mapping()
-    delivery_partners = dsl_utils.id_name_mapping()
-    site_decided = Boolean()
-    government_assistance = Boolean()
-    client_cannot_provide_total_investment = Boolean()
-    total_investment = Double()
-    foreign_equity_investment = Double()
+    non_fdi_r_and_d_budget = Boolean()
     number_new_jobs = Integer()
-    stage = dsl_utils.id_name_mapping()
+    number_safeguarded_jobs = Long()
+    modified_on = Date()
+    project_arrived_in_triage_on = Date()
     project_code = dsl_utils.SortableCaseInsensitiveKeywordText(copy_to='project_code_trigram')
     project_code_trigram = dsl_utils.TrigramText()
-    referral_source_activity = dsl_utils.id_name_mapping()
-    referral_source_activity_marketing = dsl_utils.id_name_mapping()
-    referral_source_activity_website = dsl_utils.id_name_mapping()
-    referral_source_activity_event = dsl_utils.SortableCaseInsensitiveKeywordText()
-    referral_source_adviser = _referral_source_adviser_mapping()
-    sector = dsl_utils.sector_mapping()
-    status = dsl_utils.SortableCaseInsensitiveKeywordText()
-    average_salary = dsl_utils.id_name_mapping()
-    date_lost = Date()
-    country_lost_to = _country_lost_to_mapping()
-    date_abandoned = Date()
-    project_arrived_in_triage_on = Date()
     proposal_deadline = Date()
-    address_1 = Text()
-    address_2 = Text()
-    address_town = dsl_utils.SortableCaseInsensitiveKeywordText()
-    address_postcode = Text()
-    archived_on = Date()
-    client_cannot_provide_foreign_investment = Boolean()
-    client_requirements = dsl_utils.TextWithKeyword()
-    likelihood_of_landing = Long()
-    number_safeguarded_jobs = Long()
     other_business_activity = dsl_utils.TextWithKeyword()
     quotable_as_public_case_study = Boolean()
+    r_and_d_budget = Boolean()
     reason_abandoned = dsl_utils.TextWithKeyword()
     reason_delayed = dsl_utils.TextWithKeyword()
     reason_lost = dsl_utils.TextWithKeyword()
+    referral_source_activity = dsl_utils.id_name_mapping()
+    referral_source_activity_event = dsl_utils.SortableCaseInsensitiveKeywordText()
+    referral_source_activity_marketing = dsl_utils.id_name_mapping()
+    referral_source_activity_website = dsl_utils.id_name_mapping()
+    referral_source_adviser = _referral_source_adviser_mapping()
+    sector = dsl_utils.sector_mapping()
+    site_decided = Boolean()
     some_new_jobs = Boolean()
-    will_new_jobs_last_two_years = Boolean()
+    specific_programme = dsl_utils.id_name_mapping()
+    stage = dsl_utils.id_name_mapping()
+    status = dsl_utils.SortableCaseInsensitiveKeywordText()
+    team_members = dsl_utils.contact_or_adviser_mapping('team_members', include_dit_team=True)
+    total_investment = Double()
+    uk_company = dsl_utils.id_name_partial_mapping('uk_company')
     uk_company_decided = Boolean()
+    uk_region_locations = dsl_utils.id_name_mapping()
+    will_new_jobs_last_two_years = Boolean()
 
     MAPPINGS = {
         'id': str,
+        'actual_uk_regions': lambda col: [
+            dict_utils.id_name_dict(c) for c in col.all()
+        ],
+        'archived_by': dict_utils.contact_or_adviser_dict,
+        'associated_non_fdi_r_and_d_project': dict_utils.investment_project_dict,
+        'average_salary': dict_utils.id_name_dict,
         'business_activities': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'client_contacts': lambda col: [dict_utils.contact_or_adviser_dict(c) for c in col.all()],
         'client_relationship_manager': dict_utils.adviser_dict_with_team,
+        'country_lost_to': dict_utils.id_name_dict,
+        'created_by': dict_utils.adviser_dict_with_team,
         'delivery_partners': lambda col: [
             dict_utils.id_name_dict(c) for c in col.all()
-        ],
-        'team_members': lambda col: [
-            dict_utils.contact_or_adviser_dict(c.adviser, include_dit_team=True) for c in col.all()
         ],
         'fdi_type': dict_utils.id_name_dict,
         'fdi_value': dict_utils.id_name_dict,
         'intermediate_company': dict_utils.id_name_dict,
+        'investment_type': dict_utils.id_name_dict,
         'investor_company': dict_utils.id_name_dict,
         'investor_type': dict_utils.id_name_dict,
         'level_of_involvement': dict_utils.id_name_dict,
-        'specific_programme': dict_utils.id_name_dict,
-        'uk_region_locations': lambda col: [
-            dict_utils.id_name_dict(c) for c in col.all()
-        ],
-        'actual_uk_regions': lambda col: [
-            dict_utils.id_name_dict(c) for c in col.all()
-        ],
-        'uk_company': dict_utils.id_name_dict,
-        'investment_type': dict_utils.id_name_dict,
-        'associated_non_fdi_r_and_d_project': dict_utils.investment_project_dict,
-        'stage': dict_utils.id_name_dict,
+        'project_assurance_adviser': dict_utils.adviser_dict_with_team,
+        'project_code': str,
+        'project_manager': dict_utils.adviser_dict_with_team,
         'referral_source_activity': dict_utils.id_name_dict,
         'referral_source_activity_marketing': dict_utils.id_name_dict,
         'referral_source_activity_website': dict_utils.id_name_dict,
         'referral_source_adviser': dict_utils.contact_or_adviser_dict,
         'sector': dict_utils.sector_dict,
-        'project_code': str,
-        'average_salary': dict_utils.id_name_dict,
-        'archived_by': dict_utils.contact_or_adviser_dict,
-        'project_manager': dict_utils.adviser_dict_with_team,
-        'project_assurance_adviser': dict_utils.adviser_dict_with_team,
-        'country_lost_to': dict_utils.id_name_dict,
-        'created_by': dict_utils.adviser_dict_with_team,
+        'specific_programme': dict_utils.id_name_dict,
+        'stage': dict_utils.id_name_dict,
+        'team_members': lambda col: [
+            dict_utils.contact_or_adviser_dict(c.adviser, include_dit_team=True) for c in col.all()
+        ],
+        'uk_company': dict_utils.id_name_dict,
+        'uk_region_locations': lambda col: [
+            dict_utils.id_name_dict(c) for c in col.all()
+        ],
     }
 
     COMPUTED_MAPPINGS = {


### PR DESCRIPTION
Issue number: N/A

### Description of change

As these had generally lost any meaningful order, this loosely sorts the attributes and mapping dictionaries for some of the models alphabetically.

I've left `id` at the top, and kept address fields in address-line order, but we could change that if we want.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
