### PR TITLE
Add feature news fragment for investment project search export

### DIFF
--- a/changelog/investment/export-projects.feature
+++ b/changelog/investment/export-projects.feature
@@ -1,0 +1,1 @@
+It's now possible to export investment project search results as a CSV file (up to a maximum of 5000 results).


### PR DESCRIPTION
### Description of change

There was one for the API changes, but one for the feature itself was missing.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
