### PR TITLE
Fix proposition document list endpoint

### DIFF
--- a/changelog/investment/proposition-document-list.bugfix
+++ b/changelog/investment/proposition-document-list.bugfix
@@ -1,0 +1,1 @@
+Restricted users can now list proposition documents associated to their team's investment projects.

--- a/datahub/investment/permissions.py
+++ b/datahub/investment/permissions.py
@@ -123,6 +123,25 @@ class IsAssociatedToInvestmentProjectPermission(IsAssociatedToObjectPermission):
     checker_class = InvestmentProjectAssociationChecker
 
 
+class IsAssociatedToInvestmentProjectPermissionMixin:
+    """
+    This checks if user has permission to access a view attached to Investment Project.
+
+    It is meant to be used with IsAssociatedToObjectPermission.
+    """
+
+    def has_permission(self, request, view):
+        """Returns whether the user has permissions for a view."""
+        if self.checker.should_apply_restrictions(request, view.action):
+            investment_project = InvestmentProject.objects.get(
+                pk=request.parser_context['kwargs']['project_pk']
+            )
+            if not self.checker.is_associated(request, investment_project):
+                return False
+
+        return super().has_permission(request, view)
+
+
 class IsAssociatedToInvestmentProjectFilter(BaseFilterBackend):
     """Filter for LEPs users to see only associated InvestmentProjects."""
 

--- a/datahub/investment/proposition/permissions.py
+++ b/datahub/investment/proposition/permissions.py
@@ -1,10 +1,8 @@
-from rest_framework.exceptions import ValidationError
-
 from datahub.core.permissions import IsAssociatedToObjectPermission, ViewBasedModelPermissions
 from datahub.core.utils import StrEnum
-from datahub.investment.models import InvestmentProject
 from datahub.investment.permissions import (
-    InvestmentProjectAssociationCheckerBase, IsAssociatedToInvestmentProjectFilter
+    InvestmentProjectAssociationCheckerBase,
+    IsAssociatedToInvestmentProjectPermissionMixin,
 )
 from datahub.investment.proposition.models import Proposition, PropositionDocument
 
