### PR TITLE
Use a server-side database cursor when bulk syncing items to Elasticsearch

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -120,6 +120,7 @@ DATABASES = {
         **env.db('DATABASE_URL'),
         'ATOMIC_REQUESTS': True,
         'CONN_MAX_AGE': env.int('DATABASE_CONN_MAX_AGE', 0),
+        'DISABLE_SERVER_SIDE_CURSORS': False,
     }
 }
 

--- a/datahub/company/management/commands/sync_ch.py
+++ b/datahub/company/management/commands/sync_ch.py
@@ -229,7 +229,7 @@ class CHSynchroniser:
             ch_company_rows = iter_ch_csv_from_url(csv_url, tmp_file_creator)
 
             batch_iter = slice_iterable_into_chunks(
-                ch_company_rows, settings.BULK_INSERT_BATCH_SIZE, lambda x: x
+                ch_company_rows, settings.BULK_INSERT_BATCH_SIZE
             )
             with connection.cursor() as cursor:
                 for batch in batch_iter:

--- a/datahub/core/test/test_audit.py
+++ b/datahub/core/test/test_audit.py
@@ -5,6 +5,7 @@ import pytest
 from reversion.models import Version
 
 from datahub.core.audit import AuditViewSet
+from datahub.core.test_utils import MockQuerySet
 
 
 def test_audit_log_diff_algo():
