### PR TITLE
Schedule the full ES sync to run daily

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: python manage.py collectstatic --noinput && python manage.py distributed_migrate --noinput && python manage.py init_es && gunicorn config.wsgi --config config/gunicorn.py
 init_rev: python manage.py createinitialrevisions
-celeryworker: celery worker -A config -l info
+celeryworker: celery worker -A config -l info -O fair --prefetch-multiplier 1 -Q celery,long-running
 celerybeat: celery beat -A config -l info

--- a/README.md
+++ b/README.md
@@ -142,8 +142,11 @@ Dependencies:
 14. Start celery:
 
     ```shell
-    celery worker -A config -l info -B
+    celery worker -A config -l info -Q celery,long-running -B
     ```
+    
+    Note that in production the `-O fair --prefetch-multiplier 1` arguments are also used for better fairness when
+    long-running tasks are running or pending execution.
 
 ## Local development
 

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -247,6 +247,11 @@ if REDIS_BASE_URL:
             'ssl_cert_reqs': ssl.CERT_NONE
         }
         CELERY_BROKER_USE_SSL = CELERY_REDIS_BACKEND_USE_SSL
+    CELERY_TASK_ROUTES = {
+        'datahub.search.tasks.*': {
+            'queue': 'long-running'
+        }
+    }
     CELERY_BEAT_SCHEDULE = {
         'refresh_pending_payment_gateway_sessions': {
             'task': 'datahub.omis.payment.tasks.refresh_pending_payment_gateway_sessions',
@@ -254,6 +259,10 @@ if REDIS_BASE_URL:
             'kwargs': {
                 'age_check': 60  # in minutes
             }
+        },
+        'sync_es': {
+            'task': 'datahub.search.tasks.sync_all_models',
+            'schedule': crontab(minute=0, hour=1),
         },
     }
     CELERY_WORKER_LOG_FORMAT = (

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -8,6 +8,7 @@ https://docs.djangoproject.com/en/dev/ref/settings/
 """
 
 import ssl
+from datetime import timedelta
 
 import environ
 from celery.schedules import crontab
@@ -247,6 +248,13 @@ if REDIS_BASE_URL:
             'ssl_cert_reqs': ssl.CERT_NONE
         }
         CELERY_BROKER_USE_SSL = CELERY_REDIS_BACKEND_USE_SSL
+
+    # Increase timeout from one hour for long-running tasks
+    # (If the timeout is reached before a task, Celery will start it again. This
+    # would affect in particular any long-running tasks using acks_late=True.)
+    CELERY_BROKER_TRANSPORT_OPTIONS = {
+        'visibility_timeout': int(timedelta(hours=9).total_seconds())
+    }
     CELERY_TASK_ROUTES = {
         'datahub.search.tasks.*': {
             'queue': 'long-running'

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -256,7 +256,7 @@ if REDIS_BASE_URL:
         'visibility_timeout': int(timedelta(hours=9).total_seconds())
     }
     CELERY_TASK_ROUTES = {
-        'datahub.search.tasks.*': {
+        'datahub.search.tasks.sync_model': {
             'queue': 'long-running'
         }
     }

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -82,17 +82,16 @@ class SearchApp:
 @lru_cache(maxsize=None)
 def get_search_apps():
     """Registers all search apps specified in `SEARCH_APPS`."""
-    search_apps = []
+    return tuple(get_search_app(cls_path) for cls_path in SEARCH_APPS)
 
-    for search_mod in SEARCH_APPS:
-        mod_path, _, cls_name = search_mod.rpartition('.')
-        mod = import_module(mod_path)
-        SearchClass = getattr(mod, cls_name)  # noqa: N806
 
-        app = SearchClass(mod_path)
-        search_apps.append(app)
-
-    return search_apps
+@lru_cache(maxsize=None)
+def get_search_app(cls_path):
+    """Registers a single search app."""
+    mod_path, _, cls_name = cls_path.rpartition('.')
+    mod = import_module(mod_path)
+    cls = getattr(mod, cls_name)
+    return cls(mod_path)
 
 
 class SearchConfig(AppConfig):

--- a/datahub/search/bulk_sync.py
+++ b/datahub/search/bulk_sync.py
@@ -1,0 +1,69 @@
+from logging import getLogger
+
+from django.core.paginator import Paginator
+from django.db import models
+
+from datahub.search.apps import get_search_apps
+from datahub.search.elasticsearch import bulk
+
+logger = getLogger(__name__)
+
+DEFAULT_BATCH_SIZE = 600
+
+
+def get_datasets(models=None):
+    """
+    Returns datasets that will be synchronised with Elasticsearch.
+
+    :param models: list of search app names to index, None for all
+    """
+    search_apps = get_search_apps()
+
+    # if models empty, assume all models
+    if not models:
+        models = [search_app.name for search_app in search_apps]
+
+    return [
+        search_app.get_dataset()
+        for search_app in search_apps
+        if search_app.name in models
+    ]
+
+
+def _batch_rows(qs, batch_size=DEFAULT_BATCH_SIZE):
+    """Yields QuerySet in chunks."""
+    paginator = Paginator(qs, batch_size)
+    for page in range(1, paginator.num_pages + 1):
+        yield paginator.page(page).object_list
+
+
+def sync_dataset(item, batch_size=DEFAULT_BATCH_SIZE):
+    """Sends dataset to ElasticSearch in batches of batch_size."""
+    model_name = item.es_model.__name__
+    logger.info(f'Processing {model_name} records...')
+
+    rows_processed = 0
+    total_rows = (
+        item.queryset.count()
+        if isinstance(item.queryset, models.query.QuerySet) else len(item.queryset)
+    )
+    batches_processed = 0
+    batches = _batch_rows(item.queryset, batch_size=batch_size)
+    for batch in batches:
+        actions = list(item.es_model.dbmodels_to_es_documents(batch))
+        num_actions = len(actions)
+        bulk(
+            actions=actions,
+            chunk_size=num_actions,
+            request_timeout=300,
+            raise_on_error=True,
+            raise_on_exception=True,
+        )
+
+        rows_processed += num_actions
+        batches_processed += 1
+        if batches_processed % 100 == 0:
+            logger.info(f'{model_name} rows processed: {rows_processed}/{total_rows} '
+                        f'{rows_processed*100//total_rows}%')
+
+    logger.info(f'{model_name} rows processed: {rows_processed}/{total_rows} 100%.')

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -10,6 +10,8 @@ from ...apps import get_search_apps
 
 logger = getLogger(__name__)
 
+DEFAULT_BATCH_SIZE = 600
+
 
 def get_datasets(models=None):
     """
@@ -30,14 +32,14 @@ def get_datasets(models=None):
     ]
 
 
