### PR TITLE
Command to update global hq.

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -247,7 +247,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         ),
         'subsidiary_cannot_be_a_global_headquarters': ugettext_lazy(
             'A company cannot both be and have a global headquarters.',
-        )
+        ),
     }
 
     registered_address_country = NestedRelatedField(meta_models.Country)
@@ -353,16 +353,22 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         at the model itself.
         """
         if global_headquarters:
-            # checks if global_headquarters is global_headquarters
-            if global_headquarters.headquarter_type_id != UUID(HeadquarterType.ghq.value.id):
-                raise serializers.ValidationError(
-                    self.error_messages['global_headquarters_company_is_not_a_global_headquarters']
-                )
-
             # checks if global_headquarters is not pointing to an instance of the model
             if self.instance == global_headquarters:
                 raise serializers.ValidationError(
                     self.error_messages['invalid_global_headquarters']
+                )
+
+            # checks if instance is global headquarters
+            if self.instance.headquarter_type_id == UUID(HeadquarterType.ghq.value.id):
+                raise serializers.ValidationError(
+                    self.error_messages['subsidiary_cannot_be_a_global_headquarters']
+                )
+
+            # checks if global_headquarters is global_headquarters
+            if global_headquarters.headquarter_type_id != UUID(HeadquarterType.ghq.value.id):
+                raise serializers.ValidationError(
+                    self.error_messages['global_headquarters_company_is_not_a_global_headquarters']
                 )
 
         return global_headquarters

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -237,7 +237,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         'uk_establishment_not_in_uk': ugettext_lazy(
             'A UK establishment (branch of non-UK company) must be in the UK.'
         ),
-        'headquarter_type_is_not_global_headquarters': ugettext_lazy(
+        'global_headquarters_hq_type_is_not_global_headquarters': ugettext_lazy(
             'Company to be linked as global headquarters must be a global headquarters.'
         ),
         'invalid_global_headquarters': ugettext_lazy(
@@ -315,7 +315,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         """Performs cross-field validation."""
         combiner = DataCombiner(self.instance, data)
 
-        if any({'global_headquarters', 'headquarter_type'} & set(data)):
+        if {'global_headquarters', 'headquarter_type'} & data.keys():
             headquarter_type_id = combiner.get_value_id('headquarter_type')
             global_headquarters_id = combiner.get_value_id('global_headquarters')
             if (
@@ -363,7 +363,9 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             # checks if global_headquarters is global_headquarters
             if global_headquarters.headquarter_type_id != UUID(HeadquarterType.ghq.value.id):
                 raise serializers.ValidationError(
-                    self.error_messages['headquarter_type_is_not_global_headquarters']
+                    self.error_messages[
+                        'global_headquarters_hq_type_is_not_global_headquarters'
+                    ]
                 )
 
         return global_headquarters

--- a/datahub/dbmaintenance/management/base.py
+++ b/datahub/dbmaintenance/management/base.py
@@ -32,6 +32,12 @@ class CSVBaseCommand(BaseCommand):
         """Define extra arguments."""
         parser.add_argument('bucket', help='S3 bucket where the CSV is stored.')
         parser.add_argument('object_key', help='S3 key of the CSV file.')
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            default=False,
+            help='If True it only simulates the command without saving the changes.',
+        )
 
     def handle(self, *args, **options):
         """Process the CSV file."""

--- a/datahub/dbmaintenance/management/commands/update_adviser_contact_email.py
+++ b/datahub/dbmaintenance/management/commands/update_adviser_contact_email.py
@@ -8,16 +8,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update the contact_email for advisers."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         pk = parse_uuid(row['id'])

--- a/datahub/dbmaintenance/management/commands/update_adviser_telephone_number.py
+++ b/datahub/dbmaintenance/management/commands/update_adviser_telephone_number.py
@@ -7,17 +7,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update adviser.telephone_number."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         adviser = Advisor.objects.get(pk=row['id'])

--- a/datahub/dbmaintenance/management/commands/update_company_company_number.py
+++ b/datahub/dbmaintenance/management/commands/update_company_company_number.py
@@ -13,16 +13,6 @@ logger = getLogger(__name__)
 class Command(CSVBaseCommand):
     """Command to update Company.company_number."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            default=False,
