### PR TITLE
Filter interaction by event and include contact job title in result

### DIFF
--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -40,7 +40,9 @@ class InteractionSerializer(serializers.ModelSerializer):
     }
 
     company = NestedRelatedField(Company)
-    contact = NestedRelatedField(Contact)
+    contact = NestedRelatedField(Contact, extra_fields=(
+        'name', 'first_name', 'last_name', 'job_title'
+    ))
     dit_adviser = NestedAdviserField()
     created_by = NestedAdviserField(read_only=True)
     dit_team = NestedRelatedField(Team)

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -1,5 +1,7 @@
-from datetime import date
+from datetime import date, datetime
 
+import pytest
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 from reversion.models import Version
@@ -7,7 +9,9 @@ from reversion.models import Version
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core.constants import Service, Team
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
-from datahub.core.test_utils import APITestMixin, create_test_user, random_obj_for_model
+from datahub.core.test_utils import (
+    APITestMixin, create_test_user, format_date_or_datetime, random_obj_for_model
+)
 from datahub.event.test.factories import EventFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import TeamFactory
@@ -124,6 +128,7 @@ class TestListInteractions(APITestMixin):
         event = EventFactory()
 
         CompanyInteractionFactory.create_batch(3, contact=contact)
+        EventServiceDeliveryFactory.create_batch(3)
         service_deliveries = EventServiceDeliveryFactory.create_batch(3, event=event)
 
         url = reverse('api-v3:interaction:collection')
@@ -133,9 +138,57 @@ class TestListInteractions(APITestMixin):
         response_data = response.json()
         assert response_data['count'] == 3
 
-        actual_ids = {i['id'] for i in response_data['results']}
-        expected_ids = {str(i.id) for i in service_deliveries}
+        actual_ids = {result['id'] for result in response_data['results']}
+        expected_ids = {str(service_delivery.id) for service_delivery in service_deliveries}
         assert actual_ids == expected_ids
