### PR TITLE
Add SQL queries to delete_orphans for related models

### DIFF
--- a/datahub/cleanup/management/commands/_base_command.py
+++ b/datahub/cleanup/management/commands/_base_command.py
@@ -41,8 +41,7 @@ class BaseCleanupCommand(BaseCommand):
         simulation_group.add_argument(
             '--simulate',
             action='store_true',
-            help='Simulates the command by performing the deletions and rolling them back. Also'
-                 'prints the SQL query.',
+            help='Simulates the command by performing the deletions and rolling them back.',
         )
         simulation_group.add_argument(
             '--only-print-queries',
@@ -60,10 +59,8 @@ class BaseCleanupCommand(BaseCommand):
         model = apps.get_model(model_name)
         qs = self._get_query(model)
 
-        if is_simulation or only_print_queries:
-            self._print_queries(model, qs)
-
         if only_print_queries:
+            self._print_queries(model, qs)
             return
 
         try:

--- a/datahub/cleanup/management/commands/_base_command.py
+++ b/datahub/cleanup/management/commands/_base_command.py
@@ -4,11 +4,12 @@ from logging import getLogger
 from dateutil.utils import today
 from django.apps import apps
 from django.core.management import BaseCommand
+from django.db.models import Subquery
 from django.db.transaction import atomic
 from django.template.defaultfilters import capfirst
 from django.utils.timezone import utc
 
-from datahub.cleanup.query_utils import get_unreferenced_objects_query
+from datahub.cleanup.query_utils import get_relations_to_delete, get_unreferenced_objects_query
 from datahub.search.deletion import update_es_after_deletions
 
 logger = getLogger(__name__)
@@ -59,11 +60,8 @@ class BaseCleanupCommand(BaseCommand):
         model = apps.get_model(model_name)
         qs = self._get_query(model)
 
-        model_verbose_name = capfirst(model._meta.verbose_name_plural)
-        logger.info(f'{model_verbose_name} to delete: {qs.count()}')
-
         if is_simulation or only_print_queries:
-            logger.info(f'SQL:\n{qs.query}')
+            self._print_queries(model, qs)
 
         if only_print_queries:
             return
@@ -86,6 +84,18 @@ class BaseCleanupCommand(BaseCommand):
         except SimulationRollback:
             logger.info(f'Deletions rolled back')
 
+    def _print_queries(self, model, qs):
+        # relationships that would get deleted in cascade
+        for related in get_relations_to_delete(model):
+            related_model = related.related_model
+            related_qs = related_model._base_manager.filter(
+                **{f'{related.field.name}__in': Subquery(qs.values('pk'))}
+            )
+            _print_query(related_model, related_qs, related)
+
+        # main model
+        _print_query(model, qs)
+
     def _get_query(self, model):
         config = self.CONFIGS[model._meta.label]
 
@@ -94,3 +104,18 @@ class BaseCleanupCommand(BaseCommand):
         ).order_by(
             f'-{config.date_field}'
         )
+
+
+def _print_query(model, qs, relation=None):
+    model_verbose_name = capfirst(model._meta.verbose_name_plural)
+
+    logger.info(
+        ''.join((
+            f'{model_verbose_name} to delete',
+            f' (via {model._meta.model_name}.{relation.remote_field.name})' if relation else '',
+            f': {qs.count()}'
+        ))
+    )
+
+    logger.info('SQL:')
+    logger.info(qs.query)

--- a/datahub/cleanup/query_utils.py
+++ b/datahub/cleanup/query_utils.py
@@ -1,6 +1,7 @@
 from secrets import token_urlsafe
 
 from django.db.models import Exists, OuterRef
+from django.db.models.deletion import CASCADE, get_candidate_relations_to_delete
 
 
 def get_related_fields(model):
@@ -40,3 +41,18 @@ def get_unreferenced_objects_query(model):
     filter_args = {identifier: False for identifier in identifiers}
 
     return qs.filter(**filter_args)
+
+
+def get_relations_to_delete(model):
+    """
+    Returns all the fields of `model` that point to models which would get deleted
+    (on cascade) as a result this model getting deleted.
+
+    :param model: model class
+    :returns: list of fields of `model` that point to models deleted in cascade
+    """
+    candidates = get_candidate_relations_to_delete(model._meta)
+    return [
+        field for field in candidates
+        if field.field.remote_field.on_delete == CASCADE
+    ]