-            help='If True it only simulates the command without saving changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         pk = parse_uuid(row['id'])

--- a/datahub/dbmaintenance/management/commands/update_company_global_hq.py
+++ b/datahub/dbmaintenance/management/commands/update_company_global_hq.py
@@ -52,5 +52,6 @@ class Command(CSVBaseCommand):
                 return
 
             with reversion.create_revision():
+                serializer.validated_data['modified_by'] = None
                 serializer.save()
                 reversion.set_comment('Global HQ data correction.')

--- a/datahub/dbmaintenance/management/commands/update_company_global_hq.py
+++ b/datahub/dbmaintenance/management/commands/update_company_global_hq.py
@@ -14,7 +14,6 @@ class Command(CSVBaseCommand):
         parser.add_argument(
             '--overwrite',
             action='store_true',
-            dest='overwrite',
             default=False,
             help='If true it will overwrite all provided records.'
         )
@@ -30,14 +29,11 @@ class Command(CSVBaseCommand):
 
     def _process_row(self, row, simulate=False, overwrite=False, **options):
         """Process one single row."""
-        company = Company.objects.get(pk=row['id'])
-        global_hq = None
+        company = Company.objects.get(pk=parse_uuid(row['id']))
         global_hq_id = parse_uuid(row['global_hq_id'])
-        if global_hq_id is not None:
-            global_hq = Company.objects.get(pk=global_hq_id)
 
         if self._should_update(company, overwrite=overwrite):
-            company.global_headquarters = global_hq
+            company.global_headquarters_id = global_hq_id
 
             if simulate:
                 return
@@ -48,4 +44,4 @@ class Command(CSVBaseCommand):
                         'global_headquarters',
                     )
                 )
-                reversion.set_comment('Global HQ data migration.')
+                reversion.set_comment('Global HQ data correction.')

--- a/datahub/dbmaintenance/management/commands/update_company_global_hq.py
+++ b/datahub/dbmaintenance/management/commands/update_company_global_hq.py
@@ -6,7 +6,7 @@ from ..base import CSVBaseCommand
 
 
 class Command(CSVBaseCommand):
-    """Command to update Company.headquarter_type."""
+    """Command to update Company.global_headquarters."""
 
     def add_arguments(self, parser):
         """Define extra arguments."""

--- a/datahub/dbmaintenance/management/commands/update_company_global_hq.py
+++ b/datahub/dbmaintenance/management/commands/update_company_global_hq.py
@@ -12,13 +12,6 @@ class Command(CSVBaseCommand):
         """Define extra arguments."""
         super().add_arguments(parser)
         parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-        parser.add_argument(
             '--override',
             action='store_true',
             dest='override',

--- a/datahub/dbmaintenance/management/commands/update_company_global_hq.py
+++ b/datahub/dbmaintenance/management/commands/update_company_global_hq.py
@@ -1,0 +1,52 @@
+import uuid
+
+import reversion
+
+from datahub.company.models import Company
+from ..base import CSVBaseCommand
+
+
+class Command(CSVBaseCommand):
+    """Command to update Company.headquarter_type."""
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        super().add_arguments(parser)
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            dest='simulate',
+            default=False,
+            help='If True it only simulates the command without saving the changes.',
+        )
+
+    # Assume companies with a current Global HQ are correct, as this data did not come from CDMS
+    def _should_update(self, company):
+        return company.global_headquarters == None
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        company = Company.objects.get(pk=row['id'])
+        global_hq = None
+        if _parse_uuid(row['global_hq_id']) != None:
+            global_hq = Company.objects.get(pk=_parse_uuid(row['global_hq_id']))
+
+        if self._should_update(company):
+            company.global_headquarters = global_hq
+
+            if simulate:
+                return
+
+            with reversion.create_revision():
+                company.save(
+                    update_fields=(
+                        'global_headquarters',
+                    )
+                )
+                reversion.set_comment('Global HQ data migration.')
+
+
+def _parse_uuid(id_):
+    if not id_ or id_.lower().strip() == 'null':
+        return None
+    return uuid.UUID(id_)

