### PR TITLE
Add update_one_list_fields command to update One List fields

### DIFF
--- a/datahub/dbmaintenance/management/base.py
+++ b/datahub/dbmaintenance/management/base.py
@@ -39,11 +39,13 @@ class CSVBaseCommand(BaseCommand):
             help='If True it only simulates the command without saving the changes.',
         )
 
-    def handle(self, *args, **options):
-        """Process the CSV file."""
-        result = {True: 0, False: 0}
+    def _handle(self, *args, **options):
+        """
+        Internal version of the `handle` method.
 
-        logger.info(f'Started')
+        :returns: dict with count of records successful and failed updates
+        """
+        result = {True: 0, False: 0}
 
         s3_client = get_s3_client()
         response = s3_client.get_object(
@@ -58,6 +60,13 @@ class CSVBaseCommand(BaseCommand):
             for row in reader:
                 succeeded = self.process_row(row, **options)
                 result[succeeded] += 1
+        return result
+
+    def handle(self, *args, **options):
+        """Process the CSV file."""
+        logger.info(f'Started')
+
+        result = self._handle(*args, **options)
 
         logger.info(f'Finished - succeeded: {result[True]}, failed: {result[False]}')
 

--- a/datahub/dbmaintenance/management/commands/update_one_list_fields.py
+++ b/datahub/dbmaintenance/management/commands/update_one_list_fields.py
@@ -1,0 +1,165 @@
+from functools import lru_cache
+from logging import getLogger
+
+import reversion
+from django.db.models import Q
+
+from datahub.company.models import Advisor, Company
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.metadata.models import CompanyClassification
+from ..base import CSVBaseCommand
+
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """
+    Command to update:
+    - Company.classification
+    - Company.one_list_account_owner
+
+    If --reset-unmatched=true, all the records not in the CSV will have
+    the fields above set to None.
+    """
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        super().add_arguments(parser)
+        parser.add_argument(
+            '--reset-unmatched',
+            action='store_true',
+            default=False,
+            help=(
+                'If true, Data Hub records not present '
+                'in the CSV will have classification and one_list_account_owner set to None.'
+            )
+        )
+
+    def _handle(self, *args, simulate=False, reset_unmatched=False, **options):
+        """
+        Same as the super class but it adds some logic before and after it.
+
+        This is because we want to reset all the records that are not found in the CSV if
+        reset-unmatched is speficied.
+        """
+        # if reset_unmatched, store current state in a dict so that we can remove the companies
+        # as we process them and reset the remaining items.
+        if reset_unmatched:
+            qs = Company.objects.filter(
+                Q(classification_id__isnull=False) | Q(one_list_account_owner_id__isnull=False)
+            )
+            self.companies_to_reset = {company.id: company for company in qs}
+        else:
+            self.companies_to_reset = {}
+
+        # process CSV and remove companies from self.companies_to_reset
+        result = super()._handle(
+            *args,
+            reset_unmatched=reset_unmatched,
+            simulate=simulate,
+            **options
+        )
+
+        # reset all remaining unmatched companies
+        if reset_unmatched:
+            for company in self.companies_to_reset.values():
+                succeeded = self.reset_unmatched(company, simulate)
+                result[succeeded] += 1
+
+        return result
+
+    def reset_unmatched(self, company, simulate):
+        """
+        Reset one list fields for `company`.
+
+        :param company: the Company to update
+        :param simulate: True if the change should not be committed to the database
+        :returns: True if the company has been processed successfully, False otherwise.
+        """
+        try:
+            self._update_company(
+                company,
+                new_classification_id=None,
+                new_one_list_account_owner_id=None,
+                simulate=simulate
+            )
+        except Exception as e:
+            logger.exception(f'Resetting company {company} - Failed')
+            return False
+        else:
+            logger.info(f'Resetting company {company} - OK')
+            return True
+
+    @lru_cache(maxsize=None)
+    def get_classification(self, pk):
+        """
+        :param pk: primary key of the instance to get
+        :returns: CompanyClassification with id == `pk`
+        """
+        if not pk:
+            return None
+        return CompanyClassification.objects.get(pk=pk)
+
+    @lru_cache(maxsize=None)
+    def get_adviser(self, pk):
+        """
+        :param pk: primary key of the instance to get
+        :returns: Advisor with id == `pk`
+        """
+        if not pk:
+            return None
+        return Advisor.objects.get(pk=pk)
+
+    def _update_company(
+        self, company, new_classification_id, new_one_list_account_owner_id, simulate
+    ):
+        """
+        Update `company` with the new values.
+
+        :param new_classification_id: new CompanyClassification value
+        :param new_one_list_account_owner_id: new Advisor value
+        :param simulate: True if the change should not be committed to the database
+        """
+        company.classification = self.get_classification(new_classification_id)
+        company.one_list_account_owner = self.get_adviser(new_one_list_account_owner_id)
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            company.save(
+                update_fields=(
+                    'classification_id',
+                    'one_list_account_owner_id',
+                )
+            )
+            reversion.set_comment('Classification and One List account owner correction.')
+
+    def _should_update(self, company, classification_id, one_list_account_owner_id):
+        """
+        Check if `company` should be updated.
+
+        :param company: Company to update
+        :param classification_id: new CompanyClassification value
+        :param one_list_account_owner_id: new Advisor value
+        :return: True if `company` needs updating
+        """
+        return (
+            company.classification_id != classification_id
+        ) or (
+            company.one_list_account_owner_id != one_list_account_owner_id
+        )
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        company = Company.objects.get(pk=parse_uuid(row['id']))
+
+        # remove company.pk from the list of companies to reset
+        self.companies_to_reset.pop(company.pk, None)
+
+        classification_id = parse_uuid(row['classification_id'])
+        one_list_account_owner_id = parse_uuid(row['one_list_account_owner_id'])
+
+        if self._should_update(company, classification_id, one_list_account_owner_id):
+            self._update_company(company, classification_id, one_list_account_owner_id, simulate)

--- a/datahub/dbmaintenance/test/commands/test_update_one_list_fields.py
+++ b/datahub/dbmaintenance/test/commands/test_update_one_list_fields.py
@@ -1,0 +1,277 @@
+from io import BytesIO
+from itertools import chain
+
+import factory
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.core.test_utils import random_obj_for_model, random_obj_for_queryset
+from datahub.metadata.models import CompanyClassification
+
+pytestmark = pytest.mark.django_db
+
+
+def save_prev_fields(company, *fields):
+    """
+    Save the `fields` to different private attributes so that we can compare original
+    values against new ones.
+    """
+    for field in fields:
+        setattr(company, f'_prev_{field}', getattr(company, field))
+
+
+def assert_did_not_change(company, *fields):
+    """
+    Assert that the company fields did not change.
+    It assumes `save_prev_fields` has been called before the potential change.
+    """
+    for field in fields:
+        assert getattr(company, field) == getattr(company, f'_prev_{field}')
+
+
+def assert_changed(company, *fields):
+    """
+    Assert that the company fields changed.
+    It assumes `save_prev_fields` has been called before the potential change.
+    """
+    for field in fields:
+        assert getattr(company, field) != getattr(company, f'_prev_{field}')
+
+
+@pytest.mark.parametrize('reset_unmatched', (False, True))
+def test_run(s3_stubber, caplog, reset_unmatched):
+    """
+    Test that the command updates the specified records (ignoring ones with errors).
+    If `reset_unmatched` is False, the existing records not in the CSV are kept untouched,
+    otherwise they are set to None.
+    """
+    caplog.set_level('ERROR')
+
+    new_classification = random_obj_for_model(CompanyClassification)
+    one_list_companies = CompanyFactory.create_batch(
+        8,
+        classification=factory.LazyFunction(
+            lambda: random_obj_for_queryset(
+                CompanyClassification.objects.exclude(pk=new_classification.pk)
+            )
+        ),
+        one_list_account_owner=factory.SubFactory(AdviserFactory)
+    )
+    non_one_list_companies = CompanyFactory.create_batch(
+        3,
+        classification=None,
+        one_list_account_owner=None
+    )
+
+    for company in chain(one_list_companies, non_one_list_companies):
+        save_prev_fields(company, 'classification_id', 'one_list_account_owner_id')
+
+    advisers = AdviserFactory.create_batch(4)
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,classification_id,one_list_account_owner_id
+00000000-0000-0000-0000-000000000000,test,test
+{one_list_companies[0].pk},{one_list_companies[0].classification_id},{one_list_companies[0].one_list_account_owner_id}
+{one_list_companies[1].pk},{one_list_companies[1].classification_id},{advisers[0].pk}
+{one_list_companies[2].pk},{new_classification.pk},{one_list_companies[2].one_list_account_owner_id}
+{one_list_companies[3].pk},null,null
+{one_list_companies[4].pk},00000000-0000-0000-0000-000000000000,{advisers[1].pk}
+{one_list_companies[5].pk},{new_classification.pk},00000000-0000-0000-0000-000000000000
+{non_one_list_companies[0].pk},{new_classification.pk},{advisers[2].pk}
+{non_one_list_companies[1].pk},00000000-0000-0000-0000-000000000000,{advisers[3].pk}
+{non_one_list_companies[2].pk},{new_classification.pk},00000000-0000-0000-0000-000000000000
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {'Body': BytesIO(csv_content.encode(encoding='utf-8'))},
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_one_list_fields', bucket, object_key, reset_unmatched=reset_unmatched)
+
+    for company in chain(one_list_companies, non_one_list_companies):
+        company.refresh_from_db()
+
+    # assert exceptions
+    assert len(caplog.records) == 5
+    assert 'Company matching query does not exist' in caplog.records[0].exc_text
+    assert 'CompanyClassification matching query does not exist' in caplog.records[1].exc_text
+    assert 'Advisor matching query does not exist' in caplog.records[2].exc_text
+    assert 'CompanyClassification matching query does not exist' in caplog.records[3].exc_text
+    assert 'Advisor matching query does not exist' in caplog.records[4].exc_text
+
+    # one_list_companies[0]: nothing changed
+    assert_did_not_change(one_list_companies[0], 'classification_id', 'one_list_account_owner_id')
+
+    # one_list_companies[1]: only one_list_account_owner_id changed
+    assert_changed(one_list_companies[1], 'one_list_account_owner_id')
+    assert_did_not_change(one_list_companies[1], 'classification_id')
+    assert one_list_companies[1].one_list_account_owner == advisers[0]
+
+    # one_list_companies[2]: only classification_id changed
+    assert_did_not_change(one_list_companies[2], 'one_list_account_owner_id')
+    assert_changed(one_list_companies[2], 'classification_id')
+    assert one_list_companies[2].classification == new_classification
+
+    # one_list_companies[3]: all changed
+    assert_changed(one_list_companies[3], 'classification_id', 'one_list_account_owner_id')
+    assert one_list_companies[3].classification_id is None
+    assert one_list_companies[3].one_list_account_owner_id is None
+
+    # one_list_companies[4]: nothing changed
+    assert_did_not_change(one_list_companies[4], 'classification_id', 'one_list_account_owner_id')
+
+    # one_list_companies[5]: nothing changed
+    assert_did_not_change(one_list_companies[5], 'classification_id', 'one_list_account_owner_id')
+
+    # non_one_list_companies[0]: all changed
+    assert_changed(non_one_list_companies[0], 'classification_id', 'one_list_account_owner_id')
+    assert non_one_list_companies[0].one_list_account_owner == advisers[2]
+    assert non_one_list_companies[0].classification == new_classification
+
+    # non_one_list_companies[1]: nothing changed
+    assert_did_not_change(
+        non_one_list_companies[1], 'classification_id', 'one_list_account_owner_id'
+    )
+
+    # non_one_list_companies[2]: nothing changed
+    assert_did_not_change(
+        non_one_list_companies[2], 'classification_id', 'one_list_account_owner_id'
+    )
+
+    # one_list_companies[6] / [7]: if reset_unmatched == False => nothing changed else all changed
+    if reset_unmatched:
+        assert_changed(one_list_companies[6], 'classification_id', 'one_list_account_owner_id')
+        assert_changed(one_list_companies[7], 'classification_id', 'one_list_account_owner_id')
+        assert one_list_companies[6].classification is None
+        assert one_list_companies[6].one_list_account_owner is None
+
+        assert one_list_companies[7].classification is None
+        assert one_list_companies[7].one_list_account_owner is None
+    else:
+        assert_did_not_change(
+            one_list_companies[6], 'classification_id', 'one_list_account_owner_id'
+        )
+        assert_did_not_change(
+            one_list_companies[7], 'classification_id', 'one_list_account_owner_id'
+        )
+
+
+@pytest.mark.parametrize('reset_unmatched', (False, ))
+def test_simulate(s3_stubber, caplog, reset_unmatched):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+
+    new_classification = random_obj_for_model(CompanyClassification)
+    one_list_companies = CompanyFactory.create_batch(
+        8,
+        classification=factory.LazyFunction(
+            lambda: random_obj_for_queryset(
+                CompanyClassification.objects.exclude(pk=new_classification.pk)
+            )
+        ),
+        one_list_account_owner=factory.SubFactory(AdviserFactory)
+    )
+    non_one_list_companies = CompanyFactory.create_batch(
+        3,
+        classification=None,
+        one_list_account_owner=None
+    )
+
+    for company in chain(one_list_companies, non_one_list_companies):
+        save_prev_fields(company, 'classification_id', 'one_list_account_owner_id')
+
+    advisers = AdviserFactory.create_batch(4)
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,classification_id,one_list_account_owner_id
+00000000-0000-0000-0000-000000000000,test,test
+{one_list_companies[0].pk},{one_list_companies[0].classification_id},{one_list_companies[0].one_list_account_owner_id}
+{one_list_companies[1].pk},{one_list_companies[1].classification_id},{advisers[0].pk}
+{one_list_companies[2].pk},{new_classification.pk},{one_list_companies[2].one_list_account_owner_id}
+{one_list_companies[3].pk},null,null
+{one_list_companies[4].pk},00000000-0000-0000-0000-000000000000,{advisers[1].pk}
+{one_list_companies[5].pk},{new_classification.pk},00000000-0000-0000-0000-000000000000
+{non_one_list_companies[0].pk},{new_classification.pk},{advisers[2].pk}
+{non_one_list_companies[1].pk},00000000-0000-0000-0000-000000000000,{advisers[3].pk}
+{non_one_list_companies[2].pk},{new_classification.pk},00000000-0000-0000-0000-000000000000
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {'Body': BytesIO(csv_content.encode(encoding='utf-8'))},
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command(
+        'update_one_list_fields',
+        bucket,
+        object_key,
+        reset_unmatched=reset_unmatched,
+        simulate=True
+    )
+
+    for company in chain(one_list_companies, non_one_list_companies):
+        company.refresh_from_db()
+
+    # assert exceptions
+    assert len(caplog.records) == 5
+    assert 'Company matching query does not exist' in caplog.records[0].exc_text
+    assert 'CompanyClassification matching query does not exist' in caplog.records[1].exc_text
+    assert 'Advisor matching query does not exist' in caplog.records[2].exc_text
+    assert 'CompanyClassification matching query does not exist' in caplog.records[3].exc_text
+    assert 'Advisor matching query does not exist' in caplog.records[4].exc_text
+
+    # assert that nothing really changed
+    for company in chain(one_list_companies, non_one_list_companies):
+        assert_did_not_change(company, 'classification_id', 'one_list_account_owner_id')
+
+
+def test_audit_log(s3_stubber, caplog):
+    """Test that reversion revisions are created."""
+    classifications = CompanyClassification.objects.order_by('?')[:2]
+    company_without_change, company_with_change = CompanyFactory.create_batch(
+        2,
+        classification=classifications[0],
+        one_list_account_owner=AdviserFactory()
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,classification_id,one_list_account_owner_id
+{company_without_change.pk},{company_without_change.classification_id},{company_without_change.one_list_account_owner_id}
+{company_with_change.pk},{classifications[1].pk},{AdviserFactory().pk}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key
+        }
+    )
+
+    call_command('update_one_list_fields', bucket, object_key)
+
+    assert len(caplog.records) == 0
+
+    versions = Version.objects.get_for_object(company_without_change)
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(company_with_change)
+    assert versions.count() == 1
+    assert versions[0].revision.comment == 'Classification and One List account owner correction.'


### PR DESCRIPTION
This adds a new django command to update `classification` and `one_list_account_owner` with the values from the CSV.

If `reset_unmatched` is set, all the records not in the CSV will have those fields set to None.