### PR TITLE
Add trailing commas to some of the apps

### DIFF
--- a/datahub/activity_stream/test/test_activity_stream_views.py
+++ b/datahub/activity_stream/test/test_activity_stream_views.py
@@ -19,8 +19,14 @@ def _url_incorrect_path():
     return 'http://testserver' + reverse('api-v3:activity-stream:index') + 'incorrect/'
 
 
-def _auth_sender(key_id='some-id', secret_key='some-secret', url=_url,
-                 method='GET', content='', content_type=''):
+def _auth_sender(
+    key_id='some-id',
+    secret_key='some-secret',
+    url=_url,
+    method='GET',
+    content='',
+    content_type='',
+):
     credentials = {
         'id': key_id,
         'key': secret_key,
@@ -42,7 +48,7 @@ def _auth_sender(key_id='some-id', secret_key='some-secret', url=_url,
             # If no X-Forwarded-For header
             dict(
                 content_type='',
-                HTTP_AUTHORIZATION=_auth_sender().request_header
+                HTTP_AUTHORIZATION=_auth_sender().request_header,
             ),
             {'detail': 'Incorrect authentication credentials.'},
         ),

--- a/datahub/activity_stream/urls.py
+++ b/datahub/activity_stream/urls.py
@@ -6,6 +6,6 @@ activity_stream_urls = [
     path(
         'activity-stream/',
         ActivityStreamViewSet.as_view({'get': 'list'}),
-        name='index'
+        name='index',
     ),
 ]

--- a/datahub/activity_stream/views.py
+++ b/datahub/activity_stream/views.py
@@ -22,8 +22,10 @@ def _lookup_credentials(access_key_id):
     """Raises a HawkFail if the passed ID is not equal to
     settings.ACTIVITY_STREAM_ACCESS_KEY_ID
     """
-    if not constant_time_compare(access_key_id,
-                                 settings.ACTIVITY_STREAM_ACCESS_KEY_ID):
+    if not constant_time_compare(
+        access_key_id,
+        settings.ACTIVITY_STREAM_ACCESS_KEY_ID,
+    ):
         raise HawkFail(f'No Hawk ID of {access_key_id}')
 
     return {
@@ -83,7 +85,7 @@ class _ActivityStreamAuthentication(BaseAuthentication):
         """
         if 'HTTP_X_FORWARDED_FOR' not in request.META:
             logger.warning(
-                'Failed authentication: no X-Forwarded-For header passed'
+                'Failed authentication: no X-Forwarded-For header passed',
             )
             raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
 
@@ -93,7 +95,7 @@ class _ActivityStreamAuthentication(BaseAuthentication):
         if remote_address not in settings.ACTIVITY_STREAM_IP_WHITELIST:
             logger.warning(
                 'Failed authentication: the X-Forwarded-For header did not '
-                'start with an IP in the whitelist'
+                'start with an IP in the whitelist',
             )
             raise AuthenticationFailed(INCORRECT_CREDENTIALS_MESSAGE)
 

--- a/datahub/admin_report/report.py
+++ b/datahub/admin_report/report.py
@@ -61,7 +61,7 @@ class Report:
         if 'ID' in cls.field_titles.values():
             raise DataHubException(
                 'ID cannot be used as a column title due to the potential confusion with SYLK '
-                'files in e.g. Excel'
+                'files in e.g. Excel',
             )
 
 

--- a/datahub/admin_report/tests/test_report.py
+++ b/datahub/admin_report/tests/test_report.py
@@ -12,8 +12,7 @@ pytestmark = pytest.mark.django_db
     (
         ((), {}),
         (('change_metadatamodel',), {'MetadataModel': ['MetadataReport']}),
-    )
-
+    ),
 )
 def test_get_reports_by_model(permission_codenames, expected_result):
     """Test get_reports_by_model() for various cases."""
@@ -30,8 +29,7 @@ def test_get_reports_by_model(permission_codenames, expected_result):
     (
         ((), True),
         (('change_metadatamodel',), False),
-    )
-
+    ),
 )
 def test_get_report_by_id(permission_codenames, should_raise):
     """Test get_report_by_id() for various cases."""

--- a/datahub/admin_report/tests/test_views.py
+++ b/datahub/admin_report/tests/test_views.py
@@ -18,7 +18,7 @@ class TestReportAdmin(AdminTestMixin):
         (
             reverse('admin-report:index'),
             reverse('admin-report:download-report', kwargs={'report_id': 'test-report'}),
-        )
+        ),
     )
     def test_redirects_to_login_page_if_not_logged_in(self, url):
         """Test that the view redirects to the login page if the user isn't authenticated."""
@@ -34,7 +34,7 @@ class TestReportAdmin(AdminTestMixin):
         (
             reverse('admin-report:index'),
             reverse('admin-report:download-report', kwargs={'report_id': 'test-report'}),
-        )
+        ),
     )
     def test_redirects_to_login_page_if_not_staff(self, url):
         """Test that the view redirects to the login page if the user isn't a member of staff."""
