### PR TITLE
Tidy up ES utilities slightly

### DIFF
--- a/datahub/search/bulk_sync.py
+++ b/datahub/search/bulk_sync.py
@@ -32,7 +32,7 @@ def sync_app(item, batch_size=None):
     it = item.queryset.iterator(chunk_size=batch_size)
     batches = slice_iterable_into_chunks(it, batch_size)
     for batch in batches:
-        actions = list(item.es_model.dbmodels_to_es_documents(batch))
+        actions = list(item.es_model.db_objects_to_es_documents(batch))
         num_actions = len(actions)
         bulk(
             actions=actions,

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -10,7 +10,7 @@ def test_company_dbmodel_to_dict(setup_es):
     """Tests conversion of db model to dict."""
     company = CompanyFactory()
 
-    result = ESCompany.dbmodel_to_dict(company)
+    result = ESCompany.db_object_to_dict(company)
 
     keys = {
         'account_manager',
@@ -65,6 +65,6 @@ def test_company_dbmodels_to_es_documents(setup_es):
     """Tests conversion of db models to Elasticsearch documents."""
     companies = CompanyFactory.create_batch(2)
 
-    result = ESCompany.dbmodels_to_es_documents(companies)
+    result = ESCompany.db_objects_to_es_documents(companies)
 
     assert len(list(result)) == len(companies)

--- a/datahub/search/conftest.py
+++ b/datahub/search/conftest.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from django.conf import settings
 from elasticsearch.helpers.test import get_test_client
 from pytest import fixture
@@ -73,6 +75,14 @@ def _create_test_index(client, index):
         client.indices.delete(index)
 
     elasticsearch.configure_index(index, index_settings=settings.ES_INDEX_SETTINGS)
+
+
+@fixture
+def mock_es_client(monkeypatch):
+    """Patches the Elasticsearch library so that a mock client is used."""
+    mock_client = Mock()
+    monkeypatch.setattr('elasticsearch_dsl.connections.connections.get_connection', mock_client)
+    yield mock_client
 
 
 @fixture

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -11,7 +11,7 @@ def test_contact_dbmodel_to_dict(setup_es):
     """Tests conversion of db model to dict."""
     contact = ContactFactory()
 
-    result = ESContact.dbmodel_to_dict(contact)
+    result = ESContact.db_object_to_dict(contact)
 
     keys = {
         'id',
@@ -59,7 +59,7 @@ def test_contact_dbmodels_to_es_documents(setup_es):
     """Tests conversion of db models to Elasticsearch documents."""
     contacts = ContactFactory.create_batch(2)
 
-    result = ESContact.dbmodels_to_es_documents(contacts)
+    result = ESContact.db_objects_to_es_documents(contacts)
 
     assert len(list(result)) == len(contacts)
 

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -110,6 +110,11 @@ def configure_connection():
     )
 
 
+def get_client():
+    """Gets an instance of the Elasticsearch client from the connection cache."""
+    return connections.get_connection()
+
+
 ANALYZERS = (
     lowercase_keyword_analyzer,
     trigram_analyzer,
@@ -120,7 +125,7 @@ ANALYZERS = (
 
 def configure_index(index_name, index_settings=None):
     """Configures Elasticsearch index."""
-    client = connections.get_connection()
+    client = get_client()
     if not client.indices.exists(index=index_name):
         index = Index(index_name)
         for analyzer in ANALYZERS:
@@ -146,4 +151,4 @@ def init_es():
 
 def bulk(actions=None, chunk_size=None, **kwargs):
     """Send data in bulk to Elasticsearch."""
-    return es_bulk(connections.get_connection(), actions=actions, chunk_size=chunk_size, **kwargs)
+    return es_bulk(get_client(), actions=actions, chunk_size=chunk_size, **kwargs)

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -75,6 +75,14 @@ lowercase_analyzer = analysis.CustomAnalyzer(
 )
 
 
+ANALYZERS = (
+    lowercase_keyword_analyzer,
+    trigram_analyzer,
+    english_analyzer,
+    lowercase_analyzer,
+)
+
+
 def configure_connection():
     """Configure Elasticsearch default connection."""
     if settings.ES_USE_AWS_AUTH:
@@ -113,14 +121,6 @@ def configure_connection():
 def get_client():
     """Gets an instance of the Elasticsearch client from the connection cache."""
     return connections.get_connection()
-
-
-ANALYZERS = (
-    lowercase_keyword_analyzer,
-    trigram_analyzer,
-    english_analyzer,
-    lowercase_analyzer,
-)
 
 
 def configure_index(index_name, index_settings=None):

--- a/datahub/search/event/tests/test_models.py
+++ b/datahub/search/event/tests/test_models.py
@@ -10,7 +10,7 @@ def test_event_dbmodel_to_dict(setup_es):
     """Tests conversion of db model to dict."""
     event = EventFactory()
 
-    result = ESEvent.dbmodel_to_dict(event)
+    result = ESEvent.db_object_to_dict(event)
 
     keys = {
         'id',
@@ -44,6 +44,6 @@ def test_event_dbmodels_to_es_documents(setup_es):
     """Tests conversion of db models to Elasticsearch documents."""
     events = EventFactory.create_batch(2)
 
-    result = ESEvent.dbmodels_to_es_documents(events)
+    result = ESEvent.db_objects_to_es_documents(events)
 
     assert len(list(result)) == len(events)

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.django_db
 def test_interaction_to_dict(setup_es, factory_cls):
     """Test converting an interaction to a dict."""
     interaction = factory_cls()
-    result = Interaction.dbmodel_to_dict(interaction)
+    result = Interaction.db_object_to_dict(interaction)
 
     assert result == {
         'id': str(interaction.pk),
@@ -84,7 +84,7 @@ def test_service_delivery_to_dict(setup_es):
     """Test converting an interaction to a dict."""
     interaction = ServiceDeliveryFactory()
 
-    result = Interaction.dbmodel_to_dict(interaction)
+    result = Interaction.db_object_to_dict(interaction)
 
     assert result == {
         'id': str(interaction.pk),
@@ -144,6 +144,6 @@ def test_interactions_to_es_documents(setup_es):
     """Test converting 2 orders to Elasticsearch documents."""
     interactions = CompanyInteractionFactory.create_batch(2)
 
-    result = Interaction.dbmodels_to_es_documents(interactions)
+    result = Interaction.db_objects_to_es_documents(interactions)
 
     assert {item['_id'] for item in result} == {str(item.pk) for item in interactions}

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.django_db
 def test_investment_project_to_dict(setup_es):
     """Tests conversion of db model to dict."""
     project = InvestmentProjectFactory()
-    result = ESInvestmentProject.dbmodel_to_dict(project)
+    result = ESInvestmentProject.db_object_to_dict(project)
 
     keys = {
         'id',
@@ -104,6 +104,6 @@ def test_investment_project_dbmodels_to_es_documents(setup_es):
     """Tests conversion of db models to Elasticsearch documents."""
     projects = InvestmentProjectFactory.create_batch(2)
 
-    result = ESInvestmentProject.dbmodels_to_es_documents(projects)
+    result = ESInvestmentProject.db_objects_to_es_documents(projects)
 
     assert len(list(result)) == len(projects)

--- a/datahub/search/management/commands/create_alias.py
+++ b/datahub/search/management/commands/create_alias.py
@@ -1,14 +1,15 @@
 from logging import getLogger
 
 from django.core.management.base import BaseCommand
-from elasticsearch_dsl.connections import connections
+
+from datahub.search.elasticsearch import get_client
 
 logger = getLogger(__name__)
 
 
 def create_alias(current_index, alias_name):
     """Creates new alias for current index."""
-    es = connections.get_connection()
+    es = get_client()
     return es.indices.put_alias(index=current_index, name=alias_name)
 
 

--- a/datahub/search/management/commands/delete_alias.py
+++ b/datahub/search/management/commands/delete_alias.py
@@ -1,14 +1,15 @@
 from logging import getLogger
 
 from django.core.management.base import BaseCommand
-from elasticsearch_dsl.connections import connections
+
+from datahub.search.elasticsearch import get_client
 
 logger = getLogger(__name__)
 
 
 def delete_alias(current_index, alias_name):
     """Deletes alias for current index."""
-    es = connections.get_connection()
+    es = get_client()
     return es.indices.delete_alias(index=current_index, name=alias_name)
 
 

--- a/datahub/search/management/commands/get_alias.py
+++ b/datahub/search/management/commands/get_alias.py
@@ -2,14 +2,15 @@ import json
 from logging import getLogger
 
 from django.core.management.base import BaseCommand
-from elasticsearch_dsl.connections import connections
+
+from datahub.search.elasticsearch import get_client
 
 logger = getLogger(__name__)
 
 
 def get_alias(current_index):
     """Gets alias for current index."""
-    es = connections.get_connection()
+    es = get_client()
     return es.indices.get_alias(index=current_index)
 
 

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -19,7 +19,7 @@ class BaseESModel(DocType):
     @classmethod
     def es_document(cls, dbmodel):
         """Creates Elasticsearch document."""
-        source = cls.dbmodel_to_dict(dbmodel)
+        source = cls.db_object_to_dict(dbmodel)
 
         # TODO could get index and doc type from meta of other class
         return {
@@ -30,8 +30,8 @@ class BaseESModel(DocType):
         }
 
     @classmethod
-    def dbmodel_to_dict(cls, dbmodel):
-        """Converts dbmodel instance to a dictionary suitable for ElasticSearch."""
+    def db_object_to_dict(cls, dbmodel):
+        """Converts a DB model object to a dictionary suitable for Elasticsearch."""
         mapped_values = (
             (col, fn, getattr(dbmodel, col)) for col, fn in cls.MAPPINGS.items()
         )
@@ -46,7 +46,7 @@ class BaseESModel(DocType):
         return result
 
     @classmethod
-    def dbmodels_to_es_documents(cls, dbmodels):
-        """Converts db models to Elasticsearch documents."""
+    def db_objects_to_es_documents(cls, dbmodels):
+        """Converts DB model objects to Elasticsearch documents."""
         for dbmodel in dbmodels:
             yield cls.es_document(dbmodel)

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -28,7 +28,7 @@ def test_order_to_dict(Factory):
     OrderSubscriberFactory.create_batch(2, order=order)
     OrderAssigneeFactory.create_batch(2, order=order)
 
-    result = ESOrder.dbmodel_to_dict(order)
+    result = ESOrder.db_object_to_dict(order)
 
     assert result == {
         'id': str(order.pk),
@@ -161,6 +161,6 @@ def test_orders_to_es_documents():
     """Test converting 2 orders to Elasticsearch documents."""
     orders = OrderFactory.create_batch(2)
 
-    result = ESOrder.dbmodels_to_es_documents(orders)
+    result = ESOrder.db_objects_to_es_documents(orders)
 
     assert {item['_id'] for item in result} == {str(item.pk) for item in orders}

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -21,7 +21,7 @@ class MatchNone(Query):
 
 def delete_document(model, document_id):
     """Deletes specified model's document."""
-    doc = model.get(id=document_id, index=settings.ES_INDEX)
+    doc = model(_id=document_id, _index=settings.ES_INDEX)
     doc.delete()
 
 

--- a/datahub/search/test/commands/test_create_alias.py
+++ b/datahub/search/test/commands/test_create_alias.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 from django.core import management
 
@@ -9,10 +7,9 @@ from datahub.search.management.commands import create_alias
 pytestmark = pytest.mark.django_db
 
 
-@mock.patch('datahub.search.management.commands.create_alias.connections.get_connection')
-def test_create_alias(get_connection):
+def test_create_alias(mock_es_client):
     """Tests creating alias for Elasticsearch index."""
-    es = get_connection.return_value
+    es = mock_es_client.return_value
 
     current_index = 'test_index'
     alias_name = 'test_index_alias'

--- a/datahub/search/test/commands/test_delete_alias.py
+++ b/datahub/search/test/commands/test_delete_alias.py
@@ -1,5 +1,3 @@
-from unittest import mock
-
 import pytest
 from django.core import management
 
@@ -9,10 +7,9 @@ from datahub.search.management.commands import delete_alias
 pytestmark = pytest.mark.django_db
 
 
-@mock.patch('datahub.search.management.commands.delete_alias.connections.get_connection')
-def test_delete_alias(get_connection):
+def test_delete_alias(mock_es_client):
     """Tests creating alias for Elasticsearch index."""
-    es = get_connection.return_value
+    es = mock_es_client.return_value
 
     current_index = 'test_index'
     alias_name = 'test_index_alias'

--- a/datahub/search/test/commands/test_get_alias.py
+++ b/datahub/search/test/commands/test_get_alias.py
@@ -1,6 +1,5 @@
 import json
 from io import StringIO
-from unittest import mock
 
 import pytest
 from django.core import management
@@ -12,10 +11,9 @@ from datahub.search.management.commands import get_alias
 pytestmark = pytest.mark.django_db
 
 
-@mock.patch('datahub.search.management.commands.delete_alias.connections.get_connection')
-def test_get_alias(get_connection):
+def test_get_alias(mock_es_client):
     """Tests creating alias for Elasticsearch index."""
-    es = get_connection.return_value
+    es = mock_es_client.return_value
 
     current_index = 'test_index'
 

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -6,16 +6,13 @@ from .. import elasticsearch
 
 
 @mock.patch('datahub.search.elasticsearch.es_bulk')
-@mock.patch('datahub.search.elasticsearch.connections')
-def test_bulk(connections, es_bulk):
+def test_bulk(es_bulk, mock_es_client):
     """Tests detailed company search."""
-    es_bulk.return_value = {}
-    connections.get_connection.return_value = None
     actions = []
     chunk_size = 10
     elasticsearch.bulk(actions=actions, chunk_size=chunk_size)
 
-    es_bulk.assert_called_with(None, actions=actions, chunk_size=chunk_size)
+    es_bulk.assert_called_with(mock_es_client.return_value, actions=actions, chunk_size=chunk_size)
 
 
 @mock.patch('datahub.search.elasticsearch.settings')
@@ -35,14 +32,13 @@ def test_configure_connection(connections, settings):
     })
 
 
-@mock.patch('elasticsearch_dsl.connections.connections.get_connection')
-def test_configure_index_creates_index_if_it_doesnt_exist(get_connection_mock):
+def test_configure_index_creates_index_if_it_doesnt_exist(mock_es_client):
     """Test that configure_index() creates the index when it doesn't exist."""
     index = 'test-index'
     index_settings = {
         'testsetting1': 'testval1'
     }
-    connection = get_connection_mock.return_value
+    connection = mock_es_client.return_value
     connection.indices.exists.return_value = False
     elasticsearch.configure_index(index, index_settings=index_settings)
     connection.indices.create.assert_called_once_with(
@@ -110,14 +106,13 @@ def test_configure_index_creates_index_if_it_doesnt_exist(get_connection_mock):
     )
 
 
-@mock.patch('elasticsearch_dsl.connections.connections.get_connection')
-def test_configure_index_doesnt_create_index_if_it_exists(get_connection_mock):
+def test_configure_index_doesnt_create_index_if_it_exists(mock_es_client):
     """Test that configure_index() doesn't create the index when it already exists."""
     index = 'test-index'
     index_settings = {
         'testsetting1': 'testval1'
     }
-    connection = get_connection_mock.return_value
+    connection = mock_es_client.return_value
     connection.indices.exists.return_value = True
     elasticsearch.configure_index(index, index_settings=index_settings)
     connection.indices.create.assert_not_called()


### PR DESCRIPTION
Issue number: N/A

### Description of change

This makes a few small changes:

* adds a central function to get an Elasticsearch client (and associated pytest fixture for mocking)
* renames some of the methods on BaseESModel so that they make more sense
* removes a redundant get() call in delete_document()


### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
