### PR TITLE
Puts new proposition complete behaviour behind a feature flag.

### DIFF
--- a/changelog/feature-flag-utils.internal
+++ b/changelog/feature-flag-utils.internal
@@ -1,0 +1,1 @@
+It's now possible to use utility function ``is_feature_flag_active`` from **feature_flag** app to check the state of the feature flag.

--- a/changelog/investment/proposition.bugfix
+++ b/changelog/investment/proposition.bugfix
@@ -1,2 +1,3 @@
 Proposition now needs to have at least one document uploaded in order to be completed.
 It is now optional to provide details when completing a proposition.
+This functionality is behind ``proposition-documents`` feature flag, that needs to be active in order for the new behaviour to work.

--- a/datahub/feature_flag/test/test_utils.py
+++ b/datahub/feature_flag/test/test_utils.py
@@ -1,0 +1,23 @@
+import pytest
+
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+from ..utils import is_feature_flag_active
+
+# mark the whole module for db use
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize('code,is_active,lookup,expected', (
+    ('test_flag', True, 'test_flag', True),
+    ('test_flag', False, 'test_flag', False),
+    ('', None, 'test_flag', False),
+    ('test_flag', True, 'test', False)
+
+))
+def test_is_feature_flag(code, is_active, lookup, expected):
+    """Tests if is_feature_flag returns correct state of feature flag."""
+    if code != '':
+        FeatureFlagFactory(code=code, is_active=is_active)
+
+    result = is_feature_flag_active(lookup)
+    assert result is expected

--- a/datahub/feature_flag/utils.py
+++ b/datahub/feature_flag/utils.py
@@ -7,9 +7,4 @@ def is_feature_flag_active(code):
 
     If feature flag doesn't exist, it returns False.
     """
-    try:
-        feature_flag = FeatureFlag.objects.get(code=code)
-    except FeatureFlag.DoesNotExist:
-        return False
-
-    return feature_flag.is_active
+    return FeatureFlag.objects.filter(code=code, is_active=True).exists()

--- a/datahub/feature_flag/utils.py
+++ b/datahub/feature_flag/utils.py
@@ -1,0 +1,15 @@
+from .models import FeatureFlag
+
+
+def is_feature_flag_active(code):
+    """
+    Tells if given feature flag is active.
+
+    If feature flag doesn't exist, it returns False.
+    """
+    try:
+        feature_flag = FeatureFlag.objects.get(code=code)
+    except FeatureFlag.DoesNotExist:
+        return False
+
+    return feature_flag.is_active

--- a/datahub/investment/proposition/constants.py
+++ b/datahub/investment/proposition/constants.py
@@ -6,3 +6,6 @@ PropositionStatus = Choices(
     ('abandoned', 'Abandoned'),
     ('completed', 'Completed'),
 )
+
+
+FEATURE_FLAG_PROPOSITION_DOCUMENT = 'proposition-documents'

--- a/datahub/investment/proposition/models.py
+++ b/datahub/investment/proposition/models.py
@@ -11,7 +11,10 @@ from datahub.core.exceptions import APIConflictException
 from datahub.core.models import BaseModel
 from datahub.core.utils import StrEnum
 from datahub.documents.models import AbstractEntityDocumentModel, UPLOAD_STATUSES
-from datahub.investment.proposition.constants import PropositionStatus
+from datahub.feature_flag.utils import is_feature_flag_active
+from datahub.investment.proposition.constants import (
+    FEATURE_FLAG_PROPOSITION_DOCUMENT, PropositionStatus
+)
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -146,10 +149,11 @@ class Proposition(BaseModel):
         :raises ValidationError: when trying to complete proposition without uploaded documents
         :raises APIConflictException: when proposition status is not ongoing
         """
-        if self.documents.filter(document__status=UPLOAD_STATUSES.virus_scanned).count() == 0:
-            raise ValidationError({
-                'non_field_errors': ['Proposition has no documents uploaded.']
-            })
+        if is_feature_flag_active(FEATURE_FLAG_PROPOSITION_DOCUMENT):
+            if self.documents.filter(document__status=UPLOAD_STATUSES.virus_scanned).count() == 0:
+                raise ValidationError({
+                    'non_field_errors': ['Proposition has no documents uploaded.']
+                })
         self._change_status(PropositionStatus.completed, by, details)
 
     def abandon(self, by, details):

