### PR TITLE
Remove migration from legacy Elasticsearch index

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -234,8 +234,6 @@ if ES_USE_AWS_AUTH:
 
 ES_URL = env('ES5_URL')
 ES_VERIFY_CERTS = env.bool('ES_VERIFY_CERTS', True)
-# TODO: Remove once all environments have been migrated to the new structure
-ES_LEGACY_INDEX = env.str('ES_INDEX', default='')
 ES_INDEX_PREFIX = env('ES_INDEX_PREFIX')
 ES_INDEX_SETTINGS = {
     'index.mapping.single_type': True,

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -21,7 +21,6 @@ SEARCH_APPS += [
 
 # The index is set dynamically in datahub/search/conftest.py, so that tests can be parallelised.
 ES_INDEX_PREFIX = None
-ES_LEGACY_INDEX = None
 ES_INDEX_SETTINGS = {
     **ES_INDEX_SETTINGS,
     'number_of_shards': 1,

--- a/conftest.py
+++ b/conftest.py
@@ -14,7 +14,6 @@ from datahub.metadata.test.factories import SectorFactory
 from datahub.search.apps import get_search_apps
 from datahub.search.elasticsearch import (
     alias_exists,
-    associate_index_with_alias,
     create_index,
     delete_alias,
     delete_index,
@@ -199,9 +198,8 @@ def _setup_es_indexes(_es_client):
             delete_alias(write_alias)
 
         # Create indices and aliases
-        create_index(index_name, search_app.es_model._doc_type.mapping)
-        associate_index_with_alias(write_alias, index_name)
-        associate_index_with_alias(read_alias, index_name)
+        alias_names = (read_alias, write_alias)
+        create_index(index_name, search_app.es_model._doc_type.mapping, alias_names=alias_names)
 
     yield _es_client
 

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -127,14 +127,25 @@ def index_exists(index_name):
     return client.indices.exists(index_name)
 
 
-def create_index(index_name, mapping):
-    """Creates an index and initialises it with a mapping."""
+def create_index(index_name, mapping, alias_names=()):
+    """
+    Creates an index, initialises it with a mapping, and optionally associates aliases with it.
+
+    Note: If you need to perform multiple alias operations atomically, you should use
+    start_alias_transaction() instead of specifying aliases when creating an index.
+    """
     index = Index(index_name)
     for analyzer in ANALYZERS:
         index.analyzer(analyzer)
 
     index.settings(**settings.ES_INDEX_SETTINGS)
     index.mapping(mapping)
+
+    # ES allows you to specify filter criteria for aliases but we don't make use of that –
+    # hence the empty dict for each alias
+    alias_mapping = {alias_name: {} for alias_name in alias_names}
+    index.aliases(**alias_mapping)
+
     index.create()
 
 

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -10,7 +10,6 @@ from datahub.search.elasticsearch import (
     associate_index_with_alias,
     create_index,
     get_indices_for_aliases,
-    index_exists,
 )
 from datahub.search.utils import get_model_non_mapped_field_names, serialise_mapping
 
@@ -115,22 +114,14 @@ class BaseESModel(DocType):
         If force_update_mapping is True and the write alias already exists, an attempt
         is made to update to update the existing mapping in place.
         """
-        read_alias_exists = alias_exists(cls.get_read_alias())
-        write_alias_exists = alias_exists(cls.get_write_alias())
-        if not write_alias_exists:
-            # Handle migration from the legacy single-index set-up
-            # TODO: Remove once all environments have been migrated to the new structure
-            if settings.ES_LEGACY_INDEX and index_exists(settings.ES_LEGACY_INDEX):
-                index_name = settings.ES_LEGACY_INDEX
-            else:
-                index_name = cls.get_target_index_name()
-                create_index(index_name, cls._doc_type.mapping)
-
+        if not alias_exists(cls.get_write_alias()):
+            index_name = cls.get_target_index_name()
+            create_index(index_name, cls._doc_type.mapping)
             associate_index_with_alias(cls.get_write_alias(), index_name)
         elif force_update_mapping:
             cls.init(cls.get_write_alias())
 
-        if not read_alias_exists:
+        if not alias_exists(cls.get_read_alias()):
             associate_index_with_alias(cls.get_read_alias(), cls.get_write_index())
 
     @classmethod

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -116,12 +116,15 @@ class BaseESModel(DocType):
         """
         if not alias_exists(cls.get_write_alias()):
             index_name = cls.get_target_index_name()
-            create_index(index_name, cls._doc_type.mapping)
-            associate_index_with_alias(cls.get_write_alias(), index_name)
+            alias_names = (cls.get_write_alias(), cls.get_read_alias())
+            create_index(index_name, cls._doc_type.mapping, alias_names=alias_names)
         elif force_update_mapping:
             cls.init(cls.get_write_alias())
 
+        # Should not normally happen
         if not alias_exists(cls.get_read_alias()):
+            logger.warning(f'Missing read alias {cls.get_read_alias()} detected, recreating '
+                           f'the alias...')
             associate_index_with_alias(cls.get_read_alias(), cls.get_write_index())
 
     @classmethod

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -62,7 +62,7 @@ def test_creates_index(monkeypatch, mock_es_client):
 
     index = 'test-index'
     connection = mock_es_client.return_value
-    elasticsearch.create_index(index, mock_mapping)
+    elasticsearch.create_index(index, mock_mapping, alias_names=('alias1', 'alias2'))
     connection.indices.create.assert_called_once_with(
         index='test-index',
         body={
@@ -123,6 +123,10 @@ def test_creates_index(monkeypatch, mock_es_client):
                         }
                     }
                 }
+            },
+            'aliases': {
+                'alias1': {},
+                'alias2': {}
             },
             'mappings': {
                 'mapping': 'test-mapping'


### PR DESCRIPTION
Issue number: n/a

### Description of change

Probably won't merge this just yet, just getting it ready.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
