### PR TITLE
Make sync_es fail if ES index doesn't exist

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -123,10 +123,18 @@ def get_client():
     return connections.get_connection()
 
 
+def index_exists(name=settings.ES_INDEX):
+    """
+    :param name: Name of the index
+
+    :returns: True if index_name exists
+    """
+    return get_client().indices.exists(index=name)
+
+
 def configure_index(index_name, index_settings=None):
     """Configures Elasticsearch index."""
-    client = get_client()
-    if not client.indices.exists(index=index_name):
+    if not index_exists(name=index_name):
         index = Index(index_name)
         for analyzer in ANALYZERS:
             index.analyzer(analyzer)

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -1,9 +1,10 @@
 from logging import getLogger, WARNING
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
 from datahub.search.bulk_sync import get_apps_to_sync, sync_app
 from ...apps import get_search_apps
+from ...elasticsearch import index_exists
 
 logger = getLogger(__name__)
 
@@ -38,6 +39,9 @@ class Command(BaseCommand):
         """Handle."""
         es_logger = getLogger('elasticsearch')
         es_logger.setLevel(WARNING)
+
+        if not index_exists():
+            raise CommandError(f'Index and mapping not initialised, please run `init_es` first.')
 
         sync_es(
             batch_size=options['batch_size'],

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -15,6 +15,18 @@ def test_bulk(es_bulk, mock_es_client):
     es_bulk.assert_called_with(mock_es_client.return_value, actions=actions, chunk_size=chunk_size)
 
 
+@pytest.mark.parametrize('expected', (True, False))
+def test_index_exists(mock_es_client, expected):
+    """Tests that `index_exists` returns True if the index exists, False otherwise."""
+    index_name = 'test'
+
+    connection = mock_es_client.return_value
+    connection.indices.exists.return_value = expected
+
+    assert elasticsearch.index_exists(name=index_name) == expected
+    connection.indices.exists.assert_called_with(index=index_name)
+
+
 @mock.patch('datahub.search.elasticsearch.settings')
 @mock.patch('datahub.search.elasticsearch.connections')
 def test_configure_connection(connections, settings):


### PR DESCRIPTION
**Before:**
If the ES index didn't exist (e.g. new environment) and you called sync_es the underlying library would create the index and the mapping automatically by guessing it.
We expect the init_es to be called at least once to initiate ES.

**After:**
If the ES index doesn't exist now the sync_es command fails telling you to run init_es first.
