### PR TITLE
Correct company name filter for contact, interaction and order search

### DIFF
--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -35,6 +35,7 @@ class CompanyFactory(factory.django.DjangoModelFactory):
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     name = factory.Faker('company')
+    alias = factory.Faker('company')
     registered_address_1 = factory.Sequence(lambda n: f'{n} Foo st.')
     registered_address_town = 'London'
     registered_address_country_id = constants.Country.united_kingdom.value.id

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -18,7 +18,7 @@ class Company(BaseESModel):
     archived_reason = Text()
     business_type = dsl_utils.id_name_mapping()
     classification = dsl_utils.id_name_mapping()
-    companies_house_data = dsl_utils.company_mapping()
+    companies_house_data = dsl_utils.ch_company_mapping()
     company_number = dsl_utils.SortableCaseInsensitiveKeywordText()
     contacts = dsl_utils.contact_or_adviser_mapping('contacts')
     created_on = Date()
@@ -85,7 +85,7 @@ class Company(BaseESModel):
         'archived_by': dict_utils.contact_or_adviser_dict,
         'business_type': dict_utils.id_name_dict,
         'classification': dict_utils.id_name_dict,
-        'companies_house_data': dict_utils.company_dict,
+        'companies_house_data': dict_utils.ch_company_dict,
         'contacts': lambda col: [dict_utils.contact_or_adviser_dict(c) for c in col.all()],
         'employee_range': dict_utils.id_name_dict,
         'export_experience_category': dict_utils.id_name_dict,

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -23,7 +23,7 @@ class Contact(BaseESModel):
     archived_by = dsl_utils.contact_or_adviser_mapping('archived_by')
     archived_on = Date()
     archived_reason = Text()
-    company = dsl_utils.id_name_partial_mapping('company')
+    company = dsl_utils.company_mapping('company')
     company_sector = dsl_utils.sector_mapping()
     company_uk_region = dsl_utils.id_name_mapping()
     contactable_by_dit = Boolean()
@@ -65,7 +65,7 @@ class Contact(BaseESModel):
         'id': str,
         'adviser': dict_utils.contact_or_adviser_dict,
         'archived_by': dict_utils.contact_or_adviser_dict,
-        'company': dict_utils.id_name_dict,
+        'company': dict_utils.company_dict,
         'created_by': dict_utils.adviser_dict_with_team,
         'title': dict_utils.id_name_dict,
     }

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -31,6 +31,18 @@ def id_uri_dict(obj):
     }
 
 
+def company_dict(obj):
+    """Creates dictionary for a company field."""
+    if obj is None:
+        return None
+
+    return {
+        'id': str(obj.id),
+        'name': obj.name,
+        'trading_name': obj.alias,
+    }
+
+
 def contact_or_adviser_dict(obj, include_dit_team=False):
     """Creates dictionary with selected field from supplied object."""
     if obj is None:
@@ -86,7 +98,7 @@ def computed_nested_sector_dict(nested_field):
     return _computed_nested_dict(nested_field, sector_dict)
 
 
-def company_dict(obj):
+def ch_company_dict(obj):
     """Creates dictionary from a company with id and company_number keys."""
     if obj is None:
         return None

--- a/datahub/search/dsl_utils.py
+++ b/datahub/search/dsl_utils.py
@@ -96,7 +96,23 @@ def id_uri_mapping():
     })
 
 
