### PR TITLE
Add the ability to load email addresses to opt out of marketing via the admin site

### DIFF
--- a/changelog/contact/bulk-load-opt-outs.feature
+++ b/changelog/contact/bulk-load-opt-outs.feature
@@ -1,0 +1,1 @@
+A list of email addresses to opt out of marketing emails can now be loaded via the admin site.

--- a/datahub/company/admin/__init__.py
+++ b/datahub/company/admin/__init__.py
@@ -1,0 +1,14 @@
+from importlib import import_module
+
+# The Django autodiscover logic will import datahub.company.admin automatically, but not the
+# modules contained in this package. Hence, we need to import all this package's modules
+#
+# In some cases, there is only registration code and no classes to import (e.g. the metadata
+# module). So we import whole modules for all contained modules, and use import_module() to avoid
+# creating unreferenced names (as it wouldn't make sense to add them to __all__).
+
+import_module('datahub.company.admin.adviser')
+import_module('datahub.company.admin.ch_company')
+import_module('datahub.company.admin.company')
+import_module('datahub.company.admin.contact')
+import_module('datahub.company.admin.metadata')

--- a/datahub/company/admin/adviser.py
+++ b/datahub/company/admin/adviser.py
@@ -1,0 +1,59 @@
+from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
+from reversion.admin import VersionAdmin
+
+from datahub.company.models import Advisor
+
+
+@admin.register(Advisor)
+class AdviserAdmin(VersionAdmin, UserAdmin):
+    """Adviser admin."""
+
+    fieldsets = (
+        (None, {
+            'fields': (
+                'email',
+                'password'
+            )
+        }),
+        ('PERSONAL INFO', {
+            'fields': (
+                'first_name',
+                'last_name',
+                'contact_email',
+                'telephone_number',
+                'dit_team'
+            )
+        }),
+        ('PERMISSIONS', {
+            'fields': (
+                'is_active',
+                'is_staff',
+                'is_superuser',
+                'groups',
+                'user_permissions'
+            )
+        }),
+        ('IMPORTANT DATES', {
+            'fields': (
+                'last_login',
+                'date_joined'
+            )
+        }),
+    )
+    add_fieldsets = (
+        (None, {
+            'classes': ('wide',),
+            'fields': ('email', 'password1', 'password2'),
+        }),
+    )
+    list_display = ('email', 'first_name', 'last_name', 'dit_team', 'is_active', 'is_staff',)
+    search_fields = (
+        '=pk',
+        'first_name',
+        'last_name',
+        'email',
+        '=dit_team__pk',
+        'dit_team__name',
+    )
+    ordering = ('email',)

--- a/datahub/company/admin/ch_company.py
+++ b/datahub/company/admin/ch_company.py
@@ -1,0 +1,11 @@
+from django.contrib import admin
+
+from datahub.company.models import CompaniesHouseCompany
+from datahub.core.admin import ViewOnlyAdmin
+
+
+@admin.register(CompaniesHouseCompany)
+class CHCompany(ViewOnlyAdmin):
+    """Companies House company admin."""
+
+    search_fields = ['name', 'company_number']

--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -1,22 +1,10 @@
 from django import forms
 from django.contrib import admin
-from django.contrib.auth.admin import UserAdmin
 from django.db import models
 from reversion.admin import VersionAdmin
 
-from datahub.core.admin import BaseModelAdminMixin, ViewOnlyAdmin
-from datahub.metadata.admin import DisableableMetadataAdmin
-from .models import (
-    Advisor,
-    CompaniesHouseCompany,
-    Company,
-    CompanyCoreTeamMember,
-    Contact,
-    ExportExperienceCategory,
-)
-
-
-admin.site.register(ExportExperienceCategory, DisableableMetadataAdmin)
+from datahub.company.models import Company, CompanyCoreTeamMember
+from datahub.core.admin import BaseModelAdminMixin
 
 
 class CompanyCoreTeamMemberInline(admin.TabularInline):
@@ -145,97 +133,3 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
     inlines = (
         CompanyCoreTeamMemberInline,
     )
