### PR TITLE
Update to django-reversion 3.0.0

### DIFF
--- a/datahub/core/audit.py
+++ b/datahub/core/audit.py
@@ -50,7 +50,7 @@ class AuditViewSet(GenericViewSet):
                 'id': v_new.id,
                 'user': creator_repr,
                 'timestamp': v_new.revision.date_created,
-                'comment': v_new.revision.comment or '',
+                'comment': v_new.revision.get_comment() or '',
                 'changes': cls._diff_versions(
                     v_old.field_dict, v_new.field_dict
                 ),

--- a/datahub/dbmaintenance/test/commands/test_update_adviser_contact_email.py
+++ b/datahub/dbmaintenance/test/commands/test_update_adviser_contact_email.py
@@ -146,7 +146,7 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(advisers[1])
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Loaded contact email from spreadsheet.'
+    assert versions[0].revision.get_comment() == 'Loaded contact email from spreadsheet.'
 
     versions = Version.objects.get_for_object(advisers[2])
     assert versions.count() == 0

--- a/datahub/dbmaintenance/test/commands/test_update_adviser_telephone_number.py
+++ b/datahub/dbmaintenance/test/commands/test_update_adviser_telephone_number.py
@@ -112,4 +112,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(adviser)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Telephone number migration.'
+    assert versions[0].revision.get_comment() == 'Telephone number migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_company_alias.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_alias.py
@@ -134,4 +134,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(company_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Company alias correction.'
+    assert versions[0].revision.get_comment() == 'Company alias correction.'

--- a/datahub/dbmaintenance/test/commands/test_update_company_company_number.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_company_number.py
@@ -139,4 +139,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(company_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Company number updated.'
+    assert versions[0].revision.get_comment() == 'Company number updated.'

--- a/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
@@ -263,7 +263,7 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(company_needs_global_hq)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Global HQ data correction.'
+    assert versions[0].revision.get_comment() == 'Global HQ data correction.'
 
     versions = Version.objects.get_for_object(company_ghq_set_already)
     assert len(versions) == 0
@@ -304,11 +304,11 @@ def test_override_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(company_needs_global_hq)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Global HQ data correction.'
+    assert versions[0].revision.get_comment() == 'Global HQ data correction.'
 
     versions = Version.objects.get_for_object(company_ghq_set_already)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Global HQ data correction.'
+    assert versions[0].revision.get_comment() == 'Global HQ data correction.'
 
 
 def test_validation(s3_stubber, caplog):

--- a/datahub/dbmaintenance/test/commands/test_update_company_headquarter_type.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_headquarter_type.py
@@ -156,7 +156,7 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(company_no_hq_type)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Headquarter type data migration correction.'
+    assert versions[0].revision.get_comment() == 'Headquarter type data migration correction.'
 
     versions = Version.objects.get_for_object(company_ehq)
     assert len(versions) == 0

--- a/datahub/dbmaintenance/test/commands/test_update_company_name.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_name.py
@@ -134,4 +134,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(company_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Company name correction.'
+    assert versions[0].revision.get_comment() == 'Company name correction.'

--- a/datahub/dbmaintenance/test/commands/test_update_contact_accepts_dit_email_marketing.py
+++ b/datahub/dbmaintenance/test/commands/test_update_contact_accepts_dit_email_marketing.py
@@ -148,4 +148,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(contact_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Accepts DIT email marketing correction.'
+    assert versions[0].revision.get_comment() == 'Accepts DIT email marketing correction.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_actual_land_date.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_actual_land_date.py
@@ -137,4 +137,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(project_with_change)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Actual land date migration correction.'
+    assert versions[0].revision.get_comment() == 'Actual land date migration correction.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_actual_uk_regions.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_actual_uk_regions.py
@@ -141,4 +141,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(project_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Actual UK regions migration.'
+    assert versions[0].revision.get_comment() == 'Actual UK regions migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_business_activities.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_business_activities.py
@@ -149,4 +149,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(project_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Business activities data migration correction.'
+    assert versions[0].revision.get_comment() == 'Business activities data migration correction.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_comments.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_comments.py
@@ -105,7 +105,7 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(investment_projects[0])
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Comments migration.'
+    assert versions[0].revision.get_comment() == 'Comments migration.'
 
     versions = Version.objects.get_for_object(investment_projects[1])
     assert len(versions) == 0

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_company.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_company.py
@@ -205,4 +205,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(investment_project)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Companies data migration.'
+    assert versions[0].revision.get_comment() == 'Companies data migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_created_on.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_created_on.py
@@ -114,4 +114,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(investment_project)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Created On migration.'
+    assert versions[0].revision.get_comment() == 'Created On migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_delivery_partners.py
@@ -145,4 +145,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(project_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Investment delivery partners migration.'
+    assert versions[0].revision.get_comment() == 'Investment delivery partners migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_estimated_land_date.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_estimated_land_date.py
@@ -144,4 +144,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(project_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Estimated land date migration correction.'
+    assert versions[0].revision.get_comment() == 'Estimated land date migration correction.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_possible_uk_regions.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_possible_uk_regions.py
@@ -237,4 +237,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(project_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Possible UK regions data migration correction.'
+    assert versions[0].revision.get_comment() == 'Possible UK regions data migration correction.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_marketing.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_marketing.py
@@ -201,4 +201,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(investment_project)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'ReferralSourceActivityMarketing migration.'
+    assert versions[0].revision.get_comment() == 'ReferralSourceActivityMarketing migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_website.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_website.py
@@ -176,4 +176,4 @@ def test_audit_log(s3_stubber):
 
     versions = Version.objects.get_for_object(investment_project)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'ReferralSourceActivityWebsite migration.'
+    assert versions[0].revision.get_comment() == 'ReferralSourceActivityWebsite migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_sector.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_sector.py
@@ -125,4 +125,4 @@ def test_audit_log(s3_stubber):
     assert investment_project.sector == new_sector
     versions = Version.objects.get_for_object(investment_project)
     assert len(versions) == 1
-    assert versions[0].revision.comment == 'Sector migration.'
+    assert versions[0].revision.get_comment() == 'Sector migration.'

--- a/datahub/dbmaintenance/test/commands/test_update_one_list_fields.py
+++ b/datahub/dbmaintenance/test/commands/test_update_one_list_fields.py
@@ -274,4 +274,5 @@ def test_audit_log(s3_stubber, caplog):
 
     versions = Version.objects.get_for_object(company_with_change)
     assert versions.count() == 1
-    assert versions[0].revision.comment == 'Classification and One List account owner correction.'
+    comment = versions[0].revision.get_comment()
+    assert comment == 'Classification and One List account owner correction.'

--- a/requirements.in
+++ b/requirements.in
@@ -9,7 +9,7 @@ django-admin-ip-restrictor==0.2.1
 django-environ==0.4.5
 django-extensions==2.1.0
 django-filter==2.0.0
-django-reversion==2.0.13
+django-reversion==3.0.0
 django-pglocks==1.0.2
 django-model-utils==3.1.2
 django-mptt==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,9 +12,9 @@ aws-requests-auth==0.4.1
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4         # via celery
 boto3==1.7.70
-botocore==1.10.70         # via boto3, s3transfer
+botocore==1.10.75         # via boto3, s3transfer
 celery==4.2.1
-certifi==2018.4.16        # via requests
+certifi==2018.8.13        # via requests
 chardet==3.0.4            # via chardet, requests
 click==6.7                # via click, pip-tools
 coverage==4.5.1           # via pytest-cov
@@ -32,7 +32,7 @@ django-mptt==0.9.1
 django-oauth-toolkit==1.2.0
 django-pglocks==1.0.2
 django-redis==4.9.0
-django-reversion==2.0.13
+django-reversion==3.0.0
 django==2.0.8
 djangorestframework==3.8.2
 docopt==0.6.2             # via docopt, notifications-python-client


### PR DESCRIPTION
### Description of change

See https://github.com/etianen/django-reversion/blob/master/CHANGELOG.rst.

The main change is that django-reversion now stores JSON in the comment field for updates made via the admin site, and that Revision.get_comment() should be used to access comments instead of Revision.comment.

There should be little effect on us as Revision.get_comment() handles both admin JSON log entries and plain strings.

### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
