### PR TITLE
Make links in CSV exports clickable in Excel

### DIFF
--- a/changelog/csv-clickable-links.feature
+++ b/changelog/csv-clickable-links.feature
@@ -1,0 +1,1 @@
+URLs in all CSV exports and reports were made clickable when the CSV file is opened in Excel. This was achieved by using the Excel HYPERLINK() function.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -325,6 +325,7 @@ DATAHUB_FRONTEND_URL_PREFIXES = {
     'company': f'{DATAHUB_FRONTEND_BASE_URL}/companies',
     'contact': f'{DATAHUB_FRONTEND_BASE_URL}/contacts',
     'interaction': f'{DATAHUB_FRONTEND_BASE_URL}/interactions',
+    'investment-project': f'{DATAHUB_FRONTEND_BASE_URL}/investment-projects',
     'order': f'{DATAHUB_FRONTEND_BASE_URL}/omis',
 }
 

--- a/datahub/company/test/test_admin_report.py
+++ b/datahub/company/test/test_admin_report.py
@@ -150,5 +150,8 @@ def test_one_list_report_generation():
         'one_list_account_owner__contact_email': company.one_list_account_owner.contact_email,
         'registered_address_country__name': company.registered_address_country.name,
         'registered_address_town': company.registered_address_town,
-        'url': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.id}',
+        'url':
+            f'=HYPERLINK("'
+            f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.id}'
+            f'")',
     } for company in companies]

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -155,7 +155,12 @@ def get_front_end_url_expression(model_name, pk_expression):
     :param model_name:      key in settings.DATAHUB_FRONTEND_URL_PREFIXES
     :param pk_expression:   expression that resolves to the pk for the model
     """
-    return Concat(Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'), pk_expression)
+    return Concat(
+        Value('=HYPERLINK("'),
+        Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'),
+        pk_expression,
+        Value('")'),
+    )
 
 
 def _full_name_concat(first_name_field, last_name_field):

--- a/datahub/core/test/test_query_utils.py
+++ b/datahub/core/test/test_query_utils.py
@@ -159,4 +159,4 @@ def test_get_front_end_url_expression(monkeypatch):
     queryset = Book.objects.annotate(
         url=get_front_end_url_expression('book', 'pk')
     )
-    assert queryset.first().url == f'http://test/{book.pk}'
+    assert queryset.first().url == f'=HYPERLINK("http://test/{book.pk}")'

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -542,7 +542,10 @@ class TestCompanyExportView(APITestMixin):
         expected_row_data = [
             {
                 'Name': company.name,
-                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.pk}',
+                'Link':
+                    f'=HYPERLINK("'
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.pk}'
+                    f'")',
                 'Sector': get_attr_or_none(company, 'sector.name'),
                 'Country': get_attr_or_none(company, 'registered_address_country.name'),
                 'UK region': get_attr_or_none(company, 'uk_region.name'),

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -498,11 +498,16 @@ class TestContactExportView(APITestMixin):
                 'Job title': contact.job_title,
                 'Date created': contact.created_on,
                 'Archived': contact.archived,
-                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{contact.pk}',
+                'Link':
+                    f'=HYPERLINK("'
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{contact.pk}'
+                    f'")',
                 'Company': get_attr_or_none(contact, 'company.name'),
                 'Company sector': get_attr_or_none(contact, 'company.sector.name'),
                 'Company link':
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{contact.company.pk}',
+                    f'=HYPERLINK("'
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{contact.company.pk}'
+                    f'")',
                 'Company UK region': get_attr_or_none(contact, 'company.uk_region.name'),
                 'Country':
                     contact.company.registered_address_country.name

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -857,12 +857,16 @@ class TestInteractionExportView(APITestMixin):
                 'Type': interaction.get_kind_display(),
                 'Service': get_attr_or_none(interaction, 'service.name'),
                 'Subject': interaction.subject,
-                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["interaction"]}'
-                        f'/{interaction.pk}',
+                'Link':
+                    f'=HYPERLINK("'
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["interaction"]}/{interaction.pk}'
+                    f'")',
                 'Company': get_attr_or_none(interaction, 'company.name'),
                 'Company link':
+                    f'=HYPERLINK("'
                     f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
-                    f'/{interaction.company.pk}',
+                    f'/{interaction.company.pk}'
+                    f'")',
                 'Company country': get_attr_or_none(
                     interaction,
                     'company.registered_address_country.name',

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -10,6 +10,7 @@ from uuid import UUID
 import factory
 import pytest
 from dateutil.parser import parse as dateutil_parse
+from django.conf import settings
 from django.utils.timezone import utc
 from freezegun import freeze_time
 from rest_framework import status
@@ -800,6 +801,11 @@ class TestInvestmentProjectExportView(APITestMixin):
                 'Investment type': get_attr_or_none(project, 'investment_type.name'),
                 'Status': project.get_status_display(),
                 'Stage': get_attr_or_none(project, 'stage.name'),
+                'Link':
+                    f'=HYPERLINK("'
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["investment-project"]}'
+                    f'/{project.pk}'
+                    f'")',
                 'Actual land date': project.actual_land_date,
                 'Estimated land date': project.estimated_land_date,
                 'FDI value': get_attr_or_none(project, 'fdi_value.name'),

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -3,6 +3,7 @@ from django.db.models import Max
 from datahub.core.query_utils import (
     get_aggregate_subquery,
     get_choices_as_case_expression,
+    get_front_end_url_expression,
     get_full_name_expression,
     get_string_agg_subquery,
 )
@@ -80,6 +81,7 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectParams, SearchExportA
     queryset = DBInvestmentProject.objects.annotate(
         computed_project_code=get_project_code_expression(),
         status_name=get_choices_as_case_expression(DBInvestmentProject, 'status'),
+        link=get_front_end_url_expression('investment-project', 'pk'),
         date_of_latest_interaction=get_aggregate_subquery(
             DBInvestmentProject,
             Max('interactions__date'),
@@ -117,6 +119,7 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectParams, SearchExportA
         'investment_type__name': 'Investment type',
         'status_name': 'Status',
         'stage__name': 'Stage',
+        'link': 'Link',
         'actual_land_date': 'Actual land date',
         'estimated_land_date': 'Estimated land date',
         'fdi_value__name': 'FDI value',

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -481,7 +481,7 @@ class TestOrderExportView(APITestMixin):
                     sum(refund.net_amount for refund in refunds)
                 ) / 100 if refunds else None,
                 'Status': order.get_status_display(),
-                'Link': order.get_datahub_frontend_url(),
+                'Link': f'=HYPERLINK("{order.get_datahub_frontend_url()}")',
                 'Sector': order.sector.name,
                 'Market': order.primary_market.name,
                 'UK region': order.uk_region.name,
@@ -490,13 +490,15 @@ class TestOrderExportView(APITestMixin):
                     order.company.registered_address_country.name,
                 'Company UK region': get_attr_or_none(order, 'company.uk_region.name'),
                 'Company link':
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
-                    f'/{order.company.pk}',
+                    f'=HYPERLINK("'
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{order.company.pk}'
+                    f'")',
                 'Contact': order.contact.name,
                 'Contact job title': order.contact.job_title,
                 'Contact link':
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}'
-                    f'/{order.contact.pk}',
+                    f'=HYPERLINK("'
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{order.contact.pk}'
+                    f'")',
                 'Created by team': get_attr_or_none(order, 'created_by.dit_team.name'),
                 'Date created': order.created_on,
                 'Delivery date': order.delivery_date,


### PR DESCRIPTION
### Description of change

This uses the Excel function =HYPERLINK() to make URLs clickable. Not overly nice to use that in CSV files, but we agreed to do so.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