-
-
-@admin.register(Contact)
-class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
-    """Contact admin."""
-
-    search_fields = (
-        'pk',
-        'first_name',
-        'last_name',
-        'company__pk',
-        'company__name',
-    )
-    raw_id_fields = (
-        'company',
-        'adviser',
-        'archived_by',
-    )
-    readonly_fields = (
-        'created',
-        'modified',
-        'archived_documents_url_path',
-    )
-    list_display = (
-        '__str__',
-        'company',
-    )
-    exclude = (
-        'created_on',
-        'created_by',
-        'modified_on',
-        'modified_by',
-    )
-
-
-@admin.register(CompaniesHouseCompany)
-class CHCompany(ViewOnlyAdmin):
-    """Companies House company admin."""
-
-    search_fields = ['name', 'company_number']
-
-
-@admin.register(Advisor)
-class AdviserAdmin(VersionAdmin, UserAdmin):
-    """Adviser admin."""
-
-    fieldsets = (
-        (None, {
-            'fields': (
-                'email',
-                'password'
-            )
-        }),
-        ('PERSONAL INFO', {
-            'fields': (
-                'first_name',
-                'last_name',
-                'contact_email',
-                'telephone_number',
-                'dit_team'
-            )
-        }),
-        ('PERMISSIONS', {
-            'fields': (
-                'is_active',
-                'is_staff',
-                'is_superuser',
-                'groups',
-                'user_permissions'
-            )
-        }),
-        ('IMPORTANT DATES', {
-            'fields': (
-                'last_login',
-                'date_joined'
-            )
-        }),
-    )
-    add_fieldsets = (
-        (None, {
-            'classes': ('wide',),
-            'fields': ('email', 'password1', 'password2'),
-        }),
-    )
-    list_display = ('email', 'first_name', 'last_name', 'dit_team', 'is_active', 'is_staff',)
-    search_fields = (
-        '=pk',
-        'first_name',
-        'last_name',
-        'email',
-        '=dit_team__pk',
-        'dit_team__name',
-    )
-    ordering = ('email',)

--- a/datahub/company/admin/contact.py
+++ b/datahub/company/admin/contact.py
@@ -1,8 +1,142 @@
-from django.contrib import admin
+import csv
+import io
+from logging import getLogger
+from typing import NamedTuple
+
+import reversion
+from chardet import UniversalDetector
+from django import forms
+from django.contrib import admin, messages as django_messages
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.core.exceptions import PermissionDenied, ValidationError
+from django.core.validators import FileExtensionValidator
+from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils.translation import gettext
 from reversion.admin import VersionAdmin
 
 from datahub.company.models import Contact
 from datahub.core.admin import BaseModelAdminMixin
