### PR TITLE
Add company core team endpoint

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -34,8 +34,34 @@ from datahub.core.validators import (
     ValidationRule,
 )
 from datahub.metadata import models as meta_models
+from datahub.metadata.serializers import TeamWithGeographyField
+
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
+
+
+NestedAdviserField = partial(
+    NestedRelatedField,
+    'company.Advisor',
+    extra_fields=(
+        'name',
+        'first_name',
+        'last_name',
+    )
+)
+
+
+# like NestedAdviserField but includes dit_team with uk_region and country
+NestedAdviserWithTeamGeographyField = partial(
+    NestedRelatedField,
+    'company.Advisor',
+    extra_fields=(
+        'name',
+        'first_name',
+        'last_name',
+        ('dit_team', TeamWithGeographyField()),
+    )
+)
 
 
 class AdviserSerializer(serializers.ModelSerializer):
@@ -100,12 +126,6 @@ class CompaniesHouseCompanySerializer(NestedCompaniesHouseCompanySerializer):
             'business_type',
         )
         read_only_fields = fields
-
-
-NestedAdviserField = partial(
-    NestedRelatedField, 'company.Advisor',
-    extra_fields=('first_name', 'last_name', 'name')
-)
 
 
 class ContactSerializer(PermittedFieldsModelSerializer):
@@ -457,3 +477,10 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         permissions = {
             f'company.{CompanyPermission.read_company_document}': 'archived_documents_url_path',
         }
+
+
+class CompanyCoreTeamMemberSerializer(serializers.Serializer):
+    """Core Team Member Serializer."""
+
+    adviser = NestedAdviserWithTeamGeographyField()
+    is_global_account_manager = serializers.BooleanField()

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -12,6 +12,7 @@ from reversion.models import Version
 from datahub.company.constants import BusinessTypeConstant
 from datahub.company.models import CompaniesHouseCompany, Company
 from datahub.company.test.factories import (
+    AdviserFactory,
     CompaniesHouseCompanyFactory,
     CompanyFactory,
 )
@@ -1398,3 +1399,78 @@ class TestCHCompany(APITestMixin):
         response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestCompanyCoreTeam(APITestMixin):
+    """Tests for getting the core team of a company."""
+
+    def test_empty_list(self):
+        """
+        Test that if company.one_list_account_owner is null, the endpoint
+        returns an empty list.
+        """
+        company = CompanyFactory(one_list_account_owner=None)
+
+        url = reverse(
+            'api-v3:company:core-team',
+            kwargs={'pk': company.pk}
+        )
+        response = self.api_client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_with_global_account_manager(self):
+        """
+        Test that if company.one_list_account_owner is not null, the endpoint
+        returns a list with only that adviser in it.
+        """
+        dit_team = TeamFactory(
+            uk_region_id=UKRegion.east_midlands.value.id,
+            country_id=Country.united_kingdom.value.id
+        )
+        adviser = AdviserFactory(dit_team=dit_team)
+        company = CompanyFactory(one_list_account_owner=adviser)
+
+        url = reverse(
+            'api-v3:company:core-team',
+            kwargs={'pk': company.pk}
+        )
+        response = self.api_client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == [
+            {
+                'adviser': {
+                    'id': str(adviser.pk),
+                    'name': adviser.name,
+                    'first_name': adviser.first_name,
+                    'last_name': adviser.last_name,
+                    'dit_team': {
+                        'id': str(dit_team.pk),
+                        'name': dit_team.name,
+                        'uk_region': {
+                            'id': str(dit_team.uk_region.pk),
+                            'name': dit_team.uk_region.name
+                        },
+                        'country': {
+                            'id': str(dit_team.country.pk),
+                            'name': dit_team.country.name
+                        },
+                    }
+                },
+                'is_global_account_manager': True
+            }
+        ]
+
+    def test_404_with_invalid_company(self):
+        """
+        Test that if the company doesn't exist, the endpoint returns 404.
+        """
+        url = reverse(
+            'api-v3:company:core-team',
+            kwargs={'pk': '00000000-0000-0000-0000-000000000000'}
+        )
+        response = self.api_client.get(url, format='json')
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/datahub/company/urls.py
+++ b/datahub/company/urls.py
@@ -4,8 +4,8 @@ from django.urls import path
 
 from datahub.company.timeline.views import CompanyTimelineViewSet
 from datahub.company.views import (
-    CompaniesHouseCompanyViewSet, CompanyAuditViewSet, CompanyViewSet,
-    ContactAuditViewSet, ContactViewSet
+    CompaniesHouseCompanyViewSet, CompanyAuditViewSet, CompanyCoreTeamViewSet,
+    CompanyViewSet, ContactAuditViewSet, ContactViewSet
 )
 
 # CONTACT
