### PR TITLE
Add user events for document deletion

### DIFF
--- a/changelog/investment/document-deletion-auditing.internal
+++ b/changelog/investment/document-deletion-auditing.internal
@@ -1,0 +1,1 @@
+Deletion of proposition or evidence document is now logged in UserEvent model. UserEvent records can be viewed from the admin site.

--- a/datahub/investment/evidence/test/test_views.py
+++ b/datahub/investment/evidence/test/test_views.py
@@ -1,7 +1,10 @@
+import datetime
 from operator import attrgetter, itemgetter
 from unittest.mock import patch
 
 import pytest
+from django.utils.timezone import utc
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
@@ -9,6 +12,7 @@ from datahub.company.test.factories import TeamFactory
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
 from datahub.documents.models import Document, UPLOAD_STATUSES
 from datahub.investment.test.factories import InvestmentProjectFactory
+from datahub.user_event_log.models import USER_EVENT_TYPES, UserEvent
 from .factories import EvidenceTagFactory
 from .utils import create_evidence_document
 from ..models import EvidenceDocument, EvidenceDocumentPermission
@@ -585,6 +589,117 @@ class TestEvidenceDocumentViews(APITestMixin):
         response = api_client.delete(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert delete_document.called is False
+
+    @pytest.mark.parametrize('permissions,associated,allowed', DELETE_PERMISSIONS)
+    @patch('datahub.documents.tasks.delete_document.apply_async')
+    def test_document_delete_creates_user_event_log(
+        self,
+        delete_document,
+        permissions,
+        associated,
+        allowed
+    ):
+        """Tests document deletion creates user event log."""
+        user = create_test_user(permission_codenames=permissions, dit_team=TeamFactory())
+        entity_document = create_evidence_document(user, associated=associated)
+        document = entity_document.document
+        document.mark_scan_scheduled()
+        document.mark_as_scanned(True, 'reason')
+
+        url = reverse(
+            'api-v3:investment:evidence-document:document-item',
+            kwargs={
+                'project_pk': entity_document.investment_project.pk,
+                'entity_document_pk': entity_document.pk
+            }
+        )
+
+        document_pk = entity_document.document.pk
+
+        expected_user_event_data = {
+            'id': str(entity_document.pk),
+            'url': entity_document.url,
+            'status': entity_document.document.status,
+            'av_clean': entity_document.document.av_clean,
+            'created_by': {
+                'id': str(entity_document.created_by.id),
+                'first_name': entity_document.created_by.first_name,
+                'last_name': entity_document.created_by.last_name,
+                'name': entity_document.created_by.name,
+            },
+            'created_on': format_date_or_datetime(entity_document.created_on),
+            'modified_by': None,
+            'modified_on': format_date_or_datetime(entity_document.modified_on),
+            'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
+            'original_filename': entity_document.original_filename,
+            'comment': entity_document.comment,
+            'investment_project': {
+                'id': str(entity_document.investment_project.id),
+                'name': entity_document.investment_project.name,
+                'project_code': entity_document.investment_project.project_code,
+            },
+            'tags': [
+                {'id': str(tag.id), 'name': tag.name}
+                for tag in entity_document.tags.order_by('name')
+            ],
+        }
+
+        api_client = self.create_api_client(user=user)
+
+        frozen_time = datetime.datetime(2018, 1, 2, 12, 30, 50, tzinfo=utc)
+        with freeze_time(frozen_time):
+            response = api_client.delete(url)
+
+        if not allowed:
+            assert response.status_code == status.HTTP_403_FORBIDDEN
+            assert response.json() == {
+                'detail': 'You do not have permission to perform this action.'
+            }
+            return
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        delete_document.assert_called_once_with(args=(document_pk, ))
+
+        assert UserEvent.objects.count() == 1
+
+        user_event = UserEvent.objects.first()
+
+        assert user_event.adviser == user
+        assert user_event.type == USER_EVENT_TYPES.evidence_document_delete
+        assert user_event.timestamp == frozen_time
+        assert user_event.api_url_path == url
+        user_event.data['tags'] = sorted(user_event.data['tags'], key=itemgetter('name'))
+        assert user_event.data == expected_user_event_data
+
+    @patch.object(Document, 'mark_deletion_pending')
+    def test_document_delete_failure_wont_create_user_event_log(
+        self,
+        mark_deletion_pending,
+    ):
+        """Tests document deletion failure won't create user event log."""
+        mark_deletion_pending.side_effect = Exception('No way!')
+        user = create_test_user(
+            permission_codenames=(EvidenceDocumentPermission.delete_all,),
+            dit_team=TeamFactory()
+        )
+        entity_document = create_evidence_document(user, False)
+        document = entity_document.document
+        document.mark_scan_scheduled()
+        document.mark_as_scanned(True, 'reason')
+
+        url = reverse(
+            'api-v3:investment:evidence-document:document-item',
+            kwargs={
+                'project_pk': entity_document.investment_project.pk,
+                'entity_document_pk': entity_document.pk
+            }
+        )
+
+        api_client = self.create_api_client(user=user)
+        with pytest.raises(Exception):
+            api_client.delete(url)
+
+        assert UserEvent.objects.count() == 0
 
     def test_document_upload_status_no_status_without_permission(self):
         """Tests user without permission can't call upload status endpoint."""

--- a/datahub/investment/evidence/views.py
+++ b/datahub/investment/evidence/views.py
@@ -11,6 +11,8 @@ from datahub.investment.evidence.permissions import (
 from datahub.investment.evidence.serializers import EvidenceDocumentSerializer
 from datahub.investment.models import InvestmentProject
 from datahub.oauth.scopes import Scope
+from datahub.user_event_log.constants import USER_EVENT_TYPES
+from datahub.user_event_log.utils import record_user_event
 
 
 class EvidenceDocumentViewSet(BaseEntityDocumentModelViewSet):
@@ -50,6 +52,13 @@ class EvidenceDocumentViewSet(BaseEntityDocumentModelViewSet):
     def get_view_name(self):
         """Returns the view set name for the DRF UI."""
         return 'Evidence documents'
+
+    def destroy(self, request, *args, **kwargs):
+        """Record delete event."""
+        entity_document = self.get_object()
+        data = self.serializer_class(entity_document).data
+        record_user_event(request, USER_EVENT_TYPES.evidence_document_delete, data=data)
+        return super().destroy(request, *args, **kwargs)
 
     def _check_project_exists(self):
         if not InvestmentProject.objects.filter(pk=self.kwargs['project_pk']).exists():

--- a/datahub/investment/proposition/views.py
+++ b/datahub/investment/proposition/views.py
@@ -27,6 +27,8 @@ from datahub.investment.proposition.serializers import (
     PropositionSerializer,
 )
 from datahub.oauth.scopes import Scope
+from datahub.user_event_log.constants import USER_EVENT_TYPES
+from datahub.user_event_log.utils import record_user_event
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -161,3 +163,11 @@ class PropositionDocumentViewSet(BaseEntityDocumentModelViewSet):
     def get_view_name(self):
         """Returns the view set name for the DRF UI."""
         return 'Proposition documents'
+
+    def destroy(self, request, *args, **kwargs):
+        """Record delete event."""
+        entity_document = self.get_object()
+        data = self.serializer_class(entity_document).data
+        data['proposition_id'] = entity_document.proposition_id
+        record_user_event(request, USER_EVENT_TYPES.proposition_document_delete, data=data)
+        return super().destroy(request, *args, **kwargs)

--- a/datahub/user_event_log/constants.py
+++ b/datahub/user_event_log/constants.py
@@ -2,4 +2,6 @@ from model_utils import Choices
 
 USER_EVENT_TYPES = Choices(
     ('search_export', 'Exported search results'),
+    ('proposition_document_delete', 'Deleted proposition document'),
+    ('evidence_document_delete', 'Deleted evidence document'),
 )


### PR DESCRIPTION
### Description of change

This adds two user event logs for evidence and proposition document deletion. 
