### PR TITLE
Add archived filter to company search

### DIFF
--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -7,6 +7,7 @@ class SearchCompanySerializer(SearchSerializer):
     """Serialiser used to validate company search POST bodies."""
 
     account_manager = SingleOrListField(child=StringUUIDField(), required=False)
+    archived = serializers.BooleanField(required=False)
     trading_name = serializers.CharField(required=False)
     description = serializers.CharField(required=False)
     export_to_country = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -13,6 +13,7 @@ class SearchCompanyParams:
 
     FILTER_FIELDS = (
         'account_manager',
+        'archived',
         'description',
         'export_to_country',
         'future_interest_country',
@@ -24,7 +25,7 @@ class SearchCompanyParams:
         'country',
         'trading_address_country',
         'uk_based',
-        'uk_region'
+        'uk_region',
     )
 
     REMAP_FIELDS = {


### PR DESCRIPTION
Issue number: n/a

### Description of change

Adds a filter for the archived field to company search.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
