### PR TITLE
Delete orphaned versions

### DIFF
--- a/datahub/cleanup/management/commands/delete_orphaned_versions.py
+++ b/datahub/cleanup/management/commands/delete_orphaned_versions.py
@@ -1,0 +1,53 @@
+from collections import Counter
+from logging import getLogger
+
+import reversion
+from django.apps import apps
+from django.core.management import BaseCommand
+from django.db import transaction
+from reversion.models import Revision, Version
+
+logger = getLogger(__name__)
+
+
+def _get_all_model_labels():
+    return [model._meta.label for model in reversion.get_registered_models()]
+
+
+class Command(BaseCommand):
+    """Deletes all django versions for models that no longer exist in the database."""
+
+    def __repr__(self):
+        """Python representation (used for parametrised tests)."""
+        module_name = self.__class__.__module__.rsplit('.', maxsplit=1)[1]
+        return f'{module_name}.{self.__class__.__name__}()'
+
+    def add_arguments(self, parser):
+        """Handle arguments."""
+        parser.add_argument(
+            '--model-label',
+            action='append',
+            choices=_get_all_model_labels(),
+            help='Model of which we want the versions deleted. If empty, it includes all models',
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        """Main logic for the actual command."""
+        model_labels = options['model_label'] or _get_all_model_labels()
+        models = [apps.get_model(model_label) for model_label in model_labels]
+
+        logger.info(f'Deleting versions for following deleted models: {", ".join(model_labels)}')
+
+        counter = Counter()
+        for model in models:
+            _, deletions_by_model = Version.objects.get_deleted(model).delete()
+            counter.update(deletions_by_model)
+
+        # delete revisions without versions
+        _, deletions_by_model = Revision.objects.filter(version__isnull=True).delete()
+        counter.update(deletions_by_model)
+
+        logger.info(f'{sum(counter.values())} records deleted. Breakdown by model:')
+        for deletion_model, model_deletion_count in counter.items():
+            logger.info(f'{deletion_model}: {model_deletion_count}')

--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -1,0 +1,163 @@
+from unittest.mock import Mock
+
+import pytest
+import reversion
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.core import management
+from django.core.management.base import CommandError
+from reversion.models import Revision, Version
+
+from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
+from datahub.event.test.factories import EventFactory
+from datahub.interaction.test.factories import CompanyInteractionFactory
+from datahub.investment.test.factories import (
+    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory
+)
+from ...management.commands import delete_orphaned_versions
+
+
+MAPPINGS = {
+    'company.Advisor': AdviserFactory,
+    'company.Company': CompanyFactory,
+    'company.Contact': ContactFactory,
+    'event.Event': EventFactory,
+    'interaction.Interaction': CompanyInteractionFactory,
+    'investment.InvestmentProject': InvestmentProjectFactory,
+    'investment.InvestmentProjectTeamMember': InvestmentProjectTeamMemberFactory
+}
+
+
+def test_mappings():
+    """
+    Test that `MAPPINGS` includes all the data necessary for covering all the cases.
+    This is to avoid missing tests when new fields and models are added or changed.
+    """
+    assert set(delete_orphaned_versions._get_all_model_labels()) == set(MAPPINGS)
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'model_label,model_factory',
+    MAPPINGS.items()
+)
+def test_with_one_model(model_label, model_factory):
+    """
+    Test that --model_label can be used to specify which model we want the versions deleted.
+    """
+    model = apps.get_model(model_label)
+
+    with reversion.create_revision():
+        objs = model_factory.create_batch(2)
+
+    # check created versions/revisions
+    assert Version.objects.get_for_model(model).count() == 2
+    assert Revision.objects.count() == 1
+
+    objs[0].delete()  # delete just one
+
+    # check that versions/revisions haven't changed
+    assert Version.objects.get_for_model(model).count() == 2
+    assert Revision.objects.count() == 1
+
+    management.call_command(delete_orphaned_versions.Command(), model_label=[model_label])
+
+    # the revision wasn't deleted because it's still referenced by other objects
+    assert Version.objects.get_for_model(model).count() == 1
+    assert Revision.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_with_all_models(caplog):
+    """
+    Test that if --model_label is not specified, the command cleans up the versions
+    for all registered models.
+    """
+    caplog.set_level('INFO')
+
+    objs = []
+    for model_label, model_factory in MAPPINGS.items():
+        with reversion.create_revision():
+            obj, _ = model_factory.create_batch(2)  # keep only one
+            objs.append(obj)
+
+    total_versions = Version.objects.count()
+
+    for obj in objs:
+        obj.delete()
+
+    assert Version.objects.count() == total_versions
+
+    management.call_command(delete_orphaned_versions.Command())
+
+    assert Version.objects.count() == total_versions - len(MAPPINGS)
+    assert Revision.objects.count() == len(MAPPINGS)
+
+    assert f'{len(MAPPINGS)} records deleted' in caplog.text
+    assert f'reversion.Version: {len(MAPPINGS)}' in caplog.text
+
+
+@pytest.mark.django_db
+def test_delete_revisions_without_versions(caplog):
+    """
+    Test that a revision gets deleted as well if there aren't any more versions referencing it.
+    """
+    caplog.set_level('INFO')
+
+    model_label, model_factory = next(iter(MAPPINGS.items()))
+    model = apps.get_model(model_label)
+
+    with reversion.create_revision():
+        obj = model_factory()
+
+    # delete all versions indirectly created
+    Version.objects.exclude(
+        content_type=ContentType.objects.get_for_model(model),
+        object_id=obj.pk
+    ).delete()
+
+    # check that only 1 version and revision exist
+    assert Version.objects.count() == 1
+    assert Revision.objects.count() == 1
+
+    obj.delete()
+
+    # check that versions/revisions haven't changed
+    assert Version.objects.count() == 1
+    assert Revision.objects.count() == 1
+
+    management.call_command(delete_orphaned_versions.Command(), model_label=[model_label])
+
+    # the revision is deleted as well because there aren't any more versions
+    assert Version.objects.count() == 0
+    assert Revision.objects.count() == 0
+
+    assert f'reversion.Version: 1' in caplog.text
+    assert f'reversion.Revision: 1' in caplog.text
+
+
+@pytest.mark.django_db
+def test_rollback_in_case_or_error(monkeypatch):
+    """Test that if there's an exception in the logic, all the changes are rolled back."""
+    objs = []
+    for model_label, model_factory in MAPPINGS.items():
+        with reversion.create_revision():
+            objs.append(model_factory())
+
+    total_versions = Version.objects.count()
+
+    for obj in objs:
+        obj.delete()
+
+    monkeypatch.setattr(Revision.objects, 'filter', Mock(side_effect=Exception))
+
+    with pytest.raises(Exception):
+        management.call_command(delete_orphaned_versions.Command())
+
+    assert Version.objects.count() == total_versions
+
+
+def test_fails_with_invalid_model():
+    """Test that if an invalid value for model is passed in, the command errors."""
+    with pytest.raises(CommandError):
+        management.call_command(delete_orphaned_versions.Command(), 'invalid')

