### PR TITLE
Make notes optional for event service deliveries

### DIFF
--- a/datahub/interaction/migrations/0001_squashed_0019_rename_default_permissions.py
+++ b/datahub/interaction/migrations/0001_squashed_0019_rename_default_permissions.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
                 ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
                 ('date', models.DateTimeField()),
                 ('subject', models.TextField()),
-                ('notes', models.TextField(max_length=4000)),
+                ('notes', models.TextField(blank=True, max_length=4000)),
                 ('company', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='interactions', to='company.Company')),
                 ('contact', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='interactions', to='company.Contact')),
                 ('dit_adviser', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='interactions', to=settings.AUTH_USER_MODEL)),

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -138,7 +138,7 @@ class Interaction(BaseModel):
         null=True,
         on_delete=models.SET_NULL
     )
-    notes = models.TextField(max_length=settings.CDMS_TEXT_MAX_LENGTH)
+    notes = models.TextField(max_length=settings.CDMS_TEXT_MAX_LENGTH, blank=True)
     dit_team = models.ForeignKey(
         'metadata.Team', blank=True, null=True, on_delete=models.SET_NULL
     )

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -225,5 +225,10 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('event', not_),
                     when=OperatorRule('is_event', not_),
                 ),
+                ValidationRule(
+                    'required',
+                    OperatorRule('notes', is_not_blank),
+                    when=OperatorRule('is_event', not_),
+                ),
             ),
         ]

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -173,7 +173,6 @@ class TestAddInteraction(APITestMixin):
                 {
                     'date': ['This field is required.'],
                     'subject': ['This field is required.'],
-                    'notes': ['This field is required.'],
                     'company': ['This field is required.'],
                     'contact': ['This field is required.'],
                     'dit_adviser': ['This field is required.'],
@@ -188,7 +187,6 @@ class TestAddInteraction(APITestMixin):
                     'kind': Interaction.KINDS.interaction,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
-                    'notes': 'hello',
                     'company': CompanyFactory,
                     'contact': ContactFactory,
                     'dit_adviser': AdviserFactory,
@@ -196,6 +194,7 @@ class TestAddInteraction(APITestMixin):
                     'dit_team': Team.healthcare_uk.value.id,
                 },
                 {
+                    'notes': ['This field is required.'],
                     'communication_channel': ['This field is required.'],
                 }
             ),

--- a/datahub/interaction/test/views/test_policy_feedback.py
+++ b/datahub/interaction/test/views/test_policy_feedback.py
@@ -264,7 +264,6 @@ class TestAddPolicyFeedback(APITestMixin):
                 {
                     'date': ['This field is required.'],
                     'subject': ['This field is required.'],
-                    'notes': ['This field is required.'],
                     'company': ['This field is required.'],
                     'contact': ['This field is required.'],
                     'dit_adviser': ['This field is required.'],
@@ -279,7 +278,6 @@ class TestAddPolicyFeedback(APITestMixin):
                     'kind': Interaction.KINDS.policy_feedback,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
-                    'notes': 'hello',
                     'company': CompanyFactory,
                     'contact': ContactFactory,
                     'dit_adviser': AdviserFactory,
@@ -287,6 +285,7 @@ class TestAddPolicyFeedback(APITestMixin):
                     'dit_team': Team.healthcare_uk.value.id,
                 },
                 {
+                    'notes': ['This field is required.'],
                     'policy_areas': ['This field is required.'],
                     'policy_issue_type': ['This field is required.'],
                     'communication_channel': ['This field is required.'],

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -30,6 +30,7 @@ class TestAddServiceDelivery(APITestMixin):
             # non-event service delivery
             {
                 'is_event': False,
+                'notes': 'hello',
             },
             # event service delivery
             {
@@ -39,6 +40,7 @@ class TestAddServiceDelivery(APITestMixin):
             # non-event service delivery with all fields filled in
             {
                 'is_event': False,
+                'notes': 'hello',
                 'service_delivery_status': partial(random_obj_for_model, ServiceDeliveryStatus),
                 'grant_amount_offered': '9999.99',
                 'net_company_receipt': '8888.99',
@@ -56,7 +58,6 @@ class TestAddServiceDelivery(APITestMixin):
             'subject': 'whatever',
             'date': date.today().isoformat(),
             'dit_adviser': adviser.pk,
-            'notes': 'hello',
             'company': company.pk,
             'contact': contact.pk,
             'service': Service.trade_enquiry.value.id,
@@ -88,7 +89,7 @@ class TestAddServiceDelivery(APITestMixin):
                 'last_name': adviser.last_name,
                 'name': adviser.name
             },
-            'notes': 'hello',
+            'notes': request_data.get('notes', ''),
             'company': {
                 'id': str(company.pk),
                 'name': company.name
@@ -138,7 +139,6 @@ class TestAddServiceDelivery(APITestMixin):
                 {
                     'date': ['This field is required.'],
                     'subject': ['This field is required.'],
-                    'notes': ['This field is required.'],
                     'company': ['This field is required.'],
                     'contact': ['This field is required.'],
                     'dit_adviser': ['This field is required.'],
@@ -153,7 +153,6 @@ class TestAddServiceDelivery(APITestMixin):
                     'kind': Interaction.KINDS.service_delivery,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
-                    'notes': 'hello',
                     'company': CompanyFactory,
                     'contact': ContactFactory,
                     'dit_adviser': AdviserFactory,
@@ -162,6 +161,7 @@ class TestAddServiceDelivery(APITestMixin):
                 },
                 {
                     'is_event': ['This field is required.'],
+                    'notes': ['This field is required.'],
                 }
             ),
 
@@ -232,7 +232,6 @@ class TestAddServiceDelivery(APITestMixin):
                     'kind': Interaction.KINDS.service_delivery,
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
-                    'notes': 'hello',
                     'company': CompanyFactory,
                     'contact': ContactFactory,
                     'dit_adviser': AdviserFactory,


### PR DESCRIPTION
Issue number: n/a

### Description of change

This makes notes optional for event service deliveries. (Notes are still required for other types of interaction.)

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
