### PR TITLE
Get rid of issue number in pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-Issue number: 
-
 ### Description of change
 
 


### PR DESCRIPTION
Issue number: N/A

### Description of change

This gets rid of the issue number in pull request templates so that we don't have to keep typing N/A most of the time.