### PR TITLE
Add one list export link to company admin change list

### DIFF
--- a/datahub/company/templates/admin/company/change_list_object_tools.html
+++ b/datahub/company/templates/admin/company/change_list_object_tools.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_list_object_tools.html" %}
+
+{% block object-tools-items %}
+  <li>
+    <a href="{% url 'admin-report:download-report' report_id='one-list' %}">
+      Export One List
+    </a>
+  </li>
+  {{block.super}}
+{% endblock %}

--- a/datahub/company/test/test_admin.py
+++ b/datahub/company/test/test_admin.py
@@ -13,14 +13,15 @@ from .factories import (
     CompanyFactory,
 )
 from ..admin import CompanyAdmin
+from ..admin_reports import OneListReport
 from ..models import Company
 
 
 pytestmark = pytest.mark.django_db
 
 
-class TestCompanyAdmin(AdminTestMixin):
-    """Tests for the company admin."""
+class TestChangeCompanyAdmin(AdminTestMixin):
+    """Tests for the company admin change form."""
 
     def test_add_core_team_members(self):
         """Test that core team members can be added to a company."""
@@ -102,3 +103,23 @@ class TestCompanyAdmin(AdminTestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         assert company.core_team_members.count() == team_size - 1
+
+
+class TestOneListLink(AdminTestMixin):
+    """
+    Tests for the one list export.
+    """
+
+    def test_one_list_link_exists(self):
+        """
+        Test that there is a link to export the one list on the company change list.
+        """
+        url = reverse('admin:company_company_changelist')
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK
+
+        one_list_url = reverse(
+            'admin-report:download-report',
+            kwargs={'report_id': OneListReport.id}
+        )
+        assert one_list_url in response.rendered_content


### PR DESCRIPTION
### Description of change

This allows an admin user to export the one list from the django admin changelist for a company.

![screen shot 2018-08-20 at 15 28 53](https://user-images.githubusercontent.com/178865/44346469-e4c10880-a48d-11e8-9110-e83a0f82979d.png)



### Checklist

* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
