### PR TITLE
Tidy up company admin and standardise created/modified fields

### DIFF
--- a/datahub/company/admin.py
+++ b/datahub/company/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth.admin import UserAdmin
 from django.db import models
 from reversion.admin import VersionAdmin
 
-from datahub.core.admin import ReadOnlyAdmin
+from datahub.core.admin import BaseModelAdminMixin, ReadOnlyAdmin
 from datahub.metadata.admin import DisableableMetadataAdmin
 from .models import (
     Advisor,
@@ -34,9 +34,95 @@ class CompanyCoreTeamMemberInline(admin.TabularInline):
 
 
 @admin.register(Company)
-class CompanyAdmin(VersionAdmin):
+class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
     """Company admin."""
 
+    fieldsets = (
+        (
+            None,
+            {
+                'fields': (
+                    'id',
+                    'created',
+                    'modified',
+                    'name',
+                    'alias',
+                    'company_number',
+                    'vat_number',
+                    'description',
+                    'website',
+                    'business_type',
+                    'sector',
+                    'uk_region',
+                    'employee_range',
+                    'turnover_range',
+                    'classification',
+                    'one_list_account_owner',
+                )
+            }
+        ),
+        (
+            'HIERARCHY',
+            {
+                'fields': (
+                    'parent',
+                    'headquarter_type',
+                    'global_headquarters',
+                )
+            }
+        ),
+        (
+            'ADDRESS',
+            {
+                'fields': (
+                    'registered_address_1',
+                    'registered_address_2',
+                    'registered_address_town',
+                    'registered_address_county',
+                    'registered_address_postcode',
+                    'registered_address_country',
+
+                    'trading_address_1',
+                    'trading_address_2',
+                    'trading_address_town',
+                    'trading_address_county',
+                    'trading_address_postcode',
+                    'trading_address_country',
+                )
+            }
+        ),
+        (
+            'EXPORT',
+            {
+                'fields': (
+                    'export_experience_category',
+                    'export_to_countries',
+                    'future_interest_countries',
+                )
+            }
+        ),
+        (
+            'LEGACY FIELDS',
+            {
+                'fields': (
+                    'reference_code',
+                    'account_manager',
+                    'archived_documents_url_path',
+                )
+            }
+        ),
+        (
+            'ARCHIVE',
+            {
+                'fields': (
+                    'archived',
+                    'archived_on',
+                    'archived_by',
+                    'archived_reason',
+                )
+            }
+        )
+    )
     search_fields = (
         'name',
         'id',
@@ -48,10 +134,11 @@ class CompanyAdmin(VersionAdmin):
         'one_list_account_owner',
         'account_manager',
         'archived_by',
-        'created_by',
-        'modified_by',
     )
     readonly_fields = (
+        'id',
+        'created',
+        'modified',
         'archived_documents_url_path',
         'reference_code',
     )
@@ -65,7 +152,7 @@ class CompanyAdmin(VersionAdmin):
 
 
 @admin.register(Contact)
-class ContactAdmin(VersionAdmin):
+class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
     """Contact admin."""
 
     search_fields = (
@@ -79,15 +166,21 @@ class ContactAdmin(VersionAdmin):
         'company',
         'adviser',
         'archived_by',
-        'created_by',
-        'modified_by',
     )
     readonly_fields = (
+        'created',
+        'modified',
         'archived_documents_url_path',
     )
     list_display = (
         '__str__',
         'company',
+    )
+    exclude = (
+        'created_on',
+        'created_by',
+        'modified_on',
+        'modified_by',
     )
 
 
@@ -109,7 +202,7 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
                 'password'
             )
         }),
