### PR TITLE
Correct front-end URL prefix for contacts

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -322,7 +322,7 @@ if REDIS_BASE_URL:
 DATAHUB_FRONTEND_BASE_URL = env('DATAHUB_FRONTEND_BASE_URL', default='http://localhost:3000')
 DATAHUB_FRONTEND_URL_PREFIXES = {
     'company': f'{DATAHUB_FRONTEND_BASE_URL}/companies',
-    'contact': f'{DATAHUB_FRONTEND_BASE_URL}/contact',
+    'contact': f'{DATAHUB_FRONTEND_BASE_URL}/contacts',
     'interaction': f'{DATAHUB_FRONTEND_BASE_URL}/interactions',
     'order': f'{DATAHUB_FRONTEND_BASE_URL}/omis',
 }


### PR DESCRIPTION
### Description of change

I haven't added another news fragment, as this relates to the contact export which hasn't been released and there is an existing news fragment for.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
