### PR TITLE
Add sector filter to OMIS order search

### DIFF
--- a/datahub/search/omis/serializers.py
+++ b/datahub/search/omis/serializers.py
@@ -12,6 +12,7 @@ class SearchOrderSerializer(SearchSerializer):
     """Serialiser used to validate OMIS search POST bodies."""
 
     primary_market = SingleOrListField(child=StringUUIDField(), required=False)
+    sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     uk_region = SingleOrListField(child=StringUUIDField(), required=False)
     created_on_before = RelaxedDateTimeField(required=False)
     created_on_after = RelaxedDateTimeField(required=False)

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -13,6 +13,7 @@ class SearchOrderParams:
 
     FILTER_FIELDS = [
         'primary_market',
+        'sector_descends',
         'uk_region',
         'created_on_before',
         'created_on_after',
@@ -46,6 +47,10 @@ class SearchOrderParams:
             'company.name_trigram',
             'company.trading_name',
             'company.trading_name_trigram',
+        ],
+        'sector_descends': [
+            'sector.id',
+            'sector.ancestors.id',
         ],
     }
 


### PR DESCRIPTION
Issue number: n/a

### Description of change

Adds a sector_descends filter to OMIS order search.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
