### PR TITLE
Allow client to specify null as the headquarter_type in a company search

### DIFF
--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -17,7 +17,11 @@ class SearchCompanySerializer(SearchSerializer):
     export_to_country = SingleOrListField(child=StringUUIDField(), required=False)
     future_interest_country = SingleOrListField(child=StringUUIDField(), required=False)
     global_headquarters = SingleOrListField(child=StringUUIDField(), required=False)
-    headquarter_type = SingleOrListField(child=NullStringUUIDField(), required=False)
+    headquarter_type = SingleOrListField(
+        child=NullStringUUIDField(allow_null=True),
+        required=False,
+        allow_null=True
+    )
     name = serializers.CharField(required=False)
     sector = SingleOrListField(child=StringUUIDField(), required=False)
     sector_descends = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -152,7 +152,8 @@ class TestSearch(APITestMixin):
         url = reverse('api-v3:search:company')
         response = self.api_client.post(
             url,
-            query
+            query,
+            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
The frontend needs to be able to search for a list of companies, filtered on the headquarter type and specify that it wants to include companies with a null headquarters.

Previously when a null was passed it would result in an error from the serializer. This change allows nulls to be passed.
