### PR TITLE
Add adviser export to the admin site

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -67,6 +67,7 @@ LOCAL_APPS = [
     'datahub.leads',
     'datahub.metadata',
     'datahub.oauth',
+    'datahub.admin_report',
     'datahub.search.apps.SearchConfig',
     'datahub.user',
     'datahub.dbmaintenance',

--- a/config/urls.py
+++ b/config/urls.py
@@ -11,6 +11,7 @@ from . import api_urls
 
 unversioned_urls = [
     path('admin/', admin.site.urls),
+    path('', include('datahub.admin_report.urls')),
     path('ping.xml', ping, name='ping'),
     path('metadata/', include('datahub.metadata.urls')),
     path('token/', TokenView.as_view(), name='token'),

--- a/datahub/admin_report/__init__.py
+++ b/datahub/admin_report/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'datahub.admin_report.apps.AdminReportConfig'

--- a/datahub/admin_report/apps.py
+++ b/datahub/admin_report/apps.py
@@ -1,0 +1,12 @@
+from django.apps import AppConfig
+from django.utils.module_loading import autodiscover_modules
+
+
+class AdminReportConfig(AppConfig):
+    """App config for the admin_report app."""
+
+    name = 'datahub.admin_report'
+
+    def ready(self):
+        """Auto-discovers admin_report modules in loaded apps."""
+        autodiscover_modules('admin_reports')

--- a/datahub/admin_report/report.py
+++ b/datahub/admin_report/report.py
@@ -110,6 +110,11 @@ def get_reports_by_model(user):
     return reports_by_model
 
 
+def report_exists(report_id):
+    """Checks if a report exists."""
+    return report_id in _registry
+
+
 def get_report_by_id(report_id, user):
     """
     Gets a report instance for using its ID.

--- a/datahub/admin_report/report.py
+++ b/datahub/admin_report/report.py
@@ -1,0 +1,122 @@
+from typing import Sequence
+
+from django.core.exceptions import PermissionDenied
+from django.db.models import Model
+from django.utils.timezone import now
+
+from datahub.core.exceptions import DataHubException
+
+_registry = {}
+
+
+class _ReportMeta(type):
+    """
+    Metaclass for report definitions.
+
+    Used to auto-register report definitions.
+    """
+
+    def __new__(mcs, name, bases, namespace, **kwargs):  # noqa: N804
+        """
+        Creates the metaclass instance.
+
+        Called whenever a subclass of Report is defined.
+        """
+        is_abstract = namespace.pop('abstract', False)
+        cls = type.__new__(mcs, name, bases, namespace)
+        if not is_abstract:
+            cls.register()
+        return cls
+
+
+class Report(metaclass=_ReportMeta):
+    """
+    Base class for reports.
+
+    See QuerySetReport for reports based on a QuerySet.
+    """
+
+    id: str = None
+    name: str = None
+    model: Model = None
+    permissions_required: Sequence = None
+    field_titles: dict = None
+    filename_template = '{name} - {today}'
+    abstract = True
+
+    _required_attrs = (
+        'id',
+        'name',
+        'model',
+        'permissions_required',
+        'field_titles',
+    )
+
+    @classmethod
+    def register(cls):
+        """Called on class declaration to register the report."""
+        cls._validate_attrs()
+        _registry[cls.id] = cls()
+
+    def check_permission(self, user):
+        """Checks whether the user has permission for this report."""
+        return user.has_perms(self.permissions_required)
+
+    def get_filename(self):
+        """Gets the filename (excluding extension) to use for the report."""
+        today = now().date().isoformat()
+        return self.filename_template.format(name=self.name, today=today)
+
+    def rows(self):
+        """Returns an iterator of the rows for this report."""
+        raise NotImplementedError
+
+    @classmethod
+    def _validate_attrs(cls):
+        missing_attrs = [attr for attr in cls._required_attrs if getattr(cls, attr, None) is None]
+        if missing_attrs:
+            raise DataHubException(f'Required report attributes {missing_attrs} not set')
+
+
+class QuerySetReport(Report):
+    """Base class for reports based on a QuerySet."""
+
+    queryset = None
+    abstract = True
+
+    _required_attrs = (
+        *Report._required_attrs,
+        'queryset',
+    )
+
+    def rows(self):
+        """Returns an iterator of the rows for this report."""
+        return self.queryset.values(*self.field_titles.keys()).iterator()
+
+
+def get_reports_by_model(user):
+    """
+    Returns a dictionary mapping models to list of reports.
+
+    Only reports that the user is allowed to access are returned.
+    """
+    reports_by_model = {}
+
+    for report in _registry.values():
+        if report.check_permission(user):
+            reports_for_model = reports_by_model.setdefault(report.model, [])
+            reports_for_model.append(report)
+
+    return reports_by_model
+
+
+def get_report_by_id(report_id, user):
+    """
+    Gets a report instance for using its ID.
+
+    If the user does not have the correct permission for the report, PermissionDenied is raised.
+    """
+    report = _registry[report_id]
+    if not report.check_permission(user):
+        raise PermissionDenied
+    return report

--- a/datahub/admin_report/report.py
+++ b/datahub/admin_report/report.py
@@ -6,6 +6,7 @@ from django.utils.timezone import now
 
 from datahub.core.exceptions import DataHubException
 
+# Registry of all defined reports (mapping report IDs to Report instances)
 _registry = {}
 
 
@@ -41,7 +42,7 @@ class Report(metaclass=_ReportMeta):
     model: Model = None
     permissions_required: Sequence = None
     field_titles: dict = None
-    filename_template = '{name} - {today}'
+    filename_template = '{name} - {timestamp}'
     abstract = True
 
     _required_attrs = (
@@ -64,8 +65,8 @@ class Report(metaclass=_ReportMeta):
 
     def get_filename(self):
         """Gets the filename (excluding extension) to use for the report."""
-        today = now().date().isoformat()
-        return self.filename_template.format(name=self.name, today=today)
+        timestamp = now().strftime('%Y-%m-%d-%H-%M-%S')
+        return self.filename_template.format(name=self.name, timestamp=timestamp)
 
     def rows(self):
         """Returns an iterator of the rows for this report."""

--- a/datahub/admin_report/templates/admin/reports/index.html
+++ b/datahub/admin_report/templates/admin/reports/index.html
@@ -1,0 +1,23 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+{% endblock %}
+
+{% block breadcrumbs %}
+    <div class="breadcrumbs">
+        <a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+        &rsaquo; Reports
+    </div>
+{% endblock %}
+
+{% block content %}
+    {% for model, reports in reports_by_model.items %}
+        <h2>{{ model|capfirst }}</h2>
+        {% for report in reports %}
+            <a href="{% url 'admin-report:download-report' report_id=report.id %}">{{ report.name }}</a>
+        {% endfor %}
+    {% endfor %}
+{% endblock %}

--- a/datahub/admin_report/tests/conftest.py
+++ b/datahub/admin_report/tests/conftest.py
@@ -1,0 +1,16 @@
+from datahub.admin_report.report import QuerySetReport
+from datahub.core.test.support.models import MetadataModel
+
+
+class MetadataReport(QuerySetReport):
+    """Report for use in tests."""
+
+    id = 'test-report'
+    name = 'Test report'
+    model = MetadataModel
+    queryset = MetadataModel.objects.order_by('pk')
+    permissions_required = ('support.change_metadatamodel',)
+    field_titles = {
+        'id': 'ID',
+        'name': 'Name',
+    }

--- a/datahub/admin_report/tests/test_report.py
+++ b/datahub/admin_report/tests/test_report.py
@@ -1,0 +1,44 @@
+import pytest
+from django.core.exceptions import PermissionDenied
+
+from datahub.admin_report.report import get_report_by_id, get_reports_by_model
+from datahub.core.test_utils import create_test_user
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize(
+    'permission_codenames,expected_result',
+    (
+        ((), {}),
+        (('change_metadatamodel',), {'MetadataModel': ['MetadataReport']}),
+    )
+
+)
+def test_get_reports_by_model(permission_codenames, expected_result):
+    """Test get_reports_by_model() for various cases."""
+    user = create_test_user(permission_codenames=permission_codenames)
+    result = get_reports_by_model(user)
+    assert {
+        model.__name__: [report.__class__.__name__ for report in reports]
+        for model, reports in result.items()
+    } == expected_result
+
+
+@pytest.mark.parametrize(
+    'permission_codenames,should_raise',
+    (
+        ((), True),
+        (('change_metadatamodel',), False),
+    )
+
+)
+def test_get_report_by_id(permission_codenames, should_raise):
+    """Test get_report_by_id() for various cases."""
+    user = create_test_user(permission_codenames=permission_codenames)
+
+    if should_raise:
+        with pytest.raises(PermissionDenied):
+            get_report_by_id('test-report', user)
+    else:
+        assert get_report_by_id('test-report', user)

--- a/datahub/admin_report/tests/test_views.py
+++ b/datahub/admin_report/tests/test_views.py
@@ -56,6 +56,18 @@ class TestReportAdmin(AdminTestMixin):
         response = client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
+    def test_non_existent_report_download(self):
+        """
+        Test that the view returns a 404 response if the report ID does not refer to a
+        registered report.
+        """
+        url = reverse('admin-report:download-report', kwargs={'report_id': 'non-existent-report'})
+        user = create_test_user(is_staff=True, password=self.PASSWORD)
+
+        client = self.create_client(user=user)
+        response = client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     def test_report_download_without_permission(self):
         """
         Test that the view returns a 403 response if the staff user does not have the

--- a/datahub/admin_report/tests/test_views.py
+++ b/datahub/admin_report/tests/test_views.py
@@ -80,7 +80,7 @@ class TestReportAdmin(AdminTestMixin):
         response = client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @freeze_time('2018-01-01 00:00:00')
+    @freeze_time('2018-01-01 11:12:13')
     def test_report_download(self):
         """Test the download of a report."""
         obj = MetadataModelFactory()
@@ -96,7 +96,7 @@ class TestReportAdmin(AdminTestMixin):
         response = client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Disposition')) == (
-            'attachment', {'filename': 'Test report - 2018-01-01.csv'}
+            'attachment', {'filename': 'Test report - 2018-01-01-11-12-13.csv'}
         )
         assert response.getvalue().decode('utf-8') == f"""ID,Name\r
 {str(obj.pk)},{obj.name}\r

--- a/datahub/admin_report/tests/test_views.py
+++ b/datahub/admin_report/tests/test_views.py
@@ -1,0 +1,91 @@
+from cgi import parse_header
+
+import pytest
+from django.test import Client
+from django.urls import reverse
+from freezegun import freeze_time
+from rest_framework import status
+
+from datahub.core.test.support.factories import MetadataModelFactory
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+
+
+class TestReportAdmin(AdminTestMixin):
+    """Tests for the report list page."""
+
+    @pytest.mark.parametrize(
+        'url',
+        (
+            reverse('admin-report:index'),
+            reverse('admin-report:download-report', kwargs={'report_id': 'test-report'}),
+        )
+    )
+    def test_redirects_to_login_page_if_not_logged_in(self, url):
+        """Test that the view redirects to the login page if the user isn't authenticated."""
+        client = Client()
+        response = client.get(url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+
+    @pytest.mark.parametrize(
+        'url',
+        (
+            reverse('admin-report:index'),
+            reverse('admin-report:download-report', kwargs={'report_id': 'test-report'}),
+        )
+    )
+    def test_redirects_to_login_page_if_not_staff(self, url):
+        """Test that the view redirects to the login page if the user isn't a member of staff."""
+        user = create_test_user(is_staff=False, password=self.PASSWORD)
+
+        client = self.create_client(user=user)
+        response = client.get(url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+
+    def test_200_if_staff(self):
+        """Test that the view returns a 200 response if the user is an admin user."""
+        url = reverse('admin-report:index')
+        user = create_test_user(is_staff=True, password=self.PASSWORD)
+
+        client = self.create_client(user=user)
+        response = client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_report_download_without_permission(self):
+        """
+        Test that the view returns a 403 response if the staff user does not have the
+        correct permissions.
+        """
+        url = reverse('admin-report:download-report', kwargs={'report_id': 'test-report'})
+        user = create_test_user(permission_codenames=(), is_staff=True, password=self.PASSWORD)
+
+        client = self.create_client(user=user)
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @freeze_time('2018-01-01 00:00:00')
+    def test_report_download(self):
+        """Test the download of a report."""
+        obj = MetadataModelFactory()
+        url = reverse('admin-report:download-report', kwargs={'report_id': 'test-report'})
+
+        user = create_test_user(
+            permission_codenames=('change_metadatamodel',),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+
+        client = self.create_client(user=user)
+        response = client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        assert parse_header(response.get('Content-Disposition')) == (
+            'attachment', {'filename': 'Test report - 2018-01-01.csv'}
+        )
+        assert response.getvalue().decode('utf-8') == f"""ID,Name\r
+{str(obj.pk)},{obj.name}\r
+"""

--- a/datahub/admin_report/urls.py
+++ b/datahub/admin_report/urls.py
@@ -1,0 +1,19 @@
+from django.contrib.admin import site
+from django.urls import path
+
+from datahub.admin_report.views import download_report, list_reports
+
+app_name = 'admin-report'
+
+urlpatterns = [
+    path(
+        'admin/reports/',
+        site.admin_view(list_reports),
+        name='index'
+    ),
+    path(
+        'admin/reports/<report_id>/download',
+        site.admin_view(download_report),
+        name='download-report'
+    ),
+]

--- a/datahub/admin_report/views.py
+++ b/datahub/admin_report/views.py
@@ -1,10 +1,10 @@
 from csv import DictWriter
 
 from django.contrib.admin import site
-from django.http import FileResponse
+from django.http import FileResponse, Http404
 from django.template.response import TemplateResponse
 
-from datahub.admin_report.report import get_report_by_id, get_reports_by_model
+from datahub.admin_report.report import get_report_by_id, get_reports_by_model, report_exists
 from datahub.core.utils import Echo
 
 CSV_CONTENT_TYPE = 'text/csv'
@@ -31,6 +31,9 @@ def list_reports(request):
 
 def download_report(request, report_id=None):
     """Downloads a report."""
+    if not report_exists(report_id):
+        raise Http404
+
     report = get_report_by_id(report_id, request.user)
 
     # TODO: Use additional FileResponse.__init__() arguments when Django 2.1 is released

--- a/datahub/admin_report/views.py
+++ b/datahub/admin_report/views.py
@@ -1,0 +1,51 @@
+from csv import DictWriter
+
+from django.contrib.admin import site
+from django.http import FileResponse
+from django.template.response import TemplateResponse
+
+from datahub.admin_report.report import get_report_by_id, get_reports_by_model
+from datahub.core.utils import Echo
+
+CSV_CONTENT_TYPE = 'text/csv'
+REPORT_INDEX_TEMPLATE = 'admin/reports/index.html'
+
+
+def list_reports(request):
+    """View that displays a list of available reports for the current admin user."""
+    reports_by_model = {
+        model._meta.verbose_name_plural: report
+        for model, report in get_reports_by_model(request.user).items()
+    }
+
+    context = {
+        **site.each_context(request),
+        'title': 'Reports',
+        'reports_by_model': reports_by_model,
+    }
+
+    request.current_app = site.name
+
+    return TemplateResponse(request, REPORT_INDEX_TEMPLATE, context)
+
+
+def download_report(request, report_id=None):
+    """Downloads a report."""
+    report = get_report_by_id(report_id, request.user)
+
+    # TODO: Use additional FileResponse.__init__() arguments when Django 2.1 is released
+    # See https://code.djangoproject.com/ticket/16470
+    response = FileResponse(_csv_iterator(report), content_type=CSV_CONTENT_TYPE)
+
+    filename = report.get_filename()
+    response['Content-Disposition'] = f'attachment; filename="{filename}.csv"'
+    return response
+
+
+def _csv_iterator(report):
+    """Returns an iterator over the generated CSV contents."""
+    writer = DictWriter(Echo(), fieldnames=report.field_titles.keys())
+
+    yield writer.writerow(report.field_titles)
+    for row in report.rows():
+        yield writer.writerow(row)

--- a/datahub/company/admin_reports.py
+++ b/datahub/company/admin_reports.py
@@ -1,0 +1,36 @@
+from django.db.models import Case, NullBooleanField, Value, When
+from django.db.models.functions import Concat
+
+from datahub.admin_report.report import QuerySetReport
+from datahub.company.models import Advisor
+
+
+class AllAdvisersReport(QuerySetReport):
+    """Admin report for all advisers."""
+
+    id = 'all-advisers'
+    name = 'All advisers'
+    model = Advisor
+    permissions_required = ('company.read_advisor',)
+    queryset = Advisor.objects.annotate(
+        name=Concat('first_name', Value(' '), 'last_name'),
+        is_team_active=Case(
+            When(dit_team__disabled_on__isnull=True, dit_team__isnull=False, then=True),
+            When(dit_team__disabled_on__isnull=False, then=False),
+            default=None,
+            output_field=NullBooleanField()
+        ),
+    ).order_by(
+        'date_joined',
+        'pk',
+    )
+    field_titles = {
+        'id': 'ID',
+        'email': 'Username',
+        'name': 'Name',
+        'contact_email': 'Contact email',
+        'is_active': 'Is active',
+        'dit_team__name': 'Team',
+        'is_team_active': 'Is team active',
+        'dit_team__role__name': 'Team role',
+    }

--- a/datahub/company/test/test_admin_report.py
+++ b/datahub/company/test/test_admin_report.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timezone
+
+import pytest
+from django.urls import reverse
+from freezegun import freeze_time
+from rest_framework import status
+
+from datahub.company.admin_reports import AllAdvisersReport
+from datahub.company.test.factories import AdviserFactory
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+from datahub.metadata.test.factories import TeamFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestReportAdmin(AdminTestMixin):
+    """Tests for the download of the report."""
+
+    @freeze_time('2018-01-01 00:00:00')
+    def test_adviser_report_download(self):
+        """Test the download of a report."""
+        AdviserFactory.create_batch(5)
+
+        url = reverse('admin-report:download-report', kwargs={'report_id': 'all-advisers'})
+
+        user = create_test_user(
+            permission_codenames=('read_advisor',),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+
+        client = self.create_client(user=user)
+        response = client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+        # 7 = header + test user + the 5 test advisers
+        assert len(response.getvalue().decode('utf-8').splitlines()) == 7
+
+
+@freeze_time('2018-01-01 00:00:00')
+def test_adviser_report_generation():
+    """Test the generation of the report."""
+    disabled_team = TeamFactory(
+        disabled_on=datetime(1980, 1, 1, tzinfo=timezone.utc)
+    )
+    advisers = [
+        AdviserFactory(date_joined=datetime(1980, 1, 1, tzinfo=timezone.utc)),
+        AdviserFactory(date_joined=datetime(1990, 1, 1, tzinfo=timezone.utc), dit_team=None),
+        AdviserFactory(
+            date_joined=datetime(2000, 1, 1, tzinfo=timezone.utc),
+            dit_team=disabled_team
+        ),
+    ]
+
+    report = AllAdvisersReport()
+    assert list(report.rows()) == [{
+        'id': adviser.pk,
+        'email': adviser.email,
+        'name': adviser.name,
+        'contact_email': adviser.contact_email,
+        'is_active': adviser.is_active,
+        'dit_team__name': adviser.dit_team.name if adviser.dit_team else None,
+        'is_team_active': adviser.dit_team.disabled_on is None if adviser.dit_team else None,
+        'dit_team__role__name': adviser.dit_team.role.name if adviser.dit_team else None,
+    } for adviser in advisers]

--- a/datahub/core/test/support/factories.py
+++ b/datahub/core/test/support/factories.py
@@ -1,0 +1,13 @@
+from uuid import uuid4
+
+import factory
+
+
+class MetadataModelFactory(factory.django.DjangoModelFactory):
+    """MetadataModel factory."""
+
+    id = factory.LazyFunction(uuid4)
+    name = factory.Faker('sentence')
+
+    class Meta:
+        model = 'support.MetadataModel'

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -16,6 +16,19 @@ class StrEnum(str, Enum):
     """
 
 
+class Echo:
+    """
+    Writer that echoes written data.
+
+    Used for streaming large CSV files, defined as per
+    https://docs.djangoproject.com/en/2.0/howto/outputting-csv/.
+    """
+
+    def write(self, value):
+        """Returns value that is being "written"."""
+        return value
+
+
 def join_truthy_strings(*args, sep=' '):
     """Joins a list of strings using a separtor, omitting falsey values."""
     return sep.join(filter(None, args))

--- a/datahub/search/utils.py
+++ b/datahub/search/utils.py
@@ -1,11 +1,3 @@
-class Echo:
-    """Represents dummy writer."""
-
-    def write(self, value):
-        """Returns value that is being "written"."""
-        return value
-
-
 def get_model_fields(es_model):
     """Gets the field objects for an ES model."""
     return es_model._doc_type.mapping.properties._params['properties']

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -11,6 +11,7 @@ from rest_framework.fields import empty
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from datahub.core.utils import Echo
 from datahub.oauth.scopes import Scope
 from .apps import get_search_apps
 from .permissions import has_permissions_for_app, SearchAppPermissions
@@ -20,7 +21,7 @@ from .query_builder import (
     limit_search_query,
 )
 from .serializers import SearchSerializer
-from .utils import Echo, get_model_field_names
+from .utils import get_model_field_names
 
 EntitySearch = namedtuple('EntitySearch', ['model', 'name'])
 


### PR DESCRIPTION
Issue number: N/A

### Description of change

Adds a simple reporting framework for admin and the first report (an export of all advisers).

I haven't added a link to the reports page from the index yet as it seems that that's not simple (looks like it'll be easier in Django 2.1, though).

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?