### PR TITLE
Change title of ID column to Adviser ID in adviser export

### DIFF
--- a/datahub/admin_report/report.py
+++ b/datahub/admin_report/report.py
@@ -77,6 +77,11 @@ class Report(metaclass=_ReportMeta):
         missing_attrs = [attr for attr in cls._required_attrs if getattr(cls, attr, None) is None]
         if missing_attrs:
             raise DataHubException(f'Required report attributes {missing_attrs} not set')
+        if 'ID' in cls.field_titles.values():
+            raise DataHubException(
+                'ID cannot be used as a column title due to the potential confusion with SYLK '
+                'files in e.g. Excel'
+            )
 
 
 class QuerySetReport(Report):

--- a/datahub/admin_report/tests/conftest.py
+++ b/datahub/admin_report/tests/conftest.py
@@ -11,6 +11,6 @@ class MetadataReport(QuerySetReport):
     queryset = MetadataModel.objects.order_by('pk')
     permissions_required = ('support.change_metadatamodel',)
     field_titles = {
-        'id': 'ID',
+        'id': 'Test ID',
         'name': 'Name',
     }

--- a/datahub/admin_report/tests/test_views.py
+++ b/datahub/admin_report/tests/test_views.py
@@ -98,6 +98,6 @@ class TestReportAdmin(AdminTestMixin):
         assert parse_header(response.get('Content-Disposition')) == (
             'attachment', {'filename': 'Test report - 2018-01-01-11-12-13.csv'}
         )
-        assert response.getvalue().decode('utf-8') == f"""Test ID,Name\r
+        assert response.getvalue().decode('utf-8-sig') == f"""Test ID,Name\r
 {str(obj.pk)},{obj.name}\r
 """

--- a/datahub/admin_report/tests/test_views.py
+++ b/datahub/admin_report/tests/test_views.py
@@ -98,6 +98,6 @@ class TestReportAdmin(AdminTestMixin):
         assert parse_header(response.get('Content-Disposition')) == (
             'attachment', {'filename': 'Test report - 2018-01-01-11-12-13.csv'}
         )
-        assert response.getvalue().decode('utf-8') == f"""ID,Name\r
+        assert response.getvalue().decode('utf-8') == f"""Test ID,Name\r
 {str(obj.pk)},{obj.name}\r
 """

--- a/datahub/admin_report/views.py
+++ b/datahub/admin_report/views.py
@@ -1,3 +1,4 @@
+from codecs import BOM_UTF8
 from csv import DictWriter
 
 from django.contrib.admin import site
@@ -47,6 +48,7 @@ def download_report(request, report_id=None):
 
 def _csv_iterator(report):
     """Returns an iterator over the generated CSV contents."""
+    yield BOM_UTF8
     writer = DictWriter(Echo(), fieldnames=report.field_titles.keys())
 
     yield writer.writerow(report.field_titles)

--- a/datahub/company/admin_reports.py
+++ b/datahub/company/admin_reports.py
@@ -25,7 +25,7 @@ class AllAdvisersReport(QuerySetReport):
         'pk',
     )
     field_titles = {
-        'id': 'ID',
+        'id': 'Adviser ID',
         'email': 'Username',
         'name': 'Name',
         'contact_email': 'Contact email',


### PR DESCRIPTION
Issue number: 

### Description of change

This is to stop Excel thinking the file is a SYLK file.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
