### PR TITLE
Fix report key creation.

### DIFF
--- a/datahub/investment/report/tasks.py
+++ b/datahub/investment/report/tasks.py
@@ -1,7 +1,6 @@
 import tempfile
 
 from celery.task import task
-from django.conf import settings
 from django.utils.timezone import now
 
 from datahub.documents.utils import get_bucket_name, get_s3_client_for_bucket
@@ -11,7 +10,8 @@ from .spi import write_report
 
 def _get_report_key():
     report_id = now().strftime('%Y-%m-%d %H%M%S')
-    key = f'{settings.REPORT_BUCKET}/spi-reports/SPI Report {report_id}.csv'
+    bucket_name = get_bucket_name('report')
+    key = f'{bucket_name}/spi-reports/SPI Report {report_id}.csv'
     return key
 
 

--- a/datahub/investment/report/tasks.py
+++ b/datahub/investment/report/tasks.py
@@ -10,8 +10,7 @@ from .spi import write_report
 
 def _get_report_key():
     report_id = now().strftime('%Y-%m-%d %H%M%S')
-    bucket_name = get_bucket_name('report')
-    key = f'{bucket_name}/spi-reports/SPI Report {report_id}.csv'
+    key = f'spi-reports/SPI Report {report_id}.csv'
     return key
 
 

--- a/datahub/investment/report/test/test_tasks.py
+++ b/datahub/investment/report/test/test_tasks.py
@@ -1,10 +1,10 @@
-from datahub.documents.utils import get_bucket_name
+from freezegun import freeze_time
+
 from ..tasks import _get_report_key
 
 
+@freeze_time('2018-03-01 01:02:03')
 def test_get_report_key():
-    """Test that the report key is built from bucket name."""
-    bucket_name = get_bucket_name('report')
+    """Test that the report key is built from current date and time."""
     key = _get_report_key()
-
-    assert bucket_name in key
+    assert key == 'spi-reports/SPI Report 2018-03-01 010203.csv'

--- a/datahub/investment/report/test/test_tasks.py
+++ b/datahub/investment/report/test/test_tasks.py
@@ -1,0 +1,10 @@
+from datahub.documents.utils import get_bucket_name
+from ..tasks import _get_report_key
+
+
+def test_get_report_key():
+    """Test that the report key is built from bucket name."""
+    bucket_name = get_bucket_name('report')
+    key = _get_report_key()
+
+    assert bucket_name in key


### PR DESCRIPTION
### Description of change

`settings.REPORT_BUCKET` is no longer available and `get_bucket_name` function should be used to get bucket name. This fixes the problem with faulty `_get_report_key` function, preventing report bucket key from being created.