-def company_mapping():
+def company_mapping(field):
+    """Mapping for company fields."""
+    return Nested(
+        properties={
+            'id': Keyword(),
+            'name': SortableCaseInsensitiveKeywordText(copy_to=f'{field}.name_trigram'),
+            'name_trigram': TrigramText(),
+            'trading_name': SortableCaseInsensitiveKeywordText(
+                copy_to=f'{field}.trading_name_trigram'
+            ),
+            'trading_name_trigram': TrigramText(),
+        },
+        include_in_parent=True,
+    )
+
+
+def ch_company_mapping():
     """Mapping for id company_number fields."""
     return Nested(properties={
         'id': Keyword(),

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -10,7 +10,7 @@ class Interaction(BaseESModel):
     """Elasticsearch representation of Interaction model."""
 
     id = Keyword()
-    company = dsl_utils.id_name_partial_mapping('company')
+    company = dsl_utils.company_mapping('company')
     company_sector = dsl_utils.sector_mapping()
     communication_channel = dsl_utils.id_name_mapping()
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
@@ -36,7 +36,7 @@ class Interaction(BaseESModel):
 
     MAPPINGS = {
         'id': str,
-        'company': dict_utils.id_name_dict,
+        'company': dict_utils.company_dict,
         'communication_channel': dict_utils.id_name_dict,
         'contact': dict_utils.contact_or_adviser_dict,
         'dit_adviser': dict_utils.contact_or_adviser_dict,

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -24,6 +24,7 @@ def test_interaction_to_dict(setup_es, factory_cls):
         'company': {
             'id': str(interaction.company.pk),
             'name': interaction.company.name,
+            'trading_name': interaction.company.alias,
         } if interaction.company else None,
         'company_sector': {
             'id': str(interaction.company.sector.pk),
@@ -92,6 +93,7 @@ def test_service_delivery_to_dict(setup_es):
         'company': {
             'id': str(interaction.company.pk),
             'name': interaction.company.name,
+            'trading_name': interaction.company.alias,
         },
         'company_sector': {
             'id': str(interaction.company.sector.pk),

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -12,7 +12,7 @@ class Order(BaseESModel):
     reference = dsl_utils.SortableCaseInsensitiveKeywordText(copy_to=['reference_trigram'])
     reference_trigram = dsl_utils.TrigramText()
     status = dsl_utils.SortableCaseInsensitiveKeywordText()
-    company = dsl_utils.id_name_partial_mapping('company')
+    company = dsl_utils.company_mapping('company')
     contact = dsl_utils.contact_or_adviser_partial_mapping('contact')
     created_by = dsl_utils.contact_or_adviser_mapping('created_by', include_dit_team=True)
     created_on = Date()
@@ -62,7 +62,7 @@ class Order(BaseESModel):
 
     MAPPINGS = {
         'id': str,
-        'company': dict_utils.id_name_dict,
+        'company': dict_utils.company_dict,
         'contact': dict_utils.contact_or_adviser_dict,
         'created_by': dict_utils.adviser_dict_with_team,
         'primary_market': dict_utils.id_name_dict,

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -175,6 +175,16 @@ def test_mapping(setup_es):
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
                             'type': 'text'
+                        },
+                        'trading_name': {
+                            'copy_to': ['company.trading_name_trigram'],
+                            'analyzer': 'lowercase_keyword_analyzer',
+                            'fielddata': True,
+                            'type': 'text'
+                        },
+                        'trading_name_trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text'
                         }
                     },
                     'type': 'nested'
@@ -539,7 +549,8 @@ def test_indexed_doc(Factory, setup_es):
             },
             'company': {
                 'id': str(order.company.pk),
-                'name': order.company.name
+                'name': order.company.name,
+                'trading_name': order.company.alias,
             },
             'contact': {
                 'id': str(order.contact.pk),

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -34,7 +34,8 @@ def test_order_to_dict(Factory):
         'id': str(order.pk),
         'company': {
             'id': str(order.company.pk),
-            'name': order.company.name
+            'name': order.company.name,
+            'trading_name': order.company.alias,
         },
         'contact': {
             'id': str(order.contact.pk),

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -23,7 +23,7 @@ pytestmark = pytest.mark.django_db
 def setup_data(setup_es):
     """Sets up data for the tests."""
     with freeze_time('2017-01-01 13:00:00'):
-        company = CompanyFactory(name='Mercury trading')
+        company = CompanyFactory(name='Mercury trading', alias='Uranus supplies')
         contact = ContactFactory(company=company, first_name='John', last_name='Doe')
         order = OrderFactory(
             reference='abcd',
@@ -48,7 +48,7 @@ def setup_data(setup_es):
         )
 
     with freeze_time('2017-02-01 13:00:00'):
-        company = CompanyFactory(name='Venus Ltd')
+        company = CompanyFactory(name='Venus Ltd', alias='Earth outsourcing')
         contact = ContactFactory(company=company, first_name='Jenny', last_name='Cakeman')
         order = OrderWithAcceptedQuoteFactory(
             reference='efgh',
@@ -190,6 +190,14 @@ class TestSearchOrder(APITestMixin):
             ),
             (  # search by company name partial
                 {'company_name': 'Venus'},
+                ['efgh']
+            ),
+            (  # search by trading name exact
+                {'company_name': 'Earth outsourcing'},
+                ['efgh']
+            ),
+            (  # search by trading name partial
+                {'company_name': 'Earth'},
                 ['efgh']
             ),
             (  # sort by created_on ASC

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -47,6 +47,24 @@ def test_id_uri_dict():
     }
 
 
+def test_company_dict():
+    """Tests company_dict."""
+    obj = mock.Mock(
+        id=123,
+        name='Name',
+        alias='Trading',
+        spec_set=('id', 'name', 'alias')
+    )
+
+    res = dict_utils.company_dict(obj)
+
+    assert res == {
+        'id': str(obj.id),
+        'name': obj.name,
+        'trading_name': obj.alias,
+    }
+
+
 def test_contact_or_adviser_dict():
     """Tests contact_or_adviser_dict."""
     obj = mock.Mock()
@@ -109,13 +127,13 @@ def test_contact_or_adviser_dict_none_dit_team():
     }
 
 
-def test_company_dict():
-    """Tests company_dict."""
+def test_ch_company_dict():
+    """Tests ch_company_dict."""
     obj = mock.Mock()
     obj.id = 123
     obj.company_number = '01234567'
 
-    res = dict_utils.company_dict(obj)
+    res = dict_utils.ch_company_dict(obj)
 
     assert res == {
         'id': str(obj.id),

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -100,6 +100,19 @@ class TestValidateViewAttributes:
 
         assert not {field for field in view.REMAP_FIELDS if field not in view.FILTER_FIELDS}
 
+    def test_validate_composite_filter_fields(self, search_app):
+        """Validate that the values of COMPOSITE_FILTERS are valid field paths."""
+        view = search_app.view
+
+        invalid_fields = {
+            field
+            for field_list in view.COMPOSITE_FILTERS.values()
+            for field in field_list
+            if not self._model_has_field_path(search_app.es_model, field)
+        }
+
+        assert not invalid_fields
+
     @staticmethod
     def _model_has_field_path(es_model, path):
         path_components = path.split('.')


### PR DESCRIPTION
Issue number: N/A

### Description of change

The company_name filter for these models wa attempting to search by trading name (as well as name) but trading name was not being saved in ES for these models.

This adds trading name to those models (and also adds some tests to make sure the filter works).

This also adds a test to make sure all the composite filter fields are valid.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
