### PR TITLE
Fix country search in admin

### DIFF
--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -103,7 +103,7 @@ class CountryAdmin(admin.ModelAdmin):
     list_display = ('name', 'overseas_region', 'disabled_on',)
     readonly_fields = ('pk',)
     search_fields = ('name', 'pk')
-    list_filter = (DisabledOnFilter,)
+    list_filter = (DisabledOnFilter, 'overseas_region')
 
 
 @admin.register(models.Service)

--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -102,7 +102,7 @@ class CountryAdmin(admin.ModelAdmin):
     fields = ('pk', 'name', 'overseas_region', 'disabled_on',)
     list_display = ('name', 'overseas_region', 'disabled_on',)
     readonly_fields = ('pk',)
-    search_fields = ('name', 'overseas_region', 'pk')
+    search_fields = ('name', 'pk')
     list_filter = (DisabledOnFilter,)
 
 


### PR DESCRIPTION
Issue number: n/a

### Description of change

This removes overseas_country from the country search fields in admin, as it was configured incorrectly. Instead, it adds it as a filter where it makes more sense.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
