### PR TITLE
Add generic API client and Hawk request signing for requests to other APIs

### DIFF
--- a/datahub/core/api_client.py
+++ b/datahub/core/api_client.py
@@ -1,0 +1,39 @@
+from logging import getLogger
+from urllib.parse import urljoin
+
+import requests
+
+
+logger = getLogger(__name__)
+
+
+class APIClient:
+    """Generic API client."""
+
+    # Prefer JSON to other content types
+    DEFAULT_ACCEPT = 'application/json;q=0.9,*/*;q=0.8'
+
+    def __init__(self, api_url, auth=None, accept=DEFAULT_ACCEPT, default_timeout=None):
+        """Initialises the API client."""
+        self._api_url = api_url
+        self._auth = auth
+        self._accept = accept
+        self._default_timeout = default_timeout
+
+    def request(self, method, path, **kwargs):
+        """Makes an HTTP request."""
+        url = urljoin(self._api_url, path)
+        logger.info(f'Sending request: {method.upper()} {url}')
+
+        timeout = kwargs.pop('timeout', self._default_timeout)
+
+        headers = {}
+        if self._accept:
+            headers['Accept'] = self._accept
+
+        response = requests.request(
+            method, url, auth=self._auth, headers=headers, timeout=timeout, **kwargs
+        )
+        logger.info(f'Response received: {response.status_code} {method.upper()} {url}')
+        response.raise_for_status()
+        return response

--- a/datahub/core/api_client.py
+++ b/datahub/core/api_client.py
@@ -2,9 +2,55 @@ from logging import getLogger
 from urllib.parse import urljoin
 
 import requests
+from mohawk import Sender
+from requests.auth import AuthBase
 
 
 logger = getLogger(__name__)
+
+
+class HawkAuth(AuthBase):
+    """Hawk authentication class."""
+
+    def __init__(self, api_id, api_key, signing_algorithm='sha256', verify_response=True):
+        """Initialises the authenticator with the signing parameters."""
+        self._api_id = api_id
+        self._api_key = api_key
+        self._signing_algorithm = signing_algorithm
+        self._verify_response = verify_response
+
+    def __call__(self, request):
+        """Signs a request, and attaches a response verifier."""
+        credentials = {
+            'id': self._api_id,
+            'key': self._api_key,
+            'algorithm': self._signing_algorithm,
+        }
+
+        sender = Sender(
+            credentials,
+            request.url,
+            request.method,
+            content=request.body or '',
+            content_type=request.headers.get('Content-Type', '')
+        )
+
+        request.headers['Authorization'] = sender.request_header
+        if self._verify_response:
+            request.register_hook('response', _make_response_verifier(sender))
+
+        return request
+
+
+def _make_response_verifier(sender):
+    def verify_response(response, *args, **kwargs):
+        if response.ok:
+            sender.accept_response(
+                response.headers['Server-Authorization'],
+                content=response.content,
+                content_type=response.headers['Content-Type'],
+            )
+    return verify_response
 
 
 class APIClient:

--- a/datahub/core/test/test_api_client.py
+++ b/datahub/core/test/test_api_client.py
@@ -1,8 +1,52 @@
+import re
+from unittest.mock import Mock
+
 import pytest
+from freezegun import freeze_time
 from requests import HTTPError
 from requests.auth import HTTPBasicAuth
 
-from datahub.core.api_client import APIClient
+from datahub.core.api_client import APIClient, HawkAuth
+
+
+class TestHawkAuth:
+    """Tests HawkAuth."""
+
+    @freeze_time('2018-01-01 00:00:00')
+    def test_requests_with_no_body_are_signed(self):
+        """Tests that requests without a body are signed."""
+        auth = HawkAuth('test-id', 'test-key')
+        request = Mock(method='GET', url='http://test.com/test', body=None, headers={})
+        auth(request)
+
+        pattern = re.compile('Hawk mac=".*", hash=".*", id="test-id", ts="1514764800", nonce=".*"')
+        assert pattern.match(request.headers['Authorization'])
+
+    def test_exception_raised_if_response_fails_verification(self, monkeypatch):
+        """Test that responses are verified when response verification is enabled."""
+        accept_response_mock = Mock(side_effect=ValueError())
+        monkeypatch.setattr('mohawk.Sender.accept_response', accept_response_mock)
+
+        auth = HawkAuth('test-id', 'test-key')
+        request = Mock(method='GET', url='http://test.com/test', body=None, headers={})
+        auth(request)
+
+        request.register_hook.assert_called_once()
+        response = Mock(content=b'', ok=True, headers={
+            'Server-Authorization': 'test',
+            'Content-Type': 'test/test',
+        })
+
+        with pytest.raises(ValueError):
+            request.register_hook.call_args[0][1](response)
+
+    def test_response_not_verified_if_verification_disabled(self):
+        """Test that responses are not verified when response verification is disabled."""
+        auth = HawkAuth('test-id', 'test-key', verify_response=False)
+        request = Mock(method='GET', url='http://test.com/test', body=None, headers={})
+        auth(request)
+
+        request.register_hook.assert_not_called()
 
 
 class TestAPIClient:

