### PR TITLE
Remove CompanyCoreTeamMember from implicit_related_model

### DIFF
--- a/datahub/cleanup/test/commands/test_common.py
+++ b/datahub/cleanup/test/commands/test_common.py
@@ -69,9 +69,7 @@ MAPPINGS = {
             (BusinessLeadFactory, 'company'),
             (CompanyCoreTeamMemberFactory, 'company'),
         ),
-        'implicit_related_models': (
-            'company.CompanyCoreTeamMember',
-        ),
+        'implicit_related_models': (),
     },
     'event.Event': {
         'factory': EventFactory,
@@ -271,7 +269,12 @@ def test_run(cleanup_mapping, track_return_values, setup_es):
     _, deletions_by_model = return_values[0]
     assert deletions_by_model[model._meta.label] == 1
     expected_deleted_models = {model._meta.label} | set(mapping['implicit_related_models'])
-    assert set(deletions_by_model.keys()) == expected_deleted_models
+    actual_deleted_models = {  # only include models actually deleted
+        deleted_model
+        for deleted_model, deleted_count in deletions_by_model.items()
+        if deleted_count
+    }
+    assert actual_deleted_models == expected_deleted_models
 
 
 @freeze_time(FROZEN_TIME)
@@ -312,7 +315,12 @@ def test_simulate(cleanup_commands_and_configs, track_return_values, setup_es, c
     _, deletions_by_model = return_values[0]
     assert deletions_by_model[model._meta.label] == 3
     expected_deleted_models = {model._meta.label} | set(mapping['implicit_related_models'])
-    assert set(deletions_by_model.keys()) == expected_deleted_models
+    actual_deleted_models = {  # only include models actually deleted
+        deleted_model
+        for deleted_model, deleted_count in deletions_by_model.items()
+        if deleted_count
+    }
+    assert actual_deleted_models == expected_deleted_models
 
     # Check that nothing has actually been deleted
     assert model.objects.count() == 3


### PR DESCRIPTION
Issue number: N/A

### Description of change

This removes `company.CompanyCoreTeamMember` from the `implicit_related_models` company mapping when testing cleanup commands.

This also excludes the models without any deletions before comparing the returned value of `delete()` in the cleanup command test cases.

### Checklist

* ~[ ] Have any relevant search models been updated?~
* ~[ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?~
* ~[ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?~
* ~[ ] Has the admin site been updated (for new models, fields etc.)?~
* ~[ ] Has the README been updated (if needed)?~
