### PR TITLE
Deprecate account_manager field

### DIFF
--- a/changelog/company/account-manager.api
+++ b/changelog/company/account-manager.api
@@ -1,0 +1,3 @@
+``GET,POST /v3/company/<uuid:pk>`` and ``GET /v3/search/company``: the field
+``account_manager`` is deprecated and will be removed on or after August 30.
+Please use ``one_list_account_owner`` instead.

--- a/changelog/company/account-manager.db
+++ b/changelog/company/account-manager.db
@@ -1,0 +1,2 @@
+The column ``company_company.account_manager_id`` is deprecated and will be removed on or after August 30.
+Please use ``company_company.one_list_account_owner_id`` instead.

--- a/changelog/company/account-manager.removal
+++ b/changelog/company/account-manager.removal
@@ -1,0 +1,2 @@
+The field ``account_manager`` is deprecated. Please check the API and Database schema categories
+for more details.


### PR DESCRIPTION
### Description of change

This adds some news fragments for deprecating the `account_manager` field.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