--- a/datahub/investment/proposition/serializers.py
+++ b/datahub/investment/proposition/serializers.py
@@ -1,6 +1,9 @@
 from rest_framework import serializers
+from rest_framework.exceptions import ValidationError
 
 from datahub.company.serializers import NestedAdviserField
+from datahub.feature_flag.utils import is_feature_flag_active
+from datahub.investment.proposition.constants import FEATURE_FLAG_PROPOSITION_DOCUMENT
 from datahub.investment.proposition.models import Proposition, PropositionDocument
 from datahub.investment.proposition.permissions import (
     PropositionDocumentHasAssociatedInvestmentProjectValidator,
@@ -39,6 +42,13 @@ class CompletePropositionSerializer(serializers.ModelSerializer):
 
     def complete(self):
         """Complete a proposition."""
+        if not is_feature_flag_active(FEATURE_FLAG_PROPOSITION_DOCUMENT):
+            # if proposition documents are not enabled, "details" field is mandatory
+            if self.validated_data['details'] == '':
+                raise ValidationError({
+                    'details': ['This field may not be blank.']
+                })
+
         self.instance.complete(
             by=self.context['current_user'],
             details=self.validated_data['details']

--- a/datahub/investment/proposition/test/test_views.py
+++ b/datahub/investment/proposition/test/test_views.py
@@ -74,7 +74,7 @@ NON_RESTRICTED_DELETE_PERMISSIONS = (
 
 
 @pytest.fixture
-def get_proposition_document_feature_flag():
+def proposition_document_feature_flag():
     """Gets proposition document feature flag."""
     yield FeatureFlagFactory(code=FEATURE_FLAG_PROPOSITION_DOCUMENT)
 
@@ -652,15 +652,12 @@ class TestGetProposition(APITestMixin):
         assert response_data == {'detail': 'Not found.'}
 
 
+@pytest.mark.usefixtures('proposition_document_feature_flag')
 class TestCompleteProposition(APITestMixin):
     """Tests for the complete proposition view."""
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
-    def test_non_restricted_user_can_complete_proposition(
-        self,
-        permissions,
-        get_proposition_document_feature_flag
-    ):
+    def test_non_restricted_user_can_complete_proposition(self, permissions):
         """Test completing proposition by non restricted user."""
         user = create_test_user(permission_codenames=permissions)
         proposition = PropositionFactory()
@@ -717,11 +714,7 @@ class TestCompleteProposition(APITestMixin):
         }
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
-    def test_user_cannot_complete_proposition_for_non_existent_project(
-        self,
-        permissions,
-        get_proposition_document_feature_flag
-    ):
+    def test_user_cannot_complete_proposition_for_non_existent_project(self, permissions):
         """Test user cannot complete proposition for non existent investment project."""
         user = create_test_user(permission_codenames=permissions)
         proposition = PropositionFactory()
@@ -742,10 +735,7 @@ class TestCompleteProposition(APITestMixin):
         response_data = response.json()
         assert response_data == {'detail': 'Not found.'}
 
-    def test_restricted_user_can_complete_proposition(
-        self,
-        get_proposition_document_feature_flag
-    ):
+    def test_restricted_user_can_complete_proposition(self):
         """Test completing proposition by a restricted user."""
         project_creator = AdviserFactory()
         user = create_test_user(
@@ -812,10 +802,7 @@ class TestCompleteProposition(APITestMixin):
             }
         }
 
-    def test_restricted_user_cannot_complete_non_associated_ip_proposition(
-        self,
-        get_proposition_document_feature_flag
-    ):
+    def test_restricted_user_cannot_complete_non_associated_ip_proposition(self):
         """Test restricted user cannot complete non associated investment project proposition."""
         project_creator = AdviserFactory()
         user = create_test_user(
@@ -858,11 +845,7 @@ class TestCompleteProposition(APITestMixin):
             PropositionStatus.completed, PropositionStatus.abandoned,
         ),
     )