@@ -64,7 +62,10 @@ class InvestmentProjectPropositionAssociationChecker(
     associated_permission_template = _PermissionTemplate.associated
 
 
-class IsAssociatedToInvestmentProjectPropositionPermission(IsAssociatedToObjectPermission):
+class IsAssociatedToInvestmentProjectPropositionPermission(
+    IsAssociatedToInvestmentProjectPermissionMixin,
+    IsAssociatedToObjectPermission,
+):
     """Permission class based on InvestmentProjectPropositionAssociationChecker."""
 
     checker_class = InvestmentProjectPropositionAssociationChecker
@@ -72,72 +73,6 @@ class IsAssociatedToInvestmentProjectPropositionPermission(IsAssociatedToObjectP
     def get_actual_object(self, obj):
         """Returns the investment project from an Proposition object."""
         return obj.investment_project
-
-
-class IsAssociatedToInvestmentProjectPropositionFilter(IsAssociatedToInvestmentProjectFilter):
-    """Filter class which enforces investment project proposition association permission."""
-
-    model_attribute = 'investment_project'
-    checker_class = InvestmentProjectPropositionAssociationChecker
-
-
-class _HasAssociatedInvestmentProjectValidator:
-    """
-    Validator which enforces association permissions when adding associated object.
-
-    When subclassing, checker and non_associated_investment_project_message have to be overridden.
-    """
-
-    non_associated_investment_project_message = None
-    checker = None
-
-    def __init__(self):
-        """
-        Initialises the validator.
-        """
-        self.serializer = None
-
-    def set_context(self, serializer):
-        """
-        Saves a reference to the serializer object.
-        Called by DRF.
-        """
-        self.serializer = serializer
-
-    def __call__(self, attrs):
-        """
-        Performs validation. Called by DRF.
-        :param attrs:   Serializer data (post-field-validation/processing)
-        """
-        if self.serializer.instance:
-            return
-
-        request = self.serializer.context['request']
-        view = self.serializer.context['view']
-
-        if not self.checker.should_apply_restrictions(request, view.action):
-            return
-
-        project_pk = request.parser_context['kwargs']['project_pk']
-        investment_project = InvestmentProject.objects.get(pk=project_pk)
-
-        if not self.checker.is_associated(request, investment_project):
-            raise ValidationError({
-                'investment_project': self.non_associated_investment_project_message,
-            }, code='access_denied')
-
-    def __repr__(self):
-        """Returns the string representation of this object."""
-        return f'{self.__class__.__name__}()'
-
-
-class PropositionHasAssociatedInvestmentProjectValidator(_HasAssociatedInvestmentProjectValidator):
-    """Validator which enforces association permissions when adding or updating propositions."""
-
-    non_associated_investment_project_message = (
-        "You don't have permission to add a proposition for this investment project."
-    )
-    checker = InvestmentProjectPropositionAssociationChecker()
 
 
 class _PropositionDocumentViewToActionMapping:
@@ -184,13 +119,16 @@ class InvestmentProjectPropositionDocumentAssociationChecker(
     project linked to the proposition.
     """
 
-    restricted_actions = {'add', 'view', 'change'}
+    restricted_actions = {'add', 'view', 'change', 'delete'}
     model = PropositionDocument
     all_permission_template = _PermissionTemplate.all
     associated_permission_template = _PermissionTemplate.associated
 
 
-class IsAssociatedToInvestmentProjectPropositionDocumentPermission(IsAssociatedToObjectPermission):
+class IsAssociatedToInvestmentProjectPropositionDocumentPermission(
+    IsAssociatedToInvestmentProjectPermissionMixin,
+    IsAssociatedToObjectPermission,
+):
     """Permission class based on InvestmentProjectPropositionAssociationChecker."""
 
     checker_class = InvestmentProjectPropositionDocumentAssociationChecker
@@ -198,26 +136,3 @@ class IsAssociatedToInvestmentProjectPropositionDocumentPermission(IsAssociatedT
     def get_actual_object(self, obj):
         """Returns the investment project from an Proposition object."""
         return obj.proposition.investment_project
-
-
-class IsAssociatedToInvestmentProjectPropositionDocumentFilter(
-    IsAssociatedToInvestmentProjectFilter
-):
-    """
-    Filter class which enforces investment project proposition document association permission.
-    """
-
-    model_attribute = 'investment_project'
-    checker_class = InvestmentProjectPropositionDocumentAssociationChecker
-
-
-class PropositionDocumentHasAssociatedInvestmentProjectValidator(
-    _HasAssociatedInvestmentProjectValidator
-):
-    """Validator which enforces association permissions when adding or updating propositions."""
-
-    required_message = 'This field is required.'
-    non_associated_investment_project_message = (
-        "You don't have permission to add a proposition document for this investment project."
-    )
-    checker = InvestmentProjectPropositionDocumentAssociationChecker()

--- a/datahub/investment/proposition/serializers.py
+++ b/datahub/investment/proposition/serializers.py
@@ -5,10 +5,6 @@ from datahub.company.serializers import NestedAdviserField
 from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.investment.proposition.constants import FEATURE_FLAG_PROPOSITION_DOCUMENT
 from datahub.investment.proposition.models import Proposition, PropositionDocument
-from datahub.investment.proposition.permissions import (
-    PropositionDocumentHasAssociatedInvestmentProjectValidator,
-    PropositionHasAssociatedInvestmentProjectValidator,
-)
 from datahub.investment.serializers import NestedInvestmentProjectField
 
 
@@ -22,9 +18,6 @@ class CreatePropositionSerializer(serializers.ModelSerializer):
             'deadline',
             'name',
             'scope',
-        )
-        validators = (
-            PropositionHasAssociatedInvestmentProjectValidator(),
         )
 
 
@@ -98,9 +91,6 @@ class PropositionDocumentSerializer(serializers.ModelSerializer):
             'status',
         )
         read_only_fields = ('url', 'created_on', )
-        validators = (
-            PropositionDocumentHasAssociatedInvestmentProjectValidator(),
-        )
 
     def create(self, validated_data):
         """Create proposition document."""


### PR DESCRIPTION
### Description of change

~This fixes wrong look-up field for associated object filter of proposition document list view so that restricted users can now access the list endpoint.
Ideally, the endpoint should return 403 when a user is not associated with the investment project. That means the filter wouldn't be needed at all. I could tackle that in another PR.~

This checks if a restricted user is associated with the investment project when accessing proposition document endpoints. It returns 403 if a restricted user isn't associated.

This also fixes delete endpoint, where a restricted user could delete non-associated proposition document.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
