### PR TITLE
X-Forwarded-For spoofing mitigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,3 +350,22 @@ This downloads the latest data from Companies House, updates the Companies House
 See [Managing dependencies](docs/Managing&#32;dependencies.md) for information about installing, 
 adding and upgrading dependencies.
 
+## Activity Stream
+
+The `/v3/activity-stream/` endpoint is protected by two mechanisms:
+
+* IP address whitelisting via the `X-Forwarded-For` header, with a comma separated list of whitelisted IPs in the environment variable `ACTIVITY_STREAM_IP_WHITELIST`.
+
+* Hawk authentication via the `Authorization` header, with the credentials in the environment variables `ACTIVITY_STREAM_ACCESS_KEY_ID` and `ACTIVITY_STREAM_SECRET_ACCESS_KEY`.
+
+
+### IP address whitelisting
+
+The authentication blocks requests that do not have a whitelisted IP in the second-from-the-end IP in `X-Forwarded-For` header. In general, this cannot be trusted. However, in PaaS, this can be, and this is the only production environment. Ideally, this would be done at a lower level than HTTP, but this is not possible with the current architecture.
+
+If making requests to this endpoint locally, you must manually add this header.
+
+
+### Hawk authentication
+
+In general, Hawk authentication hashing the HTTP payload and `Content-Type` header, and using a nonce, are both _optional_. Here, as with the Activity Stream endpoints in other DIT projects, both are _required_. `Content-Type` may be the empty string, and if there is no payload, then it should be treated as the empty string.

--- a/datahub/activity_stream/test/test_activity_stream_views.py
+++ b/datahub/activity_stream/test/test_activity_stream_views.py
@@ -158,6 +158,7 @@ def test_if_authentication_passed_but_61_seconds_in_past_401_returned(api_client
         reverse('api-v3:activity-stream:index'),
         content_type='',
         HTTP_AUTHORIZATION=auth,
+        HTTP_X_FORWARDED_FOR='1.2.3.4',
     )
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/datahub/activity_stream/test/test_activity_stream_views.py
+++ b/datahub/activity_stream/test/test_activity_stream_views.py
@@ -53,11 +53,47 @@ def _auth_sender(
             {'detail': 'Incorrect authentication credentials.'},
         ),
         (
-            # If the first IP in X-Forwarded-For header isn't in the whitelist
+            # If second-to-last X-Forwarded-For header isn't whitelisted
             dict(
                 content_type='',
                 HTTP_AUTHORIZATION=_auth_sender().request_header,
-                HTTP_X_FORWARDED_FOR='9.9.9.9',
+                HTTP_X_FORWARDED_FOR='9.9.9.9, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the only IP address in X-Forwarded-For is whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If the only IP address in X-Forwarded-For isn't whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If third-to-last IP in X-Forwarded-For header is whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 124.124.124, 123.123.123.123',
+            ),
+            {'detail': 'Incorrect authentication credentials.'},
+        ),
+        (
+            # If last of 3 IPs in X-Forwarded-For header is whitelisted
+            dict(
+                content_type='',
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
+                HTTP_X_FORWARDED_FOR='124.124.124, 123.123.123.123, 1.2.3.4',
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),
@@ -65,7 +101,7 @@ def _auth_sender(
             # If the Authorization header isn't passed
             dict(
                 content_type='',
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
             ),
             {'detail': 'Authentication credentials were not provided.'},
         ),
@@ -73,8 +109,10 @@ def _auth_sender(
             # If the Authorization header generated from an incorrect ID
             dict(
                 content_type='',
-                HTTP_AUTHORIZATION=_auth_sender(key_id='incorrect').request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    key_id='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),
@@ -82,8 +120,10 @@ def _auth_sender(
             # If the Authorization header generated from an incorrect secret
             dict(
                 content_type='',
-                HTTP_AUTHORIZATION=_auth_sender(secret_key='incorrect').request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    secret_key='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),
@@ -91,8 +131,10 @@ def _auth_sender(
             # If the Authorization header generated from an incorrect domain
             dict(
                 content_type='',
-                HTTP_AUTHORIZATION=_auth_sender(url=_url_incorrect_domain).request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    url=_url_incorrect_domain,
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),
@@ -100,8 +142,10 @@ def _auth_sender(
             # If the Authorization header generated from an incorrect path
             dict(
                 content_type='',
-                HTTP_AUTHORIZATION=_auth_sender(url=_url_incorrect_path).request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    url=_url_incorrect_path,
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),
@@ -109,17 +153,22 @@ def _auth_sender(
             # If the Authorization header generated from an incorrect method
             dict(
                 content_type='',
-                HTTP_AUTHORIZATION=_auth_sender(method='POST').request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    method='POST',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),
         (
-            # If the Authorization header generated from an incorrect content-type
+            # If the Authorization header generated from an incorrect
+            # content-type
             dict(
                 content_type='',
-                HTTP_AUTHORIZATION=_auth_sender(content_type='incorrect').request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    content_type='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),
@@ -127,8 +176,10 @@ def _auth_sender(
             # If the Authorization header generated from incorrect content
             dict(
                 content_type='',
-                HTTP_AUTHORIZATION=_auth_sender(content='incorrect').request_header,
-                HTTP_X_FORWARDED_FOR='1.2.3.4',
+                HTTP_AUTHORIZATION=_auth_sender(
+                    content='incorrect',
+                ).request_header,
+                HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),
@@ -136,7 +187,9 @@ def _auth_sender(
 )
 @pytest.mark.django_db
 def test_401_returned(api_client, get_kwargs, expected_json):
-    """If the request isn't properly Hawk-authenticated, then a 401 is returned"""
+    """If the request isn't properly Hawk-authenticated, then a 401 is
+    returned
+    """
     response = api_client.get(
         _url(),
         **get_kwargs,
@@ -147,7 +200,7 @@ def test_401_returned(api_client, get_kwargs, expected_json):
 
 
 @pytest.mark.django_db
-def test_if_authentication_passed_but_61_seconds_in_past_401_returned(api_client):
+def test_if_61_seconds_in_past_401_returned(api_client):
     """If the Authorization header is generated 61 seconds in the past, then a
     401 is returned
     """
@@ -158,7 +211,7 @@ def test_if_authentication_passed_but_61_seconds_in_past_401_returned(api_client
         reverse('api-v3:activity-stream:index'),
         content_type='',
         HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
 
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
@@ -176,7 +229,7 @@ def test_if_authentication_reused_401_returned(api_client):
         _url(),
         content_type='',
         HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
     assert response_1.status_code == status.HTTP_200_OK
 
@@ -184,11 +237,30 @@ def test_if_authentication_reused_401_returned(api_client):
         _url(),
         content_type='',
         HTTP_AUTHORIZATION=auth,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
     assert response_2.status_code == status.HTTP_401_UNAUTHORIZED
     error = {'detail': 'Incorrect authentication credentials.'}
     assert response_2.json() == error
+
+
+@pytest.mark.django_db
+def test_empty_object_returned_with_authentication_3_ips(api_client):
+    """If the Authorization and X-Forwarded-For headers are correct,
+    with an extra IP address prepended to the X-Forwarded-For then
+    the correct, and authentic, data is returned
+    """
+    sender = _auth_sender()
+    response = api_client.get(
+        _url(),
+        content_type='',
+        HTTP_AUTHORIZATION=sender.request_header,
+        HTTP_X_FORWARDED_FOR='3.3.3.3, 1.2.3.4, 123.123.123.123',
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    content = {'secret': 'content-for-pen-test'}
+    assert response.json() == content
 
 
 @pytest.mark.django_db
@@ -201,7 +273,7 @@ def test_empty_object_returned_with_authentication(api_client):
         _url(),
         content_type='',
         HTTP_AUTHORIZATION=sender.request_header,
-        HTTP_X_FORWARDED_FOR='1.2.3.4',
+        HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
     )
 
     assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
Issue number:  N/A

### Description of change

We don't have network-level firewall capabilities, but in PaaS, the
second-to-last element in the X-Forwarded-For header cannot be spoofed.

### Checklist

* [x] ~Have any relevant search models been updated?~ N/A
* [x] ~Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?~ N/A
* [x] ~Have any relevant select-/prefetch-related field lists in the views and search apps been updated?~ N/A
* [x] ~Has the admin site been updated (for new models, fields etc.)?~ N/A
* [x] Has the README been updated (if needed)?