-    def test_cannot_complete_proposition_without_ongoing_status(
-        self,
-        proposition_status,
-        get_proposition_document_feature_flag
-    ):
+    def test_cannot_complete_proposition_without_ongoing_status(self, proposition_status):
         """Test cannot complete proposition that doesn't have ongoing status."""
         user = create_test_user(
             permission_codenames=(
@@ -894,10 +877,7 @@ class TestCompleteProposition(APITestMixin):
         assert proposition.status == proposition_status
         assert proposition.details == ''
 
-    def test_cannot_complete_proposition_without_uploading_documents(
-        self,
-        get_proposition_document_feature_flag
-    ):
+    def test_cannot_complete_proposition_without_uploading_documents(self):
         """Test cannot complete proposition without uploading documents."""
         proposition = PropositionFactory()
         url = reverse('api-v3:investment:proposition:complete', kwargs={

--- a/datahub/investment/proposition/test/test_views.py
+++ b/datahub/investment/proposition/test/test_views.py
@@ -9,7 +9,10 @@ from rest_framework.reverse import reverse
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
 from datahub.documents.models import Document, UPLOAD_STATUSES
-from datahub.investment.proposition.constants import PropositionStatus
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.investment.proposition.constants import (
+    FEATURE_FLAG_PROPOSITION_DOCUMENT, PropositionStatus
+)
 from datahub.investment.proposition.models import (
     Proposition, PropositionDocument, PropositionDocumentPermission, PropositionPermission
 )
@@ -68,6 +71,12 @@ NON_RESTRICTED_DELETE_PERMISSIONS = (
         PropositionDocumentPermission.delete_associated_investmentproject,
     )
 )
+
+
+@pytest.fixture
+def get_proposition_document_feature_flag():
+    """Gets proposition document feature flag."""
+    yield FeatureFlagFactory(code=FEATURE_FLAG_PROPOSITION_DOCUMENT)
 
 
 class TestCreateProposition(APITestMixin):
@@ -647,7 +656,11 @@ class TestCompleteProposition(APITestMixin):
     """Tests for the complete proposition view."""
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
-    def test_non_restricted_user_can_complete_proposition(self, permissions):
+    def test_non_restricted_user_can_complete_proposition(
+        self,
+        permissions,
+        get_proposition_document_feature_flag
+    ):
         """Test completing proposition by non restricted user."""
         user = create_test_user(permission_codenames=permissions)
         proposition = PropositionFactory()
@@ -704,7 +717,11 @@ class TestCompleteProposition(APITestMixin):
         }
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
-    def test_user_cannot_complete_proposition_for_non_existent_project(self, permissions):
+    def test_user_cannot_complete_proposition_for_non_existent_project(
+        self,
+        permissions,
+        get_proposition_document_feature_flag
+    ):
         """Test user cannot complete proposition for non existent investment project."""
         user = create_test_user(permission_codenames=permissions)
         proposition = PropositionFactory()
@@ -725,7 +742,10 @@ class TestCompleteProposition(APITestMixin):
         response_data = response.json()
         assert response_data == {'detail': 'Not found.'}
 
-    def test_restricted_user_can_complete_proposition(self):
+    def test_restricted_user_can_complete_proposition(
+        self,
+        get_proposition_document_feature_flag
+    ):
         """Test completing proposition by a restricted user."""
         project_creator = AdviserFactory()
         user = create_test_user(
@@ -792,7 +812,10 @@ class TestCompleteProposition(APITestMixin):
             }
         }
 
-    def test_restricted_user_cannot_complete_non_associated_ip_proposition(self):
+    def test_restricted_user_cannot_complete_non_associated_ip_proposition(
+        self,
+        get_proposition_document_feature_flag
+    ):
         """Test restricted user cannot complete non associated investment project proposition."""
         project_creator = AdviserFactory()
         user = create_test_user(
@@ -835,7 +858,11 @@ class TestCompleteProposition(APITestMixin):
             PropositionStatus.completed, PropositionStatus.abandoned,
         ),
     )
