### PR TITLE
Improve coverage of restricted interaction test views

### DIFF
--- a/datahub/interaction/test/views/utils.py
+++ b/datahub/interaction/test/views/utils.py
@@ -1,28 +1,3 @@
-from ...models import InteractionPermission
-
-
-NON_RESTRICTED_READ_PERMISSIONS = (
-    (
-        InteractionPermission.read_all,
-    ),
-    (
-        InteractionPermission.read_all,
-        InteractionPermission.read_associated_investmentproject,
-    )
-)
-
-
-NON_RESTRICTED_CHANGE_PERMISSIONS = (
-    (
-        InteractionPermission.change_all,
-    ),
-    (
-        InteractionPermission.change_all,
-        InteractionPermission.change_associated_investmentproject,
-    )
-)
-
-
 def resolve_data(data):
     """
     Given a data dict with keys and values,


### PR DESCRIPTION
This:

- adds a few more cases of non-restricted users accessing the interactions API
- fixes a bug in a test that did not use the right authentication when testing restricted interactions API
