### PR TITLE
Delete Company.parent_id from the database

### DIFF
--- a/changelog/company/delete-parent.db
+++ b/changelog/company/delete-parent.db
@@ -1,0 +1,1 @@
+The column ``company_company.parent_id`` has been deleted from the database.

--- a/changelog/company/delete-parent.removal
+++ b/changelog/company/delete-parent.removal
@@ -1,0 +1,1 @@
+The column ``company_company.parent_id`` has been deleted from the database.

--- a/datahub/company/migrations/0031_remove-parent-column.py
+++ b/datahub/company/migrations/0031_remove-parent-column.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('company', '0030_update_permissions_django_21'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name='company',
+                    name='parent',
+                    field=models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name='+',
+                        to='company.Company'
+                    )
+                ),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='company',
+            name='parent',
+        ),
+    ]


### PR DESCRIPTION
### Description of change

The field was deprecated and it has now been deleted from the database.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
