### PR TITLE
Revert make links in CSV exports clickable in Excel

### DIFF
--- a/changelog/revert-hyperlinks-in-exports.feature
+++ b/changelog/revert-hyperlinks-in-exports.feature
@@ -1,0 +1,1 @@
+URLs in CSV exports and reports are no longer clickable when the CSV file is opened in Excel. This is because the links do not behave correctly when clicked on in Excel (see https://support.microsoft.com/kb/899927 for further information on why).

--- a/datahub/company/test/test_admin_report.py
+++ b/datahub/company/test/test_admin_report.py
@@ -150,8 +150,5 @@ def test_one_list_report_generation():
         'one_list_account_owner__contact_email': company.one_list_account_owner.contact_email,
         'registered_address_country__name': company.registered_address_country.name,
         'registered_address_town': company.registered_address_town,
-        'url':
-            f'=HYPERLINK("'
-            f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.id}'
-            f'")',
+        'url': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.id}',
     } for company in companies]

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -155,12 +155,7 @@ def get_front_end_url_expression(model_name, pk_expression):
     :param model_name:      key in settings.DATAHUB_FRONTEND_URL_PREFIXES
     :param pk_expression:   expression that resolves to the pk for the model
     """
-    return Concat(
-        Value('=HYPERLINK("'),
-        Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'),
-        pk_expression,
-        Value('")'),
-    )
+    return Concat(Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'), pk_expression)
 
 
 def _full_name_concat(first_name_field, last_name_field):

--- a/datahub/core/test/test_query_utils.py
+++ b/datahub/core/test/test_query_utils.py
@@ -159,4 +159,4 @@ def test_get_front_end_url_expression(monkeypatch):
     queryset = Book.objects.annotate(
         url=get_front_end_url_expression('book', 'pk')
     )
-    assert queryset.first().url == f'=HYPERLINK("http://test/{book.pk}")'
+    assert queryset.first().url == f'http://test/{book.pk}'

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -542,10 +542,7 @@ class TestCompanyExportView(APITestMixin):
         expected_row_data = [
             {
                 'Name': company.name,
-                'Link':
-                    f'=HYPERLINK("'
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.pk}'
-                    f'")',
+                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.pk}',
                 'Sector': get_attr_or_none(company, 'sector.name'),
                 'Country': get_attr_or_none(company, 'registered_address_country.name'),
                 'UK region': get_attr_or_none(company, 'uk_region.name'),

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -498,16 +498,11 @@ class TestContactExportView(APITestMixin):
                 'Job title': contact.job_title,
                 'Date created': contact.created_on,
                 'Archived': contact.archived,
-                'Link':
-                    f'=HYPERLINK("'
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{contact.pk}'
-                    f'")',
+                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{contact.pk}',
                 'Company': get_attr_or_none(contact, 'company.name'),
                 'Company sector': get_attr_or_none(contact, 'company.sector.name'),
                 'Company link':
-                    f'=HYPERLINK("'
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{contact.company.pk}'
-                    f'")',
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{contact.company.pk}',
                 'Company UK region': get_attr_or_none(contact, 'company.uk_region.name'),
                 'Country':
                     contact.company.registered_address_country.name

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -857,16 +857,12 @@ class TestInteractionExportView(APITestMixin):
                 'Type': interaction.get_kind_display(),
                 'Service': get_attr_or_none(interaction, 'service.name'),
                 'Subject': interaction.subject,
-                'Link':
-                    f'=HYPERLINK("'
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["interaction"]}/{interaction.pk}'
-                    f'")',
+                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["interaction"]}'
+                        f'/{interaction.pk}',
                 'Company': get_attr_or_none(interaction, 'company.name'),
                 'Company link':
-                    f'=HYPERLINK("'
                     f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
-                    f'/{interaction.company.pk}'
-                    f'")',
+                    f'/{interaction.company.pk}',
                 'Company country': get_attr_or_none(
                     interaction,
                     'company.registered_address_country.name',

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -802,10 +802,8 @@ class TestInvestmentProjectExportView(APITestMixin):
                 'Status': project.get_status_display(),
                 'Stage': get_attr_or_none(project, 'stage.name'),
                 'Link':
-                    f'=HYPERLINK("'
                     f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["investment-project"]}'
-                    f'/{project.pk}'
-                    f'")',
+                    f'/{project.pk}',
                 'Actual land date': project.actual_land_date,
                 'Estimated land date': project.estimated_land_date,
                 'FDI value': get_attr_or_none(project, 'fdi_value.name'),

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -481,7 +481,7 @@ class TestOrderExportView(APITestMixin):
                     sum(refund.net_amount for refund in refunds)
                 ) / 100 if refunds else None,
                 'Status': order.get_status_display(),
-                'Link': f'=HYPERLINK("{order.get_datahub_frontend_url()}")',
+                'Link': order.get_datahub_frontend_url(),
                 'Sector': order.sector.name,
                 'Market': order.primary_market.name,
                 'UK region': order.uk_region.name,
@@ -490,15 +490,13 @@ class TestOrderExportView(APITestMixin):
                     order.company.registered_address_country.name,
                 'Company UK region': get_attr_or_none(order, 'company.uk_region.name'),
                 'Company link':
-                    f'=HYPERLINK("'
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{order.company.pk}'
-                    f'")',
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
+                    f'/{order.company.pk}',
                 'Contact': order.contact.name,
                 'Contact job title': order.contact.job_title,
                 'Contact link':
-                    f'=HYPERLINK("'
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{order.contact.pk}'
-                    f'")',
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}'
+                    f'/{order.contact.pk}',
                 'Created by team': get_attr_or_none(order, 'created_by.dit_team.name'),
                 'Date created': order.created_on,
                 'Delivery date': order.delivery_date,


### PR DESCRIPTION
### Description of change

This makes URLs in CSV exports unclickable again (in Excel). This is because hyperlinks to Data Hub pages don't behave correctly when clicked on in Excel. Excel tries to open the page itself and gets redirected to SSO, and then opens SSO in the browser. The user then ends up getting redirected to the Data Hub home page instead of the originally requested URL, as the front end stores the original URL in the user's session.

See https://support.microsoft.com/kb/899927 for further information.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
