### PR TITLE
Force loadinitialmetadata if python reuse-db is specified

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,10 +10,11 @@ from datahub.core.utils import get_s3_client
 
 
 @pytest.fixture(scope='session')
-def django_db_setup(django_db_setup, django_db_blocker):
+def django_db_setup(pytestconfig, django_db_setup, django_db_blocker):
     """Fixture for DB setup."""
+    reuse_db = pytestconfig.getoption('reuse_db')
     with django_db_blocker.unblock():
-        call_command('loadinitialmetadata')
+        call_command('loadinitialmetadata', force=reuse_db)
 
 
 @pytest.fixture(scope='session', autouse=True)


### PR DESCRIPTION
Issue number: #963 

### Description of change

This allows back the use of pytest --reuse-db by forcing the load of initialmetadata.


### Checklist

* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