--- a/datahub/core/test/test_api_client.py
+++ b/datahub/core/test/test_api_client.py
@@ -1,0 +1,82 @@
+import pytest
+from requests import HTTPError
+from requests.auth import HTTPBasicAuth
+
+from datahub.core.api_client import APIClient
+
+
+class TestAPIClient:
+    """Tests APIClient."""
+
+    def test_successful_request(self, requests_stubber):
+        """Tests making a successful request."""
+        api_url = 'http://test/v1/'
+        requests_stubber.get('http://test/v1/path/to/item', status_code=200)
+
+        api_client = APIClient(api_url)
+        response = api_client.request('GET', 'path/to/item')
+
+        assert response.status_code == 200
+        assert response.request.headers['Accept'] == APIClient.DEFAULT_ACCEPT
+        assert response.request.timeout is None
+
+    def test_raises_exception_on_unsuccessful_request(self, requests_stubber):
+        """Tests that an exception is raised on an successful request."""
+        api_url = 'http://test/v1/'
+        requests_stubber.get('http://test/v1/path/to/item', status_code=404)
+
+        api_client = APIClient(api_url)
+        with pytest.raises(HTTPError) as excinfo:
+            api_client.request('GET', 'path/to/item')
+
+        assert excinfo.value.response.status_code == 404
+
+    def test_passes_through_arguments(self, requests_stubber):
+        """Tests that auth, accept and default_timeout are passed to the request."""
+        api_url = 'http://test/v1/'
+        requests_stubber.get('http://test/v1/path/to/item', status_code=200)
+
+        api_client = APIClient(
+            api_url,
+            auth=HTTPBasicAuth('user', 'password'),
+            accept='test-accept',
+            default_timeout=10,
+        )
+        response = api_client.request('GET', 'path/to/item')
+
+        assert response.status_code == 200
+        assert response.request.headers['Accept'] == 'test-accept'
+        assert response.request.timeout == 10
+
+    def test_omits_accept_if_none(self, requests_stubber):
+        """Tests that the Accept header is not overridden when accept=None is passed."""
+        api_url = 'http://test/v1/'
+        requests_stubber.get('http://test/v1/path/to/item', status_code=200)
+
+        api_client = APIClient(
+            api_url,
+            auth=HTTPBasicAuth('user', 'password'),
+            accept=None,
+        )
+        response = api_client.request('GET', 'path/to/item')
+
+        assert response.status_code == 200
+        assert response.request.headers['Accept'] == '*/*'
+
+    @pytest.mark.parametrize('default_timeout', (10, None))
+    def test_can_override_timeout_per_request(self, requests_stubber, default_timeout):
+        """Tests that the timeout can be overridden for a specific request."""
+        api_url = 'http://test/v1/'
+        requests_stubber.get('http://test/v1/path/to/item', status_code=200)
+
+        api_client = APIClient(
+            api_url,
+            auth=HTTPBasicAuth('user', 'password'),
+            accept='test-accept',
+            default_timeout=default_timeout,
+        )
+        response = api_client.request('GET', 'path/to/item', timeout=20)
+
+        assert response.status_code == 200
+        assert response.request.headers['Accept'] == 'test-accept'
+        assert response.request.timeout == 20

--- a/requirements.in
+++ b/requirements.in
@@ -67,6 +67,7 @@ pydocstyle==2.1.1
 
 gunicorn==19.7.1
 gevent==1.2.2
+mohawk==0.3.4
 raven==6.6.0
 requests==2.18.4
 requests_toolbelt==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ aws-requests-auth==0.4.1
 backcall==0.1.0           # via ipython
 billiard==3.5.0.3         # via celery
 boto3==1.7.4
-botocore==1.10.8          # via boto3, s3transfer
+botocore==1.10.12         # via boto3, s3transfer
 celery==4.1.0
 certifi==2018.4.16        # via requests
 chardet==3.0.4            # via chardet, requests
@@ -65,6 +65,7 @@ jmespath==0.9.3           # via boto3, botocore, jmespath
 kombu==4.1.0              # via celery
 lxml==4.2.1
 mccabe==0.6.1             # via flake8, mccabe
+mohawk==0.3.4
 monotonic==1.4            # via notifications-python-client
 more-itertools==4.1.0     # via pytest
 notifications-python-client==4.8.1
@@ -101,7 +102,7 @@ requests==2.18.4
 requests_toolbelt==0.8.0
 s3transfer==0.1.13        # via boto3
 simplegeneric==0.8.1      # via ipython, simplegeneric
-six==1.11.0               # via django-environ, django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, more-itertools, pip-tools, prompt-toolkit, pydocstyle, pytest, python-dateutil, requests-mock, six, traitlets
+six==1.11.0               # via django-environ, django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mohawk, more-itertools, pip-tools, prompt-toolkit, pydocstyle, pytest, python-dateutil, requests-mock, six, traitlets
 snowballstemmer==1.2.1    # via pydocstyle, snowballstemmer
 sqlparse==0.2.4           # via django-debug-toolbar, sqlparse
 termcolor==1.1.0          # via pytest-sugar, termcolor


### PR DESCRIPTION
Issue number: N/A

### Description of change

This adds a generic API client and a Hawk authentication class compatible with requests.

These will be used for making requests to the company timeline API.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
