### PR TITLE
Assign Archived Ltd as GHQ of Venus

### DIFF
--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -141,6 +141,7 @@
     archived_documents_url_path: '/documents/123'
     created_on: '2016-06-15T10:00:00Z'
     modified_on: '2016-07-15T10:00:00Z'
+    global_headquarters: 346f78a5-1d23-4213-b4c2-bf48246a13c3
 
 - model: company.company
   pk: 731bdcc1-f685-4c8e-bd66-b356b2c16995


### PR DESCRIPTION
### Description of change

Add `Archived Ltd` as the GQH of `Venus Ltd` for testing of `Remove subsidiary` link for an archived company.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
