### PR TITLE
Update various dependencies

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -23,9 +23,9 @@ python-dateutil==2.7.3
 psycopg2==2.7.5
 psycogreen==1.0
 
-boto3==1.7.59
+boto3==1.7.65
 
-notifications-python-client==4.8.2
+notifications-python-client==4.10.0
 
 # REDIS
 django-redis==4.9.0
@@ -40,15 +40,15 @@ celery==4.2.1
 
 # Testing and dev
 pytest==3.6.3
-pytest-django==3.3.2
+pytest-django==3.3.3
 pytest-sugar==0.9.1
 pytest-cov==2.5.1
-pytest-xdist==1.22.2
+pytest-xdist==1.22.4
 ipython==6.4.0
 ipdb==0.11
 factory-boy==2.11.1
 freezegun==0.3.10
-requests-mock==1.5.0
+requests-mock==1.5.2
 django-debug-toolbar==1.9.1
 werkzeug==0.14.1  # Required by runserver_plus - useful for local dev
 pip-tools==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ attrs==18.1.0             # via pytest
 aws-requests-auth==0.4.1
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4         # via celery
-boto3==1.7.59
-botocore==1.10.59         # via boto3, s3transfer
+boto3==1.7.65
+botocore==1.10.65         # via boto3, s3transfer
 celery==4.2.1
 certifi==2018.4.16        # via requests
 chardet==3.0.4            # via chardet, requests
@@ -69,7 +69,7 @@ mccabe==0.6.1             # via flake8, mccabe
 mohawk==0.3.4
 monotonic==1.5            # via notifications-python-client
 more-itertools==4.2.0     # via pytest
-notifications-python-client==4.8.2
+notifications-python-client==4.10.0
 oauthlib==2.1.0           # via django-oauth-toolkit
 parso==0.3.1              # via jedi
 pep8-naming==0.7.0
@@ -88,17 +88,17 @@ pyflakes==1.6.0           # via flake8
 pygments==2.2.0           # via ipython, pygments
 pyjwt==1.6.4              # via notifications-python-client
 pytest-cov==2.5.1
-pytest-django==3.3.2
+pytest-django==3.3.3
 pytest-forked==0.2        # via pytest-xdist
 pytest-sugar==0.9.1
-pytest-xdist==1.22.2
+pytest-xdist==1.22.4
 pytest==3.6.3
 python-dateutil==2.7.3
 pytz==2018.5              # via celery, django
 pyyaml==3.13
 raven==6.9.0
 redis==2.10.6             # via django-redis
-requests-mock==1.5.0
+requests-mock==1.5.2
 requests==2.19.1
 requests_toolbelt==0.8.0
 s3transfer==0.1.13        # via boto3


### PR DESCRIPTION
Issue number: n/a

### Description of change

Updates various dependencies. Change logs:

- https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst
- https://requests-mock.readthedocs.io/en/latest/release-notes.html
- https://pytest-django.readthedocs.io/en/latest/changelog.html
- https://github.com/alphagov/notifications-python-client/blob/master/CHANGELOG.md
- https://github.com/boto/boto3/blob/develop/CHANGELOG.rst

There is still django-reversion 3.0.0 to update to:

https://github.com/etianen/django-reversion/blob/master/CHANGELOG.rst

I'm not sure of the full impact of the comment change, so have left that for another PR.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
