### PR TITLE
Add the ability to restrict access to the admin site by IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 
 | Variable name | Required | Description |
 | ------------- | ------------- | ------------- |
+| `ALLOWED_ADMIN_IPS` | No | IP addresses (comma-separated) that can access the admin site when RESTRICT_ADMIN is True. |
+| `ALLOWED_ADMIN_IP_RANGES` | No | IP address ranges (comma-separated) that can access the admin site when RESTRICT_ADMIN is True. |
 | `AV_SERVICE_URL` | Yes | URL for ClamAV service. If not configured, virus scanning will fail. |
 | `AWS_ACCESS_KEY_ID` | No | Used as part of [boto3 auto-configuration](http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials). |
 | `AWS_DEFAULT_REGION` | No | [Default region used by boto3.](http://boto3.readthedocs.io/en/latest/guide/configuration.html#environment-variable-configuration) |
@@ -239,6 +241,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `REDIS_CELERY_DB`  | No | redis db for celery (default 1) |
 | `RESOURCE_SERVER_INTROSPECTION_URL` | If SSO enabled | RFC 7662 token introspection URL used for signle sign-on |
 | `RESOURCE_SERVER_AUTH_TOKEN` | If SSO enabled | Access token for RFC 7662 token introspection server |
+| `RESTRICT_ADMIN` | No | Whether to restrict access to the admin site by IP address. |
 | `SENTRY_ENVIRONMENT`  | Yes | Value for the environment tag in Sentry. |
 | `SSO_ENABLED` | Yes | Whether single sign-on via RFC 7662 token introspection is enabled |
 | `WEB_CONCURRENCY` | No | Number of Gunicorn workers (set automatically by Heroku, otherwise defaults to 1). |

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -89,6 +89,7 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'admin_ip_restrictor.middleware.AdminIPRestrictorMiddleware',
     'datahub.core.reversion.NonAtomicRevisionMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware'
 ]
@@ -149,6 +150,13 @@ AUTH_USER_MODEL = 'company.Advisor'
 AUTHENTICATION_BACKENDS = [
     'datahub.core.auth.TeamModelPermissionsBackend'
 ]
+
+
+# django-admin-ip-restrictor
+
+RESTRICT_ADMIN = env.bool('RESTRICT_ADMIN', False)
+ALLOWED_ADMIN_IPS = env.list('ALLOWED_ADMIN_IPS', default=[])
+ALLOWED_ADMIN_IP_RANGES = env.list('ALLOWED_ADMIN_IP_RANGES', default=[])
 
 # django-oauth-toolkit settings
 

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ cssselect==1.0.3
 # Django and django related
 Django==2.0.4
 djangorestframework==3.8.2
+django-admin-ip-restrictor==0.2.1
 django-environ==0.4.4
 django-extensions==2.0.6
 django-filter==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ aws-requests-auth==0.4.1
 backcall==0.1.0           # via ipython
 billiard==3.5.0.3         # via celery
 boto3==1.7.4
-botocore==1.10.4          # via boto3, s3transfer
+botocore==1.10.8          # via boto3, s3transfer
 celery==4.1.0
 certifi==2018.4.16        # via requests
 chardet==3.0.4            # via chardet, requests
@@ -19,11 +19,13 @@ click==6.7                # via click, pip-tools
 coverage==4.5.1           # via pytest-cov
 cssselect==1.0.3
 decorator==4.3.0          # via ipython, traitlets
+django-admin-ip-restrictor==0.2.1
 django-debug-toolbar==1.9.1
 django-environ==0.4.4
 django-extensions==2.0.6
 django-filter==1.1.0
-django-js-asset==1.0.0    # via django-mptt
+django-ipware==2.1.0      # via django-admin-ip-restrictor
+django-js-asset==1.1.0    # via django-mptt
 django-model-utils==3.1.1
 django-mptt==0.9.0
 django-oauth-toolkit==1.1.0


### PR DESCRIPTION
Issue number: DH-1661

### Description of change

Currently the only place we can apply IP restrictions is in the app layer, so this takes a similar approach to other DIT applications (such as directory-api).

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
