### PR TITLE
Add team to account managers in GET company endpoint

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -51,6 +51,17 @@ NestedAdviserField = partial(
 )
 
 
+NestedAdviserWithTeamField = partial(
+    NestedRelatedField,
+    'company.Advisor',
+    extra_fields=(
+        'name',
+        'first_name',
+        'last_name',
+        ('dit_team', NestedRelatedField('metadata.Team'))
+    )
+)
+
 # like NestedAdviserField but includes dit_team with uk_region and country
 NestedAdviserWithTeamGeographyField = partial(
     NestedRelatedField,
@@ -280,7 +291,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
     trading_address_country = NestedRelatedField(
         meta_models.Country, required=False, allow_null=True
     )
-    account_manager = NestedAdviserField(required=False, allow_null=True)
+    account_manager = NestedAdviserWithTeamField(required=False, allow_null=True)
     archived_by = NestedAdviserField(read_only=True)
     business_type = NestedRelatedField(
         meta_models.BusinessType, required=False, allow_null=True
@@ -302,7 +313,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
     headquarter_type = NestedRelatedField(
         meta_models.HeadquarterType, required=False, allow_null=True
     )
-    one_list_account_owner = NestedAdviserField(
+    one_list_account_owner = NestedAdviserWithTeamField(
         required=False, allow_null=True
     )
     global_headquarters = NestedRelatedField(

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -205,7 +205,9 @@ class TestGetCompany(APITestMixin):
             vat_number='009485769',
             registered_address_1='Goodbye St',
             registered_address_town='Barland',
-            registered_address_country_id=Country.united_kingdom.value.id
+            registered_address_country_id=Country.united_kingdom.value.id,
+            account_manager=AdviserFactory(),
+            one_list_account_owner=AdviserFactory()
         )
         user = create_test_user(
             permission_codenames=(
@@ -255,7 +257,16 @@ class TestGetCompany(APITestMixin):
                 'id': str(Country.united_kingdom.value.id),
                 'name': Country.united_kingdom.value.name,
             },
-            'account_manager': None,
+            'account_manager': {
+                'id': str(company.account_manager.pk),
+                'name': company.account_manager.name,
+                'first_name': company.account_manager.first_name,
+                'last_name': company.account_manager.last_name,
+                'dit_team': {
+                    'id': str(company.account_manager.dit_team.id),
+                    'name': company.account_manager.dit_team.name,
+                },
+            },
             'archived': False,
             'archived_by': None,
             'archived_documents_url_path': company.archived_documents_url_path,
@@ -279,7 +290,16 @@ class TestGetCompany(APITestMixin):
             'future_interest_countries': [],
             'headquarter_type': None,
             'modified_on': format_date_or_datetime(company.modified_on),
-            'one_list_account_owner': None,
+            'one_list_account_owner': {
+                'id': str(company.one_list_account_owner.pk),
+                'name': company.one_list_account_owner.name,
+                'first_name': company.one_list_account_owner.first_name,
+                'last_name': company.one_list_account_owner.last_name,
+                'dit_team': {
+                    'id': str(company.one_list_account_owner.dit_team.id),
+                    'name': company.one_list_account_owner.dit_team.name,
+                },
+            },
             'global_headquarters': None,
             'sector': {
                 'id': str(company.sector.id),
@@ -377,7 +397,10 @@ class TestGetCompany(APITestMixin):
         )
     )
     def test_get_company_with_website(self, input_website, expected_website):
-        """Test add new company with trading_address."""
+        """
+        Test that if the website field on a company doesn't have any scheme
+        specified, the endpoint adds it automatically.
+        """
         company = CompanyFactory(
             website=input_website
         )


### PR DESCRIPTION
### Description of change

This adds `dit_team` to the `account_manager` and `one_list_account_owner` fields to the GET company endpoint response data.

We only really need the `one_list_account_owner` to be updated but I've changed the `account_manager` field as well for consistency.