+
+    @pytest.mark.parametrize(
+        'sort', ('last_name', 'first_name')
+    )
+    def test_sort_by_contact_names(self, sort):
+        """List of interactions sorted by contact name"""
+        interactions = EventServiceDeliveryFactory.create_batch(3)
+
+        url = reverse('api-v3:interaction:collection')
+        response = self.api_client.get(url, data={
+            'sortby': f'contact__{sort}',
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(interactions)
+        expected_names = sorted(getattr(interaction.contact, sort) for interaction in interactions)
+        actual_names = [result['contact'][sort] for result in response_data['results']]
+        assert expected_names == actual_names
+
+    def test_sort_by_created_on(self):
+        """Test sorting by created_on."""
+        creation_times = [
+            datetime(2015, 1, 1),
+            datetime(2016, 1, 1),
+            datetime(2019, 1, 1),
+            datetime(2020, 1, 1),
+            datetime(2005, 1, 1),
+        ]
+
+        for creation_time in creation_times:
+            with freeze_time(creation_time):
+                EventServiceDeliveryFactory()
+
+        url = reverse('api-v3:interaction:collection')
+        response = self.api_client.get(url, data={
+            'sortby': 'created_on',
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(creation_times)
+        expected_timestamps = [
+            format_date_or_datetime(creation_time)
+            for creation_time in sorted(creation_times)
+        ]
+        actual_timestamps = [result['created_on'] for result in response_data['results']]
+        assert expected_timestamps == actual_timestamps
 
 
 class TestInteractionVersioning(APITestMixin):

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -129,7 +129,10 @@ class TestAddInteraction(APITestMixin):
             },
             'contact': {
                 'id': str(contact.pk),
-                'name': contact.name
+                'name': contact.name,
+                'first_name': contact.first_name,
+                'last_name': contact.last_name,
+                'job_title': contact.job_title,
             },
             'event': None,
             'service': {
@@ -382,7 +385,10 @@ class TestGetInteraction(APITestMixin):
             },
             'contact': {
                 'id': str(interaction.contact.pk),
-                'name': interaction.contact.name
+                'name': interaction.contact.name,
+                'first_name': interaction.contact.first_name,
+                'last_name': interaction.contact.last_name,
+                'job_title': interaction.contact.job_title,
             },
             'event': None,
             'service': {
@@ -451,7 +457,10 @@ class TestGetInteraction(APITestMixin):
             },
             'contact': {
                 'id': str(interaction.contact.pk),
-                'name': interaction.contact.name
+                'name': interaction.contact.name,
+                'first_name': interaction.contact.first_name,
+                'last_name': interaction.contact.last_name,
+                'job_title': interaction.contact.job_title,
             },
             'event': None,
             'service': {
@@ -528,7 +537,10 @@ class TestGetInteraction(APITestMixin):
             },
             'contact': {
                 'id': str(interaction.contact.pk),
-                'name': interaction.contact.name
+                'name': interaction.contact.name,
+                'first_name': interaction.contact.first_name,
+                'last_name': interaction.contact.last_name,
+                'job_title': interaction.contact.job_title,
             },
             'event': None,
             'service': {

--- a/datahub/interaction/test/views/test_policy_feedback.py
+++ b/datahub/interaction/test/views/test_policy_feedback.py
@@ -98,7 +98,10 @@ class TestAddPolicyFeedback(APITestMixin):
             },
             'contact': {
                 'id': str(contact.pk),
-                'name': contact.name
+                'name': contact.name,
+                'first_name': contact.first_name,
+                'last_name': contact.last_name,
+                'job_title': contact.job_title,
             },
             'event': None,
             'service': {
@@ -306,7 +309,10 @@ class TestUpdatePolicyFeedback(APITestMixin):
             },
             'contact': {
                 'id': str(interaction.contact.pk),
-                'name': interaction.contact.name
+                'name': interaction.contact.name,
+                'first_name': interaction.contact.first_name,
+                'last_name': interaction.contact.last_name,
+                'job_title': interaction.contact.job_title,
             },
             'event': None,
             'service': {
@@ -403,7 +409,10 @@ class TestGetPolicyFeedback(APITestMixin):
             },
             'contact': {
                 'id': str(interaction.contact.pk),
-                'name': interaction.contact.name
+                'name': interaction.contact.name,
+                'first_name': interaction.contact.first_name,
+                'last_name': interaction.contact.last_name,
+                'job_title': interaction.contact.job_title,
             },
             'event': None,
             'service': {

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -94,7 +94,10 @@ class TestAddServiceDelivery(APITestMixin):
             },
             'contact': {
                 'id': str(contact.pk),
-                'name': contact.name
+                'name': contact.name,
+                'first_name': contact.first_name,
+                'last_name': contact.last_name,
+                'job_title': contact.job_title,
             },
             'event': request_data.get('event'),
             'service': {

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -33,6 +33,6 @@ class InteractionViewSet(CoreViewSet):
         OrderingFilter,
         PolicyFeedbackPermissionFilter,
     )
-    filter_fields = ['company_id', 'contact_id', 'investment_project_id']
-    ordering_fields = ('date', 'created_on')
+    filter_fields = ['company_id', 'contact_id', 'investment_project_id', 'event_id']
+    ordering_fields = ('date', 'created_on', 'contact__last_name', 'contact__first_name')
     ordering = ('-date', '-created_on')

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -33,6 +33,6 @@ class InteractionViewSet(CoreViewSet):
         OrderingFilter,
         PolicyFeedbackPermissionFilter,
     )
-    filter_fields = ['company_id', 'contact_id', 'investment_project_id', 'event_id']
-    ordering_fields = ('date', 'created_on', 'contact__last_name', 'contact__first_name')
+    filter_fields = ['company_id', 'contact_id', 'event_id', 'investment_project_id']
+    ordering_fields = ('contact__first_name', 'contact__last_name', 'created_on', 'date')
     ordering = ('-date', '-created_on')


### PR DESCRIPTION
Adds a filter to the interactions API to allow interactions to be fetched that are associated with a given event, to find people who have attended an event. The view also allows that result to be sorted by contact last name and first name.

The Screen that lists the attendees needs to show the associated contact job title so the interaction serializer adds that.