### PR TITLE
Allow sorting interactions by adviser and subject in endpoint

### DIFF
--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -40,5 +40,8 @@ class InteractionViewSet(CoreViewSet):
         'contact__last_name',
         'created_on',
         'date',
+        'dit_adviser__first_name',
+        'dit_adviser__last_name',
+        'subject',
     )
     ordering = ('-date', '-created_on')


### PR DESCRIPTION
### Description of change

This adds the ability to sort interactions by `dit_adviser` `first_name` or `last_name` and by `subject` in the collection endpoint.

The related test has been changed to make it always deterministic.