### PR TITLE
Add better read-only admin class using view permissions

### DIFF
--- a/changelog/read-only-admin.feature
+++ b/changelog/read-only-admin.feature
@@ -1,0 +1,2 @@
+Existing read-only model views in the admin site were updated to disable the change button
+that previously had no purpose.

--- a/datahub/company/admin.py
+++ b/datahub/company/admin.py
@@ -4,7 +4,7 @@ from django.contrib.auth.admin import UserAdmin
 from django.db import models
 from reversion.admin import VersionAdmin
 
-from datahub.core.admin import BaseModelAdminMixin, ReadOnlyAdmin
+from datahub.core.admin import BaseModelAdminMixin, ViewOnlyAdmin
 from datahub.metadata.admin import DisableableMetadataAdmin
 from .models import (
     Advisor,
@@ -183,7 +183,7 @@ class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
 
 
 @admin.register(CompaniesHouseCompany)
-class CHCompany(ReadOnlyAdmin):
+class CHCompany(ViewOnlyAdmin):
     """Companies House company admin."""
 
     search_fields = ['name', 'company_number']

--- a/datahub/core/admin.py
+++ b/datahub/core/admin.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from django.contrib import admin
 from django.template.defaultfilters import date as date_filter, time as time_filter
 from django.urls import reverse
@@ -29,8 +27,8 @@ class DisabledOnFilter(admin.SimpleListFilter):
         return queryset
 
 
-class ReadOnlyAdmin(admin.ModelAdmin):
-    """ModelAdmin subclass that makes models viewable but not editable."""
+class ViewAndChangeOnlyAdmin(admin.ModelAdmin):
+    """ModelAdmin subclass that restricts adding and deletion at all times."""
 
     def has_add_permission(self, request, obj=None):
         """
@@ -48,25 +46,22 @@ class ReadOnlyAdmin(admin.ModelAdmin):
         """
         return False
 
-    def get_readonly_fields(self, request, obj=None):
+
+class ViewOnlyAdmin(ViewAndChangeOnlyAdmin):
+    """
+    ModelAdmin subclass that restricts adding, changing and deleting at all times.
+
+    The user must have the relevant view or change permission in order to be able to view the
+    model.
+    """
+
+    def has_change_permission(self, request, obj=None):
         """
-        Gets the read-only fields for this model.
+        Gets whether the user can change objects for this model.
 
-        Always returns all fields.
+        Always returns False.
         """
-        # if reaonly_fields defined explicitly, use that
-        if self.readonly_fields:
-            return self.readonly_fields
-
-        # OrderedDict used instead of set to preserve order
-        readonly_fields = list(OrderedDict.fromkeys(
-            [field.name for field in self.opts.local_fields] +
-            [field.name for field in self.opts.local_many_to_many]
-        ))
-
-        if 'is_submitted' in readonly_fields:
-            readonly_fields.remove('is_submitted')
-        return readonly_fields
+        return False
 
 
 class BaseModelAdminMixin:

--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from mptt.admin import MPTTModelAdmin
 
-from datahub.core.admin import DisabledOnFilter, ReadOnlyAdmin
+from datahub.core.admin import DisabledOnFilter, ViewAndChangeOnlyAdmin, ViewOnlyAdmin
 from . import models
 
 
@@ -50,7 +50,7 @@ class DisableableMetadataAdmin(admin.ModelAdmin):
     list_filter = (DisabledOnFilter,)
 
 
-class ReadOnlyMetadataAdmin(ReadOnlyAdmin):
+class ReadOnlyMetadataAdmin(ViewOnlyAdmin):
     """
     Generic admin for metadata models that shouldn't be edited.
 
@@ -76,7 +76,7 @@ class OrderedMetadataAdmin(admin.ModelAdmin):
     list_filter = (DisabledOnFilter,)
 
 
-class EditableOrderOnlyOrderedMetadataAdmin(OrderedMetadataAdmin, ReadOnlyAdmin):
+class EditableOrderOnlyOrderedMetadataAdmin(OrderedMetadataAdmin, ViewAndChangeOnlyAdmin):
     """
     Generic admin for ordered metadata models with editable order.
 

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -20,7 +20,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_protect
 
-from datahub.core.admin import BaseModelAdminMixin, ReadOnlyAdmin
+from datahub.core.admin import BaseModelAdminMixin, ViewAndChangeOnlyAdmin
 from datahub.core.exceptions import APIConflictException
 from . import validators
 from .models import CancellationReason, Order
@@ -63,7 +63,7 @@ class CancelOrderForm(forms.Form):
 
 
 @admin.register(Order)
-class OrderAdmin(BaseModelAdminMixin, ReadOnlyAdmin):
+class OrderAdmin(BaseModelAdminMixin, ViewAndChangeOnlyAdmin):
     """Admin for orders."""
 
     list_display = ('reference', 'company', 'status', 'created_on', 'modified_on')


### PR DESCRIPTION
### Description of change

This splits the old ReadOnlyAdmin into a ViewAndChangeOnlyAdmin and a ViewOnlyAdmin using the new view permissions in Django 2.1.

Subclasses using the old ReadOnlyAdmin have been updated to use one of the new classes as appropriate.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
