### PR TITLE
Don't force -vv when running pytest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: python -m pytest -n 4 --cov -s --junitxml=test-reports/junit.xml
+          command: python -m pytest -n 4 -p no:sugar --cov -s --junitxml=test-reports/junit.xml
 
       - store_test_results:
           path: test-reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
 
       - run:
           name: Run tests
-          command: python -m pytest -n 4 -p no:sugar --cov -s --junitxml=test-reports/junit.xml
+          command: python -m pytest -n 4 -p no:sugar --cov --junitxml=test-reports/junit.xml
 
       - store_test_results:
           path: test-reports

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --ds=config.settings.test -vv
+addopts = --ds=config.settings.test
 norecursedirs = env
 filterwarnings =
     ignore:`settings.OMIS_NOTIFICATION_API_KEY`


### PR DESCRIPTION
Issue number: n/a

### Description of change

I'm not sure why we were forcing -vv in pytest.ini. The PYTEST_ADDOPTS environment variable can be used to force that if needed, so there doesn't seem to be much sense in forcing that for everyone.

This also disables pytest-sugar during CI builds as the output was being mangled somewhat. -s was also removed, as although it's nice to see full output, it was breaking pytest's built-in progress percentage for some reason.

### Checklist

* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