@@ -97,7 +97,7 @@ class TestReportAdmin(AdminTestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})
         assert parse_header(response.get('Content-Disposition')) == (
-            'attachment', {'filename': 'Test report - 2018-01-01-11-12-13.csv'}
+            'attachment', {'filename': 'Test report - 2018-01-01-11-12-13.csv'},
         )
         assert response.getvalue().decode('utf-8-sig') == f"""Test ID,Name\r
 {str(obj.pk)},{obj.name}\r

--- a/datahub/admin_report/urls.py
+++ b/datahub/admin_report/urls.py
@@ -9,11 +9,11 @@ urlpatterns = [
     path(
         'admin/reports/',
         site.admin_view(list_reports),
-        name='index'
+        name='index',
     ),
     path(
         'admin/reports/<report_id>/download',
         site.admin_view(download_report),
-        name='download-report'
+        name='download-report',
     ),
 ]

--- a/datahub/cleanup/management/commands/_base_command.py
+++ b/datahub/cleanup/management/commands/_base_command.py
@@ -86,7 +86,7 @@ class BaseCleanupCommand(BaseCommand):
         for related in get_relations_to_delete(model):
             related_model = related.related_model
             related_qs = related_model._base_manager.filter(
-                **{f'{related.field.name}__in': Subquery(qs.values('pk'))}
+                **{f'{related.field.name}__in': Subquery(qs.values('pk'))},
             )
             _print_query(related_model, related_qs, related)
 
@@ -97,9 +97,9 @@ class BaseCleanupCommand(BaseCommand):
         config = self.CONFIGS[model._meta.label]
 
         return get_unreferenced_objects_query(model).filter(
-            **{f'{config.date_field}__lt': today(tzinfo=utc) - config.age_threshold}
+            **{f'{config.date_field}__lt': today(tzinfo=utc) - config.age_threshold},
         ).order_by(
-            f'-{config.date_field}'
+            f'-{config.date_field}',
         )
 
 
@@ -110,8 +110,8 @@ def _print_query(model, qs, relation=None):
         ''.join((
             f'{model_verbose_name} to delete',
             f' (via {model._meta.model_name}.{relation.remote_field.name})' if relation else '',
-            f': {qs.count()}'
-        ))
+            f': {qs.count()}',
+        )),
     )
 
     logger.info('SQL:')

--- a/datahub/cleanup/management/commands/delete_old_records.py
+++ b/datahub/cleanup/management/commands/delete_old_records.py
@@ -7,9 +7,11 @@ from datahub.cleanup.management.commands._base_command import BaseCleanupCommand
 class Command(BaseCleanupCommand):
     """Command for deleting very old records (as per the data retention policy)."""
 
-    help = ('Irrevocably deletes very old records for a model, using the criteria defined in the '
-            'DIT Data Hub retention policy. A simulation can be performed using the --simulate '
-            'argument.')
+    help = (
+        'Irrevocably deletes very old records for a model, using the criteria defined in the '
+        'DIT Data Hub retention policy. A simulation can be performed using the --simulate '
+        'argument.'
+    )
 
     CONFIGS = {
         # TODO: Before adding any more configurations, get_unreferenced_objects_query()

--- a/datahub/cleanup/management/commands/delete_orphans.py
+++ b/datahub/cleanup/management/commands/delete_orphans.py
@@ -20,6 +20,6 @@ class Command(BaseCleanupCommand):
         'company.Company': ModelCleanupConfig(ORPHAN_AGE_THRESHOLD),
         'event.Event': ModelCleanupConfig(
             age_threshold=relativedelta(months=18),
-            date_field='end_date'
-        )
+            date_field='end_date',
+        ),
     }

--- a/datahub/cleanup/test/commands/test_common.py
+++ b/datahub/cleanup/test/commands/test_common.py
@@ -167,8 +167,8 @@ def cleanup_mapping(request):
     'model_name',
     # Get unique models only – must be in a consistent order for parallelised tests
     sorted(
-        {model_name for command_cls in COMMAND_CLASSES for model_name in command_cls.CONFIGS}
-    )
+        {model_name for command_cls in COMMAND_CLASSES for model_name in command_cls.CONFIGS},
+    ),
 )
 def test_mappings(model_name):
     """
