### PR TITLE
Correct a couple of invalid search SORT_BY_FIELDS

### DIFF
--- a/datahub/search/companieshousecompany/serializers.py
+++ b/datahub/search/companieshousecompany/serializers.py
@@ -17,6 +17,6 @@ class SearchCompaniesHouseCompanySerializer(SearchSerializer):
     incorporation_date_before = RelaxedDateTimeField(required=False)
 
     SORT_BY_FIELDS = (
-        'incorporated_date',
+        'incorporation_date',
         'name',
     )

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -66,7 +66,7 @@ class SearchInvestmentProjectSerializer(SearchSerializer):
         'referral_source_activity_event',
         'referral_source_activity_marketing.name',
         'referral_source_activity_website.name',
-        'referral_source_advisor.name',
+        'referral_source_adviser.name',
         'sector.name',
         'site_decided',
         'stage.name',

--- a/datahub/search/test/test_serializers.py
+++ b/datahub/search/test/test_serializers.py
@@ -2,6 +2,7 @@ import pytest
 from rest_framework import serializers
 
 from datahub.search.serializers import SingleOrListField
+from datahub.search.test.utils import model_has_field_path
 
 
 class TestSingleOrListField:
@@ -32,3 +33,19 @@ class TestSingleOrListField:
             field.run_validation(['', ''])
 
         assert excinfo.value.get_codes() == {0: ['blank'], 1: ['blank']}
+
+
+class TestSerializerAttributes:
+    """Validates the field names specified in class attributes on serialiser classes."""
+
+    def test_sort_by_fields(self, search_app):
+        """Validate that the values of SORT_BY_FIELDS are valid field paths."""
+        view = search_app.view
+
+        invalid_fields = {
+            field
+            for field in view.serializer_class.SORT_BY_FIELDS
+            if not model_has_field_path(search_app.es_model, field)
+        }
+
+        assert not invalid_fields

--- a/datahub/search/test/utils.py
+++ b/datahub/search/test/utils.py
@@ -1,0 +1,20 @@
+from elasticsearch_dsl import AttrDict
+
+from datahub.search.utils import get_model_fields
+
+
+def model_has_field_path(es_model, path):
+    """Checks whether a field path (e.g. company.id) exists in a model."""
+    path_components = path.split('.')
+    fields = get_model_fields(es_model)
+
+    for sub_field_name in path_components:
+        if sub_field_name not in fields:
+            return False
+
+        sub_field = fields.get(sub_field_name)
+        fields = getattr(sub_field, 'properties', AttrDict({})).to_dict()
+        if not fields:
+            fields = getattr(sub_field, 'fields', {})
+
+    return True


### PR DESCRIPTION
Issue number: N/A

### Description of change

Corrects a couple of typos in the SORT_BY_FIELDS values for search. (Of course, this means that they aren't being used, but I'll leave reviewing the lists for a future exercise.)

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
