### PR TITLE
Change datetime format in CSV files to improve compatibility with Excel

### DIFF
--- a/changelog/csv-datetimes.feature
+++ b/changelog/csv-datetimes.feature
@@ -1,0 +1,2 @@
+The format of timestamps in CSV exports and reports was changed to YYYY-MM-DD HH-MM-SS for better compatibility with
+Microsoft Excel.

--- a/datahub/core/csv.py
+++ b/datahub/core/csv.py
@@ -1,5 +1,6 @@
 from codecs import BOM_UTF8
 from csv import DictWriter
+from datetime import datetime
 
 from django.http import StreamingHttpResponse
 
@@ -21,7 +22,7 @@ def csv_iterator(rows, field_titles):
 
         yield writer.writerow(field_titles)
         for row in rows:
-            yield writer.writerow(row)
+            yield writer.writerow(_transform_csv_row(row))
     except Exception:
         # Because CSV responses are normally streamed, a 200 response will already have been
         # returned if an error occurs at this point. Hence we append an error to the CSV
@@ -41,3 +42,23 @@ def create_csv_response(rows, field_titles, filename):
 
     response['Content-Disposition'] = f'attachment; filename="{filename}.csv"'
     return response
+
+
+def _transform_csv_row(row):
+    return {key: _transform_csv_value(val) for key, val in row.items()}
+
+
+def _transform_csv_value(value):
+    """
+    Transforms values before they are written to a CSV file for better compatibility with Excel.
+
+    In particular, datetimes are formatted in a way that results in better compatibility with
+    Excel. Other values are passed through unchanged (the csv module automatically formats None
+    as an empty string).
+
+    These transformations are specific to CSV files and won't necessarily apply to other file
+    formats.
+    """
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d %H:%M:%S')
+    return value

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -275,4 +275,6 @@ def _format_csv_value(value):
     """Converts a value to a string in the way that is expected in CSV exports."""
     if value is None:
         return ''
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d %H:%M:%S')
     return str(value)

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -853,7 +853,7 @@ class TestInteractionExportView(APITestMixin):
 
         expected_row_data = [
             {
-                'Date': str(interaction.date),
+                'Date': interaction.date,
                 'Type': interaction.get_kind_display(),
                 'Service': get_attr_or_none(interaction, 'service.name'),
                 'Subject': interaction.subject,


### PR DESCRIPTION
### Description of change

Effectively this omits microseconds and time zones so that Excel automatically recognises it as a date/time field.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