@@ -68,6 +68,10 @@ company_unarchive = CompanyViewSet.as_view({
     'post': 'unarchive',
 })
 
+company_core_team = CompanyCoreTeamViewSet.as_view({
+    'get': 'list'
+})
+
 ch_company_list = CompaniesHouseCompanyViewSet.as_view({
     'get': 'list'
 })
@@ -83,6 +87,7 @@ company_urls = [
     path('company/<uuid:pk>/unarchive', company_unarchive, name='unarchive'),
     path('company/<uuid:pk>/audit', company_audit, name='audit-item'),
     path('company/<uuid:pk>/timeline', company_timeline, name='timeline-collection'),
+    path('company/<uuid:pk>/core-team', company_core_team, name='core-team'),
 ]
 
 ch_company_urls = [

--- a/datahub/core/test/test_serializers.py
+++ b/datahub/core/test/test_serializers.py
@@ -4,131 +4,188 @@ from uuid import uuid4
 import pytest
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.exceptions import ValidationError
+from rest_framework.serializers import IntegerField
 
 from datahub.core.serializers import NestedRelatedField, RelaxedURLField
 
 
-def test_nested_rel_field_to_internal_dict():
-    """Tests that model instances are returned for a dict with an 'id' key."""
-    model = MagicMock()
-    field = NestedRelatedField(model)
-    uuid_ = uuid4()
-    assert field.to_internal_value({'id': str(uuid_)})
-    assert model.objects.all().get.call_args_list == [call(pk=uuid_)]
+class TestNestedRelatedField:
+    """Tests related to NestedRelatedField."""
 
+    def test_to_internal_dict(self):
+        """Tests that model instances are returned for a dict with an 'id' key."""
+        model = MagicMock()
+        field = NestedRelatedField(model)
+        uuid_ = uuid4()
+        assert field.to_internal_value({'id': str(uuid_)})
+        assert model.objects.all().get.call_args_list == [call(pk=uuid_)]
 
-def test_nested_rel_field_to_internal_str():
-    """Tests that model instances are returned for a dict with an 'id' key."""
-    model = MagicMock()
-    field = NestedRelatedField(model)
-    uuid_ = uuid4()
-    assert field.to_internal_value(str(uuid_))
-    assert model.objects.all().get.call_args_list == [call(pk=uuid_)]
+    def test_to_internal_str(self):
+        """Tests that model instances are returned for a dict with an 'id' key."""
+        model = MagicMock()
+        field = NestedRelatedField(model)
+        uuid_ = uuid4()
+        assert field.to_internal_value(str(uuid_))
+        assert model.objects.all().get.call_args_list == [call(pk=uuid_)]
 
+    def test_to_internal_invalid_id(self):
+        """Tests that a dict with an invalid UUID raises an exception."""
+        model = MagicMock()
+        field = NestedRelatedField(model)
+        with pytest.raises(ValidationError):
+            field.to_internal_value({'id': 'xxx'})
 
-def test_nested_rel_field_to_internal_invalid_id():
-    """Tests that a dict with an invalid UUID raises an exception."""
-    model = MagicMock()
-    field = NestedRelatedField(model)
-    with pytest.raises(ValidationError):
-        field.to_internal_value({'id': 'xxx'})
+    def test_to_internal_no_id(self):
+        """Tests that a dict without an id raises an exception."""
+        model = MagicMock()
+        field = NestedRelatedField(model)
+        with pytest.raises(ValidationError):
+            field.to_internal_value({})
 
+    def test_to_internal_wrong_type(self):
+        """Tests that a non-dict value raises an exception."""
+        model = MagicMock()
+        field = NestedRelatedField(model)
+        with pytest.raises(ValidationError):
+            field.to_internal_value([])
 
-def test_nested_rel_field_to_internal_no_id():
-    """Tests that a dict without an id raises an exception."""
-    model = MagicMock()
-    field = NestedRelatedField(model)
-    with pytest.raises(ValidationError):
-        field.to_internal_value({})
+    def test_to_internal_non_existent_id(self):
+        """Tests an id of a non-existent object raises an exception."""
+        model = MagicMock()
+        model.objects().all.get.return_value = ObjectDoesNotExist
+        field = NestedRelatedField(model)
+        with pytest.raises(ValidationError):
+            field.to_internal_value({})
 
+    def test_to_representation(self):
+        """Tests that a model instance is converted to a dict."""
+        model = Mock()
+        uuid_ = uuid4()
+        instance = Mock(id=uuid_, pk=uuid_)
+        instance.name = 'instance name'
+        field = NestedRelatedField(model)
+        assert field.to_representation(instance) == {
+            'id': str(instance.id),
+            'name': instance.name
+        }
 
-def test_nested_rel_field_to_internal_wrong_type():
-    """Tests that a non-dict value raises an exception."""
-    model = MagicMock()
-    field = NestedRelatedField(model)
-    with pytest.raises(ValidationError):
-        field.to_internal_value([])
-
-
-def test_nested_rel_field_to_internal_non_existent_id():
-    """Tests an id of a non-existent object raises an exception."""
-    model = MagicMock()
-    model.objects().all.get.return_value = ObjectDoesNotExist
-    field = NestedRelatedField(model)
-    with pytest.raises(ValidationError):
-        field.to_internal_value({})
-
-
-def test_nested_rel_field_to_repr():
-    """Tests that a model instance is converted to a dict."""
-    model = Mock()
-    uuid_ = uuid4()
-    instance = Mock(id=uuid_, pk=uuid_)
-    instance.name = 'instance name'
-    field = NestedRelatedField(model)
-    assert field.to_representation(instance) == {
-        'id': str(instance.id),
-        'name': instance.name
-    }
-
-
-def test_nested_rel_field_to_repr_extra_fields():
-    """Tests that a model instance is converted to a dict with extra fields."""
-    model = Mock()
-    uuid_ = uuid4()
-    uuid2_ = uuid4()
-    instance = Mock(id=uuid_, pk=uuid_, test_field='12as', test2=uuid2_)
-    field = NestedRelatedField(model, extra_fields=('test_field', 'test2'))
-    assert field.to_representation(instance) == {
-        'id': str(instance.id),
-        'test_field': instance.test_field,
-        'test2': str(uuid2_)
-    }
-
-
-def test_nested_rel_field_to_choices():
-    """Tests that model choices are returned."""
-    model = Mock()
-    uuid_ = uuid4()
-    instance = Mock(id=uuid_, pk=uuid_)
-    instance.name = 'instance name'
-    model.objects.all.return_value = [instance] * 2
-    field = NestedRelatedField(model)
-    assert (list(field.get_choices().items()) == [(str(instance.id),
-                                                   str(instance))] * 2)
-
-
-def test_nested_rel_field_to_choices_limit():
-    """Tests that model choices are limited and returned."""
-    model = Mock()
-    uuid_ = uuid4()
-    instance = Mock(id=uuid_, pk=uuid_)
-    instance.name = 'instance name'
-    model.objects.all.return_value = [instance] * 2
-    field = NestedRelatedField(model)
-    assert (list(field.get_choices(1).items()) == [(str(instance.id),
-                                                    str(instance))])
-
-    @pytest.mark.parametrize(
-        'input_website,expected_website', (
-            ('www.google.com', 'http://www.google.com'),
-            ('http://www.google.com', 'http://www.google.com'),
-            ('https://www.google.com', 'https://www.google.com'),
-            ('', ''),
+    def test_to_representation_extra_fields(self):
+        """Tests that a model instance is converted to a dict with extra fields."""
+        model = Mock()
+        uuid_ = uuid4()
+        uuid2_ = uuid4()
+        instance = Mock(id=uuid_, pk=uuid_, test_field='12as', test2=uuid2_, test3='10')
+        field = NestedRelatedField(
+            model,
+            extra_fields=(
+                'test_field',
+                'test2',
+                ('test3', IntegerField()),
+            )
         )
-    )
-    def test_url_field_input(self, input_website, expected_website):
-        """Tests that RelaxedURLField prepends http:// when one is not provided."""
-        assert RelaxedURLField().run_validation(input_website) == expected_website
+        assert field.to_representation(instance) == {
+            'id': str(instance.id),
+            'test_field': instance.test_field,
+            'test2': uuid2_,
+            'test3': 10
+        }
 
-    @pytest.mark.parametrize(
-        'input_website,expected_website', (
-            ('www.google.com', 'http://www.google.com'),
-            ('http://www.google.com', 'http://www.google.com'),
-            ('https://www.google.com', 'https://www.google.com'),
-            ('', ''),
+    def test_to_representation_extra_fields_with_nested_related(self):
+        """
+        Tests that if the field has a nested related field,
+        `to_representation` returns '<nested-field>': {...} using the nested mapping.
+        """
+        nested_pk = uuid4()
+        nested_instance = Mock(id=nested_pk, pk=nested_pk, field1='field1_value')
+        nested_field = NestedRelatedField(
+            Mock(),
+            extra_fields=(
+                'field1',
+            )
         )
-    )
-    def test_url_field_output(self, input_website, expected_website):
-        """Tests that RelaxedURLField prepends http:// when one is not stored."""
-        assert RelaxedURLField().to_representation(input_website) == expected_website
+
+        instance_pk = uuid4()
+        instance = Mock(id=instance_pk, pk=instance_pk, nested_instance=nested_instance)
+        field = NestedRelatedField(
+            Mock(),
+            extra_fields=(
+                ('nested_instance', nested_field),
+            )
+        )
+        assert field.to_representation(instance) == {
+            'id': str(instance.id),
+            'nested_instance': {
+                'id': str(nested_pk),
+                'field1': 'field1_value',
+            },
+        }
+
+    def test_to_representation_extra_fields_with_nested_related_none(self):
+        """
+        Tests that if the field has a nested related field and its value is
+        None, `to_representation` returns '<nested-field>': None.
+        """
+        nested_field = NestedRelatedField(
+            Mock(),
+            extra_fields=(
+                'field1',
+            )
+        )
+
+        instance_pk = uuid4()
+        instance = Mock(id=instance_pk, pk=instance_pk, nested_instance=None)
+        field = NestedRelatedField(
+            Mock(),
+            extra_fields=(
+                ('nested_instance', nested_field),
+            )
+        )
+        assert field.to_representation(instance) == {
+            'id': str(instance.id),
+            'nested_instance': None,
+        }
+
+    def test_to_choices(self):
+        """Tests that model choices are returned."""
+        model = Mock()
+        uuid_ = uuid4()
+        instance = Mock(id=uuid_, pk=uuid_)
+        instance.name = 'instance name'
+        model.objects.all.return_value = [instance] * 2
+        field = NestedRelatedField(model)
+        assert (list(field.get_choices().items()) == [(str(instance.id), str(instance))] * 2)
+
+    def test_to_choices_limit(self):
+        """Tests that model choices are limited and returned."""
+        model = Mock()
+        uuid_ = uuid4()
+        instance = Mock(id=uuid_, pk=uuid_)
+        instance.name = 'instance name'
+        model.objects.all.return_value = [instance] * 2
+        field = NestedRelatedField(model)
+        assert (list(field.get_choices(1).items()) == [(str(instance.id),
+                                                        str(instance))])
+
+        @pytest.mark.parametrize(
+            'input_website,expected_website', (
+                ('www.google.com', 'http://www.google.com'),
+                ('http://www.google.com', 'http://www.google.com'),
+                ('https://www.google.com', 'https://www.google.com'),
+                ('', ''),
+            )
+        )
+        def test_url_field_input(self, input_website, expected_website):
+            """Tests that RelaxedURLField prepends http:// when one is not provided."""
+            assert RelaxedURLField().run_validation(input_website) == expected_website
+
+        @pytest.mark.parametrize(
+            'input_website,expected_website', (
+                ('www.google.com', 'http://www.google.com'),
+                ('http://www.google.com', 'http://www.google.com'),
+                ('https://www.google.com', 'https://www.google.com'),
+                ('', ''),
+            )
+        )
+        def test_url_field_output(self, input_website, expected_website):
+            """Tests that RelaxedURLField prepends http:// when one is not stored."""
+            assert RelaxedURLField().to_representation(input_website) == expected_website

--- a/datahub/metadata/serializers.py
+++ b/datahub/metadata/serializers.py
@@ -1,7 +1,20 @@
+from functools import partial
+
 from rest_framework import serializers
 
 from datahub.core.serializers import ConstantModelSerializer, NestedRelatedField
 from .models import Country, Service, TeamRole, UKRegion
+
+
+TeamWithGeographyField = partial(
+    NestedRelatedField,
+    'metadata.Team',
+    extra_fields=(
+        'name',
+        ('uk_region', NestedRelatedField(UKRegion, read_only=True)),
+        ('country', NestedRelatedField(Country, read_only=True)),
+    )
+)
 
 
 class ServiceSerializer(ConstantModelSerializer):


### PR DESCRIPTION
### Description of change

This adds a new endpoint `/v3/company/<company-pk>/core-team` which returns a list with only the global account manager in it at the moment.

The next step will be to create a new table for team members and add those to the returned list.

This also refactor `NestedRelatedField` to allow explicit field mapping as well.

### Checklist

* [ ] ~Have any relevant search models been updated?~
* [ ] ~Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?~
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] ~Has the admin site been updated (for new models, fields etc.)?~
* [ ] ~Has the README been updated (if needed)?~
