### PR TITLE
Add environment variable to enable/disable daily ES sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `DJANGO_SENTRY_DSN`  | Yes | |
 | `DJANGO_SETTINGS_MODULE`  | Yes | |
 | `DOCUMENTS_BUCKET`  | Yes | S3 bucket for document storage. |
+| `ENABLE_DAILY_ES_SYNC` | No | Whether to enable the daily ES sync (default=False). |
 | `ES_INDEX`  | Yes | |
 | `ES_URL`  | Yes | |
 | `ES_VERIFY_CERTS`  | No | |

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -276,11 +276,13 @@ if REDIS_BASE_URL:
                 'age_check': 60  # in minutes
             }
         },
-        'sync_es': {
+    }
+    if env.bool('ENABLE_DAILY_ES_SYNC', False):
+        CELERY_BEAT_SCHEDULE['sync_es'] = {
             'task': 'datahub.search.tasks.sync_all_models',
             'schedule': crontab(minute=0, hour=1),
-        },
-    }
+        }
+
     CELERY_WORKER_LOG_FORMAT = (
         "[%(asctime)s: %(levelname)s/%(processName)s] [%(name)s] %(message)s"
     )


### PR DESCRIPTION
Issue number: N/A

### Description of change

Adds an environment variable to control whether the daily ES sync is enabled (so that it can be disabled while some performance problems are investigated).

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
