### PR TITLE
Add global headquarters filter and sorting options to companies endpoint

### DIFF
--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -30,6 +30,9 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
 
     required_scopes = (Scope.internal_front_end,)
     serializer_class = CompanySerializer
+    filter_backends = (DjangoFilterBackend, OrderingFilter)
+    filter_fields = ('global_headquarters_id',)
+    ordering_fields = ('name', 'created_on')
     queryset = Company.objects.select_related(
         'account_manager',
         'archived_by',


### PR DESCRIPTION
Issue number: n/a

### Description of change

Adds a global_headquarters_id filter and name and created_on sorting options to the /v3/companies endpoint.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
