### PR TITLE
Make communication channel invalid for policy feedback interactions

### DIFF
--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -25,9 +25,6 @@ class InteractionSerializer(serializers.ModelSerializer):
         'invalid_for_non_service_delivery': ugettext_lazy(
             'This field is only valid for service deliveries.'
         ),
-        'invalid_for_service_delivery': ugettext_lazy(
-            'This field is not valid for service deliveries.'
-        ),
         'invalid_for_non_interaction': ugettext_lazy(
             'This field is only valid for interactions.'
         ),
@@ -123,7 +120,6 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('communication_channel', bool),
                     when=InRule('kind', [
                         Interaction.KINDS.interaction,
-                        Interaction.KINDS.policy_feedback
                     ]),
                 ),
                 ValidationRule(
@@ -135,9 +131,12 @@ class InteractionSerializer(serializers.ModelSerializer):
                     ]),
                 ),
                 ValidationRule(
-                    'invalid_for_service_delivery',
+                    'invalid_for_non_interaction',
                     OperatorRule('communication_channel', not_),
-                    when=EqualsRule('kind', Interaction.KINDS.service_delivery),
+                    when=InRule('kind', [
+                        Interaction.KINDS.service_delivery,
+                        Interaction.KINDS.policy_feedback,
+                    ]),
                 ),
                 ValidationRule(
                     'invalid_for_non_service_delivery',

--- a/datahub/interaction/test/views/test_policy_feedback.py
+++ b/datahub/interaction/test/views/test_policy_feedback.py
@@ -28,12 +28,10 @@ class TestAddPolicyFeedback(APITestMixin):
         contact = ContactFactory()
         policy_area = random_obj_for_model(PolicyArea)
         policy_issue_type = random_obj_for_model(PolicyIssueType)
-        communication_channel = random_obj_for_model(CommunicationChannel)
 
         url = reverse('api-v3:interaction:collection')
         request_data = {
             'kind': Interaction.KINDS.policy_feedback,
-            'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
@@ -62,10 +60,7 @@ class TestAddPolicyFeedback(APITestMixin):
             'policy_issue_type': {
                 'id': str(policy_issue_type.pk), 'name': policy_issue_type.name
             },
-            'communication_channel': {
-                'id': str(communication_channel.pk),
-                'name': communication_channel.name
-            },
+            'communication_channel': None,
             'subject': 'whatever',
             'date': '2017-04-18',
             'dit_adviser': {
@@ -146,7 +141,6 @@ class TestAddPolicyFeedback(APITestMixin):
                 {
                     'policy_area': ['This field is required.'],
                     'policy_issue_type': ['This field is required.'],
-                    'communication_channel': ['This field is required.'],
                 }
             ),
 
@@ -185,6 +179,7 @@ class TestAddPolicyFeedback(APITestMixin):
                     ],
                     'grant_amount_offered': ['This field is only valid for service deliveries.'],
                     'net_company_receipt': ['This field is only valid for service deliveries.'],
+                    'communication_channel': ['This field is only valid for interactions.'],
                     'investment_project': ['This field is only valid for interactions.']
                 }
             ),

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -188,7 +188,7 @@ class TestAddServiceDelivery(APITestMixin):
                     'investment_project': InvestmentProjectFactory,
                 },
                 {
-                    'communication_channel': ['This field is not valid for service deliveries.'],
+                    'communication_channel': ['This field is only valid for interactions.'],
                     'policy_area': ['This field is only valid for policy feedback.'],
                     'policy_issue_type': ['This field is only valid for policy feedback.'],
                     'investment_project': ['This field is only valid for interactions.']


### PR DESCRIPTION
Issue number: N/A

### Description of change

Communication channel isn't meant to be part of the form for policy feedback. (The test data was already correct.)

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
