### PR TITLE
Add support for CORS

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -53,6 +53,7 @@ THIRD_PARTY_APPS = [
     'oauth2_provider',
     'django_filters',
     'mptt',
+    'corsheaders',
 ]
 
 LOCAL_APPS = [
@@ -90,6 +91,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -389,3 +391,5 @@ DOCUMENT_BUCKETS = {
         'aws_region': env('REPORT_AWS_REGION', default=''),
     }
 }
+
+CORS_ORIGIN_ALLOW_ALL = True

--- a/requirements.in
+++ b/requirements.in
@@ -8,6 +8,7 @@ djangorestframework==3.8.2
 django-admin-ip-restrictor==0.2.1
 django-environ==0.4.5
 django-extensions==2.1.0
+django-cors-headers==2.4.0
 django-filter==2.0.0
 django-reversion==3.0.0
 django-pglocks==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ coverage==4.5.1           # via pytest-cov
 cssselect==1.0.3
 decorator==4.3.0          # via ipython, traitlets
 django-admin-ip-restrictor==0.2.1
+django-cors-headers==2.4.0
 django-debug-toolbar==1.9.1
 django-environ==0.4.5
 django-extensions==2.1.0


### PR DESCRIPTION
This change uses the django-cors-headers module to add support for CORS.
This enables the use of Axios in the frontend express app as well as direct calls to the API from the browser.