@@ -207,7 +207,7 @@ def create_orphanable_model(factory, config, date_value):
     """
     with freeze_time(date_value):
         return factory(
-            **{config.date_field: date_value}
+            **{config.date_field: date_value},
         )
 
 

--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -12,7 +12,7 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory, Conta
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.investment.test.factories import (
-    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory
+    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
 )
 from ...management.commands import delete_orphaned_versions
 
@@ -24,7 +24,7 @@ MAPPINGS = {
     'event.Event': EventFactory,
     'interaction.Interaction': CompanyInteractionFactory,
     'investment.InvestmentProject': InvestmentProjectFactory,
-    'investment.InvestmentProjectTeamMember': InvestmentProjectTeamMemberFactory
+    'investment.InvestmentProjectTeamMember': InvestmentProjectTeamMemberFactory,
 }
 
 
@@ -39,7 +39,7 @@ def test_mappings():
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     'model_label,model_factory',
-    MAPPINGS.items()
+    MAPPINGS.items(),
 )
 def test_with_one_model(model_label, model_factory):
     """
@@ -113,7 +113,7 @@ def test_delete_revisions_without_versions(caplog):
     # delete all versions indirectly created
     Version.objects.exclude(
         content_type=ContentType.objects.get_for_model(model),
-        object_id=obj.pk
+        object_id=obj.pk,
     ).delete()
 
     # check that only 1 version and revision exist

--- a/datahub/feature_flag/admin.py
+++ b/datahub/feature_flag/admin.py
@@ -8,7 +8,7 @@ from datahub.feature_flag.models import FeatureFlag
 class FeatureFlagAdmin(BaseModelAdminMixin, admin.ModelAdmin):
     """Feature flag admin."""
 
-    list_display = ('code', 'description', 'is_active', 'created_by', 'created_on',)
+    list_display = ('code', 'description', 'is_active', 'created_by', 'created_on')
     search_fields = ('code',)
     readonly_fields = (
         'id',

--- a/datahub/feature_flag/test/test_utils.py
+++ b/datahub/feature_flag/test/test_utils.py
@@ -7,13 +7,15 @@ from ..utils import is_feature_flag_active
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize('code,is_active,lookup,expected', (
-    ('test_flag', True, 'test_flag', True),
-    ('test_flag', False, 'test_flag', False),
-    ('', None, 'test_flag', False),
-    ('test_flag', True, 'test', False)
-
-))
+@pytest.mark.parametrize(
+    'code,is_active,lookup,expected',
+    (
+        ('test_flag', True, 'test_flag', True),
+        ('test_flag', False, 'test_flag', False),
+        ('', None, 'test_flag', False),
+        ('test_flag', True, 'test', False),
+    ),
+)
 def test_is_feature_flag(code, is_active, lookup, expected):
     """Tests if is_feature_flag returns correct state of feature flag."""
     if code != '':

--- a/datahub/feature_flag/test/test_views.py
+++ b/datahub/feature_flag/test/test_views.py
@@ -32,7 +32,7 @@ class TestListFeatureFlags(APITestMixin):
             (
                 {
                     'code': feature_flag.code,
-                    'is_active': feature_flag.is_active
+                    'is_active': feature_flag.is_active,
                 } for feature_flag in feature_flags
             ),
             key=lambda item: item['code'],

--- a/datahub/ping/views.py
+++ b/datahub/ping/views.py
@@ -20,7 +20,7 @@ def ping(request):
     if all(item[0] for item in checked.values()):
         return HttpResponse(
             PINGDOM_TEMPLATE.format(status='OK'),
-            content_type='text/xml'
+            content_type='text/xml',
         )
     else:
         body = PINGDOM_TEMPLATE.format(status='FALSE')
@@ -29,5 +29,5 @@ def ping(request):
         return HttpResponse(
             body,
             status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            content_type='text/xml'
+            content_type='text/xml',
         )

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -23,7 +23,7 @@ class TestUserView(APITestMixin):
         permissions = PermissionFactory.create_batch(
             len(permission_names),
             codename=factory.Iterator(permission_names),
-            content_type=content_type
+            content_type=content_type,
         )
 
         group = GroupFactory()

--- a/datahub/user_event_log/test/test_utils.py
+++ b/datahub/user_event_log/test/test_utils.py
@@ -16,19 +16,19 @@ from datahub.user_event_log.utils import record_user_event
         (None, None),
         (
             {'a': 'b'},
-            {'a': 'b'}
+            {'a': 'b'},
         ),
         (
             {'a': datetime(2016, 10, 10, 1, 0, 2, tzinfo=utc)},
-            {'a': '2016-10-10T01:00:02Z'}
+            {'a': '2016-10-10T01:00:02Z'},
         ),
         (
             {'a': UUID('73c18056-c592-478b-baf9-3b1322dd0dcf')},
-            {'a': '73c18056-c592-478b-baf9-3b1322dd0dcf'}
+            {'a': '73c18056-c592-478b-baf9-3b1322dd0dcf'},
         ),
         ('string', 'string'),
         ([0, 2, 3], [0, 2, 3]),
-    )
+    ),
 )
 @pytest.mark.django_db
 def test_record_user_event(data, expected_data):


### PR DESCRIPTION
### Description of change

Adds (previously missing) trailing commas to some of the apps. Other apps to follow in future PRs. Once we're fully compliant we enable `flake8-commas`.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