+from datahub.search.signals import disable_search_signal_receivers
+
+
+logger = getLogger(__name__)
+
+
+class LoadEmailMarketingOptOutsForm(forms.Form):
+    """Form used for loading a CSV file to opt out contacts from email marketing."""
+
+    HEADER_DECODE_ERROR_MESSAGE = gettext('There was an error decoding the file contents.')
+    BODY_DECODE_ERROR_MESSAGE = gettext(
+        'There was an error decoding the text in the file provided. No records have been '
+        'modified.',
+    )
+    NO_EMAIL_COLUMN_MESSAGE = gettext('This file does not contain an email column.')
+
+    email_list = forms.FileField(
+        label='Email list (CSV file)',
+        validators=[FileExtensionValidator(allowed_extensions=('csv',))],
+    )
+
+    def clean_email_list(self):
+        """Validates the uploaded CSV file and creates a CSV DictReader from it."""
+        # This could be an instance of InMemoryUploadedFile or TemporaryUploadedFile
+        # (depending on the file size)
+        file_field = self.cleaned_data['email_list']
+
+        # Guess the file encoding (primarily to check for a UTF-8 BOM)
+        encoding_detector = UniversalDetector()
+        for chunk in file_field.chunks():
+            encoding_detector.feed(chunk)
+            if encoding_detector.done:
+                break
+
+        detection_result = encoding_detector.close()
+        encoding = detection_result['encoding']
+
+        file_field.seek(0)
+        csv_reader = csv.DictReader(io.TextIOWrapper(file_field, encoding=encoding))
+
+        self._validate_columns(csv_reader)
+        return csv_reader
+
+    def save(self, user):
+        """
+        Persists the data to the database.
+
+        :raises ValidationError: Occurs if there is a problem while reading the data from the
+                                 CSV file.
+        """
+        try:
+            return self._save(user)
+        except UnicodeError:
+            # This will only be triggered for invalid Unicode that is relatively deep in the file,
+            # as invalid Unicode near the beginning of the file will be picked up by
+            # clean_email_list().
+            raise ValidationError(self.BODY_DECODE_ERROR_MESSAGE, code='body-unicode-error')
+
+    save.alters_data = True
+
+    @classmethod
+    def _validate_columns(cls, csv_reader):
+        try:
+            fieldnames = csv_reader.fieldnames
+        except UnicodeError as exc:
+            raise ValidationError(
+                cls.HEADER_DECODE_ERROR_MESSAGE,
+                code='header-unicode-error',
+            ) from exc
+
+        if 'email' not in fieldnames:
+            raise ValidationError(cls.NO_EMAIL_COLUMN_MESSAGE, code='no-email-column')
+
+    @reversion.create_revision()
+    @disable_search_signal_receivers(Contact)
+    def _save(self, user):
+        reversion.set_user(user)
+        reversion.set_comment('Loaded bulk email opt-out list.')
+
+        num_contacts_matched = 0
+        num_contacts_updated = 0
+        num_non_matching_email_addresses = 0
+
+        for row in self.cleaned_data['email_list']:
+            email = row['email'].strip()
+
+            if not email:
+                continue
+
+            contacts = Contact.objects.filter(email__iexact=email)
+
+            for contact in contacts:
+                num_contacts_matched += 1
+
+                if contact.accepts_dit_email_marketing:
+                    num_contacts_updated += 1
+                    contact.accepts_dit_email_marketing = False
+                    contact.modified_by = user
+                    contact.save()
+
+            if not contacts:
+                logger.warning(f'Could not find a contact with email address {email}')
+                num_non_matching_email_addresses += 1
+
+        return _ProcessOptOutResult(
+            num_contacts_matched,
+            num_contacts_updated,
+            num_non_matching_email_addresses,
+        )
+
+
+class _ProcessOptOutResult(NamedTuple):
+    num_contacts_matched: int
+    num_contacts_updated: int
+    num_non_matching_email_addresses: int
+
+    @property
+    def num_contacts_skipped(self):
+        return self.num_contacts_matched - self.num_contacts_updated
 
 
 @admin.register(Contact)
@@ -36,3 +170,70 @@ class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
         'modified_on',
         'modified_by',
     )
+
+    def get_urls(self):
+        """Gets the URLs for this model."""
+        model_meta = self.model._meta
+        return [
+            *super().get_urls(),
+            path(
+                'load-email-marketing-opt-outs',
+                self.admin_site.admin_view(self.opt_out_form),
+                name=f'{model_meta.app_label}_{model_meta.model_name}'
+                     f'_load-email-marketing-opt-outs',
+            ),
+        ]
+
+    def opt_out_form(self, request, *args, **kwargs):
+        """View containing a form to load email marketing opt outs."""
+        if not self.has_change_permission(request):
+            raise PermissionDenied
+
+        if request.method != 'POST':
+            return self._opt_out_form_response(request, LoadEmailMarketingOptOutsForm())
+
+        form = LoadEmailMarketingOptOutsForm(request.POST, request.FILES)
+        if not form.is_valid():
+            return self._opt_out_form_response(request, form)
+
+        try:
+            opt_out_res = form.save(request.user)
+        except ValidationError as exc:
+            return self._opt_out_error_response(request, exc.messages)
+
+        return self._opt_out_success_response(request, opt_out_res)
+
+    def _opt_out_form_response(self, request, form):
+        template_name = 'admin/company/contact/load_email_marketing_opt_outs.html'
+        title = 'Load email marketing opt-outs'
+
+        context = {
+            **self.admin_site.each_context(request),
+            'opts': self.model._meta,
+            'title': title,
+            'form': form,
+        }
+        return TemplateResponse(request, template_name, context)
+
+    def _opt_out_error_response(self, request, messages):
+        for message in messages:
+            self.message_user(request, message, django_messages.ERROR)
+
+        return self._opt_out_form_response(request, LoadEmailMarketingOptOutsForm())
+
+    def _opt_out_success_response(self, request, opt_out_res):
+        success_msg = (
+            f'{opt_out_res.num_contacts_updated} contacts opted out of marketing emails '
+            f'and {opt_out_res.num_contacts_skipped} contacts already opted out'
+        )
+        self.message_user(request, success_msg, django_messages.SUCCESS)
+
+        if opt_out_res.num_non_matching_email_addresses:
+            warning_msg = (
+                f'{opt_out_res.num_non_matching_email_addresses} email addresses did not match a '
+                f'contact'
+            )
+            self.message_user(request, warning_msg, django_messages.WARNING)
+
+        changelist_url = reverse(admin_urlname(self.model._meta, 'changelist'))
+        return HttpResponseRedirect(changelist_url)

