### PR TITLE
Deprecate contact marketing fields no longer available in CSV download.

### DIFF
--- a/changelog/contact/remove-redundant-csv-fields.api
+++ b/changelog/contact/remove-redundant-csv-fields.api
@@ -1,0 +1,2 @@
+```GET,POST /v3/contact``` and ```GET,POST /v3/contact/<uuid:pk>``` the fields contactable_by_dit, contactable_by_uk_dit_partners, contactable_by_overseas_dit_partners, contactable_by_email, contactable_by_phone are deprecated and will be removed on or after September 11
+

--- a/changelog/contact/remove-redundant-csv-fields.db
+++ b/changelog/contact/remove-redundant-csv-fields.db
@@ -1,0 +1,9 @@
+The column ```contact.contactable_by_dit``` is deprecated and may be removed on or after 11 September.
+
+The column ```contact.contactable_by_uk_dit_partners```  is deprecated and may be removed on or after 11 September.
+
+The column ```contact.contactable_by_overseas_dit_partners```  is deprecated and may be removed on or after 11 September.
+
+The column ```contact.contactable_by_email```  is deprecated and may be removed on or after 11 September.
+
+The column ```contact.contactable_by_phone```  is deprecated and may be removed on or after 11 September.

--- a/changelog/contact/remove-redundant-csv-fields.removal
+++ b/changelog/contact/remove-redundant-csv-fields.removal
@@ -1,0 +1,13 @@
+The field ``contactable_by_dit`` is deprecated. Please check the API and Database schema categories
+for more details.
+
+The field ``contactable_by_uk_dit_partners`` is deprecated. Please check the API and Database schema categories
+
+The field ``contactable_by_overseas_dit_partners`` is deprecated. Please check the API and Database schema categories
+for more details.
+
+The field ``contactable_by_email`` is deprecated. Please check the API and Database schema categories
+for more details.
+
+The field ``contactable_by_phone`` is deprecated. Please check the API and Database schema categories
+for more details.


### PR DESCRIPTION
### Description of change

Deprecate contact marketing fields that are no longer available in the CSV download:
    
 ```contactable_by_dit```
```contactable_by_uk_dit_partners```
```contactable_by_overseas_dit_partners```
```contactable_by_email```
```contactable_by_phone```
    
These fields will be removed on or after September 10th.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions

~* [ ] Have any relevant search models been updated?~
Not applicable - deprecating fields.

~* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?~
Not applicable - deprecating fields.

~* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?~
Not applicable - deprecating fields.

~* [ ] Has the admin site been updated (for new models, fields etc.)?~
Not applicable - deprecating fields.

~* [ ] Has the README been updated (if needed)?~
Shouldn't be needed.