### PR TITLE
Add disabled_on to /v3/event responses

### DIFF
--- a/datahub/event/serializers.py
+++ b/datahub/event/serializers.py
@@ -99,7 +99,7 @@ class EventSerializer(serializers.ModelSerializer):
             'address_postcode',
             'address_town',
             'archived_documents_url_path',
-            'uk_region',
+            'disabled_on',
             'end_date',
             'event_type',
             'id',
@@ -112,7 +112,9 @@ class EventSerializer(serializers.ModelSerializer):
             'start_date',
             'teams',
             'service',
+            'uk_region',
         )
         read_only_fields = (
             'archived_documents_url_path',
+            'disabled_on',
         )

--- a/datahub/event/test/factories.py
+++ b/datahub/event/test/factories.py
@@ -1,6 +1,7 @@
 import uuid
 
 import factory
+from django.utils.timezone import utc
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import Country, Service, Team, UKRegion
@@ -41,3 +42,9 @@ class EventFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'event.Event'
+
+
+class DisabledEventFactory(EventFactory):
+    """Disabled event factory."""
+
+    disabled_on = factory.Faker('past_datetime', tzinfo=utc)


### PR DESCRIPTION
Issue number: n/a

### Description of change

Adds the `disabled_on` field to responses in `/v3/event` and `/v3/event/<id>`.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
