### PR TITLE
Change test data to use correct service type for events

### DIFF
--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -1234,7 +1234,7 @@
     related_programmes:
       - 1abe5563-6482-41d8-b566-6a9ee9e37c5f
     uk_region: 864cd12a-6095-e211-a939-e4115bead28a
-    service: 9584b82b-3499-e211-a939-e4115bead28a
+    service: 9484b82b-3499-e211-a939-e4115bead28a
     created_on: '2017-01-05T00:00:00Z'
     modified_on: '2017-01-05T00:00:00Z'
 
@@ -1260,7 +1260,7 @@
       - 4e4d24c2-9698-e211-a939-e4115bead28a
     related_programmes:
       - d352a68f-aaf4-4c43-b39d-9bca67a8322e
-    service: ccf9b82b-3499-e211-a939-e4115bead28a
+    service: 9484b82b-3499-e211-a939-e4115bead28a
     archived_documents_url_path: '/documents/123'
     created_on: '2017-01-25T00:00:00Z'
     modified_on: '2017-01-25T00:00:00Z'


### PR DESCRIPTION
The event edit screen is changing to only show services for the event context, unfortunately, the test data currently does not assign event services to events.