-def _batch_rows(qs, batch_size=100):
+def _batch_rows(qs, batch_size=DEFAULT_BATCH_SIZE):
     """Yields QuerySet in chunks."""
     paginator = Paginator(qs, batch_size)
     for page in range(1, paginator.num_pages + 1):
         yield paginator.page(page).object_list
 
 
-def sync_dataset(item, batch_size=1):
+def sync_dataset(item, batch_size=DEFAULT_BATCH_SIZE):
     """Sends dataset to ElasticSearch in batches of batch_size."""
     model_name = item.es_model.__name__
     logger.info(f'Processing {model_name} records...')
@@ -82,7 +84,7 @@ class Command(BaseCommand):
         parser.add_argument(
             '--batch_size',
             dest='batch_size',
-            default=600,
+            default=DEFAULT_BATCH_SIZE,
             help='Batch size - number of rows processed at a time',
         )
         parser.add_argument(

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -1,71 +1,11 @@
 from logging import getLogger, WARNING
 
 from django.core.management.base import BaseCommand
-from django.core.paginator import Paginator
-from django.db import models
 
-from datahub.search.elasticsearch import bulk
+from datahub.search.bulk_sync import DEFAULT_BATCH_SIZE, get_datasets, sync_dataset
 from ...apps import get_search_apps
 
-
 logger = getLogger(__name__)
-
-DEFAULT_BATCH_SIZE = 600
-
-
-def get_datasets(models=None):
-    """
-    Returns datasets that will be synchronised with Elasticsearch.
-
-    :param models: list of search app names to index, None for all
-    """
-    search_apps = get_search_apps()
-
-    # if models empty, assume all models
-    if not models:
-        models = [search_app.name for search_app in search_apps]
-
-    return [
-        search_app.get_dataset()
-        for search_app in search_apps
-        if search_app.name in models
-    ]
-
-
-def _batch_rows(qs, batch_size=DEFAULT_BATCH_SIZE):
-    """Yields QuerySet in chunks."""
-    paginator = Paginator(qs, batch_size)
-    for page in range(1, paginator.num_pages + 1):
-        yield paginator.page(page).object_list
-
-
-def sync_dataset(item, batch_size=DEFAULT_BATCH_SIZE):
-    """Sends dataset to ElasticSearch in batches of batch_size."""
-    model_name = item.es_model.__name__
-    logger.info(f'Processing {model_name} records...')
-
-    rows_processed = 0
-    total_rows = item.queryset.count() \
-        if isinstance(item.queryset, models.query.QuerySet) else len(item.queryset)
-    batches_processed = 0
-    batches = _batch_rows(item.queryset, batch_size=batch_size)
-    for batch in batches:
-        actions = list(item.es_model.dbmodels_to_es_documents(batch))
-        num_actions = len(actions)
-        bulk(actions=actions,
-             chunk_size=num_actions,
-             request_timeout=300,
-             raise_on_error=True,
-             raise_on_exception=True,
-             )
-
-        rows_processed += num_actions
-        batches_processed += 1
-        if batches_processed % 100 == 0:
-            logger.info(f'{model_name} rows processed: {rows_processed}/{total_rows} '
-                        f'{rows_processed*100//total_rows}%')
-
-    logger.info(f'{model_name} rows processed: {rows_processed}/{total_rows} 100%.')
 
 
 def sync_es(batch_size, datasets):

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 
 from datahub.search.apps import get_search_app, SEARCH_APPS
-from datahub.search.management.commands.sync_es import sync_dataset
+from datahub.search.bulk_sync import sync_dataset
 
 
 @shared_task(acks_late=True, priority=9)

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -1,0 +1,32 @@
+from celery import shared_task
+
+from datahub.search.apps import get_search_app, SEARCH_APPS
+from datahub.search.management.commands.sync_es import sync_dataset
+
+
+@shared_task(acks_late=True, priority=9)
+def sync_all_models():
+    """
+    Task that starts sub-tasks to sync all models to Elasticsearch.
+
+    acks_late is set to True so that the task restarts if interrupted.
+
+    priority is set to the lowest priority (for Redis, 0 is the highest priority).
+    """
+    for search_app_cls_path in SEARCH_APPS:
+        sync_model.apply_async(
+            args=(search_app_cls_path,),
+        )
+
+
+@shared_task(acks_late=True, priority=9)
+def sync_model(search_app_cls_path):
+    """
+    Task that syncs a single model to Elasticsearch.
+
+    acks_late is set to True so that the task restarts if interrupted.
+
+    priority is set to the lowest priority (for Redis, 0 is the highest priority).
+    """
+    search_app = get_search_app(search_app_cls_path)
+    sync_dataset(search_app.get_dataset())

--- a/datahub/search/test/commands/test_sync_es.py
+++ b/datahub/search/test/commands/test_sync_es.py
@@ -15,18 +15,7 @@ from ...models import DataSet
 pytestmark = pytest.mark.django_db
 
 
-def test_batch_rows():
-    """Tests _batch_rows."""
-    rows = ({}, {}, {})
-
-    res = list(sync_es._batch_rows(rows, batch_size=2))
-
-    assert len(res) == 2
-    assert len(res[0]) == 2
-    assert len(res[1]) == 1
-
-
-@mock.patch('datahub.search.management.commands.sync_es.bulk')
+@mock.patch('datahub.search.bulk_sync.bulk')
 @mock.patch('datahub.search.management.commands.sync_es.get_datasets')
 def test_sync_dataset(get_datasets, bulk, setup_es):
     """Tests syncing dataset up to Elasticsearch."""
@@ -45,7 +34,7 @@ def test_sync_dataset(get_datasets, bulk, setup_es):
     'search_model',
     (app.name for app in get_search_apps())
 )