--- a/datahub/company/admin/contact.py
+++ b/datahub/company/admin/contact.py
@@ -1,0 +1,38 @@
+from django.contrib import admin
+from reversion.admin import VersionAdmin
+
+from datahub.company.models import Contact
+from datahub.core.admin import BaseModelAdminMixin
+
+
+@admin.register(Contact)
+class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
+    """Contact admin."""
+
+    search_fields = (
+        'pk',
+        'first_name',
+        'last_name',
+        'company__pk',
+        'company__name',
+    )
+    raw_id_fields = (
+        'company',
+        'adviser',
+        'archived_by',
+    )
+    readonly_fields = (
+        'created',
+        'modified',
+        'archived_documents_url_path',
+    )
+    list_display = (
+        '__str__',
+        'company',
+    )
+    exclude = (
+        'created_on',
+        'created_by',
+        'modified_on',
+        'modified_by',
+    )

--- a/datahub/company/admin/metadata.py
+++ b/datahub/company/admin/metadata.py
@@ -1,0 +1,7 @@
+from django.contrib import admin
+
+from datahub.company.models import ExportExperienceCategory
+from datahub.metadata.admin import DisableableMetadataAdmin
+
+
+admin.site.register(ExportExperienceCategory, DisableableMetadataAdmin)

--- a/datahub/company/templates/admin/company/contact/change_list_object_tools.html
+++ b/datahub/company/templates/admin/company/contact/change_list_object_tools.html
@@ -1,0 +1,12 @@
+{% extends "admin/change_list_object_tools.html" %}
+
+{% block object-tools-items %}
+  {% if has_change_permission %}
+    <li>
+      <a href="{% url 'admin:company_contact_load-email-marketing-opt-outs' %}">
+        Load marketing opt-outs
+      </a>
+    </li>
+  {% endif %}
+  {{block.super}}
+{% endblock %}

--- a/datahub/company/templates/admin/company/contact/load_email_marketing_opt_outs.html
+++ b/datahub/company/templates/admin/company/contact/load_email_marketing_opt_outs.html
@@ -1,0 +1,49 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+{% endblock %}
+
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; {{ title }}}
+</div>
+{% endblock %}
+
+{% block content %}
+  <p>Select a CSV file to opt out a list of email addresses from email marketing.</p>
+  <ul>
+    <li>The CSV file should contain a column (titled 'email') with the email addresses to opt out</li>
+    <li>Only the primary email address of a contact is checked against the list (alternative email addresses are ignored)</li>
+    <li>If multiple contacts match an email address, all of those contacts will be opted out of marketing emails</li>
+  </ul>
+  <form action="" method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+
+    {% for field in form %}
+        <div class="fieldWrapper">
+            {{ field.errors }}
+            {{ field.label_tag }} {{ field }}
+            {% if field.help_text %}
+            <p class="help">{{ field.help_text|safe }}</p>
+            {% endif %}
+        </div>
+    {% endfor %}
+
+    <div>
+      <input type="submit" value="{% trans 'Submit' %}">
+    </div>
+  </form>
+{% endblock %}

