### PR TITLE
Block editing of archived contacts

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -27,6 +27,7 @@ from datahub.core.validators import (
     AllIsBlankRule,
     AnyIsNotBlankRule,
     EqualsRule,
+    NotArchivedValidator,
     OperatorRule,
     RequiredUnlessAlreadyBlankValidator,
     RulesBasedValidator,
@@ -182,6 +183,7 @@ class ContactSerializer(PermittedFieldsModelSerializer):
             'archived_documents_url_path',
         )
         validators = [
+            NotArchivedValidator(),
             RulesBasedValidator(
                 ValidationRule(
                     'contact_preferences_required',

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -109,3 +109,12 @@ class ContactFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'company.Contact'
+
+
+class ArchivedContactFactory(ContactFactory):
+    """Factory for an archived contact."""
+
+    archived = True
+    archived_on = factory.Faker('past_datetime', tzinfo=utc)
+    archived_by = factory.LazyFunction(lambda: random_obj_for_model(Advisor))
+    archived_reason = factory.Faker('sentence')


### PR DESCRIPTION
Issue number: n/a

### Description of change

This blocks direct editing of archived contacts (via the API).

(This doesn't consider consider current contacts that belong to an archived company, as we need to discuss a bit more how that will work.)

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