--- a/datahub/dbmaintenance/management/commands/update_company_global_hq.py
+++ b/datahub/dbmaintenance/management/commands/update_company_global_hq.py
@@ -12,23 +12,23 @@ class Command(CSVBaseCommand):
         """Define extra arguments."""
         super().add_arguments(parser)
         parser.add_argument(
-            '--override',
+            '--overwrite',
             action='store_true',
-            dest='override',
+            dest='overwrite',
             default=False,
-            help='If true it will overwrite records having already set global hq.'
+            help='If true it will overwrite all provided records.'
         )
 
-    def _should_update(self, company, override=False):
+    def _should_update(self, company, overwrite=False):
         """Determine if we should update the company."""
-        if override:
+        if overwrite:
             return True
 
         # Assume companies with a current Global HQ are correct,
         # as this data did not come from CDMS
         return company.global_headquarters is None
 
-    def _process_row(self, row, simulate=False, override=False, **options):
+    def _process_row(self, row, simulate=False, overwrite=False, **options):
         """Process one single row."""
         company = Company.objects.get(pk=row['id'])
         global_hq = None
@@ -36,7 +36,7 @@ class Command(CSVBaseCommand):
         if global_hq_id is not None:
             global_hq = Company.objects.get(pk=global_hq_id)
 
-        if self._should_update(company, override=override):
+        if self._should_update(company, overwrite=overwrite):
             company.global_headquarters = global_hq
 
             if simulate:

--- a/datahub/dbmaintenance/management/commands/update_company_headquarter_type.py
+++ b/datahub/dbmaintenance/management/commands/update_company_headquarter_type.py
@@ -9,17 +9,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update Company.headquarter_type."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _should_update(self, company, headquarter_type_id):
         return company.headquarter_type_id != headquarter_type_id
 

--- a/datahub/dbmaintenance/management/commands/update_investment_project_actual_land_date.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_actual_land_date.py
@@ -19,17 +19,6 @@ class Command(CSVBaseCommand):
     Any projects in the Won stage are not updated.
     """
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         investment_project = InvestmentProject.objects.get(pk=row['id'])

--- a/datahub/dbmaintenance/management/commands/update_investment_project_actual_uk_regions.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_actual_uk_regions.py
@@ -13,17 +13,6 @@ logger = getLogger(__name__)
 class Command(CSVBaseCommand):
     """Command to update InvestmentProject.actual_uk_regions."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         pk = parse_uuid(row['id'])

--- a/datahub/dbmaintenance/management/commands/update_investment_project_comments.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_comments.py
@@ -7,17 +7,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update investment_project.description."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         # "Id" is not a typo

--- a/datahub/dbmaintenance/management/commands/update_investment_project_company.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_company.py
@@ -12,17 +12,6 @@ class Command(CSVBaseCommand):
     investor_company, intermediate_company, uk_company, uk_company_decided.
     """
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _parse_company_id(self, company_id):
         """
         :param company_id: string representing uuid of the company

--- a/datahub/dbmaintenance/management/commands/update_investment_project_created_on.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_created_on.py
@@ -9,17 +9,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update investment_project.created_on."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         investment_project = InvestmentProject.objects.get(pk=row['id'])

--- a/datahub/dbmaintenance/management/commands/update_investment_project_delivery_partners.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_delivery_partners.py
@@ -13,17 +13,6 @@ logger = getLogger(__name__)
 class Command(CSVBaseCommand):
     """Command to update InvestmentProject.delivery_partners."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         pk = parse_uuid(row['id'])

--- a/datahub/dbmaintenance/management/commands/update_investment_project_estimated_land_date.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_estimated_land_date.py
@@ -16,17 +16,6 @@ class Command(CSVBaseCommand):
     investment_project.allow_blank_estimated_land_date.
     """
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""
         pk = parse_uuid(row['id'])