-@mock.patch('datahub.search.management.commands.sync_es.bulk')
+@mock.patch('datahub.search.bulk_sync.bulk')
 def test_sync_one_model(bulk, setup_es, search_model):
     """
     Test that --model can be used to specify what we weant to sync.
@@ -55,7 +44,7 @@ def test_sync_one_model(bulk, setup_es, search_model):
     assert bulk.call_count == 1
 
 
-@mock.patch('datahub.search.management.commands.sync_es.bulk')
+@mock.patch('datahub.search.bulk_sync.bulk')
 def test_sync_all_models(bulk, setup_es):
     """
     Test that if --model is not used, all the search apps are synced.
@@ -65,7 +54,7 @@ def test_sync_all_models(bulk, setup_es):
     assert bulk.call_count == len(get_search_apps())
 
 
-@mock.patch('datahub.search.management.commands.sync_es.bulk')
+@mock.patch('datahub.search.bulk_sync.bulk')
 def test_sync_invalid_model(bulk, setup_es):
     """
     Test that if an invalid value is used with --model, nothing gets synced.

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -1,0 +1,12 @@
+from datahub.search.bulk_sync import _batch_rows
+
+
+def test_batch_rows():
+    """Tests _batch_rows."""
+    rows = ({}, {}, {})
+
+    res = list(_batch_rows(rows, batch_size=2))
+
+    assert len(res) == 2
+    assert len(res[0]) == 2
+    assert len(res[1]) == 1

--- a/datahub/search/test/test_tasks.py
+++ b/datahub/search/test/test_tasks.py
@@ -1,0 +1,31 @@
+from unittest.mock import Mock
+
+from datahub.search.apps import SEARCH_APPS
+from datahub.search.tasks import sync_all_models, sync_model
+
+
+def test_sync_model(monkeypatch):
+    """Test that the sync_model task starts an ES sync for that model."""
+    get_search_app_mock = Mock()
+    monkeypatch.setattr('datahub.search.tasks.get_search_app', get_search_app_mock)
+
+    sync_dataset_mock = Mock()
+    monkeypatch.setattr('datahub.search.tasks.sync_dataset', sync_dataset_mock)
+
+    search_app_path = SEARCH_APPS[0]
+    sync_model.apply(args=(search_app_path,))
+
+    get_search_app_mock.assert_called_once_with(search_app_path)
+    sync_dataset_mock.assert_called_once_with(
+        get_search_app_mock.return_value.get_dataset.return_value
+    )
+
+
+def test_sync_all_models(monkeypatch):
+    """Test that the sync_all_models task start sub-tasks to sync all models."""
+    sync_model_mock = Mock()
+    monkeypatch.setattr('datahub.search.tasks.sync_model', sync_model_mock)
+
+    sync_all_models.apply()
+    tasks_created = {call[1]['args'][0] for call in sync_model_mock.apply_async.call_args_list}
+    assert tasks_created == frozenset(SEARCH_APPS)


### PR DESCRIPTION
Issue number: DH-1660

### Description of change

This adds a couple of tasks for syncing all objects for a particular model, and schedules it to run overnight.

The new tasks are routed to a different Celery queue to separate long-running tasks from other tasks. Also a couple of extra Celery arguments were added to help avoid long-running tasks from hogging workers. We could also add additional commands to the Procfile so that we can start Celery worker processes with different arguments (e.g. for different queues), though I haven't done this for now as I think our needs remain fairly simple.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
