### PR TITLE
Pass search app by name to sync_model Celery task

### DIFF
--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -68,15 +68,26 @@ class SearchApp:
         return None
 
 
-@lru_cache(maxsize=None)
 def get_search_apps():
-    """Registers all search apps specified in `SEARCH_APPS`."""
-    return tuple(get_search_app(cls_path) for cls_path in SEARCH_APPS)
+    """Gets all registered search apps."""
+    return _load_search_apps().values()
+
+
+def get_search_app(app_name):
+    """Gets a single search app (by name)."""
+    return _load_search_apps()[app_name]
 
 
 @lru_cache(maxsize=None)
-def get_search_app(cls_path):
-    """Registers a single search app."""
+def _load_search_apps():
+    """Loads and registers all search apps specified in `SEARCH_APPS`."""
+    apps = (_load_search_app(cls_path) for cls_path in SEARCH_APPS)
+    return {app.name: app for app in apps}
+
+
+@lru_cache(maxsize=None)
+def _load_search_app(cls_path):
+    """Loads and registers a single search app."""
     mod_path, _, cls_name = cls_path.rpartition('.')
     mod = import_module(mod_path)
     cls = getattr(mod, cls_name)

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -1,6 +1,6 @@
 from celery import shared_task
 
-from datahub.search.apps import get_search_app, SEARCH_APPS
+from datahub.search.apps import get_search_app, get_search_apps
 from datahub.search.bulk_sync import sync_app
 
 
@@ -13,14 +13,14 @@ def sync_all_models():
 
     priority is set to the lowest priority (for Redis, 0 is the highest priority).
     """
-    for search_app_cls_path in SEARCH_APPS:
+    for search_app in get_search_apps():
         sync_model.apply_async(
-            args=(search_app_cls_path,),
+            args=(search_app.name,),
         )
 
 
 @shared_task(acks_late=True, priority=9)
-def sync_model(search_app_cls_path):
+def sync_model(search_app_name):
     """
     Task that syncs a single model to Elasticsearch.
 
@@ -28,5 +28,5 @@ def sync_model(search_app_cls_path):
 
     priority is set to the lowest priority (for Redis, 0 is the highest priority).
     """
-    search_app = get_search_app(search_app_cls_path)
+    search_app = get_search_app(search_app_name)
     sync_app(search_app)


### PR DESCRIPTION
Issue number: N/A

### Description of change

Small change to add the ability to get a search app by name, and use that for the sync_model Celery task (instead of the class path).

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