-        ('Personal info', {
+        ('PERSONAL INFO', {
             'fields': (
                 'first_name',
                 'last_name',
@@ -118,7 +211,7 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
                 'dit_team'
             )
         }),
-        ('Permissions', {
+        ('PERMISSIONS', {
             'fields': (
                 'is_active',
                 'is_staff',
@@ -127,7 +220,7 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
                 'user_permissions'
             )
         }),
-        ('Important dates', {
+        ('IMPORTANT DATES', {
             'fields': (
                 'last_login',
                 'date_joined'

--- a/datahub/documents/admin.py
+++ b/datahub/documents/admin.py
@@ -1,10 +1,11 @@
 from django.contrib import admin
 
+from datahub.core.admin import BaseModelAdminMixin
 from datahub.documents import models
 
 
 @admin.register(models.Document)
-class DocumentsAdmin(admin.ModelAdmin):
+class DocumentsAdmin(BaseModelAdminMixin, admin.ModelAdmin):
     """Documents admin."""
 
     list_display = (
@@ -12,10 +13,18 @@ class DocumentsAdmin(admin.ModelAdmin):
     )
     raw_id_fields = (
         'archived_by',
-        'created_by',
-        'modified_by',
     )
     list_filter = (
         'av_clean',
     )
+    readonly_fields = (
+        'created',
+        'modified',
+    )
     date_hierarchy = 'created_on'
+    exclude = (
+        'created_on',
+        'created_by',
+        'modified_on',
+        'modified_by',
+    )

--- a/datahub/event/admin.py
+++ b/datahub/event/admin.py
@@ -6,7 +6,7 @@ from django.template.response import TemplateResponse
 from django.utils.timezone import now
 from reversion.admin import VersionAdmin
 
-from datahub.core.admin import DisabledOnFilter
+from datahub.core.admin import BaseModelAdminMixin, DisabledOnFilter
 from datahub.event.models import Event, EventType, LocationType, Programme
 from datahub.metadata.admin import DisableableMetadataAdmin
 
@@ -40,11 +40,13 @@ def confirm_action(title, action_message):
 
 
 @admin.register(Event)
-class EventAdmin(VersionAdmin):
+class EventAdmin(BaseModelAdminMixin, VersionAdmin):
     """Admin for Events."""
 
     fields = (
         'name',
+        'created',
+        'modified',
         'event_type',
         'start_date',
         'end_date',
@@ -78,6 +80,8 @@ class EventAdmin(VersionAdmin):
     )
     readonly_fields = (
         'id',
+        'created',
+        'modified',
         'archived_documents_url_path',
     )
     search_fields = ('name', 'pk')
@@ -86,8 +90,6 @@ class EventAdmin(VersionAdmin):
         'lead_team',
         'teams',
         'organiser',
-        'modified_by',
-        'created_by',
     )
 
     actions = ('disable_selected', 'enable_selected',)

--- a/datahub/feature_flag/admin.py
+++ b/datahub/feature_flag/admin.py
@@ -1,32 +1,23 @@
 from django.contrib import admin
 
+from datahub.core.admin import BaseModelAdminMixin
 from datahub.feature_flag.models import FeatureFlag
 
 
 @admin.register(FeatureFlag)
-class FeatureFlagAdmin(admin.ModelAdmin):
+class FeatureFlagAdmin(BaseModelAdminMixin, admin.ModelAdmin):
     """Feature flag admin."""
 
     list_display = ('code', 'description', 'is_active', 'created_by', 'created_on',)
     search_fields = ('code',)
     readonly_fields = (
         'id',
-        'created_by',
+        'created',
+        'modified',
+    )
+    exclude = (
         'created_on',
-        'modified_by',
-        'modified_on',
-    )
-    raw_id_fields = (
         'created_by',
+        'modified_on',
         'modified_by',
     )
-
-    def save_model(self, request, obj, form, change):
-        """
-        Populate created_by/modified_by from the logged in user.
-        """
-        if not change:
-            obj.created_by = request.user
-        obj.modified_by = request.user
-
-        super().save_model(request, obj, form, change)

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from reversion.admin import VersionAdmin
 
-from datahub.core.admin import custom_add_permission, custom_change_permission
+from datahub.core.admin import BaseModelAdminMixin, custom_add_permission, custom_change_permission
 from datahub.interaction.models import InteractionPermission, PolicyArea, PolicyIssueType
 from datahub.metadata.admin import DisableableMetadataAdmin, OrderedMetadataAdmin
 from .models import CommunicationChannel, Interaction
@@ -14,7 +14,7 @@ admin.site.register((PolicyArea, PolicyIssueType), OrderedMetadataAdmin)
 @admin.register(Interaction)
 @custom_add_permission(InteractionPermission.add_all)
 @custom_change_permission(InteractionPermission.change_all)
-class InteractionAdmin(VersionAdmin):
+class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
     """Interaction admin."""
 
     search_fields = (
@@ -39,17 +39,21 @@ class InteractionAdmin(VersionAdmin):
         'dit_adviser',
         'investment_project',
         'contact',
-        'created_by',
-        'modified_by',
     )
     readonly_fields = (
         'archived_documents_url_path',
-        'created_on',
-        'modified_on',
+        'created',
+        'modified',
     )
     list_select_related = (
         'company',
         'contact',
         'investment_project',
         'investment_project__investor_company',
+    )
+    exclude = (
+        'created_on',
+        'created_by',
+        'modified_on',
+        'modified_by',
     )

--- a/datahub/investment/admin.py
+++ b/datahub/investment/admin.py
@@ -4,6 +4,7 @@ from django.contrib import admin
 from reversion.admin import VersionAdmin
 
 from datahub.core.admin import (
+    BaseModelAdminMixin,
     custom_add_permission,
     custom_change_permission,
     custom_delete_permission,
@@ -23,7 +24,7 @@ from datahub.metadata.admin import DisableableMetadataAdmin
 
 @admin.register(InvestmentProject)
 @custom_change_permission(InvestmentProjectPermission.change_all)
-class InvestmentProjectAdmin(VersionAdmin):
+class InvestmentProjectAdmin(BaseModelAdminMixin, VersionAdmin):
     """Investment project admin."""
 
     search_fields = (
@@ -41,19 +42,25 @@ class InvestmentProjectAdmin(VersionAdmin):
         'project_manager',
         'project_assurance_adviser',
         'uk_company',
-        'created_by',
-        'modified_by',
     )
     readonly_fields = (
         'allow_blank_estimated_land_date',
         'allow_blank_possible_uk_regions',
         'archived_documents_url_path',
         'comments',
+        'created',
+        'modified',
     )
     list_display = (
         'name',
         'investor_company',
         'stage',
+    )
+    exclude = (
+        'created_on',
+        'created_by',
+        'modified_on',
+        'modified_by',
     )
 
 
@@ -71,7 +78,7 @@ class InvestmentProjectTeamMemberAdmin(VersionAdmin):
 
 
 @admin.register(IProjectDocument)
-class IProjectDocumentAdmin(admin.ModelAdmin):
+class IProjectDocumentAdmin(BaseModelAdminMixin, admin.ModelAdmin):
     """Investment project document admin."""
 
     list_display = (
@@ -84,10 +91,18 @@ class IProjectDocumentAdmin(admin.ModelAdmin):
         'archived_by',
         'project',
         'document',
-        'created_by',
-        'modified_by',
     )
     date_hierarchy = 'created_on'
+    readonly_fields = (
+        'created',
+        'modified',
+    )
+    exclude = (
+        'created_on',
+        'created_by',
+        'modified_on',
+        'modified_by',
+    )
 
 
 admin.site.register((

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -10,7 +10,6 @@ from django.contrib.admin.utils import quote, unquote
 from django.core.exceptions import PermissionDenied
 from django.db import router, transaction
 from django.http import HttpResponseRedirect
-from django.template.defaultfilters import date as date_filter, time as time_filter
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
@@ -21,7 +20,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_protect
 
-from datahub.core.admin import ReadOnlyAdmin
+from datahub.core.admin import BaseModelAdminMixin, ReadOnlyAdmin
 from datahub.core.exceptions import APIConflictException
 from . import validators
 from .models import CancellationReason, Order
@@ -64,7 +63,7 @@ class CancelOrderForm(forms.Form):
 
 
 @admin.register(Order)
-class OrderAdmin(ReadOnlyAdmin):
+class OrderAdmin(BaseModelAdminMixin, ReadOnlyAdmin):
     """Admin for orders."""
 
     list_display = ('reference', 'company', 'status', 'created_on', 'modified_on')
@@ -92,21 +91,6 @@ class OrderAdmin(ReadOnlyAdmin):
         'uk_advisers', 'post_advisers'
     )
     readonly_fields = fields
-
-    def _get_description_for_timed_event(self, event_on, event_by):
-        return (
-            f'on {date_filter(event_on)} '
-            f'at {time_filter(event_on)} '
-            f'by {event_by or "Unknown"}'
-        )
-
-    def created(self, order):
-        """:returns: created on/by details."""
-        return self._get_description_for_timed_event(order.created_on, order.created_by)
-
-    def modified(self, order):
-        """:returns: modified on/by details."""
-        return self._get_description_for_timed_event(order.modified_on, order.modified_by)
 
     def completed(self, order):
         """:returns: completed on/by details."""

--- a/datahub/omis/payment/admin.py
+++ b/datahub/omis/payment/admin.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.template.defaultfilters import date as date_formatter
 from django.utils.translation import ugettext_lazy as _
 
+from datahub.core.admin import BaseModelAdminMixin
 from datahub.omis.order.constants import OrderStatus
 from .constants import RefundStatus
 from .models import Refund
@@ -171,7 +172,7 @@ class RefundForm(forms.ModelForm):
 
 
 @admin.register(Refund)
-class RefundAdmin(admin.ModelAdmin):
+class RefundAdmin(BaseModelAdminMixin, admin.ModelAdmin):
     """Refund admin."""
 
     form = RefundForm
@@ -193,18 +194,14 @@ class RefundAdmin(admin.ModelAdmin):
     raw_id_fields = (
         'order',
         'requested_by',
-        'created_by',
-        'modified_by',
         'level1_approved_by',
         'level2_approved_by',
     )
     readonly_fields = (
         'id',
         'reference',
-        'created_by',
-        'created_on',
-        'modified_by',
-        'modified_on',
+        'created',
+        'modified',
         'total_amount',
     )
     list_select_related = (
@@ -212,15 +209,8 @@ class RefundAdmin(admin.ModelAdmin):
     )
 
     def save_model(self, request, obj, form, change):
-        """
-        Populate total_amount from other fields and
-        created_by/modified_by from the logged in user.
-        """
+        """Populate total_amount from other fields."""
         if 'total_amount' in form.cleaned_data:
             obj.total_amount = form.cleaned_data['total_amount']
-
-        if not change:
-            obj.created_by = request.user
-        obj.modified_by = request.user
 
         super().save_model(request, obj, form, change)


### PR DESCRIPTION
Issue number: N/A

### Description of change

This:
- groups fields in fieldsets on the company admin change page
- defines a new `BaseModelAdminMixin` for all `ModelAdmin` with model extending `core.BaseModel`. This updates created_by/modified_by automatically and can show those fields as readonly descriptions in the change form (see screenshot).

### Checklist

* ~[ ] Have any relevant search models been updated?~
* ~[ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?~
* ~[ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?~
* [x] Has the admin site been updated (for new models, fields etc.)?
* ~[ ] Has the README been updated (if needed)?~

![localhost_8000_admin_company_company_cf5a637f-6056-41ae-8694-dd6790a63794_change](https://user-images.githubusercontent.com/178865/43525778-a4a5560e-959a-11e8-9968-48b77ed89c8e.png)