-    def test_cannot_complete_proposition_without_ongoing_status(self, proposition_status):
+    def test_cannot_complete_proposition_without_ongoing_status(
+        self,
+        proposition_status,
+        get_proposition_document_feature_flag
+    ):
         """Test cannot complete proposition that doesn't have ongoing status."""
         user = create_test_user(
             permission_codenames=(
@@ -867,7 +894,10 @@ class TestCompleteProposition(APITestMixin):
         assert proposition.status == proposition_status
         assert proposition.details == ''
 
-    def test_cannot_complete_proposition_without_uploading_documents(self):
+    def test_cannot_complete_proposition_without_uploading_documents(
+        self,
+        get_proposition_document_feature_flag
+    ):
         """Test cannot complete proposition without uploading documents."""
         proposition = PropositionFactory()
         url = reverse('api-v3:investment:proposition:complete', kwargs={
@@ -878,6 +908,246 @@ class TestCompleteProposition(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data['non_field_errors'] == ['Proposition has no documents uploaded.']
+        proposition.refresh_from_db()
+        assert proposition.status == PropositionStatus.ongoing
+
+
+class TestLegacyCompleteProposition(APITestMixin):
+    """Tests for the legacy complete proposition view."""
+
+    @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
+    def test_non_restricted_user_can_complete_proposition(self, permissions):
+        """Test completing proposition by non restricted user."""
+        proposition = PropositionFactory()
+
+        url = reverse('api-v3:investment:proposition:complete', kwargs={
+            'proposition_pk': proposition.pk,
+            'project_pk': proposition.investment_project.pk,
+        })
+
+        user = create_test_user(permission_codenames=permissions)
+        api_client = self.create_api_client(user=user)
+        response = api_client.post(
+            url,
+            {
+                'details': 'All done 100% satisfaction.',
+            },
+            format='json',
+        )
+        proposition.refresh_from_db()
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert proposition.modified_by == user
+        assert response_data == {
+            'id': str(proposition.pk),
+            'investment_project': {
+                'name': proposition.investment_project.name,
+                'project_code': proposition.investment_project.project_code,
+                'id': str(proposition.investment_project.pk)
+            },
+            'adviser': {
+                'first_name': proposition.adviser.first_name,
+                'last_name': proposition.adviser.last_name,
+                'name': proposition.adviser.name,
+                'id': str(proposition.adviser.pk)
+            },
+            'deadline': proposition.deadline.isoformat(),
+            'status': PropositionStatus.completed,
+            'name': proposition.name,
+            'scope': proposition.scope,
+            'created_on': format_date_or_datetime(proposition.created_on),
+            'created_by': {
+                'first_name': proposition.created_by.first_name,
+                'last_name': proposition.created_by.last_name,
+                'name': proposition.created_by.name,
+                'id': str(proposition.created_by.pk),
+            },
+            'details': 'All done 100% satisfaction.',
+            'modified_on': format_date_or_datetime(proposition.modified_on),
+            'modified_by': {
+                'first_name': proposition.modified_by.first_name,
+                'last_name': proposition.modified_by.last_name,
+                'name': proposition.modified_by.name,
+                'id': str(proposition.modified_by.pk),
+            }
+        }
+
+    @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
+    def test_user_cannot_complete_proposition_for_non_existent_project(self, permissions):
+        """Test user cannot complete proposition for non existent investment project."""
+        proposition = PropositionFactory()
+
+        url = reverse('api-v3:investment:proposition:complete', kwargs={
+            'proposition_pk': proposition.pk,
+            'project_pk': uuid.uuid4(),
+        })
+
+        user = create_test_user(permission_codenames=permissions)
+        api_client = self.create_api_client(user=user)
+        response = api_client.post(
+            url,
+            {
+                'details': 'All done 100% satisfaction.',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        response_data = response.json()
+        assert response_data == {'detail': 'Not found.'}
+
+    def test_restricted_user_can_complete_proposition(self):
+        """Test completing proposition by a restricted user."""
+        project_creator = AdviserFactory()
+        investment_project = InvestmentProjectFactory(
+            created_by=project_creator
+        )
+        proposition = PropositionFactory(
+            investment_project=investment_project
+        )
+
+        url = reverse('api-v3:investment:proposition:complete', kwargs={
+            'proposition_pk': proposition.pk,
+            'project_pk': proposition.investment_project.pk,
+        })
+
+        user = create_test_user(
+            permission_codenames=(
+                PropositionPermission.change_associated_investmentproject,
+            ),
+            dit_team=project_creator.dit_team,
+        )
+        api_client = self.create_api_client(user=user)
+        response = api_client.post(
+            url,
+            {
+                'details': 'All done 100% satisfaction.',
+            },
+            format='json',
+        )
+        proposition.refresh_from_db()
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert proposition.modified_by == user
+        assert response_data == {
+            'id': str(proposition.pk),
+            'investment_project': {
+                'name': proposition.investment_project.name,
+                'project_code': proposition.investment_project.project_code,
+                'id': str(proposition.investment_project.pk)
+            },
+            'adviser': {
+                'first_name': proposition.adviser.first_name,
+                'last_name': proposition.adviser.last_name,
+                'name': proposition.adviser.name,
+                'id': str(proposition.adviser.pk)
+            },
+            'deadline': proposition.deadline.isoformat(),
+            'status': PropositionStatus.completed,
+            'name': proposition.name,
+            'scope': proposition.scope,
+            'created_on': format_date_or_datetime(proposition.created_on),
+            'created_by': {
+                'first_name': proposition.created_by.first_name,
+                'last_name': proposition.created_by.last_name,
+                'name': proposition.created_by.name,
+                'id': str(proposition.created_by.pk),
+            },
+            'details': 'All done 100% satisfaction.',
+            'modified_on': format_date_or_datetime(proposition.modified_on),
+            'modified_by': {
+                'first_name': proposition.modified_by.first_name,
+                'last_name': proposition.modified_by.last_name,
+                'name': proposition.modified_by.name,
+                'id': str(proposition.modified_by.pk),
+            }
+        }
+
+    def test_restricted_user_cannot_complete_non_associated_ip_proposition(self):
+        """Test restricted user cannot complete non associated investment project proposition."""
+        project_creator = AdviserFactory()
+        investment_project = InvestmentProjectFactory(
+            created_by=project_creator
+        )
+        proposition = PropositionFactory(
+            investment_project=investment_project
+        )
+
+        url = reverse('api-v3:investment:proposition:complete', kwargs={
+            'proposition_pk': proposition.pk,
+            'project_pk': proposition.investment_project.pk,
+        })
+
+        user = create_test_user(
+            permission_codenames=(
+                PropositionPermission.change_associated_investmentproject,
+            ),
+            dit_team=TeamFactory(),
+        )
+        api_client = self.create_api_client(user=user)
+        response = api_client.post(
+            url,
+            {
+                'details': 'All done 100% satisfaction.',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        response_data = response.json()
+        assert response_data == {
+            'detail': 'You do not have permission to perform this action.'
+        }
+
+        proposition.refresh_from_db()
+        assert proposition.details == ''
+        assert proposition.modified_by != user
+
+    @pytest.mark.parametrize(
+        'proposition_status', (
+            PropositionStatus.completed, PropositionStatus.abandoned,
+        ),
+    )
+    def test_cannot_complete_proposition_without_ongoing_status(self, proposition_status):
+        """Test cannot complete proposition that doesn't have ongoing status."""
+        proposition = PropositionFactory(
+            status=proposition_status
+        )
+        url = reverse('api-v3:investment:proposition:complete', kwargs={
+            'proposition_pk': proposition.pk,
+            'project_pk': proposition.investment_project.pk,
+        })
+        response = self.api_client.post(
+            url,
+            {
+                'details': 'All done 100% satisfaction.',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_409_CONFLICT
+        response_data = response.json()
+        detail = f'The action cannot be performed in the current status {proposition_status}.'
+        assert response_data['detail'] == detail
+
+        proposition.refresh_from_db()
+        assert proposition.status == proposition_status
+        assert proposition.details == ''
+
+    def test_cannot_complete_proposition_without_details(self):
+        """Test cannot complete proposition without giving details."""
+        proposition = PropositionFactory()
+        url = reverse('api-v3:investment:proposition:complete', kwargs={
+            'proposition_pk': proposition.pk,
+            'project_pk': proposition.investment_project.pk,
+        })
+        response = self.api_client.post(
+            url,
+            {
+                'details': '',
+            },
+            format='json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        response_data = response.json()
+        assert response_data['details'] == ['This field may not be blank.']
         proposition.refresh_from_db()
         assert proposition.status == PropositionStatus.ongoing
 


### PR DESCRIPTION
### Description of change

This puts the new behaviour of proposition complete functionality behind the feature flag. If `proposition-documents` feature flag is active, new functionality becomes enabled.
This adds a suite of tests for old behaviour in `TestLegacyCompleteProposition` class.
It also adds a utility function in the feature_flag app that gets the "state" of the feature flag.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
