### PR TITLE
Add utility function for annotating queries with the full sector name

### DIFF
--- a/datahub/metadata/query_utils.py
+++ b/datahub/metadata/query_utils.py
@@ -1,0 +1,45 @@
+from django.db.models import F, Func, OuterRef, Subquery, TextField, Value
+
+from datahub.metadata.models import Sector
+
+
+class _SectorStringAgg(Func):
+    function = 'STRING_AGG'
+    template = '%(function)s(%(expressions)s ORDER BY "lft")'
+
+
+def get_sector_name_subquery(relation_name=None):
+    """
+    Generates a subquery that can be used to add sector names to a query set as an annotation.
+
+    Usage examples:
+
+        Sector.objects.annotate(name=get_sector_name_subquery())
+        Company.objects.annotate(sector_name=get_sector_name_subquery('sector'))
+
+    The generated SQL expression for the column (in the first example) will be similar to:
+
+        SELECT STRING_AGG(U0."segment", ' : ' ORDER BY "lft") AS "name"
+        FROM "metadata_sector" U0
+        WHERE (
+            U0."lft" <= ("metadata_sector"."lft")
+            AND U0."rght" >= ("metadata_sector"."rght")
+            AND U0."tree_id" = ("metadata_sector"."tree_id")
+        )
+
+    (Refer to the django-mptt documentation for information on what the lft, rght and tree_id
+    columns mean.)
+
+    (The base manager is used here to avoid the default ordering being added to the query.)
+    """
+    outer_ref_prefix = f'{relation_name}__' if relation_name is not None else ''
+
+    subquery = Sector._base_manager.annotate(
+        name=_SectorStringAgg(F('segment'), Value(Sector.PATH_SEPARATOR))
+    ).filter(
+        lft__lte=OuterRef(f'{outer_ref_prefix}lft'),
+        rght__gte=OuterRef(f'{outer_ref_prefix}rght'),
+        tree_id=OuterRef(f'{outer_ref_prefix}tree_id'),
+    ).values('name')
+
+    return Subquery(subquery, output_field=TextField())

--- a/datahub/metadata/test/test_query_utils.py
+++ b/datahub/metadata/test/test_query_utils.py
@@ -1,0 +1,60 @@
+import pytest
+
+from datahub.metadata.models import Sector
+from datahub.metadata.query_utils import get_sector_name_subquery
+from datahub.metadata.test.factories import SectorFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_annotated_sector_name_root_node():
+    """Test the sector name annotation for a sector at root level."""
+    sector = SectorFactory(parent=None)
+    annotated_sector = Sector.objects.annotate(
+        name_annotation=get_sector_name_subquery()
+    ).get(
+        pk=sector.pk
+    )
+
+    assert annotated_sector.name_annotation == sector.name
+
+
+def test_annotated_sector_name_level_one():
+    """Test the sector name annotation for a sector one level deep."""
+    parent = SectorFactory()
+    sector = SectorFactory(parent=parent)
+    annotated_sector = Sector.objects.annotate(
+        name_annotation=get_sector_name_subquery()
+    ).get(
+        pk=sector.pk
+    )
+
+    assert annotated_sector.name_annotation == sector.name
+
+
+def test_annotated_sector_name_level_two():
+    """Test the sector name annotation for a sector two levels deep."""
+    grandparent = SectorFactory()
+    parent = SectorFactory(parent=grandparent)
+    sector = SectorFactory(parent=parent)
+    annotated_sector = Sector.objects.annotate(
+        name_annotation=get_sector_name_subquery()
+    ).get(
+        pk=sector.pk
+    )
+
+    assert annotated_sector.name_annotation == sector.name
+
+
+def test_annotated_sector_name_via_relation():
+    """Test the sector name annotation via a relation."""
+    grandparent = SectorFactory()
+    parent = SectorFactory(parent=grandparent)
+    sector = SectorFactory(parent=parent)
+    annotated_sector = Sector.objects.annotate(
+        parent_name_annotation=get_sector_name_subquery('parent')
+    ).get(
+        pk=sector.pk
+    )
+
+    assert annotated_sector.parent_name_annotation == parent.name


### PR DESCRIPTION
### Description of change

Adds a helper function that can be used to generate a subquery that can be passed to QuerySet.annotate() to annotate a query set with the full sector names.

This will be used when defining query sets for reports and data exports.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
