### PR TITLE
Add management command to update investment project business activities

### DIFF
--- a/datahub/dbmaintenance/management/commands/update_investment_project_business_activities.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_business_activities.py
@@ -1,0 +1,38 @@
+from logging import getLogger
+
+import reversion
+
+from datahub.dbmaintenance.utils import parse_uuid, parse_uuid_list
+from datahub.investment.models import InvestmentProject
+from ..base import CSVBaseCommand
+
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """Command to update investment_project.business_activities."""
+
+    def _process_row(self, row, simulate=False, ignore_old_regions=False, **options):
+        """Processes a CSV file row."""
+        pk = parse_uuid(row['id'])
+        investment_project = InvestmentProject.objects.get(pk=pk)
+        old_business_activity_ids = parse_uuid_list(row['old_business_activities'])
+        new_business_activity_ids = parse_uuid_list(row['new_business_activities'])
+
+        current_business_activities = investment_project.business_activities.all()
+        current_business_activity_ids = {activity.pk for activity in current_business_activities}
+
+        if current_business_activity_ids == set(new_business_activity_ids):
+            return
+
+        if current_business_activity_ids != set(old_business_activity_ids):
+            logger.warning('Not updating project %s as its business activities have changed', pk)
+            return
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            investment_project.business_activities.set(new_business_activity_ids)
+            reversion.set_comment('Business activities data migration correction.')

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_business_activities.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_business_activities.py
@@ -1,0 +1,152 @@
+from io import BytesIO
+
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.investment.test.factories import InvestmentProjectFactory
+from datahub.metadata.models import InvestmentBusinessActivity
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """
+    Test that the command updates the specified records, checking if current business activities
+    match the old business activities in the CSV.
+    """
+    caplog.set_level('ERROR')
+
+    business_activities = list(InvestmentBusinessActivity.objects.all())
+    old_business_activities = [[], [], business_activities[0:2], business_activities[2:3]]
+    investment_projects = InvestmentProjectFactory.create_batch(4)
+
+    for project, project_business_activities in zip(investment_projects, old_business_activities):
+        project.business_activities.set(project_business_activities)
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,old_business_activities,new_business_activities
+00000000-0000-0000-0000-000000000000,null,null
+{investment_projects[0].pk},null,null
+{investment_projects[1].pk},null,{business_activities[2].pk}
+{investment_projects[2].pk},"{business_activities[0].pk},{business_activities[1].pk}","{business_activities[0].pk},{business_activities[1].pk}"
+{investment_projects[3].pk},{business_activities[5].pk},"{business_activities[0].pk},{business_activities[1].pk},{business_activities[2].pk},{business_activities[3].pk}"
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        }
+    )
+
+    call_command('update_investment_project_business_activities', bucket, object_key)
+
+    for project in investment_projects:
+        project.refresh_from_db()
+
+    assert 'InvestmentProject matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+    assert [list(project.business_activities.all()) for project in investment_projects] == [
+        [],
+        business_activities[2:3],
+        business_activities[0:2],
+        business_activities[2:3],  # Old business activities did not match
+    ]
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+
+    business_activities = list(InvestmentBusinessActivity.objects.all())
+    old_business_activities = [[], [], business_activities[0:2], business_activities[2:3]]
+    investment_projects = InvestmentProjectFactory.create_batch(4)
+
+    for project, project_business_activities in zip(investment_projects, old_business_activities):
+        project.business_activities.set(project_business_activities)
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,old_business_activities,new_business_activities
+00000000-0000-0000-0000-000000000000,null,null
+{investment_projects[0].pk},null,null
+{investment_projects[1].pk},null,{business_activities[2].pk}
+{investment_projects[2].pk},"{business_activities[0].pk},{business_activities[1].pk}","{business_activities[0].pk},{business_activities[1].pk}"
+{investment_projects[3].pk},{business_activities[5].pk},"{business_activities[0].pk},{business_activities[1].pk},{business_activities[2].pk},{business_activities[3].pk}"
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        }
+    )
+
+    call_command(
+        'update_investment_project_business_activities',
+        bucket,
+        object_key,
+        simulate=True,
+    )
+
+    for project in investment_projects:
+        project.refresh_from_db()
+
+    assert 'InvestmentProject matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+    assert [list(project.business_activities.all())
+            for project in investment_projects] == old_business_activities
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    business_activities = list(InvestmentBusinessActivity.objects.all())
+
+    project_without_change = InvestmentProjectFactory(business_activities=business_activities[0:1])
+    project_with_change = InvestmentProjectFactory(business_activities=[])
+    project_already_updated = InvestmentProjectFactory(
+        business_activities=business_activities[0:1]
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,old_business_activities,new_business_activities
+{project_without_change.pk},{business_activities[1].pk},{business_activities[0].pk}
+{project_with_change.pk},null,{business_activities[2].pk}
+{project_already_updated.pk},{business_activities[0].pk},{business_activities[0].pk}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        }
+    )
+
+    call_command('update_investment_project_business_activities', bucket, object_key)
+
+    versions = Version.objects.get_for_object(project_without_change)
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(project_already_updated)
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(project_with_change)
+    assert versions.count() == 1
+    assert versions[0].revision.comment == 'Business activities data migration correction.'


### PR DESCRIPTION
Issue number: n/a

### Description of change

Adds a dbmaintenance command to update the business activities for investment projects using a CSV file.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