--- a/datahub/company/test/admin/test_company.py
+++ b/datahub/company/test/admin/test_company.py
@@ -6,15 +6,15 @@ from django.contrib.admin.sites import site
 from django.urls import reverse
 from rest_framework import status
 
-from datahub.core.test_utils import AdminTestMixin
-from .factories import (
+from datahub.company.admin.company import CompanyAdmin
+from datahub.company.admin_reports import OneListReport
+from datahub.company.models import Company
+from datahub.company.test.factories import (
     AdviserFactory,
     CompanyCoreTeamMemberFactory,
     CompanyFactory,
 )
-from ..admin import CompanyAdmin
-from ..admin_reports import OneListReport
-from ..models import Company
+from datahub.core.test_utils import AdminTestMixin
 
 
 pytestmark = pytest.mark.django_db

--- a/datahub/company/test/admin/test_contact.py
+++ b/datahub/company/test/admin/test_contact.py
@@ -1,0 +1,361 @@
+import io
+from codecs import BOM_UTF8
+from datetime import datetime
+from os.path import splitext
+from unittest.mock import Mock
+
+import factory
+import pytest
+from django.contrib import messages as django_messages
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.test import Client
+from django.urls import reverse
+from django.utils.timezone import utc
+from freezegun import freeze_time
+from rest_framework import status
+from reversion.models import Version
+
+from datahub.company.models import Contact, ContactPermission
+from datahub.company.test.factories import ContactFactory
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+
+pytestmark = pytest.mark.django_db
+
+
+class TestContactAdminChangeList(AdminTestMixin):
+    """Tests for the contact admin change list."""
+
+    def test_load_opt_outs_link_exists(self):
+        """
+        Test that there is a link to load email marketing opt outs on the contact change list page.
+        """
+        change_list_url = reverse(admin_urlname(Contact._meta, 'changelist'))
+        response = self.client.get(change_list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        load_opt_outs_url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        assert load_opt_outs_url in response.rendered_content
+
+    def test_load_opt_outs_link_does_not_exist_if_only_has_view_permission(self):
+        """
+        Test that there is not a link to load email marketing opt outs if the user only has view
+        (but not change) permission for contacts.
+        """
+        change_list_url = reverse(admin_urlname(Contact._meta, 'changelist'))
+        user = create_test_user(
+            permission_codenames=(ContactPermission.view_contact,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+
+        client = self.create_client(user=user)
+        response = client.get(change_list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        load_opt_outs_url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        assert f'Select {Contact._meta.verbose_name} to view' in response.rendered_content
+        assert load_opt_outs_url not in response.rendered_content
+
+
+class TestContactAdminOptOutForm(AdminTestMixin):
+    """Tests for the contact admin load email marketing opt outs form."""
+
+    def test_redirects_to_login_page_if_not_logged_in(self):
+        """Test that the view redirects to the login page if the user isn't authenticated."""
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        client = Client()
+        response = client.get(url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+
+    def test_redirects_to_login_page_if_not_staff(self):
+        """Test that the view redirects to the login page if the user isn't a member of staff."""
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        user = create_test_user(is_staff=False, password=self.PASSWORD)
+
+        client = self.create_client(user=user)
+        response = client.get(url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+
+    def test_permission_denied_if_staff_and_without_change_permission(self):
+        """
+        Test that the view returns a 403 response if the staff user does not have the
+        change contact permission.
+        """
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        user = create_test_user(
+            permission_codenames=(ContactPermission.view_contact,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+
+        client = self.create_client(user=user)
+        response = client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize('filename', ('noext', 'file.blah', 'test.test', 'test.csv.docx'))
+    def test_does_not_allow_invalid_file_extensions(self, filename):
+        """Test that the form rejects various invalid file extensions."""
+        file = io.BytesIO(b'test')
+        file.name = filename
+
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        response = self.client.post(
+            url,
+            data={
+                'email_list': file,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        form = response.context['form']
+        _, ext = splitext(filename)
+
+        assert 'email_list' in form.errors
+        assert form.errors['email_list'] == [
+            f"File extension '{ext[1:]}' is not allowed. Allowed extensions are: 'csv'.",
+        ]
+
+    def test_does_not_allow_file_without_email_column(self):
+        """Test that the form rejects a CSV file that doesn't contain an email column."""
+        file = io.BytesIO(b'test\r\nrow')
+        file.name = 'test.csv'
+
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        response = self.client.post(
+            url,
+            data={
+                'email_list': file,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        form = response.context['form']
+
+        assert 'email_list' in form.errors
+        assert form.errors['email_list'] == ['This file does not contain an email column.']
+
+    def test_does_not_allow_file_with_bad_utf8_in_header(self):
+        """Test that the form rejects a CSV file with invalid UTF-8 in its header."""
+        file = io.BytesIO(
+            b''.join((BOM_UTF8, b'test\xc3\x28\r\nrow')),
+        )
+        file.name = 'test.csv'
+
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        response = self.client.post(
+            url,
+            data={
+                'email_list': file,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        form = response.context['form']
+
+        assert 'email_list' in form.errors
+        assert form.errors['email_list'] == ['There was an error decoding the file contents.']
+
+    def test_does_not_allow_file_with_bad_utf8_after_header(self, monkeypatch):
+        """
+        Test that the form rejects a CSV file with invalid UTF-8 after its header.
+
+        As reading and decoding happens in chunks, we patch the the function to validate the
+        columns in the form because it can decode text that is close to the header.
+
+        (That means in reality, this check will only be triggered for invalid Unicode sequences
+        that are relatively deep in the file.)
+        """
+        monkeypatch.setattr(
+            'datahub.company.admin.contact.LoadEmailMarketingOptOutsForm._validate_columns',
+            Mock(),
+        )
+
+        creation_time = datetime(2011, 2, 1, 14, 0, 10, tzinfo=utc)
+        with freeze_time(creation_time):
+            contact = ContactFactory(
+                email='test1@datahub',
+                accepts_dit_email_marketing=True,
+            )
+        csv_body = b""""email\r
+test1@datahub\r
+\xc3\x28
+"""
+        file = io.BytesIO(
+            b''.join((BOM_UTF8, csv_body)),
+        )
+        file.name = 'test.csv'
+
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+        with freeze_time('2014-05-03 19:00:16'):
+            response = self.client.post(
+                url,
+                data={
+                    'email_list': file,
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        messages = list(response.context['messages'])
+        assert len(messages) == 1
+        assert messages[0].level == django_messages.ERROR
+        assert messages[0].message == (
+            'There was an error decoding the text in the file provided. No records have been '
+            'modified.'
+        )
+
+        # Changes should have been rolled back
+        contact.refresh_from_db()
+        assert contact.accepts_dit_email_marketing is True
+        assert contact.modified_on == creation_time
+
+    @pytest.mark.parametrize('encoding', ('utf-8', 'utf-8-sig'))
+    def test_opts_out_contacts(self, encoding):
+        """
+        Test that accepts_dit_email_marketing is updated for the contacts specified in the CSV
+        file.
+        """
+        filename = 'filea.csv'
+        emails = [
+            'test1@datahub',
+            'test1@datahub',
+            'test2@datahub',
+            'test2@datahub',
+            'test3@datahub',
+            'test4@datahub',
+        ]
+        marketing_status = [True, True, True, False, True, True]
+        creation_time = datetime(2011, 2, 1, 14, 0, 10, tzinfo=utc)
+        with freeze_time(creation_time):
+            contacts = ContactFactory.create_batch(
+                len(emails),
+                email=factory.Iterator(emails),
+                accepts_dit_email_marketing=factory.Iterator(marketing_status),
+                modified_by=None,
+            )
+
+        file = io.BytesIO("""email\r
+test1@datahub\r
+TEST2@datahub\r
+test6@datahub\r
+""".encode(encoding=encoding))
+        file.name = filename
+
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+
+        post_time = datetime(2014, 5, 3, 19, 0, 16, tzinfo=utc)
+        with freeze_time(post_time):
+            response = self.client.post(
+                url,
+                follow=True,
+                data={
+                    'email_list': file,
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        change_list_url = reverse(admin_urlname(Contact._meta, 'changelist'))
+        assert response.redirect_chain[0][0] == change_list_url
+
+        for contact in contacts:
+            contact.refresh_from_db()
+
+        assert [contact.accepts_dit_email_marketing for contact in contacts] == [
+            False, False, False, False, True, True,
+        ]
+        assert [contact.modified_on for contact in contacts] == [
+            post_time, post_time, post_time, creation_time, creation_time, creation_time,
+        ]
+        assert [contact.modified_by for contact in contacts] == [
+            self.user, self.user, self.user, None, None, None,
+        ]
+
+        messages = list(response.context['messages'])
+        assert len(messages) == 2
+        assert messages[0].level == django_messages.SUCCESS
+        assert messages[0].message == (
+            '3 contacts opted out of marketing emails and 1 contacts already opted out'
+        )
+        assert messages[1].level == django_messages.WARNING
+        assert messages[1].message == '1 email addresses did not match a contact'
+
+    def test_updates_audit_log(self):
+        """Test that audit log entries are created for modified contacts."""
+        creation_time = datetime(2011, 2, 1, 14, 0, 10, tzinfo=utc)
+        with freeze_time(creation_time):
+            contact_with_change = ContactFactory(
+                email='test1@datahub',
+                accepts_dit_email_marketing=True,
+            )
+            contact_without_change = ContactFactory(
+                email='test2@datahub',
+                accepts_dit_email_marketing=True,
+            )
+            contact_already_opted_out = ContactFactory(
+                email='test1@datahub',
+                accepts_dit_email_marketing=False,
+            )
+
+        file = io.BytesIO("""email\r
+test1@datahub\r
+""".encode())
+        file.name = 'test.csv'
+
+        url = reverse(
+            admin_urlname(Contact._meta, 'load-email-marketing-opt-outs'),
+        )
+
+        post_time = datetime(2014, 5, 3, 19, 0, 16, tzinfo=utc)
+        with freeze_time(post_time):
+            response = self.client.post(
+                url,
+                follow=True,
+                data={
+                    'email_list': file,
+                },
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        change_list_url = reverse(admin_urlname(Contact._meta, 'changelist'))
+        assert response.redirect_chain[0][0] == change_list_url
+
+        versions = Version.objects.get_for_object(contact_with_change)
+        assert versions.count() == 1
+        assert versions[0].revision.get_comment() == 'Loaded bulk email opt-out list.'
+
+        versions = Version.objects.get_for_object(contact_without_change)
+        assert versions.count() == 0
+
+        versions = Version.objects.get_for_object(contact_already_opted_out)
+        assert versions.count() == 0

--- a/requirements.in
+++ b/requirements.in
@@ -13,9 +13,10 @@ django-reversion==3.0.0
 django-pglocks==1.0.2
 django-model-utils==3.1.2
 django-mptt==0.9.1
-
 django-oauth-toolkit==1.2.0
 whitenoise==3.3.1
+
+chardet==3.0.4
 pyyaml==3.13
 python-dateutil==2.7.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,10 @@ aws-requests-auth==0.4.2
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4         # via celery
 boto3==1.9.4
-botocore==1.12.4          # via boto3, s3transfer
+botocore==1.12.7          # via boto3, s3transfer
 celery==4.2.1
 certifi==2018.8.24        # via requests
-chardet==3.0.4            # via chardet, requests
+chardet==3.0.4
 click==6.7                # via click, pip-tools, towncrier
 coverage==4.5.1           # via pytest-cov
 cssselect==1.0.3


### PR DESCRIPTION
### Description of change

Adds a button on the contact change list page in the admin site that takes you to a form to load a CSV file of email addresses to opt out of email marketing.

Also splits up datahub.company.admin into a subpackage containing multiple module.

Would suggest looking at the two commits separately.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
