### PR TITLE
Preparation for daily Elasticsearch sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ docker-cleanup:
 migrate:
 	docker-compose run leeloo python manage.py migrate
 
+init-es:
+	docker-compose run leeloo python manage.py init_es
+
 makemigrations:
 	docker-compose run leeloo python manage.py makemigrations
 

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: python manage.py collectstatic --noinput && python manage.py distributed_migrate --noinput && gunicorn config.wsgi --config config/gunicorn.py
+web: python manage.py collectstatic --noinput && python manage.py distributed_migrate --noinput && python manage.py init_es && gunicorn config.wsgi --config config/gunicorn.py
 init_rev: python manage.py createinitialrevisions
 celeryworker: celery worker -A config -l info
 celerybeat: celery beat -A config -l info

--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
     docker-compose build
     ```
 
-3.  Populate the db:
+3.  Populate the database and initialise Elasticsearch:
 
     ```shell
     docker-compose run leeloo ./manage.py migrate
+    docker-compose run leeloo ./manage.py init_es
     docker-compose run leeloo ./manage.py loadinitialmetadata
     docker-compose run leeloo ./manage.py createinitialrevisions
     ```
@@ -108,11 +109,11 @@ Dependencies:
 
 9. Make sure you have redis running locally and that the REDIS_BASE_URL in your `.env` is up-to-date.
 
-10.  Configure and populate the db:
+10.  Populate the database and initialise Elasticsearch:
 
     ```shell
     ./manage.py migrate
-    ./manage.py createsuperuser
+    ./manage.py init_es
 
     ./manage.py loadinitialmetadata
     ./manage.py createinitialrevisions
@@ -126,13 +127,19 @@ Dependencies:
     ./manage.py sync_es
     ```
 
-12. Start the server:
+12.  Create a superuser:
+
+    ```shell
+    ./manage.py createsuperuser
+    ```
+    
+13. Start the server:
 
     ```shell
     ./manage.py runserver
     ```
 
-13. Start celery:
+14. Start celery:
 
     ```shell
     celery worker -A config -l info -B
@@ -265,6 +272,12 @@ These commands are generally only intended to be used on a blank database.
 
 
 ### Elasticsearch
+
+Create the Elasticsearch index (if it doesn't exist) and update the mapping:
+
+```shell
+./manage.py init_es
+```
 
 Resync all Elasticsearch records:
 

--- a/config/celery.py
+++ b/config/celery.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from celery import Celery
+from celery.signals import after_setup_logger
 from raven import Client
 from raven.contrib.celery import register_logger_signal, register_signal
 
@@ -31,3 +32,10 @@ register_logger_signal(client)
 
 # hook into the Celery error handler
 register_signal(client, ignore_expected=True)
+
+
+@after_setup_logger.connect
+def after_setup_logger_handler(**kwargs):
+    """As the Elasticsearch module is noisy, set its log level to WARNING for Celery workers."""
+    es_logger = logging.getLogger('elasticsearch')
+    es_logger.setLevel(logging.WARNING)

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -256,6 +256,9 @@ if REDIS_BASE_URL:
             }
         },
     }
+    CELERY_WORKER_LOG_FORMAT = (
+        "[%(asctime)s: %(levelname)s/%(processName)s] [%(name)s] %(message)s"
+    )
 
 # FRONTEND
 DATAHUB_FRONTEND_BASE_URL = env('DATAHUB_FRONTEND_BASE_URL', default='http://localhost:3000')

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -36,11 +36,6 @@ class SearchApp:
         self.mod = mod
         self.mod_signals = f'{self.mod}.signals'
 
