### PR TITLE
Add tests to validate FILTER_FIELDS and REMAP_FIELDS on search views

### DIFF
--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -34,7 +34,7 @@ class SearchCompanyParams:
         'global_headquarters': 'global_headquarters.id',
         'headquarter_type': 'headquarter_type.id',
         'sector': 'sector.id',
-        'registered_address_country': 'address_country.id',
+        'registered_address_country': 'registered_address_country.id',
         'trading_address_country': 'trading_address_country.id',
         'uk_region': 'uk_region.id',
     }

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -34,7 +34,6 @@ class SearchCompanyParams:
         'global_headquarters': 'global_headquarters.id',
         'headquarter_type': 'headquarter_type.id',
         'sector': 'sector.id',
-        'registered_address_country': 'registered_address_country.id',
         'trading_address_country': 'trading_address_country.id',
         'uk_region': 'uk_region.id',
     }

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -23,8 +23,6 @@ class SearchCompanyParams:
         'sector_descends',
         'country',
         'trading_address_country',
-        'trading_address_postcode',
-        'trading_address_town',
         'uk_based',
         'uk_region'
     )

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -7,6 +7,17 @@ from datahub.search import elasticsearch
 from .apps import get_search_apps
 
 
+def pytest_generate_tests(metafunc):
+    """Parametrises tests that use the `search_app` fixture."""
+    if 'search_app' in metafunc.fixturenames:
+        apps = get_search_apps()
+        metafunc.parametrize(
+            'search_app',
+            apps,
+            ids=[app.__class__.__name__ for app in apps]
+        )
+
+
 @fixture(scope='session')
 def _es_client(worker_id):
     """

--- a/datahub/search/test/test_models.py
+++ b/datahub/search/test/test_models.py
@@ -2,19 +2,7 @@ import inspect
 
 from django.utils.functional import cached_property
 
-from datahub.search.apps import get_search_apps
 from datahub.search.utils import get_model_copy_to_target_field_names, get_model_field_names
-
-
-def pytest_generate_tests(metafunc):
-    """Parametrizes the tests that use the `search_app` fixture."""
-    if 'search_app' in metafunc.fixturenames:
-        apps = get_search_apps()
-        metafunc.parametrize(
-            'search_app',
-            apps,
-            ids=[app.__class__.__name__ for app in apps]
-        )
 
 
 def test_validate_model_fields(search_app):

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -83,7 +83,7 @@ class TestValidateViewAttributes:
         invalid_fields = frozenset(view.FILTER_FIELDS) - valid_fields
         assert not invalid_fields
 
-    def test_validate_remap_fields(self, search_app):
+    def test_validate_remap_fields_exist(self, search_app):
         """Validate that the values of REMAP_FIELDS are valid field paths."""
         view = search_app.view
 
@@ -93,6 +93,12 @@ class TestValidateViewAttributes:
         }
 
         assert not invalid_fields
+
+    def test_validate_remap_fields_are_used_in_filters(self, search_app):
+        """Validate that the values of REMAP_FIELDS are used in a filter."""
+        view = search_app.view
+
+        assert not {field for field in view.REMAP_FIELDS if field not in view.FILTER_FIELDS}
 
     @staticmethod
     def _model_has_field_path(es_model, path):

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 import factory
 import pytest
+from elasticsearch_dsl import AttrDict
 from rest_framework import status
 from rest_framework.reverse import reverse
 
@@ -14,6 +15,7 @@ from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import TeamFactory
 from datahub.omis.order.test.factories import OrderFactory
+from datahub.search.utils import get_model_fields
 
 pytestmark = pytest.mark.django_db
 
@@ -80,6 +82,33 @@ class TestValidateViewAttributes:
 
         invalid_fields = frozenset(view.FILTER_FIELDS) - valid_fields
         assert not invalid_fields
+
+    def test_validate_remap_fields(self, search_app):
+        """Validate that the values of REMAP_FIELDS are valid field paths."""
+        view = search_app.view
+
+        invalid_fields = {
+            field for field in view.REMAP_FIELDS.values()
+            if not self._model_has_field_path(search_app.es_model, field)
+        }
+
+        assert not invalid_fields
+
+    @staticmethod
+    def _model_has_field_path(es_model, path):
+        path_components = path.split('.')
+        fields = get_model_fields(es_model)
+
+        for sub_field_name in path_components:
+            if sub_field_name not in fields:
+                return False
+
+            sub_field = fields.get(sub_field_name)
+            fields = getattr(sub_field, 'properties', AttrDict({})).to_dict()
+            if not fields:
+                fields = getattr(sub_field, 'fields', {})
+
+        return True
 
 
 class TestSearch(APITestMixin):

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -70,6 +70,18 @@ def setup_data():
     )
 
 
+class TestValidateViewAttributes:
+    """Validates the field names specified in various class attributes on views."""
+
+    def test_validate_filter_fields_are_in_serializer(self, search_app):
+        """Validates that all filter fields exist in the serializer class."""
+        view = search_app.view
+        valid_fields = view.serializer_class._declared_fields.keys()
+
+        invalid_fields = frozenset(view.FILTER_FIELDS) - valid_fields
+        assert not invalid_fields
+
+
 class TestSearch(APITestMixin):
     """Tests search views."""
 


### PR DESCRIPTION
Issue number: N/A

### Description of change

This adds a few tests to validate FILTER_FIELDS and REMAP_FIELDS on the search views (and fixes a few minor problems revealed by those tests).

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
