### PR TITLE
Add news fragment for investment project search results export

### DIFF
--- a/changelog/investment/export-endpoint.api
+++ b/changelog/investment/export-endpoint.api
@@ -1,0 +1,3 @@
+``POST /v3/search/investment_project/export`` was added for exporting investment project search
+results as a CSV file with up to 5000 rows. The ``investment.export_investmentproject``
+permission was also added and is required to use this endpoint.


### PR DESCRIPTION
### Description of change

Adds a news fragment for this change that was merged just before the towncrier PR was.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
