### PR TITLE
Make a team required for events

### DIFF
--- a/datahub/event/serializers.py
+++ b/datahub/event/serializers.py
@@ -21,8 +21,8 @@ class EventSerializer(serializers.ModelSerializer):
     event_type = NestedRelatedField('event.EventType')
     location_type = NestedRelatedField('event.LocationType', required=False, allow_null=True)
     organiser = NestedAdviserField(required=False, allow_null=True)
-    lead_team = NestedRelatedField('metadata.Team', required=False, allow_null=True)
-    teams = NestedRelatedField('metadata.Team', many=True, required=False, allow_empty=True)
+    lead_team = NestedRelatedField('metadata.Team')
+    teams = NestedRelatedField('metadata.Team', many=True, allow_empty=False)
     address_country = NestedRelatedField('metadata.Country')
     uk_region = NestedRelatedField('metadata.UKRegion', required=False, allow_null=True)
     related_programmes = NestedRelatedField(
@@ -55,7 +55,7 @@ class EventSerializer(serializers.ModelSerializer):
         lead_team = combiner.get_value('lead_team')
         teams = combiner.get_value_to_many('teams')
 
-        if lead_team and lead_team not in teams:
+        if lead_team not in teams:
             errors['lead_team'] = self.error_messages['lead_team_not_in_teams']
 
         return errors


### PR DESCRIPTION
Issue number: n/a

### Description of change

This makes lead_team required for events (and it also makes teams required as lead_team must be in teams). This change is also being applied for existing events in the system.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
