### PR TITLE
Add POSTGRES_URL to docker-compose.env

### DIFF
--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,4 +1,5 @@
 DATABASE_URL=postgresql://postgres@postgres/datahub
+POSTGRES_URL=tcp://postgres:5432
 DATAHUB_SECRET=secret
 DEBUG=True
 DJANGO_SECRET_KEY=changeme


### PR DESCRIPTION
That's because `setup-uat.sh` uses this env var to wait for postgres and it's useful to have it in docker-compose.env when run locally.