--- a/datahub/cleanup/test/commands/test_common.py
+++ b/datahub/cleanup/test/commands/test_common.py
@@ -272,7 +272,7 @@ def test_run(cleanup_mapping, track_return_values, setup_es):
 @pytest.mark.django_db
 def test_simulate(cleanup_commands_and_configs, track_return_values, setup_es, caplog):
     """
-    Test that if --simulate=True is passed in, the command only simulates the action
+    Test that if --simulate is passed in, the command only simulates the action
     without making any actual changes.
     """
     caplog.set_level('INFO')
@@ -297,15 +297,6 @@ def test_simulate(cleanup_commands_and_configs, track_return_values, setup_es, c
     management.call_command(command, model_name, simulate=True)
 
     setup_es.indices.refresh()
-
-    # Check that 3 records would have been deleted and the related objects
-    log_text = caplog.text.lower()
-    assert f'{model._meta.verbose_name_plural} to delete: 3' in log_text
-
-    for relation in get_relations_to_delete(model):
-        related_meta = relation.related_model._meta
-        assert f'{related_meta.verbose_name_plural} to delete: ' in log_text
-        assert f'from "{related_meta.db_table}"' in log_text
 
     # Check which models were actually deleted
     return_values = delete_return_value_tracker.return_values

--- a/datahub/cleanup/test/commands/test_common.py
+++ b/datahub/cleanup/test/commands/test_common.py
@@ -13,7 +13,7 @@ from django.utils.timezone import utc
 from freezegun import freeze_time
 
 from datahub.cleanup.management.commands import delete_old_records, delete_orphans
-from datahub.cleanup.query_utils import get_related_fields
+from datahub.cleanup.query_utils import get_related_fields, get_relations_to_delete
 from datahub.cleanup.test.commands.factories import ShallowInvestmentProjectFactory
 from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core.exceptions import DataHubException
@@ -298,8 +298,14 @@ def test_simulate(cleanup_commands_and_configs, track_return_values, setup_es, c
 
     setup_es.indices.refresh()
 
-    # Check that 3 records would have been deleted
-    assert 'to delete: 3' in caplog.text
+    # Check that 3 records would have been deleted and the related objects
+    log_text = caplog.text.lower()
+    assert f'{model._meta.verbose_name_plural} to delete: 3' in log_text
+
+    for relation in get_relations_to_delete(model):
+        related_meta = relation.related_model._meta
+        assert f'{related_meta.verbose_name_plural} to delete: ' in log_text
+        assert f'from "{related_meta.db_table}"' in log_text
 
     # Check which models were actually deleted
     return_values = delete_return_value_tracker.return_values
@@ -327,6 +333,7 @@ def test_only_print_queries(cleanup_commands_and_configs, monkeypatch, caplog):
 
     command, model_name, config = cleanup_commands_and_configs
 
+    model = apps.get_model(model_name)
     mapping = MAPPINGS[model_name]
     model_factory = mapping['factory']
     datetime_older_than_threshold = FROZEN_TIME - config.age_threshold - relativedelta(days=1)
@@ -337,7 +344,17 @@ def test_only_print_queries(cleanup_commands_and_configs, monkeypatch, caplog):
     management.call_command(command, model_name, only_print_queries=True)
 
     assert not delete_mock.called
-    assert 'SQL:' in caplog.text
+
+    log_text = caplog.text.lower()
+    assert f'{model._meta.verbose_name_plural} to delete:' in log_text
+
+    for relation in get_relations_to_delete(model):
+        related_meta = relation.related_model._meta
+        assert (
+            f'{related_meta.verbose_name_plural} to delete '
+            f'(via {related_meta.model_name}.{relation.remote_field.name}): '
+        ) in log_text
+        assert f'from "{related_meta.db_table}"' in log_text
 
 
 @pytest.mark.parametrize('cleanup_command_cls', COMMAND_CLASSES, ids=str)


### PR DESCRIPTION
Issue number: NA

### Description of change

Before: we were only printing the SQL query for deleting the main orphaned model

After: we are also printing the SQL queries for all related models which would get deleted in cascade


### Checklist

* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
