### PR TITLE
Add ability to sort interactions by company name

### DIFF
--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -1,6 +1,8 @@
 from datetime import date, datetime
 from operator import attrgetter
+from random import sample
 
+import factory
 import pytest
 from freezegun import freeze_time
 from rest_framework import status
@@ -165,6 +167,32 @@ class TestListInteractions(APITestMixin):
         expected_names = sorted(map(attrgetter(f'{field}.{sub_field}'), interactions))
         actual_names = [result[field][sub_field] for result in response_data['results']]
         assert expected_names == actual_names
+
+    def test_sort_by_first_and_last_name(self):
+        """Test sorting interactions by first_name with a secondary last_name sort."""
+        contacts = [
+            ContactFactory(first_name='Alfred', last_name='Jones'),
+            ContactFactory(first_name='Alfred', last_name='Terry'),
+            ContactFactory(first_name='Thomas', last_name='Richards'),
+            ContactFactory(first_name='Thomas', last_name='West'),
+        ]
+        interactions = EventServiceDeliveryFactory.create_batch(
+            len(contacts),
+            contact=factory.Iterator(sample(contacts, k=len(contacts)))
+        )
+
+        url = reverse('api-v3:interaction:collection')
+        response = self.api_client.get(url, data={
+            'sortby': 'contact__first_name,contact__last_name',
+        })
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(interactions)
+        results = response_data['results']
+        actual_contact_ids = [interaction['contact']['id'] for interaction in results]
+        expected_contact_ids = [str(contact.pk) for contact in contacts]
+        assert actual_contact_ids == expected_contact_ids
 
     def test_sort_by_created_on(self):
         """Test sorting by created_on."""

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -34,5 +34,11 @@ class InteractionViewSet(CoreViewSet):
         PolicyFeedbackPermissionFilter,
     )
     filter_fields = ['company_id', 'contact_id', 'event_id', 'investment_project_id']
-    ordering_fields = ('contact__first_name', 'contact__last_name', 'created_on', 'date')
+    ordering_fields = (
+        'company__name',
+        'contact__first_name',
+        'contact__last_name',
+        'created_on',
+        'date',
+    )
     ordering = ('-date', '-created_on')


### PR DESCRIPTION
Issue number: n/a

### Description of change

Adds `company__name` to the ordering fields for the interactions view. This will be used for sorting event attendees.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