--- a/datahub/event/test/factories.py
+++ b/datahub/event/test/factories.py
@@ -17,7 +17,7 @@ class EventFactory(factory.django.DjangoModelFactory):
     modified_by = factory.SubFactory(AdviserFactory)
     name = factory.Faker('text')
     event_type_id = EventType.seminar.value.id
-    start_date = factory.Faker('date')
+    start_date = factory.Faker('date_object')
     end_date = factory.LazyAttribute(lambda event: event.start_date)
     location_type_id = LocationType.hq.value.id
     address_1 = factory.Faker('text')

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -48,8 +48,8 @@ class TestGetEventView(APITestMixin):
                 'id': str(event.event_type.id),
                 'name': str(event.event_type.name),
             },
-            'start_date': event.start_date,
-            'end_date': event.end_date,
+            'start_date': event.start_date.isoformat(),
+            'end_date': event.end_date.isoformat(),
             'location_type': {
                 'id': str(event.location_type.id),
                 'name': event.location_type.name,

--- a/datahub/omis/payment/test/factories.py
+++ b/datahub/omis/payment/test/factories.py
@@ -20,7 +20,7 @@ class PaymentFactory(factory.django.DjangoModelFactory):
     additional_reference = factory.Faker('pystr')
     amount = factory.Faker('random_int', max=100)
     method = constants.PaymentMethod.bacs
-    received_on = factory.Faker('date')
+    received_on = factory.Faker('date_object')
 
     class Meta:
         model = 'omis-payment.Payment'

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -599,13 +599,13 @@ class TestSearchExport(APITestMixin):
                 TestSearchExport._get_random_constant_id(BusinessTypeConstant),
             'classification_id': random_obj_for_model(CompanyClassification).pk,
             'company_number': ch.company_number,
-            'created_on': factory.Faker('date'),
+            'created_on': factory.Faker('date_object'),
             'description': factory.Faker('text'),
             'employee_range_id':
                 TestSearchExport._get_random_constant_id(constants.EmployeeRange),
             'headquarter_type_id':
                 TestSearchExport._get_random_constant_id(constants.HeadquarterType),
-            'modified_on': factory.Faker('date'),
+            'modified_on': factory.Faker('date_object'),
             'name': name,
             'one_list_account_owner': AdviserFactory(),
             'registered_address_1': factory.Faker('street_name'),
@@ -629,7 +629,7 @@ class TestSearchExport(APITestMixin):
         if archived:
             data.update({
                 'archived_by': AdviserFactory(),
-                'archived_on': factory.Faker('date'),
+                'archived_on': factory.Faker('date_object'),
                 'archived_reason': factory.Faker('text'),
             })
 


### PR DESCRIPTION
### Description of change

This adds a new command `delete_orphaned_versions` which deletes all the `reversion.Version` records related to objects no longer in the database.
`reversion.Revision` records without versions are deleted as well.

`--model-label` can be passed in to specify the model(s) to consider. 
All models are used if model_label is not passed in.

### Checklist

~* [ ] Have any relevant search models been updated?~
~* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?~
~* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?~
~* [ ] Has the admin site been updated (for new models, fields etc.)?~
~* [ ] Has the README been updated (if needed)?~