-    def init_all(self):
-        """Initialise all ES configs."""
-        self.init_es()
-        self.connect_signals()
-
     def init_es(self):
         """
         Makes sure mappings exist in Elasticsearch.
@@ -106,17 +101,10 @@ class SearchConfig(AppConfig):
     name = 'datahub.search'
     verbose_name = 'Search'
 
-    def __init__(self, *args, **kwargs):
-        """Initialises this AppConfig"""
-        super().__init__(*args, **kwargs)
-        self.search_apps = {}
-
     def ready(self):
         """Configures Elasticsearch default connection."""
-        from datahub.search import elasticsearch
+        from datahub.search.elasticsearch import configure_connection
 
-        elasticsearch.configure_connection()
-        elasticsearch.configure_index(settings.ES_INDEX, settings.ES_INDEX_SETTINGS)
-
-        for search_app in get_search_apps():
-            search_app.init_all()
+        configure_connection()
+        for app in get_search_apps():
+            app.connect_signals()

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -72,7 +72,7 @@ def _create_test_index(client, index):
     if client.indices.exists(index=index):
         client.indices.delete(index)
 
-    elasticsearch.configure_index(index, settings.ES_INDEX_SETTINGS)
+    elasticsearch.configure_index(index, index_settings=settings.ES_INDEX_SETTINGS)
 
 
 @fixture

--- a/datahub/search/management/commands/init_es.py
+++ b/datahub/search/management/commands/init_es.py
@@ -1,0 +1,17 @@
+from logging import getLogger
+
+from django.core.management.base import BaseCommand
+
+from datahub.search.elasticsearch import init_es
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Command for creating the index and updating the mapping."""
+
+    help = "Creates the Elasticsearch index (if necessary) and updates the index's mapping."
+
+    def handle(self, *args, **options):
+        """Executes the command."""
+        init_es()

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -8,6 +8,9 @@ from datahub.search.elasticsearch import bulk
 from ...apps import get_search_apps
 
 
+logger = getLogger(__name__)
+
+
 def get_datasets(models=None):
     """
     Returns datasets that will be synchronised with Elasticsearch.
@@ -34,11 +37,10 @@ def _batch_rows(qs, batch_size=100):
         yield paginator.page(page).object_list
 
 
-def sync_dataset(item, batch_size=1, stdout=None):
+def sync_dataset(item, batch_size=1):
     """Sends dataset to ElasticSearch in batches of batch_size."""
     model_name = item.es_model.__name__
-    if stdout:
-        stdout.write(f'Processing {model_name} records...')
+    logger.info(f'Processing {model_name} records...')
 
     rows_processed = 0
     total_rows = item.queryset.count() \
@@ -57,20 +59,19 @@ def sync_dataset(item, batch_size=1, stdout=None):
 
         rows_processed += num_actions
         batches_processed += 1
-        if stdout and batches_processed % 100 == 0:
-            stdout.write(f'{model_name} rows processed: {rows_processed}/{total_rows} '
-                         f'{rows_processed*100//total_rows}%')
+        if batches_processed % 100 == 0:
+            logger.info(f'{model_name} rows processed: {rows_processed}/{total_rows} '
+                        f'{rows_processed*100//total_rows}%')
 
-    if stdout:
-        stdout.write(f'{model_name} rows processed: {rows_processed}/{total_rows} 100%.')
+    logger.info(f'{model_name} rows processed: {rows_processed}/{total_rows} 100%.')
 
 
-def sync_es(batch_size, datasets, stdout=None):
+def sync_es(batch_size, datasets):
     """Sends data to Elasticsearch."""
     for item in datasets:
-        sync_dataset(item, batch_size=batch_size, stdout=stdout)
-    if stdout:
-        stdout.write(f'Elasticsearch sync complete!')
+        sync_dataset(item, batch_size=batch_size)
+
+    logger.info('Elasticsearch sync complete!')
 
 
 class Command(BaseCommand):
@@ -94,11 +95,10 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         """Handle."""
-        root_logger = getLogger()
-        root_logger.setLevel(WARNING)
+        es_logger = getLogger('elasticsearch')
+        es_logger.setLevel(WARNING)
 
         sync_es(
             batch_size=options['batch_size'],
-            datasets=get_datasets(options['model']),
-            stdout=self.stdout
+            datasets=get_datasets(options['model'])
         )

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -5,6 +5,7 @@
 
 dockerize -wait ${POSTGRES_URL} -wait ${ES5_URL} -timeout 60s
 python /app/manage.py migrate
+python /app/manage.py init_es
 python /app/manage.py loadinitialmetadata
 
 # TODO abstract this into a method in ./manage.py

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -xe
 python /app/manage.py migrate --noinput
+python /app/manage.py init_es
 python /app/manage.py collectstatic --noinput
 python /app/manage.py runserver_plus 0.0.0.0:8000


### PR DESCRIPTION
Issue number: DH-1660

### Description of change

This makes a few changes in preparation for the ES sync Celery task:

1. Moves ES index creation and the updating of the mapping to a dedicated management command.

This stops the initialisation being done unnecessarily (e.g. for manage.py migrate), and also stops the Elasticsearch connection being shared amongst Celery workers (due to how elasticsearch-dsl manages connections, and how Celery forks). 

2. Changes sync_es functions to use a logger.

This is so that they can be used outside of the Django management command infrastructure.

3. Changes the Celery worker log format to include the logger name.

4. Sets the Elasticsearch logger log level to WARNING for Celery tasks (to cut down on noise).

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