--- a/datahub/dbmaintenance/management/commands/update_investment_project_possible_uk_regions.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_possible_uk_regions.py
@@ -21,13 +21,6 @@ class Command(CSVBaseCommand):
         super().add_arguments(parser)
 
         parser.add_argument(
-            '--simulate',
-            action='store_true',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
-        parser.add_argument(
             '--ignore-old-regions',
             action='store_true',
             default=False,

--- a/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_marketing.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_marketing.py
@@ -10,17 +10,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update investment_project.referral_source_activity/_marketing."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     @lru_cache(maxsize=None)
     def get_referral_source_activity(self, referral_source_activity_id):
         """

--- a/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_website.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_website.py
@@ -10,17 +10,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update investment_project.referral_source_activity/_website."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     @lru_cache(maxsize=None)
     def get_referral_source_activity(self, referral_source_activity_id):
         """

--- a/datahub/dbmaintenance/management/commands/update_investment_project_sector.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_sector.py
@@ -10,17 +10,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update investment_project.sector."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     @lru_cache(maxsize=None)
     def get_sector(self, sector_id):
         """

--- a/datahub/dbmaintenance/management/commands/update_omis_uk_regions.py
+++ b/datahub/dbmaintenance/management/commands/update_omis_uk_regions.py
@@ -8,17 +8,6 @@ from ..base import CSVBaseCommand
 class Command(CSVBaseCommand):
     """Command to update order.uk_region."""
 
-    def add_arguments(self, parser):
-        """Define extra arguments."""
-        super().add_arguments(parser)
-        parser.add_argument(
-            '--simulate',
-            action='store_true',
-            dest='simulate',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-
     @lru_cache(maxsize=None)
     def get_region(self, uk_region_id):
         """

--- a/datahub/dbmaintenance/management/commands/update_service_delivery_grant_fields.py
+++ b/datahub/dbmaintenance/management/commands/update_service_delivery_grant_fields.py
@@ -10,12 +10,6 @@ class Command(CSVBaseCommand):
         """Define extra arguments."""
         super().add_arguments(parser)
         parser.add_argument(
-            '--simulate',
-            action='store_true',
-            default=False,
-            help='If True it only simulates the command without saving the changes.',
-        )
-        parser.add_argument(
             '--overwrite',
             action='store_true',
             default=False,

--- a/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
@@ -1,0 +1,177 @@
+from io import BytesIO
+from uuid import UUID
+
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.constants import HeadquarterType
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('ERROR')
+
+    company_needs_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_to_be_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_ghq_for_test = CompanyFactory(
+        global_headquarters=None
+    )
+    company_ghq_set_already = CompanyFactory(
+        global_headquarters = company_ghq_for_test
+    )
+
+    companies = [
+        company_needs_global_hq,
+        company_to_be_global_hq,
+        company_ghq_for_test,
+        company_ghq_set_already,
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,global_hq_id
+00000000-0000-0000-0000-000000000000,NULL
+{company_needs_global_hq.id},{company_to_be_global_hq.id}
+{company_to_be_global_hq.id},NULL
+{company_ghq_set_already.id},{company_to_be_global_hq.id}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_company_global_hq', bucket, object_key)
+
+    for company in companies:
+        company.refresh_from_db()
+
+    # Missing from data, fail
+    print("***** ***** ***** HUH", caplog.text)
+    assert 'Company matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+    assert company_needs_global_hq.global_headquarters == company_to_be_global_hq
+    assert company_to_be_global_hq.global_headquarters == None
+    # Should not be updated
+    assert company_ghq_set_already.global_headquarters == company_ghq_for_test
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+
+    company_needs_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_to_be_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_ghq_for_test = CompanyFactory(
+        global_headquarters=None
+    )
+    company_ghq_set_already = CompanyFactory(
+        global_headquarters = company_ghq_for_test
+    )
+
+    companies = [
+        company_needs_global_hq,
+        company_to_be_global_hq,
+        company_ghq_for_test,
+        company_ghq_set_already,
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,global_hq_id
+00000000-0000-0000-0000-000000000000,NULL
+{company_needs_global_hq.id},{company_to_be_global_hq.id}
+{company_to_be_global_hq.id},NULL
+{company_ghq_set_already.id},{company_to_be_global_hq.id}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_company_global_hq', bucket, object_key, simulate=True)
+
+    for company in companies:
+        company.refresh_from_db()
+
+    # Missing from data, fail
+    assert 'Company matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+
+    assert company_needs_global_hq.global_headquarters == None
+    assert company_to_be_global_hq.global_headquarters == None
+    # Should not be updated
+    assert company_ghq_set_already.global_headquarters == company_ghq_for_test
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    company_needs_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_ghq_for_test = CompanyFactory(
+        global_headquarters=None
+    )
+    # Should not change
+    company_ghq_set_already = CompanyFactory(
+        global_headquarters = company_ghq_for_test
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,global_hq_id
+{company_needs_global_hq.id},{company_to_be_global_hq.id}
+{company_ghq_set_already.id},NULL
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_company_global_hq', bucket, object_key)
+
+    versions = Version.objects.get_for_object(company_needs_global_hq)
+    for v in versions:
+        print(v)
+    assert len(versions) == 1
+    assert versions[0].revision.comment == 'Global HQ data migration.'
+
+    print(company_ghq_set_already.global_headquarters)
+    versions = Version.objects.get_for_object(company_ghq_set_already)
+    for v in versions:
+        print(v)
+    assert len(versions) == 0

--- a/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
@@ -5,6 +5,7 @@ from django.core.management import call_command
 from reversion.models import Version
 
 from datahub.company.test.factories import CompanyFactory
+from datahub.core.constants import HeadquarterType
 
 pytestmark = pytest.mark.django_db
 
@@ -17,11 +18,14 @@ def test_run(s3_stubber, caplog):
     """
     caplog.set_level('ERROR')
     global_hq = CompanyFactory(
-        global_headquarters=None
+        headquarter_type_id=HeadquarterType.ghq.value.id,
+        global_headquarters=None,
     )
     other_global_hq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
         global_headquarters=None
     )
+
     company_needs_global_hq = CompanyFactory(
         global_headquarters=None
     )
@@ -81,9 +85,11 @@ def test_overwrite(s3_stubber, caplog):
     """
     caplog.set_level('ERROR')
     global_hq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
         global_headquarters=None
     )
     other_global_hq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
         global_headquarters=None
     )
 
@@ -146,34 +152,40 @@ def test_overwrite(s3_stubber, caplog):
 def test_simulate(s3_stubber, caplog, overwrite):
     """Test that the command simulates updates if --simulate is passed in."""
     caplog.set_level('ERROR')
+    global_hq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
+        global_headquarters=None
+    )
+    other_global_hq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
+        global_headquarters=None
+    )
 
     company_needs_global_hq = CompanyFactory(
         global_headquarters=None
     )
-    company_to_be_global_hq = CompanyFactory(
-        global_headquarters=None
+    company_should_get_new_global_hq = CompanyFactory(
+        global_headquarters=other_global_hq
     )
-    global_hq = CompanyFactory(
-        global_headquarters=None
-    )
-    company_global_hq_set_already = CompanyFactory(
-        global_headquarters=global_hq
+    company_should_have_global_hq_removed = CompanyFactory(
+        global_headquarters=other_global_hq
     )
 
     companies = [
-        company_needs_global_hq,
-        company_to_be_global_hq,
         global_hq,
-        company_global_hq_set_already,
+        other_global_hq,
+        company_needs_global_hq,
+        company_should_get_new_global_hq,
+        company_should_have_global_hq_removed,
     ]
 
     bucket = 'test_bucket'
     object_key = 'test_key'
     csv_content = f"""id,global_hq_id
 00000000-0000-0000-0000-000000000000,NULL
-{company_needs_global_hq.id},{company_to_be_global_hq.id}
-{company_to_be_global_hq.id},NULL
-{company_global_hq_set_already.id},{company_to_be_global_hq.id}
+{company_needs_global_hq.id},{global_hq.id}
+{company_should_get_new_global_hq.id},{global_hq.id}
+{company_should_have_global_hq_removed.id},NULL
 """
 
     s3_stubber.add_response(
@@ -203,16 +215,17 @@ def test_simulate(s3_stubber, caplog, overwrite):
     assert len(caplog.records) == 1
 
     assert company_needs_global_hq.global_headquarters is None
-    assert company_to_be_global_hq.global_headquarters is None
-    assert company_global_hq_set_already.global_headquarters == global_hq
+    assert company_should_get_new_global_hq.global_headquarters == other_global_hq
+    assert company_should_have_global_hq_removed.global_headquarters == other_global_hq
 
 
 def test_audit_log(s3_stubber):
     """Test that reversion revisions are created."""
-    company_needs_global_hq = CompanyFactory(
+    company_ghq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
         global_headquarters=None
     )
-    company_ghq = CompanyFactory(
+    company_needs_global_hq = CompanyFactory(
         global_headquarters=None
     )
     # Should not change
@@ -250,10 +263,11 @@ def test_audit_log(s3_stubber):
 
 def test_override_audit_log(s3_stubber):
     """Test that reversion revisions are created."""
-    company_needs_global_hq = CompanyFactory(
+    company_ghq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
         global_headquarters=None
     )
-    company_ghq = CompanyFactory(
+    company_needs_global_hq = CompanyFactory(
         global_headquarters=None
     )
     company_ghq_set_already = CompanyFactory(
@@ -287,3 +301,64 @@ def test_override_audit_log(s3_stubber):
     versions = Version.objects.get_for_object(company_ghq_set_already)
     assert len(versions) == 1
     assert versions[0].revision.comment == 'Global HQ data correction.'
+
+
+def test_validation(s3_stubber, caplog):
+    """Test that data is being validated."""
+    caplog.set_level('ERROR')
+    not_a_global_hq = CompanyFactory(
+        global_headquarters=None,
+    )
+    valid_global_hq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
+        global_headquarters=None
+    )
+    other_valid_global_hq = CompanyFactory(
+        headquarter_type_id=HeadquarterType.ghq.value.id,
+        global_headquarters=None
+    )
+
+    company_needs_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+
+    companies = [
+        not_a_global_hq,
+        valid_global_hq,
+        other_valid_global_hq,
+        company_needs_global_hq,
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,global_hq_id
+00000000-0000-0000-0000-000000000000,NULL
+{company_needs_global_hq.id},{not_a_global_hq.id}
+{valid_global_hq.id},{other_valid_global_hq.id}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_company_global_hq', bucket, object_key)
+
+    for company in companies:
+        company.refresh_from_db()
+
+    assert 'Company matching query does not exist' in caplog.text
+
+    invalid_ghq = 'Company to be linked as global headquarters must be a global headquarters.'
+    assert invalid_ghq in caplog.text
+
+    subsidiary_error = 'A company cannot both be and have a global headquarters'
+    assert subsidiary_error in caplog.text
+
+    assert len(caplog.records) == 3

--- a/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
@@ -242,7 +242,7 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(company_needs_global_hq)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Global HQ data migration.'
+    assert versions[0].revision.comment == 'Global HQ data correction.'
 
     versions = Version.objects.get_for_object(company_ghq_set_already)
     assert len(versions) == 0
@@ -282,8 +282,8 @@ def test_override_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(company_needs_global_hq)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Global HQ data migration.'
+    assert versions[0].revision.comment == 'Global HQ data correction.'
 
     versions = Version.objects.get_for_object(company_ghq_set_already)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Global HQ data migration.'
+    assert versions[0].revision.comment == 'Global HQ data correction.'

--- a/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
@@ -74,6 +74,7 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert company_needs_global_hq.global_headquarters == global_hq
+    assert company_needs_global_hq.modified_by is None
 
     # Should not be updated
     assert company_should_keep_current_global_hq.global_headquarters == other_global_hq
@@ -142,8 +143,11 @@ def test_overwrite(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert company_needs_global_hq.global_headquarters == global_hq
+    assert company_needs_global_hq.modified_by is None
     assert company_should_get_new_global_hq.global_headquarters == global_hq
+    assert company_should_get_new_global_hq.modified_by is None
     assert company_should_have_global_hq_removed.global_headquarters is None
+    assert company_should_get_new_global_hq.modified_by is None
 
 
 @pytest.mark.parametrize(
@@ -216,8 +220,11 @@ def test_simulate(s3_stubber, caplog, overwrite):
     assert len(caplog.records) == 1
 
     assert company_needs_global_hq.global_headquarters is None
+    assert company_needs_global_hq.modified_by is not None
     assert company_should_get_new_global_hq.global_headquarters == other_global_hq
+    assert company_should_get_new_global_hq.modified_by is not None
     assert company_should_have_global_hq_removed.global_headquarters == other_global_hq
+    assert company_should_have_global_hq_removed.modified_by is not None
 
 
 def test_audit_log(s3_stubber):

--- a/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
@@ -1,47 +1,52 @@
 from io import BytesIO
-from uuid import UUID
 
 import pytest
 from django.core.management import call_command
 from reversion.models import Version
 
 from datahub.company.test.factories import CompanyFactory
-from datahub.core.constants import HeadquarterType
 
 pytestmark = pytest.mark.django_db
 
 
 def test_run(s3_stubber, caplog):
-    """Test that the command updates the specified records (ignoring ones with errors)."""
-    caplog.set_level('ERROR')
+    """
+    Test that the command updates the specified records.
 
+    Ignores ones with global hq already assigned or with errors.
+    """
+    caplog.set_level('ERROR')
+    company_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_other_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
     company_needs_global_hq = CompanyFactory(
         global_headquarters=None
     )
-    company_to_be_global_hq = CompanyFactory(
-        global_headquarters=None
+    company_should_keep_current_global_hq = CompanyFactory(
+        global_headquarters=company_other_global_hq
     )
-    company_ghq_for_test = CompanyFactory(
-        global_headquarters=None
-    )
-    company_ghq_set_already = CompanyFactory(
-        global_headquarters = company_ghq_for_test
+    company_should_also_keep_global_hq = CompanyFactory(
+        global_headquarters=company_other_global_hq
     )
 
     companies = [
+        company_global_hq,
+        company_other_global_hq,
         company_needs_global_hq,
-        company_to_be_global_hq,
-        company_ghq_for_test,
-        company_ghq_set_already,
+        company_should_keep_current_global_hq,
+        company_should_also_keep_global_hq,
     ]
 
     bucket = 'test_bucket'
     object_key = 'test_key'
     csv_content = f"""id,global_hq_id
 00000000-0000-0000-0000-000000000000,NULL
-{company_needs_global_hq.id},{company_to_be_global_hq.id}
-{company_to_be_global_hq.id},NULL
-{company_ghq_set_already.id},{company_to_be_global_hq.id}
+{company_needs_global_hq.id},{company_global_hq.id}
+{company_should_keep_current_global_hq.id},{company_global_hq.id}
+{company_should_also_keep_global_hq.id},NULL
 """
 
     s3_stubber.add_response(
@@ -61,17 +66,85 @@ def test_run(s3_stubber, caplog):
         company.refresh_from_db()
 
     # Missing from data, fail
-    print("***** ***** ***** HUH", caplog.text)
     assert 'Company matching query does not exist' in caplog.text
     assert len(caplog.records) == 1
 
-    assert company_needs_global_hq.global_headquarters == company_to_be_global_hq
-    assert company_to_be_global_hq.global_headquarters == None
+    assert company_needs_global_hq.global_headquarters == company_global_hq
     # Should not be updated
-    assert company_ghq_set_already.global_headquarters == company_ghq_for_test
+    assert company_should_keep_current_global_hq.global_headquarters == company_other_global_hq
+    assert company_should_also_keep_global_hq.global_headquarters == company_other_global_hq
 
 
-def test_simulate(s3_stubber, caplog):
+def test_override(s3_stubber, caplog):
+    """
+    Test that the command updates all specified records (ignoring ones with errors).
+    """
+    caplog.set_level('ERROR')
+    company_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_other_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+
+    company_needs_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_should_get_new_global_hq = CompanyFactory(
+        global_headquarters=company_other_global_hq
+    )
+    company_should_have_global_hq_removed = CompanyFactory(
+        global_headquarters=company_other_global_hq
+    )
+
+    companies = [
+        company_global_hq,
+        company_other_global_hq,
+        company_needs_global_hq,
+        company_should_get_new_global_hq,
+        company_should_have_global_hq_removed,
+    ]
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,global_hq_id
+00000000-0000-0000-0000-000000000000,NULL
+{company_needs_global_hq.id},{company_global_hq.id}
+{company_should_get_new_global_hq.id},{company_global_hq.id}
+{company_should_have_global_hq_removed.id},NULL
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_company_global_hq', bucket, object_key, override=True)
+
+    for company in companies:
+        company.refresh_from_db()
+
+    # Missing from data, fail
+    assert 'Company matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+    assert company_needs_global_hq.global_headquarters == company_global_hq
+    # Should not be updated
+    assert company_should_get_new_global_hq.global_headquarters == company_global_hq
+    assert company_should_have_global_hq_removed.global_headquarters is None
+
+
+@pytest.mark.parametrize(
+    'override',
+    (True, False)
+)
+def test_simulate(s3_stubber, caplog, override):
     """Test that the command simulates updates if --simulate is passed in."""
     caplog.set_level('ERROR')
 
@@ -85,7 +158,7 @@ def test_simulate(s3_stubber, caplog):
         global_headquarters=None
     )
     company_ghq_set_already = CompanyFactory(
-        global_headquarters = company_ghq_for_test
+        global_headquarters=company_ghq_for_test
     )
 
     companies = [
@@ -115,7 +188,13 @@ def test_simulate(s3_stubber, caplog):
         }
     )
 
-    call_command('update_company_global_hq', bucket, object_key, simulate=True)
+    call_command(
+        'update_company_global_hq',
+        bucket,
+        object_key,
+        simulate=True,
+        override=override
+    )
 
     for company in companies:
         company.refresh_from_db()
@@ -124,9 +203,8 @@ def test_simulate(s3_stubber, caplog):
     assert 'Company matching query does not exist' in caplog.text
     assert len(caplog.records) == 1
 
-
-    assert company_needs_global_hq.global_headquarters == None
-    assert company_to_be_global_hq.global_headquarters == None
+    assert company_needs_global_hq.global_headquarters is None
+    assert company_to_be_global_hq.global_headquarters is None
     # Should not be updated
     assert company_ghq_set_already.global_headquarters == company_ghq_for_test
 
@@ -136,18 +214,18 @@ def test_audit_log(s3_stubber):
     company_needs_global_hq = CompanyFactory(
         global_headquarters=None
     )
-    company_ghq_for_test = CompanyFactory(
+    company_ghq = CompanyFactory(
         global_headquarters=None
     )
     # Should not change
     company_ghq_set_already = CompanyFactory(
-        global_headquarters = company_ghq_for_test
+        global_headquarters=company_ghq
     )
 
     bucket = 'test_bucket'
     object_key = 'test_key'
     csv_content = f"""id,global_hq_id
-{company_needs_global_hq.id},{company_to_be_global_hq.id}
+{company_needs_global_hq.id},{company_ghq.id}
 {company_ghq_set_already.id},NULL
 """
 
@@ -165,13 +243,49 @@ def test_audit_log(s3_stubber):
     call_command('update_company_global_hq', bucket, object_key)
 
     versions = Version.objects.get_for_object(company_needs_global_hq)
-    for v in versions:
-        print(v)
     assert len(versions) == 1
     assert versions[0].revision.comment == 'Global HQ data migration.'
 
-    print(company_ghq_set_already.global_headquarters)
     versions = Version.objects.get_for_object(company_ghq_set_already)
-    for v in versions:
-        print(v)
     assert len(versions) == 0
+
+
+def test_override_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    company_needs_global_hq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_ghq = CompanyFactory(
+        global_headquarters=None
+    )
+    company_ghq_set_already = CompanyFactory(
+        global_headquarters=company_ghq
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,global_hq_id
+{company_needs_global_hq.id},{company_ghq.id}
+{company_ghq_set_already.id},NULL
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_company_global_hq', bucket, object_key, override=True)
+
+    versions = Version.objects.get_for_object(company_needs_global_hq)
+    assert len(versions) == 1
+    assert versions[0].revision.comment == 'Global HQ data migration.'
+
+    versions = Version.objects.get_for_object(company_ghq_set_already)
+    assert len(versions) == 1
+    assert versions[0].revision.comment == 'Global HQ data migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
@@ -74,6 +74,7 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert company_needs_global_hq.global_headquarters == global_hq
+
     # Should not be updated
     assert company_should_keep_current_global_hq.global_headquarters == other_global_hq
     assert company_should_also_keep_global_hq.global_headquarters == other_global_hq


### PR DESCRIPTION
Issue number: DH-1608

### Description of change

This adds a command that updates given company's global hq if global hq doesn't already exist. 
It adds additional parameter `overwrite` which cause command to write global hq regardless if it exists. 

I also moved `simulate` param to the base command class as it was present in all commands.

### Checklist

* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