@@ -63,24 +64,13 @@ def test_audit_log_pagination(num_versions, offset, limit, exp_results, exp_next
     assert [result['id'] for result in results] == list(exp_results)
 
 
-class _VersionQuerySetStub:
+class _VersionQuerySetStub(MockQuerySet):
     """VersionQuerySet stub."""
 
     def __init__(self, count):
         """Initialises the instance, creating some stub version instances to return as results."""
-        self.items = [MagicMock(id=n) for n in range(count)]
-
-    def __getitem__(self, item):
-        """Returns items from the fake data generated."""
-        return self.items[item]
-
-    def __len__(self):
-        """Returns the number of items generated."""
-        return len(self.items)
-
-    def count(self):
-        """Returns the number of items generated."""
-        return len(self.items)
+        items = [MagicMock(id=n) for n in range(count)]
+        super().__init__(items)
 
 
 def _create_get_for_object_stub(num_versions):

--- a/datahub/core/test/test_utils.py
+++ b/datahub/core/test/test_utils.py
@@ -9,8 +9,6 @@ from datahub.core.utils import (
     join_truthy_strings, load_constants_to_database, slice_iterable_into_chunks
 )
 
-pytestmark = pytest.mark.django_db
-
 
 @pytest.mark.parametrize(
     'args,sep,res',
@@ -36,6 +34,14 @@ def test_slice_iterable_into_chunks():
     assert len(chunks) == 10
 
 
+def test_slice_iterable_into_chunks_default_obj_creator():
+    """Test slice iterable into chunks using the default object creator."""
+    size = 2
+    iterable = range(5)
+    chunks = list(slice_iterable_into_chunks(iterable, size))
+    assert list(chunks) == [[0, 1], [2, 3], [4]]
+
+
 class _MetadataModelConstant(Enum):
     object_2 = Constant('Object 2a', 'c2ed6ff6-4a09-41ba-bda2-f4cdb2f96833')
     object_3 = Constant('Object 3b', '09afd6ef-deff-4b0f-9c5b-4816d3ddac09')
@@ -43,6 +49,7 @@ class _MetadataModelConstant(Enum):
     object_5 = Constant('Object 5', '6ea0e2a2-0b2b-408c-a621-aff49f58496e')
 
 
+@pytest.mark.django_db
 def test_load_constants_to_database():
     """
     Test loading constants to the database.

--- a/datahub/core/test/test_utils.py
+++ b/datahub/core/test/test_utils.py
@@ -28,18 +28,10 @@ def test_join_truthy_strings(args, sep, res):
 
 def test_slice_iterable_into_chunks():
     """Test slice iterable into chunks."""
-    size = 10
-    iterable = range(100)
-    chunks = list(slice_iterable_into_chunks(iterable, size, lambda x: x))
-    assert len(chunks) == 10
-
-
-def test_slice_iterable_into_chunks_default_obj_creator():
-    """Test slice iterable into chunks using the default object creator."""
     size = 2
     iterable = range(5)
     chunks = list(slice_iterable_into_chunks(iterable, size))
-    assert list(chunks) == [[0, 1], [2, 3], [4]]
+    assert chunks == [[0, 1], [2, 3], [4]]
 
 
 class _MetadataModelConstant(Enum):

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -176,3 +176,31 @@ def random_obj_for_model(model):
 def random_obj_for_queryset(queryset):
     """Returns a random object for a queryset."""
     return queryset.order_by('?').first()
+
+
+class MockQuerySet:
+    """Mock version of QuerySet that represents a fixed set of items."""
+
+    def __init__(self, items):
+        """Initialises the mock query set."""
+        self._items = items
+
+    def __getitem__(self, item):
+        """Returns an item."""
+        return self._items[item]
+
+    def __iter__(self):
+        """Returns an iterator over the query set items."""
+        return iter(self._items)
+
+    def __len__(self):
+        """Returns the number of items in the query set."""
+        return len(self._items)
+
+    def iterator(self, chunk_size=None):
+        """Returns an iterator over the query set items."""
+        return iter(self._items)
+
+    def count(self):
+        """Returns the number of items in the query set."""
+        return len(self._items)

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -38,12 +38,12 @@ def stream_to_file_pointer(url, fp):
         fp.write(chunk)
 
 
-def slice_iterable_into_chunks(iterable, batch_size, obj_creator=lambda x: x):
+def slice_iterable_into_chunks(iterable, batch_size):
     """Collect data into fixed-length chunks or blocks."""
     iterator = iter(iterable)
     while True:
         batch_iter = islice(iterator, batch_size)
-        objects = [obj_creator(row) for row in batch_iter]
+        objects = [row for row in batch_iter]
         if not objects:
             break
         yield objects

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -38,7 +38,7 @@ def stream_to_file_pointer(url, fp):
         fp.write(chunk)
 
 
-def slice_iterable_into_chunks(iterable, batch_size, obj_creator):
+def slice_iterable_into_chunks(iterable, batch_size, obj_creator=lambda x: x):
     """Collect data into fixed-length chunks or blocks."""
     iterator = iter(iterable)
     while True:

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -4,8 +4,6 @@ from importlib import import_module
 from django.apps import AppConfig
 from django.conf import settings
 
-from .models import DataSet
-
 
 SEARCH_APPS = [
     'datahub.search.companieshousecompany.CompaniesHouseCompanySearchApp',
@@ -26,6 +24,7 @@ class SearchApp:
 
     name = None
     es_model = None
+    bulk_batch_size = 2000
     view = None
     export_view = None
     queryset = None
@@ -56,10 +55,6 @@ class SearchApp:
         signals_mod = import_module(self.mod_signals)
         for receiver in signals_mod.receivers:
             receiver.disconnect()
-
-    def get_dataset(self):
-        """Returns dataset that will be synchronised with Elasticsearch."""
-        return DataSet(self.queryset, self.es_model)
 
     def get_permission_filters(self, request):
         """

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -57,15 +57,9 @@ class SearchApp:
         for receiver in signals_mod.receivers:
             receiver.disconnect()
 
-    def get_queryset(self):
-        """Gets the queryset that will be synced with Elasticsearch."""
-        return self.queryset.order_by('pk')
-
     def get_dataset(self):
         """Returns dataset that will be synchronised with Elasticsearch."""
-        queryset = self.get_queryset()
-
-        return DataSet(queryset, self.es_model)
+        return DataSet(self.queryset, self.es_model)
 
     def get_permission_filters(self, request):
         """

--- a/datahub/search/companieshousecompany/apps.py
+++ b/datahub/search/companieshousecompany/apps.py
@@ -11,6 +11,6 @@ class CompaniesHouseCompanySearchApp(SearchApp):
     es_model = CompaniesHouseCompany
     view = SearchCompaniesHouseCompanyAPIView
     permission_required = ('company.read_companieshousecompany',)
-    queryset = DBCompaniesHouseCompany.objects.prefetch_related(
+    queryset = DBCompaniesHouseCompany.objects.select_related(
         'registered_address_country',
     )

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -12,16 +12,13 @@ class CompanySearchApp(SearchApp):
     view = SearchCompanyAPIView
     export_view = SearchCompanyExportAPIView
     permission_required = ('company.read_company',)
-    queryset = DBCompany.objects.prefetch_related(
+    queryset = DBCompany.objects.select_related(
         'account_manager',
         'archived_by',
         'business_type',
         'classification',
-        'contacts',
         'employee_range',
         'export_experience_category',
-        'export_to_countries',
-        'future_interest_countries',
         'headquarter_type',
         'one_list_account_owner',
         'parent',

--- a/datahub/search/contact/apps.py
+++ b/datahub/search/contact/apps.py
@@ -12,7 +12,7 @@ class ContactSearchApp(SearchApp):
     view = SearchContactAPIView
     export_view = SearchContactExportAPIView
     permission_required = ('company.read_contact',)
-    queryset = DBContact.objects.prefetch_related(
+    queryset = DBContact.objects.select_related(
         'title',
         'company',
         'adviser',

--- a/datahub/search/event/apps.py
+++ b/datahub/search/event/apps.py
@@ -12,14 +12,12 @@ class EventSearchApp(SearchApp):
     view = SearchEventAPIView
     export_view = SearchEventExportAPIView
     permission_required = ('event.read_event',)
-    queryset = DBEvent.objects.prefetch_related(
+    queryset = DBEvent.objects.select_related(
         'address_country',
         'event_type',
         'location_type',
         'organiser',
         'lead_team',
-        'related_programmes',
-        'teams',
         'uk_region',
         'service',
     )

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -13,7 +13,7 @@ class InteractionSearchApp(SearchApp):
     view = SearchInteractionAPIView
     export_view = SearchInteractionExportAPIView
     permission_required = (f'interaction.{InteractionPermission.read_all}',)
-    queryset = DBInteraction.objects.prefetch_related(
+    queryset = DBInteraction.objects.select_related(
         'company',
         'company__sector',
         'company__sector__parent',

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -1,9 +1,6 @@
-from django.db.models import Prefetch
-
 from datahub.investment.models import (
     InvestmentProject as DBInvestmentProject,
     InvestmentProjectPermission,
-    InvestmentProjectTeamMember as DBInvestmentProjectTeamMember,
 )
 from datahub.investment.permissions import (
     get_association_filters, InvestmentProjectAssociationChecker
@@ -24,15 +21,10 @@ class InvestmentSearchApp(SearchApp):
         f'investment.{InvestmentProjectPermission.read_all}',
         f'investment.{InvestmentProjectPermission.read_associated}'
     )
-    queryset = DBInvestmentProject.objects.prefetch_related(
-        'actual_uk_regions',
+    queryset = DBInvestmentProject.objects.select_related(
         'archived_by',
         'average_salary',
-        'business_activities',
-        'client_contacts',
         'client_relationship_manager',
-        'competitor_countries',
-        'delivery_partners',
         'fdi_type',
         'intermediate_company',
         'investment_type',
@@ -50,12 +42,8 @@ class InvestmentSearchApp(SearchApp):
         'sector__parent',
         'sector__parent__parent',
         'specific_programme',
-        'strategic_drivers',
         'stage',
         'uk_company',
-        'uk_region_locations',
-        Prefetch('team_members',
-                 queryset=DBInvestmentProjectTeamMember.objects.prefetch_related('adviser')),
     )
 
     def get_permission_filters(self, request):

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -15,6 +15,11 @@ class InvestmentSearchApp(SearchApp):
 
     name = 'investment_project'
     es_model = InvestmentProject
+    # Investment project documents are very large, so the bulk_batch_size is set to a lower value
+    # to keep bulk requests below 10 MB.
+    # (In some environments, the maximum ES request size is 10 MB. This is dependent on the AWS
+    # EC2 instance type.)
+    bulk_batch_size = 1000
     view = SearchInvestmentProjectAPIView
     export_view = SearchInvestmentProjectExportAPIView
     permission_required = (

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -2,16 +2,16 @@ from logging import getLogger, WARNING
 
 from django.core.management.base import BaseCommand
 
-from datahub.search.bulk_sync import DEFAULT_BATCH_SIZE, get_datasets, sync_dataset
+from datahub.search.bulk_sync import get_apps_to_sync, sync_app
 from ...apps import get_search_apps
 
 logger = getLogger(__name__)
 
 
-def sync_es(batch_size, datasets):
+def sync_es(batch_size, search_apps):
     """Sends data to Elasticsearch."""
-    for item in datasets:
-        sync_dataset(item, batch_size=batch_size)
+    for app in search_apps:
+        sync_app(app, batch_size=batch_size)
 
     logger.info('Elasticsearch sync complete!')
 
@@ -24,8 +24,8 @@ class Command(BaseCommand):
         parser.add_argument(
             '--batch_size',
             type=int,
-            default=DEFAULT_BATCH_SIZE,
-            help='Batch size - number of rows processed at a time',
+            help='Batch size - number of rows processed at a time (defaults to per-model '
+                 'defaults)',
         )
         parser.add_argument(
             '--model',
@@ -41,5 +41,5 @@ class Command(BaseCommand):
 
         sync_es(
             batch_size=options['batch_size'],
-            datasets=get_datasets(options['model'])
+            search_apps=get_apps_to_sync(options['model'])
         )

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -23,13 +23,12 @@ class Command(BaseCommand):
         """Handle arguments."""
         parser.add_argument(
             '--batch_size',
-            dest='batch_size',
+            type=int,
             default=DEFAULT_BATCH_SIZE,
             help='Batch size - number of rows processed at a time',
         )
         parser.add_argument(
             '--model',
-            dest='model',
             action='append',
             choices=[search_app.name for search_app in get_search_apps()],
             help='Search model to import. If empty, it imports all',

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -1,11 +1,7 @@
-from collections import namedtuple
-
 from django.conf import settings
 from elasticsearch_dsl import DocType, MetaField
 
 from datahub.search.utils import get_model_non_mapped_field_names
-
-DataSet = namedtuple('DataSet', ('queryset', 'es_model',))
 
 
 class BaseESModel(DocType):

--- a/datahub/search/omis/apps.py
+++ b/datahub/search/omis/apps.py
@@ -11,13 +11,10 @@ class OrderSearchApp(SearchApp):
     es_model = Order
     view = SearchOrderAPIView
     permission_required = ('order.read_order',)
-    queryset = DBOrder.objects.prefetch_related(
+    queryset = DBOrder.objects.select_related(
         'company',
         'contact',
         'created_by',
         'primary_market',
         'sector',
-        'service_types',
-        'subscribers',
-        'assignees',
     )

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -1,7 +1,7 @@
 from celery import shared_task
 
 from datahub.search.apps import get_search_app, SEARCH_APPS
-from datahub.search.bulk_sync import sync_dataset
+from datahub.search.bulk_sync import sync_app
 
 
 @shared_task(acks_late=True, priority=9)
@@ -29,4 +29,4 @@ def sync_model(search_app_cls_path):
     priority is set to the lowest priority (for Redis, 0 is the highest priority).
     """
     search_app = get_search_app(search_app_cls_path)
-    sync_dataset(search_app.get_dataset())
+    sync_app(search_app)

--- a/datahub/search/test/commands/test_sync_es.py
+++ b/datahub/search/test/commands/test_sync_es.py
@@ -14,11 +14,11 @@ from ...investment.models import InvestmentProject as ESInvestmentProject
 
 
 @mock.patch('datahub.search.bulk_sync.bulk')
-@mock.patch('datahub.search.management.commands.sync_es.get_datasets')
+@mock.patch('datahub.search.management.commands.sync_es.get_apps_to_sync')
 @pytest.mark.django_db
-def test_sync_dataset(get_datasets, bulk):
-    """Tests syncing dataset up to Elasticsearch."""
-    get_datasets.return_value = (
+def test_sync_es(get_apps_to_sync, bulk):
+    """Tests syncing app to Elasticsearch."""
+    get_apps_to_sync.return_value = (
         mock.Mock(queryset=MockQuerySet([CompanyFactory(), CompanyFactory()]), es_model=ESCompany),
         mock.Mock(queryset=MockQuerySet([ContactFactory()]), es_model=ESContact),
         mock.Mock(
@@ -36,31 +36,31 @@ def test_sync_dataset(get_datasets, bulk):
     'search_model',
     (app.name for app in get_search_apps())
 )
-@mock.patch('datahub.search.management.commands.sync_es.sync_dataset')
-def test_sync_one_model(sync_dataset_mock, search_model):
+@mock.patch('datahub.search.management.commands.sync_es.sync_app')
+def test_sync_one_model(sync_app_mock, search_model):
     """
     Test that --model can be used to specify what we weant to sync.
     """
     management.call_command(sync_es.Command(), model=[search_model])
 
-    assert sync_dataset_mock.call_count == 1
+    assert sync_app_mock.call_count == 1
 
 
-@mock.patch('datahub.search.management.commands.sync_es.sync_dataset')
-def test_sync_all_models(sync_dataset_mock):
+@mock.patch('datahub.search.management.commands.sync_es.sync_app')
+def test_sync_all_models(sync_app_mock):
     """
     Test that if --model is not used, all the search apps are synced.
     """
     management.call_command(sync_es.Command())
 
-    assert sync_dataset_mock.call_count == len(get_search_apps())
+    assert sync_app_mock.call_count == len(get_search_apps())
 
 
-@mock.patch('datahub.search.management.commands.sync_es.sync_dataset')
-def test_sync_invalid_model(sync_dataset_mock):
+@mock.patch('datahub.search.management.commands.sync_es.sync_app')
+def test_sync_invalid_model(sync_app_mock):
     """
     Test that if an invalid value is used with --model, nothing gets synced.
     """
     management.call_command(sync_es.Command(), model='invalid')
 
-    assert sync_dataset_mock.call_count == 0
+    assert sync_app_mock.call_count == 0

--- a/datahub/search/test/commands/test_sync_es.py
+++ b/datahub/search/test/commands/test_sync_es.py
@@ -4,25 +4,27 @@ import pytest
 from django.core import management
 
 from datahub.company.test.factories import CompanyFactory, ContactFactory
+from datahub.core.test_utils import MockQuerySet
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.search.management.commands import sync_es
 from ...apps import get_search_apps
 from ...company.models import Company as ESCompany
 from ...contact.models import Contact as ESContact
 from ...investment.models import InvestmentProject as ESInvestmentProject
-from ...models import DataSet
-
-pytestmark = pytest.mark.django_db
 
 
 @mock.patch('datahub.search.bulk_sync.bulk')
 @mock.patch('datahub.search.management.commands.sync_es.get_datasets')
-def test_sync_dataset(get_datasets, bulk, setup_es):
+@pytest.mark.django_db
+def test_sync_dataset(get_datasets, bulk):
     """Tests syncing dataset up to Elasticsearch."""
     get_datasets.return_value = (
-        DataSet([CompanyFactory(), CompanyFactory()], ESCompany),
-        DataSet([ContactFactory()], ESContact),
-        DataSet([InvestmentProjectFactory()], ESInvestmentProject)
+        mock.Mock(queryset=MockQuerySet([CompanyFactory(), CompanyFactory()]), es_model=ESCompany),
+        mock.Mock(queryset=MockQuerySet([ContactFactory()]), es_model=ESContact),
+        mock.Mock(
+            queryset=MockQuerySet([InvestmentProjectFactory()]),
+            es_model=ESInvestmentProject,
+        )
     )
 
     management.call_command(sync_es.Command(), batch_size=1)
@@ -34,31 +36,31 @@ def test_sync_dataset(get_datasets, bulk, setup_es):
     'search_model',
     (app.name for app in get_search_apps())
 )
-@mock.patch('datahub.search.bulk_sync.bulk')
-def test_sync_one_model(bulk, setup_es, search_model):
+@mock.patch('datahub.search.management.commands.sync_es.sync_dataset')
+def test_sync_one_model(sync_dataset_mock, search_model):
     """
     Test that --model can be used to specify what we weant to sync.
     """
     management.call_command(sync_es.Command(), model=[search_model])
 
-    assert bulk.call_count == 1
+    assert sync_dataset_mock.call_count == 1
 
 
-@mock.patch('datahub.search.bulk_sync.bulk')
-def test_sync_all_models(bulk, setup_es):
+@mock.patch('datahub.search.management.commands.sync_es.sync_dataset')
+def test_sync_all_models(sync_dataset_mock):
     """
     Test that if --model is not used, all the search apps are synced.
     """
     management.call_command(sync_es.Command())
 
-    assert bulk.call_count == len(get_search_apps())
+    assert sync_dataset_mock.call_count == len(get_search_apps())
 
 
-@mock.patch('datahub.search.bulk_sync.bulk')
-def test_sync_invalid_model(bulk, setup_es):
+@mock.patch('datahub.search.management.commands.sync_es.sync_dataset')
+def test_sync_invalid_model(sync_dataset_mock):
     """
     Test that if an invalid value is used with --model, nothing gets synced.
     """
     management.call_command(sync_es.Command(), model='invalid')
 
-    assert bulk.call_count == 0
+    assert sync_dataset_mock.call_count == 0

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -1,22 +1,35 @@
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
 from datahub.company.test.factories import CompanyFactory
 from datahub.core.test_utils import MockQuerySet
-from datahub.search.bulk_sync import sync_dataset
+from datahub.search.bulk_sync import sync_app
 from datahub.search.company.models import Company as ESCompany
 
 pytestmark = pytest.mark.django_db
 
 
 @patch('datahub.search.bulk_sync.bulk')
-def test_sync_dataset(bulk):
+def test_sync_app_with_default_batch_size(bulk):
+    """Tests syncing a data set to Elasticsearch."""
+    data_set = Mock(
+        queryset=MockQuerySet([CompanyFactory(), CompanyFactory()]),
+        es_model=ESCompany,
+        bulk_batch_size=100,
+    )
+    sync_app(data_set)
+
+    assert bulk.call_count == 1
+
+
+@patch('datahub.search.bulk_sync.bulk')
+def test_sync_app_with_overridden_batch_size(bulk):
     """Tests syncing a data set to Elasticsearch."""
     data_set = Mock(
         queryset=MockQuerySet([CompanyFactory(), CompanyFactory()]),
         es_model=ESCompany,
     )
-    sync_dataset(data_set, batch_size=1)
+    sync_app(data_set, batch_size=1)
 
     assert bulk.call_count == 2

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -1,12 +1,22 @@
-from datahub.search.bulk_sync import _batch_rows
+from unittest.mock import patch, Mock
+
+import pytest
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.test_utils import MockQuerySet
+from datahub.search.bulk_sync import sync_dataset
+from datahub.search.company.models import Company as ESCompany
+
+pytestmark = pytest.mark.django_db
 
 
-def test_batch_rows():
-    """Tests _batch_rows."""
-    rows = ({}, {}, {})
+@patch('datahub.search.bulk_sync.bulk')
+def test_sync_dataset(bulk):
+    """Tests syncing a data set to Elasticsearch."""
+    data_set = Mock(
+        queryset=MockQuerySet([CompanyFactory(), CompanyFactory()]),
+        es_model=ESCompany,
+    )
+    sync_dataset(data_set, batch_size=1)
 
-    res = list(_batch_rows(rows, batch_size=2))
-
-    assert len(res) == 2
-    assert len(res[0]) == 2
-    assert len(res[1]) == 1
+    assert bulk.call_count == 2

--- a/datahub/search/test/test_tasks.py
+++ b/datahub/search/test/test_tasks.py
@@ -9,16 +9,14 @@ def test_sync_model(monkeypatch):
     get_search_app_mock = Mock()
     monkeypatch.setattr('datahub.search.tasks.get_search_app', get_search_app_mock)
 
-    sync_dataset_mock = Mock()
-    monkeypatch.setattr('datahub.search.tasks.sync_dataset', sync_dataset_mock)
+    sync_app_mock = Mock()
+    monkeypatch.setattr('datahub.search.tasks.sync_app', sync_app_mock)
 
     search_app_path = SEARCH_APPS[0]
     sync_model.apply(args=(search_app_path,))
 
     get_search_app_mock.assert_called_once_with(search_app_path)
-    sync_dataset_mock.assert_called_once_with(
-        get_search_app_mock.return_value.get_dataset.return_value
-    )
+    sync_app_mock.assert_called_once_with(get_search_app_mock.return_value)
 
 
 def test_sync_all_models(monkeypatch):


### PR DESCRIPTION
Issue number: N/A

### Description of change

This significantly speeds up syncing very large data sets, and reduces load on the database server. The previous limit and offset method for iterating through a large query set became significantly slower as the offset got larger (placing a lot of strain on the database server).

Django does not support prefetching data when using server-side cursors, so this removes prefetches for to-many fields (and switches other fields to select-related). (For that reason, this method may be slightly slower for small data sets.)

No undesirable side effects (such as row or table locking) have been observed while a cursor is open.

This also configures the default batch size to vary per model, as the document sizes for different models will vary.

Lastly, DataSet was removed as it was adding complexity and didn't seem like it was giving us much benefit after the other changes.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
