### PR TITLE
Set default request format during tests to 'json'

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -204,7 +204,8 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'payment_gateway_session.create': '5/min',
     },
-    'ORDERING_PARAM': 'sortby'
+    'ORDERING_PARAM': 'sortby',
+    'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }
 
 # Simplified static file serving.

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -420,7 +420,7 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'name': 'Acme',
         })
 
@@ -459,7 +459,7 @@ class TestUpdateCompany(APITestMixin):
             'registered_address_country': Country.united_states.value.id,
         }
 
-        response = self.api_client.patch(url, format='json', data=update_data)
+        response = self.api_client.patch(url, data=update_data)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['name'] == update_data['name']
@@ -479,7 +479,7 @@ class TestUpdateCompany(APITestMixin):
         )
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'reference_code': 'XYZ',
             'archived_documents_url_path': 'new_path'
         })
@@ -498,7 +498,7 @@ class TestUpdateCompany(APITestMixin):
         )
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'trading_name': 'a' * 600,
         })
 
@@ -527,7 +527,7 @@ class TestUpdateCompany(APITestMixin):
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
         response = self.api_client.patch(url, {
             field: None,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -552,7 +552,7 @@ class TestUpdateCompany(APITestMixin):
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
         response = self.api_client.patch(url, {
             field: None,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()[field] is None
@@ -572,7 +572,7 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'global_headquarters': headquarter.id,
         })
         if is_valid:
@@ -595,7 +595,7 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'global_headquarters': None,
         })
 
@@ -612,7 +612,7 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'global_headquarters': company.id,
         })
 
@@ -634,7 +634,7 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'headquarter_type': HeadquarterType.ghq.value.id,
         })
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -664,7 +664,7 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'headquarter_type': changed_to,
         })
 
@@ -685,7 +685,7 @@ class TestAddCompany(APITestMixin):
     def test_add_uk_company(self):
         """Test add new UK company."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': 'Trading name',
             'business_type': {'id': BusinessTypeConstant.company.value.id},
@@ -721,14 +721,14 @@ class TestAddCompany(APITestMixin):
             'trading_address_1': '1 Hello st.',
             'trading_address_town': 'Dublin',
             'uk_region': UKRegion.england.value.id
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_201_CREATED
 
     def test_add_uk_company_without_uk_region(self):
         """Test add new UK without UK region company."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': None,
             'business_type': {'id': BusinessTypeConstant.company.value.id},
@@ -746,7 +746,7 @@ class TestAddCompany(APITestMixin):
     def test_add_not_uk_company(self):
         """Test add new not UK company."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': None,
             'business_type': {'id': BusinessTypeConstant.company.value.id},
@@ -764,7 +764,7 @@ class TestAddCompany(APITestMixin):
     def test_add_company_partial_trading_address(self):
         """Test add new company with partial trading address."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'business_type': {'id': BusinessTypeConstant.company.value.id},
             'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
@@ -786,7 +786,7 @@ class TestAddCompany(APITestMixin):
     def test_add_company_with_trading_address(self):
         """Test add new company with trading_address."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'business_type': {'id': BusinessTypeConstant.company.value.id},
             'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
@@ -831,7 +831,7 @@ class TestAddCompany(APITestMixin):
             'registered_address_1': None,
             'registered_address_town': None,
             'registered_address_country': None
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -851,7 +851,7 @@ class TestAddCompany(APITestMixin):
             'registered_address_1': '',
             'registered_address_town': '',
             'registered_address_country': None,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -875,7 +875,7 @@ class TestAddCompany(APITestMixin):
             'registered_address_town': 'London',
             'registered_address_country': Country.united_kingdom.value.id,
             'uk_region': UKRegion.england.value.id,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()[field] == ['This field is required.']
@@ -892,7 +892,7 @@ class TestAddCompany(APITestMixin):
     def test_add_company_with_website(self, input_website, expected_website):
         """Test add new company with trading_address."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'business_type': {'id': BusinessTypeConstant.company.value.id},
             'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
@@ -914,7 +914,7 @@ class TestAddCompany(APITestMixin):
     def test_add_uk_establishment(self):
         """Test adding a UK establishment."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': 'Trading name',
             'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
@@ -936,7 +936,7 @@ class TestAddCompany(APITestMixin):
     def test_cannot_add_uk_establishment_without_number(self):
         """Test that a UK establishment cannot be added without a company number."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': 'Trading name',
             'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
@@ -960,7 +960,7 @@ class TestAddCompany(APITestMixin):
     def test_cannot_add_uk_establishment_as_foreign_company(self):
         """Test that adding a UK establishment fails if its country is not UK."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': 'Trading name',
             'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
@@ -987,7 +987,7 @@ class TestAddCompany(APITestMixin):
         Test that adding a UK establishment fails if its company number does not start with BR.
         """
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': 'Trading name',
             'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
@@ -1015,7 +1015,7 @@ class TestAddCompany(APITestMixin):
         characters.
         """
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': 'Trading name',
             'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
@@ -1041,7 +1041,7 @@ class TestAddCompany(APITestMixin):
     def test_no_company_number_validation_for_normal_uk_companies(self):
         """Test that no validation is done on company number for normal companies."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'name': 'Acme',
             'trading_name': 'Trading name',
             'business_type': {'id': BusinessTypeConstant.private_limited_company.value.id},
@@ -1068,7 +1068,7 @@ class TestArchiveCompany(APITestMixin):
         """Test company archive."""
         company = CompanyFactory()
         url = reverse('api-v3:company:archive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -1079,7 +1079,7 @@ class TestArchiveCompany(APITestMixin):
         """Test company archive."""
         company = CompanyFactory()
         url = reverse('api-v3:company:archive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, {'reason': 'foo'}, format='json')
+        response = self.api_client.post(url, {'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -1097,7 +1097,7 @@ class TestArchiveCompany(APITestMixin):
             uk_region_id=None,
         )
         url = reverse('api-v3:company:archive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, {'reason': 'foo'}, format='json')
+        response = self.api_client.post(url, {'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -1120,7 +1120,7 @@ class TestUnarchiveCompany(APITestMixin):
             archived_reason='Dissolved',
         )
         url = reverse('api-v3:company:unarchive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert not response.data['archived']
@@ -1162,7 +1162,6 @@ class TestCompanyVersioning(APITestMixin):
                 'registered_address_town': 'London',
                 'uk_region': {'id': UKRegion.england.value.id},
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -1196,7 +1195,6 @@ class TestCompanyVersioning(APITestMixin):
                 'registered_address_town': 'London',
                 'uk_region': UKRegion.england.value.id
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -1215,7 +1213,6 @@ class TestCompanyVersioning(APITestMixin):
         response = self.api_client.post(
             reverse('api-v3:company:collection'),
             data={'name': 'Acme'},
-            format='json',
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -1230,7 +1227,6 @@ class TestCompanyVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:company:item', kwargs={'pk': company.pk}),
             data={'name': 'Acme'},
-            format='json',
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -1249,7 +1245,6 @@ class TestCompanyVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:company:item', kwargs={'pk': company.pk}),
             data={'trading_name': 'a' * 600},
-            format='json',
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -1261,7 +1256,7 @@ class TestCompanyVersioning(APITestMixin):
         assert Version.objects.get_for_object(company).count() == 0
 
         url = reverse('api-v3:company:archive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, {'reason': 'foo'}, format='json')
+        response = self.api_client.post(url, {'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -1280,7 +1275,7 @@ class TestCompanyVersioning(APITestMixin):
         assert Version.objects.get_for_object(company).count() == 0
 
         url = reverse('api-v3:company:archive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert Version.objects.get_for_object(company).count() == 0
@@ -1434,7 +1429,7 @@ class TestCompanyCoreTeam(APITestMixin):
             'api-v3:company:core-team',
             kwargs={'pk': company.pk}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
@@ -1451,7 +1446,7 @@ class TestCompanyCoreTeam(APITestMixin):
             'api-v3:company:core-team',
             kwargs={'pk': company.pk}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
@@ -1509,7 +1504,7 @@ class TestCompanyCoreTeam(APITestMixin):
             'api-v3:company:core-team',
             kwargs={'pk': company.pk}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
@@ -1545,6 +1540,6 @@ class TestCompanyCoreTeam(APITestMixin):
             'api-v3:company:core-team',
             kwargs={'pk': '00000000-0000-0000-0000-000000000000'}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -60,7 +60,7 @@ class TestAddContact(APITestMixin):
             'accepts_dit_email_marketing': True,
             'contactable_by_email': True,
             'contactable_by_phone': True
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json() == {
@@ -129,7 +129,7 @@ class TestAddContact(APITestMixin):
             'telephone_number': '123456789',
             'address_same_as_company': True,
             'primary': True
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -156,7 +156,7 @@ class TestAddContact(APITestMixin):
             'telephone_number': '123456789',
             'address_same_as_company': True,
             'primary': True
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.data
@@ -192,7 +192,7 @@ class TestAddContact(APITestMixin):
             'telephone_number': '123456789',
             'address_same_as_company': True,
             'primary': True
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -212,7 +212,7 @@ class TestAddContact(APITestMixin):
             'telephone_countrycode': '+44',
             'telephone_number': '123456789',
             'primary': True
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -235,7 +235,7 @@ class TestAddContact(APITestMixin):
             'telephone_number': '123456789',
             'address_1': 'test',
             'primary': True
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -259,7 +259,7 @@ class TestAddContact(APITestMixin):
             'contactable_by_email': False,
             'contactable_by_phone': False,
             'primary': True
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -286,7 +286,7 @@ class TestAddContact(APITestMixin):
             'telephone_countrycode': '+44',
             'telephone_number': '123456789',
             'address_same_as_company': True,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -335,7 +335,7 @@ class TestEditContact(APITestMixin):
         with freeze_time('2017-04-19 13:25:30.986208'):
             response = self.api_client.patch(url, {
                 'first_name': 'New Oratio',
-            }, format='json')
+            })
 
         assert response.status_code == status.HTTP_200_OK, response.data
         assert response.json() == {
@@ -395,7 +395,7 @@ class TestEditContact(APITestMixin):
         company = ArchivedContactFactory()
 
         url = reverse('api-v3:contact:detail', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'first_name': 'new name',
         })
 
@@ -411,7 +411,7 @@ class TestEditContact(APITestMixin):
         )
 
         url = reverse('api-v3:contact:detail', kwargs={'pk': contact.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'archived_documents_url_path': 'new_path'
         })
 
@@ -718,7 +718,6 @@ class TestContactVersioning(APITestMixin):
                 'address_same_as_company': True,
                 'primary': True
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -745,7 +744,6 @@ class TestContactVersioning(APITestMixin):
                 'first_name': 'Oratio',
                 'last_name': 'Nelson',
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -761,7 +759,6 @@ class TestContactVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:contact:detail', kwargs={'pk': contact.pk}),
             data={'first_name': 'New Oratio'},
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -783,7 +780,6 @@ class TestContactVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:contact:detail', kwargs={'pk': contact.pk}),
             data={'email': 'invalid'},
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -795,7 +791,7 @@ class TestContactVersioning(APITestMixin):
         assert Version.objects.get_for_object(contact).count() == 0
 
         url = reverse('api-v3:contact:archive', kwargs={'pk': contact.id})
-        response = self.api_client.post(url, {'reason': 'foo'}, format='json')
+        response = self.api_client.post(url, {'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -814,7 +810,7 @@ class TestContactVersioning(APITestMixin):
         assert Version.objects.get_for_object(contact).count() == 0
 
         url = reverse('api-v3:contact:archive', kwargs={'pk': contact.id})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert Version.objects.get_for_object(contact).count() == 0

--- a/datahub/documents/test/test_views.py
+++ b/datahub/documents/test/test_views.py
@@ -58,7 +58,7 @@ class TestDocumentViews(APITestMixin):
 
         url = reverse('test-document-collection')
 
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'original_filename': 'test.txt',
             'my_field': 'cats cannot taste sweet',
         })
@@ -130,7 +130,7 @@ class TestDocumentViews(APITestMixin):
             'entity_document_pk': entity_document.pk
         })
 
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['status'] == 'virus_scanning_scheduled'

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -143,7 +143,7 @@ class TestCreateEventView(APITestMixin):
             'lead_team': team.pk,
             'teams': [team.pk],
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = _get_canonical_response_data(response)
@@ -209,7 +209,7 @@ class TestCreateEventView(APITestMixin):
             'related_programmes': [Programme.great_branded.value.id],
             'service': Service.trade_enquiry.value.id,
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = _get_canonical_response_data(response)
@@ -286,7 +286,7 @@ class TestCreateEventView(APITestMixin):
             'service': Service.trade_enquiry.value.id,
             'start_date': '2010-09-12',
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -310,7 +310,7 @@ class TestCreateEventView(APITestMixin):
             'lead_team': team.pk,
             'teams': [team.pk],
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -335,7 +335,7 @@ class TestCreateEventView(APITestMixin):
             'lead_team': team.pk,
             'teams': [team.pk],
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -359,7 +359,7 @@ class TestCreateEventView(APITestMixin):
             'lead_team': team.pk,
             'teams': [team.pk],
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -384,7 +384,7 @@ class TestCreateEventView(APITestMixin):
             'lead_team': team.pk,
             'teams': [team.pk],
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -396,7 +396,7 @@ class TestCreateEventView(APITestMixin):
         """Tests creating an event without required fields."""
         url = reverse('api-v3:event:collection')
         request_data = {}
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -428,7 +428,7 @@ class TestCreateEventView(APITestMixin):
             'start_date': None,
             'teams': []
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -475,7 +475,7 @@ class TestUpdateEventView(APITestMixin):
             'related_programmes': [Programme.great_challenge_fund.value.id],
             'service': Service.account_management.value.id,
         }
-        response = self.api_client.patch(url, request_data, format='json')
+        response = self.api_client.patch(url, request_data)
         assert response.status_code == status.HTTP_200_OK
 
         response_data = _get_canonical_response_data(response)
@@ -541,7 +541,7 @@ class TestUpdateEventView(APITestMixin):
         request_data = {
             'lead_team': Team.healthcare_uk.value.id,
         }
-        response = self.api_client.patch(url, request_data, format='json')
+        response = self.api_client.patch(url, request_data)
         assert response.status_code == status.HTTP_200_OK
 
         response_data = _get_canonical_response_data(response)
@@ -555,7 +555,7 @@ class TestUpdateEventView(APITestMixin):
         request_data = {
             'end_date': None,
         }
-        response = self.api_client.patch(url, request_data, format='json')
+        response = self.api_client.patch(url, request_data)
 
         response_data = response.json()
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -569,7 +569,7 @@ class TestUpdateEventView(APITestMixin):
         request_data = {
             'lead_team': Team.food_from_britain.value.id,
         }
-        response = self.api_client.patch(url, request_data, format='json')
+        response = self.api_client.patch(url, request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
         response_data = response.json()
@@ -582,7 +582,7 @@ class TestUpdateEventView(APITestMixin):
         event = DisabledEventFactory(archived_documents_url_path='old_path')
 
         url = reverse('api-v3:event:item', kwargs={'pk': event.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'archived_documents_url_path': 'new_path',
             'disabled_on': None,
         })
@@ -616,7 +616,6 @@ class TestEventVersioning(APITestMixin):
                 'lead_team': team.pk,
                 'teams': [team.pk],
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -638,7 +637,6 @@ class TestEventVersioning(APITestMixin):
         response = self.api_client.post(
             reverse('api-v3:event:collection'),
             data={'name': 'Grand exhibition'},
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -653,7 +651,6 @@ class TestEventVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:event:item', kwargs={'pk': event.pk}),
             data={'name': 'Annual exhibition'},
-            format='json'
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.data['name'] == 'Annual exhibition'
@@ -673,7 +670,6 @@ class TestEventVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:event:item', kwargs={'pk': event.pk}),
             data={'event_type': 'invalid'},
-            format='json'
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert Version.objects.get_for_object(event).count() == 0

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -46,7 +46,7 @@ class TestUpdateInteraction(APITestMixin):
         )
 
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'archived_documents_url_path': 'new_path'
         })
 
@@ -60,7 +60,7 @@ class TestUpdateInteraction(APITestMixin):
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = self.api_client.patch(url, {
             'date': 'abcd-de-fe',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -305,7 +305,6 @@ class TestInteractionVersioning(APITestMixin):
                 'service': Service.trade_enquiry.value.id,
                 'dit_team': Team.healthcare_uk.value.id
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -329,7 +328,6 @@ class TestInteractionVersioning(APITestMixin):
             data={
                 'kind': Interaction.KINDS.interaction,
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -344,7 +342,6 @@ class TestInteractionVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:interaction:item', kwargs={'pk': service_delivery.pk}),
             data={'subject': 'new subject'},
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -365,7 +362,6 @@ class TestInteractionVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:interaction:item', kwargs={'pk': service_delivery.pk}),
             data={'kind': 'invalid'},
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -97,7 +97,7 @@ class TestAddInteraction(APITestMixin):
         }
 
         api_client = self.create_api_client(user=adviser)
-        response = api_client.post(url, request_data, format='json')
+        response = api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -241,7 +241,7 @@ class TestAddInteraction(APITestMixin):
         """Test validation errors."""
         data = resolve_data(data)
         url = reverse('api-v3:interaction:collection')
-        response = self.api_client.post(url, data, format='json')
+        response = self.api_client.post(url, data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == errors
@@ -273,7 +273,7 @@ class TestAddInteraction(APITestMixin):
             'investment_project': project.pk,
             'service': Service.trade_enquiry.value.id,
             'dit_team': Team.healthcare_uk.value.id
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -307,7 +307,7 @@ class TestAddInteraction(APITestMixin):
             'investment_project': project.pk,
             'service': Service.trade_enquiry.value.id,
             'dit_team': Team.healthcare_uk.value.id
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -333,7 +333,7 @@ class TestAddInteraction(APITestMixin):
             'notes': 'hello',
             'service': Service.trade_enquiry.value.id,
             'dit_team': Team.healthcare_uk.value.id
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -615,7 +615,7 @@ class TestUpdateInteraction(APITestMixin):
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = api_client.patch(url, {
             'subject': 'I am another subject',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['subject'] == 'I am another subject'
@@ -631,7 +631,7 @@ class TestUpdateInteraction(APITestMixin):
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = api_client.patch(url, {
             'subject': 'I am another subject',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -650,7 +650,7 @@ class TestUpdateInteraction(APITestMixin):
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = api_client.patch(url, {
             'subject': 'I am another subject',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -675,7 +675,7 @@ class TestUpdateInteraction(APITestMixin):
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = api_client.patch(url, {
             'subject': 'I am another subject',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['subject'] == 'I am another subject'

--- a/datahub/interaction/test/views/test_policy_feedback.py
+++ b/datahub/interaction/test/views/test_policy_feedback.py
@@ -63,7 +63,7 @@ class TestAddPolicyFeedback(APITestMixin):
 
         user = create_add_policy_feedback_user()
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, request_data, format='json')
+        response = api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -242,7 +242,7 @@ class TestAddPolicyFeedback(APITestMixin):
         url = reverse('api-v3:interaction:collection')
         user = create_add_policy_feedback_user()
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, data, format='json')
+        response = api_client.post(url, data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == errors
@@ -280,7 +280,7 @@ class TestAddPolicyFeedback(APITestMixin):
         }
         user = create_user()
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, request_data, format='json')
+        response = api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -65,7 +65,7 @@ class TestAddServiceDelivery(APITestMixin):
 
             **resolve_data(extra_data)
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -255,7 +255,7 @@ class TestAddServiceDelivery(APITestMixin):
         """Test validation errors."""
         data = resolve_data(data)
         url = reverse('api-v3:interaction:collection')
-        response = self.api_client.post(url, data, format='json')
+        response = self.api_client.post(url, data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == errors
@@ -273,7 +273,7 @@ class TestUpdateServiceDelivery(APITestMixin):
         response = self.api_client.patch(url, {
             'is_event': True,
             'event': event.pk
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -291,7 +291,7 @@ class TestUpdateServiceDelivery(APITestMixin):
         response = self.api_client.patch(url, {
             'is_event': False,
             'event': None
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -305,7 +305,7 @@ class TestUpdateServiceDelivery(APITestMixin):
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = self.api_client.patch(url, {
             'grant_amount_offered': '-100.00',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -320,7 +320,7 @@ class TestUpdateServiceDelivery(APITestMixin):
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
         response = self.api_client.patch(url, {
             'net_company_receipt': '-100.00',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()

--- a/datahub/investment/evidence/test/test_views.py
+++ b/datahub/investment/evidence/test/test_views.py
@@ -172,7 +172,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         })
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json', data={
+        response = api_client.post(url, data={
             'original_filename': 'test.txt',
             'tags': [tag.pk for tag in evidence_tags],
         })
@@ -492,7 +492,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         )
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         response_data = response.json()
 
         if not allowed:
@@ -715,7 +715,7 @@ class TestEvidenceDocumentViews(APITestMixin):
 
         user = create_test_user(permission_codenames=[], dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json', data={})
+        response = api_client.post(url, data={})
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 

--- a/datahub/investment/proposition/test/test_views.py
+++ b/datahub/investment/proposition/test/test_views.py
@@ -110,7 +110,6 @@ class TestCreateProposition(APITestMixin):
                 'adviser': adviser.pk,
                 'deadline': '2018-02-10',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -171,7 +170,6 @@ class TestCreateProposition(APITestMixin):
                 'adviser': adviser.pk,
                 'deadline': '2018-02-10',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
         response_data = response.json()
@@ -199,7 +197,6 @@ class TestCreateProposition(APITestMixin):
                 'adviser': adviser.pk,
                 'deadline': '2018-02-10',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -262,7 +259,6 @@ class TestCreateProposition(APITestMixin):
                 'adviser': adviser.pk,
                 'deadline': '2018-02-10',
             },
-            format='json',
         )
         response_data = response.json()
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -277,7 +273,7 @@ class TestCreateProposition(APITestMixin):
         url = reverse('api-v3:investment:proposition:collection', kwargs={
             'project_pk': investment_project.pk
         })
-        response = self.api_client.post(url, {}, format='json')
+        response = self.api_client.post(url, {})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -317,7 +313,7 @@ class TestUpdateProposition(APITestMixin):
         })
         response = getattr(self.api_client, method)(url, {
             'name': 'hello!',
-        }, format='json')
+        })
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
@@ -708,7 +704,7 @@ class TestCompleteProposition(APITestMixin):
         })
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         proposition.refresh_from_db()
         response_data = response.json()
         assert response.status_code == status.HTTP_200_OK
@@ -764,7 +760,7 @@ class TestCompleteProposition(APITestMixin):
         })
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
         response_data = response.json()
         assert response_data == {'detail': 'Not found.'}
@@ -797,7 +793,7 @@ class TestCompleteProposition(APITestMixin):
         })
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         proposition.refresh_from_db()
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -863,7 +859,7 @@ class TestCompleteProposition(APITestMixin):
             'project_pk': proposition.investment_project.pk,
         })
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         response_data = response.json()
         assert response_data == {
@@ -901,7 +897,7 @@ class TestCompleteProposition(APITestMixin):
             'project_pk': proposition.investment_project.pk,
         })
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         response_data = response.json()
         assert response.status_code == status.HTTP_409_CONFLICT
         detail = f'The action cannot be performed in the current status {proposition_status}.'
@@ -918,7 +914,7 @@ class TestCompleteProposition(APITestMixin):
             'proposition_pk': proposition.pk,
             'project_pk': proposition.investment_project.pk,
         })
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data['non_field_errors'] == ['Proposition has no documents uploaded.']
@@ -946,7 +942,6 @@ class TestLegacyCompleteProposition(APITestMixin):
             {
                 'details': 'All done 100% satisfaction.',
             },
-            format='json',
         )
         proposition.refresh_from_db()
         assert response.status_code == status.HTTP_200_OK
@@ -1003,7 +998,6 @@ class TestLegacyCompleteProposition(APITestMixin):
             {
                 'details': 'All done 100% satisfaction.',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
         response_data = response.json()
@@ -1036,7 +1030,6 @@ class TestLegacyCompleteProposition(APITestMixin):
             {
                 'details': 'All done 100% satisfaction.',
             },
-            format='json',
         )
         proposition.refresh_from_db()
         assert response.status_code == status.HTTP_200_OK
@@ -1103,7 +1096,6 @@ class TestLegacyCompleteProposition(APITestMixin):
             {
                 'details': 'All done 100% satisfaction.',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         response_data = response.json()
@@ -1134,7 +1126,6 @@ class TestLegacyCompleteProposition(APITestMixin):
             {
                 'details': 'All done 100% satisfaction.',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_409_CONFLICT
         response_data = response.json()
@@ -1157,7 +1148,6 @@ class TestLegacyCompleteProposition(APITestMixin):
             {
                 'details': '',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -1186,7 +1176,6 @@ class TestAbandonProposition(APITestMixin):
             {
                 'details': 'Not enough information.',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_200_OK
         proposition.refresh_from_db()
@@ -1243,7 +1232,6 @@ class TestAbandonProposition(APITestMixin):
             {
                 'details': 'Not enough information.',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
         response_data = response.json()
@@ -1276,7 +1264,6 @@ class TestAbandonProposition(APITestMixin):
             {
                 'details': 'Not enough information.',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_200_OK
         proposition.refresh_from_db()
@@ -1343,7 +1330,6 @@ class TestAbandonProposition(APITestMixin):
             {
                 'details': 'Not enough information.',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         response_data = response.json()
@@ -1374,7 +1360,6 @@ class TestAbandonProposition(APITestMixin):
             {
                 'details': 'Too many cats.',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_409_CONFLICT
         response_data = response.json()
@@ -1397,7 +1382,6 @@ class TestAbandonProposition(APITestMixin):
             {
                 'details': '',
             },
-            format='json',
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -1425,7 +1409,7 @@ class TestPropositionDocumentViews(APITestMixin):
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
 
-        response = api_client.post(url, format='json', data={
+        response = api_client.post(url, data={
             'original_filename': 'test.txt',
         })
         assert response.status_code == status.HTTP_201_CREATED
@@ -1475,7 +1459,7 @@ class TestPropositionDocumentViews(APITestMixin):
 
         api_client = self.create_api_client(user=user)
 
-        response = api_client.post(url, format='json', data={
+        response = api_client.post(url, data={
             'original_filename': 'test.txt',
         })
         assert response.status_code == status.HTTP_201_CREATED
@@ -1523,7 +1507,7 @@ class TestPropositionDocumentViews(APITestMixin):
         )
         api_client = self.create_api_client(user=user)
 
-        response = api_client.post(url, format='json', data={
+        response = api_client.post(url, data={
             'original_filename': 'test.txt',
         })
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -1543,7 +1527,7 @@ class TestPropositionDocumentViews(APITestMixin):
         user = create_test_user(permission_codenames=(PropositionDocumentPermission.add_all,))
         api_client = self.create_api_client(user=user)
 
-        response = api_client.post(url, format='json', data={
+        response = api_client.post(url, data={
             'original_filename': 'test.txt',
         })
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -1941,7 +1925,7 @@ class TestPropositionDocumentViews(APITestMixin):
         )
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
 
         entity_document.document.refresh_from_db()
@@ -2000,7 +1984,7 @@ class TestPropositionDocumentViews(APITestMixin):
         )
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
 
         entity_document.document.refresh_from_db()
@@ -2054,7 +2038,7 @@ class TestPropositionDocumentViews(APITestMixin):
         )
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data == {
             'detail': 'You do not have permission to perform this action.'
@@ -2296,7 +2280,7 @@ class TestPropositionDocumentViews(APITestMixin):
             }
         )
 
-        response = self.api_client.post(url, format='json', data={})
+        response = self.api_client.post(url, data={})
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -386,7 +386,7 @@ class TestCreateView(APITestMixin):
                 'id': str(aerospace_id)
             }
         }
-        response = self.api_client.post(url, data=request_data, format='json')
+        response = self.api_client.post(url, data=request_data)
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
         assert response_data['name'] == request_data['name']
@@ -416,7 +416,7 @@ class TestCreateView(APITestMixin):
         """Test creating a project with missing required values."""
         url = reverse('api-v3:investment:investment-collection')
         request_data = {}
-        response = self.api_client.post(url, data=request_data, format='json')
+        response = self.api_client.post(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -447,7 +447,7 @@ class TestCreateView(APITestMixin):
             'referral_source_adviser': None,
             'sector': None
         }
-        response = self.api_client.post(url, data=request_data, format='json')
+        response = self.api_client.post(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -470,7 +470,7 @@ class TestCreateView(APITestMixin):
             'business_activities': [],
             'client_contacts': []
         }
-        response = self.api_client.post(url, data=request_data, format='json')
+        response = self.api_client.post(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data.keys() >= {
@@ -524,7 +524,7 @@ class TestCreateView(APITestMixin):
                 'id': str(aerospace_id)
             }
         }
-        response = self.api_client.post(url, data=request_data, format='json')
+        response = self.api_client.post(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -942,7 +942,7 @@ class TestPartialUpdateView(APITestMixin):
             },
             'fdi_type': None
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -956,7 +956,7 @@ class TestPartialUpdateView(APITestMixin):
         request_data = {
             'likelihood_of_landing': -10
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -970,7 +970,7 @@ class TestPartialUpdateView(APITestMixin):
         request_data = {
             'likelihood_of_landing': 110
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -984,7 +984,7 @@ class TestPartialUpdateView(APITestMixin):
         request_data = {
             'priority': '6_extremely_urgent'
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -1003,7 +1003,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': str(new_contact.id)
             }]
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['name'] == request_data['name']
@@ -1019,7 +1019,7 @@ class TestPartialUpdateView(APITestMixin):
             'project_arrived_in_triage_on': '2017-04-18',
             'proposal_deadline': '2017-04-19',
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -1041,7 +1041,7 @@ class TestPartialUpdateView(APITestMixin):
         request_data = {
             'estimated_land_date': None,
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
 
     def test_change_stage_assign_pm_failure(self):
@@ -1053,7 +1053,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': constants.InvestmentProjectStage.assign_pm.value.id
             }
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -1088,7 +1088,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': constants.InvestmentProjectStage.assign_pm.value.id
             }
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
 
     def test_change_stage_active_failure(self):
@@ -1100,7 +1100,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': constants.InvestmentProjectStage.active.value.id
             }
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -1129,7 +1129,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': constants.InvestmentProjectStage.active.value.id
             }
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
 
     def test_change_stage_verify_win_failure(self):
@@ -1147,7 +1147,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': constants.InvestmentProjectStage.verify_win.value.id
             }
         }
-        response = api_client.patch(url, data=request_data, format='json')
+        response = api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -1207,7 +1207,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': constants.InvestmentProjectStage.verify_win.value.id
             }
         }
-        response = api_client.patch(url, data=request_data, format='json')
+        response = api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
 
     def test_cannot_change_stage_verify_win_if_not_pm_or_paa(self):
@@ -1224,7 +1224,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': constants.InvestmentProjectStage.verify_win.value.id
             }
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             'stage': [
@@ -1255,7 +1255,7 @@ class TestPartialUpdateView(APITestMixin):
             ]
         )
 
-        response = api_client.patch(url, data=request_data, format='json')
+        response = api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['stage'] == {
@@ -1276,7 +1276,7 @@ class TestPartialUpdateView(APITestMixin):
             },
             'actual_land_date': '2016-01-31',
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -1308,7 +1308,7 @@ class TestPartialUpdateView(APITestMixin):
         )
         adviser.save()
 
-        response = api_client.patch(url, data=request_data, format='json')
+        response = api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -1324,7 +1324,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': constants.InvestmentProjectStage.verify_win.value.id
             }
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['stage'] == {
@@ -1361,7 +1361,7 @@ class TestPartialUpdateView(APITestMixin):
         }
 
         with freeze_time(next(date_iter)):
-            response = self.api_client.patch(url, data=request_data, format='json')
+            response = self.api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -1414,7 +1414,7 @@ class TestPartialUpdateView(APITestMixin):
         }
 
         with freeze_time(datetime(2017, 4, 28, 17, 35, tzinfo=utc)):
-            response = self.api_client.patch(url, data=request_data, format='json')
+            response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
 
         response_data = response.json()
@@ -1454,7 +1454,7 @@ class TestPartialUpdateView(APITestMixin):
         request_data = {
             'project_manager': None
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
@@ -1472,7 +1472,7 @@ class TestPartialUpdateView(APITestMixin):
             'average_salary': {'id': salary_id},
             'government_assistance': True
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['number_new_jobs'] == 555
@@ -1492,7 +1492,7 @@ class TestPartialUpdateView(APITestMixin):
             'address_1': 'address 1 new',
             'address_2': 'address 2 new'
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['requirements_complete'] is False
@@ -1515,7 +1515,7 @@ class TestPartialUpdateView(APITestMixin):
         request_data = {
             'uk_region_locations': [],
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
 
     def test_patch_team_success(self):
@@ -1535,7 +1535,7 @@ class TestPartialUpdateView(APITestMixin):
                 'id': str(adviser_2.id)
             }
         }
-        response = self.api_client.patch(url, data=request_data, format='json')
+        response = self.api_client.patch(url, data=request_data)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
 
@@ -1587,7 +1587,7 @@ class TestPartialUpdateView(APITestMixin):
             }
         }
         with freeze_time(datetime(2017, 4, 30, 11, 25, tzinfo=utc)):
-            response = self.api_client.patch(url, data=request_data, format='json')
+            response = self.api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -1617,7 +1617,7 @@ class TestPartialUpdateView(APITestMixin):
         )
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
-        response = self.api_client.patch(url, format='json', data={
+        response = self.api_client.patch(url, data={
             'archived_documents_url_path': 'new_path',
             'comments': 'new_comments',
             'allow_blank_estimated_land_date': True,
@@ -1764,7 +1764,6 @@ class TestInvestmentProjectVersioning(APITestMixin):
                     'id': str(constants.Sector.aerospace_assembly_aircraft.value.id)
                 }
             },
-            format='json'
         )
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data['name'] == 'project name'
@@ -1787,7 +1786,6 @@ class TestInvestmentProjectVersioning(APITestMixin):
             data={
                 'name': 'project name'
             },
-            format='json'
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert Version.objects.count() == 0
@@ -1804,7 +1802,6 @@ class TestInvestmentProjectVersioning(APITestMixin):
                 'name': 'new name',
                 'description': 'new description',
             },
-            format='json'
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.data['name'] == 'new name'
@@ -1826,7 +1823,6 @@ class TestInvestmentProjectVersioning(APITestMixin):
         response = self.api_client.patch(
             reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk}),
             data={'likelihood_of_landing': -10},
-            format='json'
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert Version.objects.get_for_object(project).count() == 0
@@ -1840,7 +1836,6 @@ class TestInvestmentProjectVersioning(APITestMixin):
         response = self.api_client.post(
             reverse('api-v3:investment:archive-item', kwargs={'pk': project.pk}),
             data={'reason': 'foo'},
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -1861,7 +1856,7 @@ class TestInvestmentProjectVersioning(APITestMixin):
         assert Version.objects.get_for_object(project).count() == 0
 
         url = reverse('api-v3:investment:archive-item', kwargs={'pk': project.pk})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert Version.objects.get_for_object(project).count() == 0
@@ -1874,7 +1869,7 @@ class TestInvestmentProjectVersioning(APITestMixin):
         assert Version.objects.get_for_object(project).count() == 0
 
         url = reverse('api-v3:investment:unarchive-item', kwargs={'pk': project.pk})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert not response.data['archived']
@@ -1985,7 +1980,7 @@ class TestAddTeamMemberView(APITestMixin):
         """Tests adding a team member to a non-existent project."""
         url = reverse('api-v3:investment:team-member-collection',
                       kwargs={'project_pk': uuid.uuid4()})
-        response = self.api_client.post(url, format='json', data={})
+        response = self.api_client.post(url, data={})
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -1994,7 +1989,7 @@ class TestAddTeamMemberView(APITestMixin):
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:team-member-collection',
                       kwargs={'project_pk': project.pk})
-        response = self.api_client.post(url, format='json', data={})
+        response = self.api_client.post(url, data={})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -2008,7 +2003,7 @@ class TestAddTeamMemberView(APITestMixin):
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:team-member-collection',
                       kwargs={'project_pk': project.pk})
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'adviser': None,
             'role': None
         })
@@ -2026,7 +2021,7 @@ class TestAddTeamMemberView(APITestMixin):
         adviser = AdviserFactory()
         url = reverse('api-v3:investment:team-member-collection',
                       kwargs={'project_pk': project.pk})
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'adviser': {'id': str(adviser.pk)},
             'role': ''
         })
@@ -2057,7 +2052,7 @@ class TestAddTeamMemberView(APITestMixin):
             },
             'role': 'Sector adviser'
         }
-        response = api_client.post(url, format='json', data=request_data)
+        response = api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -2082,7 +2077,7 @@ class TestAddTeamMemberView(APITestMixin):
             },
             'role': 'Sector adviser'
         }
-        response = api_client.post(url, format='json', data=request_data)
+        response = api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -2103,7 +2098,7 @@ class TestAddTeamMemberView(APITestMixin):
             },
             'role': 'Sector adviser'
         }
-        response = api_client.post(url, format='json', data=request_data)
+        response = api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -2122,7 +2117,7 @@ class TestAddTeamMemberView(APITestMixin):
             },
             'role': 'Sector adviser'
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -2153,7 +2148,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
             },
             'role': 'Sector adviser'
         } for adviser in advisers]
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2192,7 +2187,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
             },
             'role': 'New role'
         } for team_member in team_members]
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2230,7 +2225,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
             },
             'role': 'Sector adviser'
         }]
-        response = api_client.put(url, format='json', data=request_data)
+        response = api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2266,7 +2261,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
             },
             'role': 'Sector adviser',
         }]
-        response = api_client.put(url, format='json', data=request_data)
+        response = api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -2287,7 +2282,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
             },
             'role': 'Sector adviser'
         }]
-        response = api_client.put(url, format='json', data=request_data)
+        response = api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2314,7 +2309,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
         url = reverse('api-v3:investment:team-member-collection',
                       kwargs={'project_pk': project.pk})
         request_data = []
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2342,7 +2337,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
             },
             'role': ''
         }]
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -2375,7 +2370,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
             },
             'role': 'Development adviser'
         }]
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -2390,7 +2385,7 @@ class TestReplaceAllTeamMembersView(APITestMixin):
         url = reverse('api-v3:investment:team-member-collection',
                       kwargs={'project_pk': uuid.uuid4()})
         request_data = []
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -2485,7 +2480,7 @@ class TestGetTeamMemberView(APITestMixin):
         })
         team = TeamFactory()
         _, api_client = _create_user_and_api_client(self, team, permissions)
-        response = api_client.get(url, format='json')
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2502,7 +2497,7 @@ class TestGetTeamMemberView(APITestMixin):
         _, api_client = _create_user_and_api_client(
             self, team, [InvestmentProjectPermission.view_associated]
         )
-        response = api_client.get(url, format='json')
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -2518,7 +2513,7 @@ class TestGetTeamMemberView(APITestMixin):
         _, api_client = _create_user_and_api_client(
             self, creator.dit_team, [InvestmentProjectPermission.view_associated]
         )
-        response = api_client.get(url, format='json')
+        response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2531,7 +2526,7 @@ class TestGetTeamMemberView(APITestMixin):
             'project_pk': project.pk,
             'adviser_pk': uuid.uuid4()
         })
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -2542,7 +2537,7 @@ class TestGetTeamMemberView(APITestMixin):
             'project_pk': uuid.uuid4(),
             'adviser_pk': adviser.pk
         })
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -2566,7 +2561,7 @@ class TestUpdateTeamMemberView(APITestMixin):
         }
         team = TeamFactory()
         _, api_client = _create_user_and_api_client(self, team, permissions)
-        response = api_client.patch(url, format='json', data=request_data)
+        response = api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2586,7 +2581,7 @@ class TestUpdateTeamMemberView(APITestMixin):
         _, api_client = _create_user_and_api_client(
             self, team, [InvestmentProjectPermission.change_associated]
         )
-        response = api_client.patch(url, format='json', data=request_data)
+        response = api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -2605,7 +2600,7 @@ class TestUpdateTeamMemberView(APITestMixin):
         _, api_client = _create_user_and_api_client(
             self, creator.dit_team, [InvestmentProjectPermission.change_associated]
         )
-        response = api_client.patch(url, format='json', data=request_data)
+        response = api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -2706,7 +2701,6 @@ class TestTeamMemberVersioning(APITestMixin):
                 },
                 'role': 'Sector adviser'
             },
-            format='json',
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -2737,7 +2731,6 @@ class TestTeamMemberVersioning(APITestMixin):
             data={
                 'adviser': {'id': 'invalid'},
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -2764,7 +2757,7 @@ class TestTeamMemberVersioning(APITestMixin):
             },
             'role': 'Sector adviser'
         } for adviser in advisers]
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response.data.sort(key=_get_adviser_id)
@@ -2812,7 +2805,7 @@ class TestTeamMemberVersioning(APITestMixin):
             },
             'role': 'New role'
         } for team_member in team_members]
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data == [{
@@ -2862,7 +2855,7 @@ class TestTeamMemberVersioning(APITestMixin):
             },
             'role': ''
         }]
-        response = self.api_client.put(url, format='json', data=request_data)
+        response = self.api_client.put(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert Version.objects.count() == 0
@@ -2905,7 +2898,6 @@ class TestTeamMemberVersioning(APITestMixin):
             data={
                 'role': 'updated role'
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -3050,7 +3042,7 @@ class TestArchiveViews(APITestMixin):
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = api_client.post(url, format='json', data={
+        response = api_client.post(url, data={
             'reason': 'archive reason'
         })
 
@@ -3071,7 +3063,7 @@ class TestArchiveViews(APITestMixin):
         project = InvestmentProjectFactory(created_by=adviser)
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = api_client.post(url, format='json', data={
+        response = api_client.post(url, data={
             'reason': 'archive reason'
         })
 
@@ -3091,7 +3083,7 @@ class TestArchiveViews(APITestMixin):
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = api_client.post(url, format='json', data={
+        response = api_client.post(url, data={
             'reason': 'archive reason'
         })
 
@@ -3102,7 +3094,7 @@ class TestArchiveViews(APITestMixin):
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -3114,7 +3106,7 @@ class TestArchiveViews(APITestMixin):
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'reason': ''
         })
 
@@ -3128,7 +3120,7 @@ class TestArchiveViews(APITestMixin):
         project = InvestmentProjectFactory()
         url = reverse('api-v3:investment:archive-item',
                       kwargs={'pk': project.pk})
-        response = self.api_client.post(url, format='json', data={
+        response = self.api_client.post(url, data={
             'reason': None
         })
 

--- a/datahub/leads/test/test_views.py
+++ b/datahub/leads/test/test_views.py
@@ -102,7 +102,7 @@ class TestBusinessLeadViews(APITestMixin):
             'last_name': 'Last name',
             'telephone_number': '+44 7000 123456'
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -116,7 +116,7 @@ class TestBusinessLeadViews(APITestMixin):
         """Tests creating a business lead without required fields."""
         url = reverse('api-v3:business-leads:lead-collection')
         request_data = {}
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -140,7 +140,7 @@ class TestBusinessLeadViews(APITestMixin):
             'first_name': 'New first name',
             'email_alternative': 'altemail@blah.com'
         }
-        response = self.api_client.patch(url, format='json', data=request_data)
+        response = self.api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -159,7 +159,7 @@ class TestBusinessLeadViews(APITestMixin):
             'company_name': None,
             'company': None
         }
-        response = self.api_client.patch(url, format='json', data=request_data)
+        response = self.api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -181,7 +181,7 @@ class TestBusinessLeadViews(APITestMixin):
         request_data = {
             'reason': 'archive test'
         }
-        response = self.api_client.post(url, format='json', data=request_data)
+        response = self.api_client.post(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -199,7 +199,7 @@ class TestBusinessLeadViews(APITestMixin):
         url = reverse('api-v3:business-leads:unarchive-lead-item', kwargs={
             'pk': lead.pk
         })
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()

--- a/datahub/omis/invoice/test/views/test_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_invoice_details.py
@@ -16,7 +16,7 @@ class TestGetInvoice(APITestMixin):
         invoice = order.invoice
 
         url = reverse('api-v3:omis:invoice:detail', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -59,7 +59,7 @@ class TestGetInvoice(APITestMixin):
     def test_404_if_order_doesnt_exist(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse('api-v3:omis:invoice:detail', kwargs={'order_pk': uuid.uuid4()})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -69,6 +69,6 @@ class TestGetInvoice(APITestMixin):
         assert not order.invoice
 
         url = reverse('api-v3:omis:invoice:detail', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/datahub/omis/invoice/test/views/test_public_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_public_invoice_details.py
@@ -35,7 +35,7 @@ class TestPublicGetInvoice(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         invoice = order.invoice
         assert response.status_code == status.HTTP_200_OK
@@ -88,7 +88,7 @@ class TestPublicGetInvoice(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -105,7 +105,7 @@ class TestPublicGetInvoice(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 

--- a/datahub/omis/order/test/views/test_order_assignees.py
+++ b/datahub/omis/order/test/views/test_order_assignees.py
@@ -24,7 +24,7 @@ class TestGetOrderAssignees(APITestMixin):
             'api-v3:omis:order:assignee',
             kwargs={'order_pk': order.id}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
@@ -46,7 +46,7 @@ class TestGetOrderAssignees(APITestMixin):
             'api-v3:omis:order:assignee',
             kwargs={'order_pk': order.id}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
@@ -70,7 +70,7 @@ class TestGetOrderAssignees(APITestMixin):
             'api-v3:omis:order:assignee',
             kwargs={'order_pk': '00000000-0000-0000-0000-000000000000'}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -163,7 +163,6 @@ class TestChangeAssigneesWhenOrderInDraft(APITestMixin):
                     'is_lead': True
                 }
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -284,7 +283,6 @@ class TestChangeAssigneesWhenOrderInDraft(APITestMixin):
                     'estimated_time': 250
                 }
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -353,7 +351,6 @@ class TestChangeAssigneesWhenOrderInDraft(APITestMixin):
                     'is_lead': assignee1.is_lead
                 }
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -438,7 +435,6 @@ class TestChangeAssigneesWhenOrderInDraft(APITestMixin):
                     'estimated_time': 300
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -484,7 +480,6 @@ class TestChangeAssigneesWhenOrderInDraft(APITestMixin):
                     'actual_time': 200,
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -569,7 +564,6 @@ class TestChangeAssigneesWhenOrderInDraft(APITestMixin):
                     'estimated_time': 0
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -597,7 +591,6 @@ class TestChangeAssigneesWhenOrderInDraft(APITestMixin):
             [{
                 'adviser': {'id': AdviserFactory().id}
             }],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_409_CONFLICT
@@ -662,7 +655,6 @@ class TestChangeAssigneesWhenOrderInPaid(APITestMixin):
                     'actual_time': 100
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -709,7 +701,6 @@ class TestChangeAssigneesWhenOrderInPaid(APITestMixin):
                     'adviser': {'id': assignee.adviser.id},
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -763,7 +754,6 @@ class TestChangeAssigneesWhenOrderInPaid(APITestMixin):
                     'actual_time': 220
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -818,7 +808,6 @@ class TestChangeAssigneesWhenOrderInPaid(APITestMixin):
                     **data
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -859,7 +848,6 @@ class TestChangeAssigneesWhenOrderInPaid(APITestMixin):
                     **data
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -929,7 +917,6 @@ class TestChangeAssigneesWhenOrderInOtherAllowedStatuses(APITestMixin):
                     'adviser': {'id': new_adviser.id},
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -982,7 +969,6 @@ class TestChangeAssigneesWhenOrderInOtherAllowedStatuses(APITestMixin):
                     'adviser': {'id': assignee.adviser.id},
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -1025,7 +1011,6 @@ class TestChangeAssigneesWhenOrderInOtherAllowedStatuses(APITestMixin):
                     **data
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -1070,7 +1055,6 @@ class TestChangeAssigneesWhenOrderInOtherAllowedStatuses(APITestMixin):
                     **data
                 },
             ],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/datahub/omis/order/test/views/test_order_details.py
+++ b/datahub/omis/order/test/views/test_order_details.py
@@ -66,7 +66,6 @@ class TestAddOrder(APITestMixin):
                 'billing_address_postcode': 'SW1A1AA',
                 'billing_address_country': Country.united_kingdom.value.id,
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -165,7 +164,6 @@ class TestAddOrder(APITestMixin):
                 'contact': {'id': contact.pk},
                 'primary_market': {'id': country.id},
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -214,7 +212,6 @@ class TestAddOrder(APITestMixin):
                 'contact': {'id': contact.pk},
                 'primary_market': {'id': country.id},
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -225,7 +222,7 @@ class TestAddOrder(APITestMixin):
     def test_general_validation(self):
         """Test create an Order general validation."""
         url = reverse('api-v3:omis:order:list')
-        response = self.api_client.post(url, {}, format='json')
+        response = self.api_client.post(url, {})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -251,7 +248,6 @@ class TestAddOrder(APITestMixin):
                     {'id': disabled_service_type.pk},
                 ],
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -272,7 +268,6 @@ class TestAddOrder(APITestMixin):
                 'contact': {'id': ContactFactory(company=company).pk},
                 'primary_market': {'id': disabled_country.pk}
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -299,7 +294,6 @@ class TestAddOrder(APITestMixin):
                 'contact': {'id': ContactFactory(company=company).pk},
                 'primary_market': {'id': non_market_country.pk}
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -331,7 +325,6 @@ class TestAddOrder(APITestMixin):
                 'contact_email': 'JohnDoe@example.com',
                 'contact_phone': '0123456789',
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -368,7 +361,6 @@ class TestAddOrder(APITestMixin):
                 'vat_number': '0123456789',
                 'vat_verified': True,
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -394,7 +386,6 @@ class TestAddOrder(APITestMixin):
                 'primary_market': {'id': country.id},
                 'billing_address_2': 'London Street',
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -423,7 +414,7 @@ class TestGeneralChangeOrder(APITestMixin):
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
         response = self.api_client.patch(
-            url, {'description': 'Updated description'}, format='json'
+            url, {'description': 'Updated description'}
         )
 
         order.refresh_from_db()
@@ -443,7 +434,6 @@ class TestGeneralChangeOrder(APITestMixin):
             {
                 'contact': {'id': other_contact.pk},
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -461,7 +451,6 @@ class TestGeneralChangeOrder(APITestMixin):
             {
                 'contact': {'id': '00000000-0000-0000-0000-000000000000'},
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -485,7 +474,6 @@ class TestGeneralChangeOrder(APITestMixin):
                     {'id': disabled_service_type.pk},
                 ]
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -523,7 +511,6 @@ class TestGeneralChangeOrder(APITestMixin):
                     {'id': disabled_in_feb.pk},
                 ]
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -566,7 +553,6 @@ class TestGeneralChangeOrder(APITestMixin):
                 'billing_email': 'JohnDoe@example.com',
                 'billing_phone': '0123456789',
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -612,7 +598,6 @@ class TestGeneralChangeOrder(APITestMixin):
         response = self.api_client.patch(
             url,
             {'vat_status': vat_status},
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -639,7 +624,6 @@ class TestGeneralChangeOrder(APITestMixin):
             {
                 'billing_address_2': 'London Street',
             },
-            format='json'
         )
 
         order.refresh_from_db()
@@ -692,7 +676,6 @@ class TestChangeOrderInDraft(APITestMixin):
                 'billing_address_postcode': 'SW1A1AA',
                 'billing_address_country': Country.united_kingdom.value.id,
             },
-            format='json'
         )
 
         order.refresh_from_db()
@@ -790,7 +773,7 @@ class TestChangeOrderInDraft(APITestMixin):
         value = value(order) if callable(value) else value
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, {field: value}, format='json')
+        response = self.api_client.patch(url, {field: value})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {field: ['This field cannot be changed at this stage.']}
 
@@ -805,7 +788,6 @@ class TestChangeOrderInDraft(APITestMixin):
                 'company': order.company.pk,
                 'primary_market': order.primary_market.pk
             },
-            format='json'
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -848,7 +830,7 @@ class TestChangeOrderInQuoteStatuses(APITestMixin):
         }
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, data, format='json')
+        response = self.api_client.patch(url, data)
         assert response.status_code == status.HTTP_200_OK
         assert {
             k: v for k, v in response.json().items() if k in data
@@ -896,7 +878,7 @@ class TestChangeOrderInQuoteStatuses(APITestMixin):
         value = value(order) if callable(value) else value
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, {field: value}, format='json')
+        response = self.api_client.patch(url, {field: value})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {field: ['This field cannot be changed at this stage.']}
 
@@ -927,7 +909,6 @@ class TestChangeOrderInQuoteStatuses(APITestMixin):
                 'description': order.description,
                 'delivery_date': order.delivery_date.isoformat(),
             },
-            format='json'
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -959,7 +940,7 @@ class TestChangeOrderInQuoteStatuses(APITestMixin):
         old_invoice = order.invoice
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, {field: value}, format='json')
+        response = self.api_client.patch(url, {field: value})
         assert response.status_code == status.HTTP_200_OK
 
         order.refresh_from_db()
@@ -984,7 +965,7 @@ class TestChangeOrderInQuoteStatuses(APITestMixin):
         old_invoice = order.invoice
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, {'vat_verified': False}, format='json')
+        response = self.api_client.patch(url, {'vat_verified': False})
         assert response.status_code == status.HTTP_200_OK
 
         order.refresh_from_db()
@@ -1032,7 +1013,7 @@ class TestChangeOrderInQuoteStatuses(APITestMixin):
             for field, value in data.items()
         }
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, data, format='json')
+        response = self.api_client.patch(url, data)
         assert response.status_code == status.HTTP_200_OK
 
         order.refresh_from_db()
@@ -1052,7 +1033,7 @@ class TestChangeOrderInPaid(APITestMixin):
         }
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, data, format='json')
+        response = self.api_client.patch(url, data)
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['contact'] == {
             'id': str(new_contact.pk),
@@ -1095,7 +1076,7 @@ class TestChangeOrderInPaid(APITestMixin):
         value = value(order) if callable(value) else value
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, {field: value}, format='json')
+        response = self.api_client.patch(url, {field: value})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {field: ['This field cannot be changed at this stage.']}
 
@@ -1131,7 +1112,6 @@ class TestChangeOrderInPaid(APITestMixin):
                 'vat_verified': order.vat_verified,
                 'po_number': order.po_number,
             },
-            format='json'
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -1184,7 +1164,7 @@ class TestChangeOrderInEndStatuses(APITestMixin):
         value = value(order) if callable(value) else value
 
         url = reverse('api-v3:omis:order:detail', kwargs={'pk': order.pk})
-        response = self.api_client.patch(url, {field: value}, format='json')
+        response = self.api_client.patch(url, {field: value})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {field: ['This field cannot be changed at this stage.']}
 
@@ -1229,7 +1209,6 @@ class TestChangeOrderInEndStatuses(APITestMixin):
 
                 'contact': order.contact.pk,
             },
-            format='json'
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -1248,7 +1227,7 @@ class TestMarkOrderAsComplete(APITestMixin):
         OrderAssigneeCompleteFactory(order=order)
 
         url = reverse('api-v3:omis:order:complete', kwargs={'pk': order.pk})
-        response = self.api_client.post(url, {}, format='json')
+        response = self.api_client.post(url, {})
 
         expected_completed_on = dateutil_parse('2017-04-18T13:00Z')
         assert response.status_code == status.HTTP_200_OK
@@ -1282,7 +1261,7 @@ class TestMarkOrderAsComplete(APITestMixin):
         OrderAssigneeCompleteFactory(order=order)
 
         url = reverse('api-v3:omis:order:complete', kwargs={'pk': order.pk})
-        response = self.api_client.post(url, {}, format='json')
+        response = self.api_client.post(url, {})
 
         assert response.status_code == status.HTTP_409_CONFLICT
         order.refresh_from_db()
@@ -1298,7 +1277,7 @@ class TestMarkOrderAsComplete(APITestMixin):
         OrderAssigneeFactory(order=order)
 
         url = reverse('api-v3:omis:order:complete', kwargs={'pk': order.pk})
-        response = self.api_client.post(url, {}, format='json')
+        response = self.api_client.post(url, {})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -1329,7 +1308,6 @@ class TestCancelOrder(APITestMixin):
                     'id': reason.pk
                 }
             },
-            format='json'
         )
 
         expected_cancelled_on = dateutil_parse('2017-04-18T13:00Z')
@@ -1375,7 +1353,6 @@ class TestCancelOrder(APITestMixin):
                     'id': reason.pk
                 }
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_409_CONFLICT
@@ -1404,7 +1381,7 @@ class TestCancelOrder(APITestMixin):
         order = OrderFactory(status=OrderStatus.draft)
 
         url = reverse('api-v3:omis:order:cancel', kwargs={'pk': order.pk})
-        response = self.api_client.post(url, data, format='json')
+        response = self.api_client.post(url, data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == errors

--- a/datahub/omis/order/test/views/test_subscriber_list.py
+++ b/datahub/omis/order/test/views/test_subscriber_list.py
@@ -25,7 +25,7 @@ class TestGetSubscriberList(APITestMixin):
             'api-v3:omis:order:subscriber-list',
             kwargs={'order_pk': order.id}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
@@ -43,7 +43,7 @@ class TestGetSubscriberList(APITestMixin):
             'api-v3:omis:order:subscriber-list',
             kwargs={'order_pk': order.id}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
@@ -70,7 +70,7 @@ class TestGetSubscriberList(APITestMixin):
             'api-v3:omis:order:subscriber-list',
             kwargs={'order_pk': '00000000-0000-0000-0000-000000000000'}
         )
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -93,7 +93,6 @@ class TestChangeSubscriberList(APITestMixin):
         response = self.api_client.put(
             url,
             [{'id': adviser.id} for adviser in advisers],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -134,7 +133,6 @@ class TestChangeSubscriberList(APITestMixin):
         response = self.api_client.put(
             url,
             [{'id': adviser.id} for adviser in final_advisers],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -164,7 +162,7 @@ class TestChangeSubscriberList(APITestMixin):
             'api-v3:omis:order:subscriber-list',
             kwargs={'order_pk': order.id}
         )
-        response = self.api_client.put(url, [], format='json')
+        response = self.api_client.put(url, [])
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
@@ -186,7 +184,7 @@ class TestChangeSubscriberList(APITestMixin):
             'id': '00000000-0000-0000-0000-000000000000'
         })
 
-        response = self.api_client.put(url, data, format='json')
+        response = self.api_client.put(url, data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == [
@@ -214,7 +212,6 @@ class TestChangeSubscriberList(APITestMixin):
         response = self.api_client.put(
             url,
             [{'id': AdviserFactory().id}],
-            format='json'
         )
 
         assert response.status_code == status.HTTP_409_CONFLICT

--- a/datahub/omis/payment/test/views/test_payments.py
+++ b/datahub/omis/payment/test/views/test_payments.py
@@ -26,7 +26,7 @@ class TestGetPayments(APITestMixin):
         PaymentFactory.create_batch(5)  # create some extra ones not linked to `order`
 
         url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
             {
@@ -44,7 +44,7 @@ class TestGetPayments(APITestMixin):
     def test_404_if_order_doesnt_exist(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': uuid.uuid4()})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -54,7 +54,7 @@ class TestGetPayments(APITestMixin):
         PaymentFactory.create_batch(5)  # create some payments not linked to `order`
 
         url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == []
@@ -90,7 +90,6 @@ class TestCreatePayments(APITestMixin):
                     'received_on': '2017-04-21'
                 }
             ],
-            format='json'
         )
         assert response.status_code == status.HTTP_201_CREATED
         response_items = sorted(response.json(), key=itemgetter('transaction_reference'))
@@ -164,7 +163,7 @@ class TestCreatePayments(APITestMixin):
         order = OrderWithAcceptedQuoteFactory()
 
         url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': order.pk})
-        response = self.api_client.post(url, data, format='json')
+        response = self.api_client.post(url, data)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == errors
 
@@ -190,7 +189,6 @@ class TestCreatePayments(APITestMixin):
                     'received_on': '2017-04-21'
                 }
             ],
-            format='json'
         )
         assert response.status_code == status.HTTP_201_CREATED
 
@@ -211,11 +209,11 @@ class TestCreatePayments(APITestMixin):
         order = OrderFactory(status=disallowed_status)
 
         url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': order.pk})
-        response = self.api_client.post(url, [], format='json')
+        response = self.api_client.post(url, [])
         assert response.status_code == status.HTTP_409_CONFLICT
 
     def test_404_if_order_doesnt_exist(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse('api-v3:omis:payment:collection', kwargs={'order_pk': uuid.uuid4()})
-        response = self.api_client.post(url, [], format='json')
+        response = self.api_client.post(url, [])
         assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/datahub/omis/payment/test/views/test_public_payment_gateway_sessions.py
+++ b/datahub/omis/payment/test/views/test_public_payment_gateway_sessions.py
@@ -71,7 +71,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_201_CREATED
 
         # check payment gateway session record created
@@ -177,7 +177,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_201_CREATED
 
         # check sessions cancelled
@@ -245,7 +245,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
         # check no session created
@@ -282,7 +282,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
         # check no session created
@@ -310,7 +310,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json() == {
             'detail': (
@@ -374,7 +374,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_409_CONFLICT
 
         # check session record
@@ -409,7 +409,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_404_if_order_doesnt_exist(self):
@@ -422,7 +422,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.parametrize('verb', ('get', 'patch', 'delete'))
@@ -457,7 +457,7 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
             scope=scope,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @freeze_time('2018-03-01 00:00:00')
@@ -511,10 +511,10 @@ class TestPublicCreatePaymentGatewaySession(APITestMixin):
 
         # the 4th time it should error
         for dummy in range(3):
-            response = client.post(url, format='json')
+            response = client.post(url)
             assert response.status_code == status.HTTP_201_CREATED
 
-        response = client.post(url, format='json')
+        response = client.post(url)
         assert response.status_code == status.HTTP_429_TOO_MANY_REQUESTS
 
 
@@ -570,7 +570,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
         # check API response
@@ -606,7 +606,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
         # check API response
@@ -665,7 +665,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
         # refresh record
@@ -731,7 +731,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
         # check API response
@@ -781,7 +781,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
 
     @pytest.mark.parametrize(
@@ -806,7 +806,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_404_if_order_doesnt_exist(self):
@@ -822,7 +822,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_404_if_session_doesnt_exist(self):
@@ -839,7 +839,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     def test_404_if_session_belongs_to_another_order(self):
@@ -860,7 +860,7 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.parametrize('verb', ('post', 'patch', 'delete'))
@@ -897,5 +897,5 @@ class TestPublicGetPaymentGatewaySession(APITestMixin):
             scope=scope,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/omis/payment/test/views/test_public_payments.py
+++ b/datahub/omis/payment/test/views/test_public_payments.py
@@ -36,7 +36,7 @@ class TestPublicGetPayments(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == [
@@ -62,7 +62,7 @@ class TestPublicGetPayments(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 

--- a/datahub/omis/quote/test/views/test_public_quote_details.py
+++ b/datahub/omis/quote/test/views/test_public_quote_details.py
@@ -40,7 +40,7 @@ class TestPublicGetQuote(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         quote = order.quote
         assert response.status_code == status.HTTP_200_OK
@@ -68,7 +68,7 @@ class TestPublicGetQuote(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['terms_and_conditions'] == ''
@@ -88,7 +88,7 @@ class TestPublicGetQuote(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         quote = order.quote
         assert response.status_code == status.HTTP_200_OK
@@ -111,7 +111,7 @@ class TestPublicGetQuote(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -128,7 +128,7 @@ class TestPublicGetQuote(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.get(url, format='json')
+        response = client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -207,7 +207,7 @@ class TestAcceptOrder(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -239,7 +239,7 @@ class TestAcceptOrder(APITestMixin):
             scope=Scope.public_omis_front_end,
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
-        response = client.post(url, format='json')
+        response = client.post(url)
 
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json() == {
@@ -264,7 +264,7 @@ class TestAcceptOrder(APITestMixin):
             grant_type=Application.GRANT_CLIENT_CREDENTIALS
         )
         with freeze_time('2017-07-12 13:00'):
-            response = client.post(url, format='json')
+            response = client.post(url)
 
             assert response.status_code == status.HTTP_200_OK
             assert response.json() == {

--- a/datahub/omis/quote/test/views/test_quote_details.py
+++ b/datahub/omis/quote/test/views/test_quote_details.py
@@ -31,7 +31,7 @@ class TestCreatePreviewOrder(APITestMixin):
             f'api-v3:omis:quote:{quote_view_name}',
             kwargs={'order_pk': uuid.uuid4()}
         )
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -44,7 +44,7 @@ class TestCreatePreviewOrder(APITestMixin):
             f'api-v3:omis:quote:{quote_view_name}',
             kwargs={'order_pk': order.pk}
         )
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json() == {'detail': "There's already an active quote."}
@@ -70,7 +70,7 @@ class TestCreatePreviewOrder(APITestMixin):
             f'api-v3:omis:quote:{quote_view_name}',
             kwargs={'order_pk': order.pk}
         )
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json() == {
@@ -98,7 +98,7 @@ class TestCreatePreviewOrder(APITestMixin):
             f'api-v3:omis:quote:{quote_view_name}',
             kwargs={'order_pk': order.pk}
         )
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -120,7 +120,7 @@ class TestCreatePreviewOrder(APITestMixin):
             f'api-v3:omis:quote:{quote_view_name}',
             kwargs={'order_pk': order.pk}
         )
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -143,7 +143,7 @@ class TestCreatePreviewOrder(APITestMixin):
         orig_quote = order.quote
 
         url = reverse('api-v3:omis:quote:detail', kwargs={'order_pk': order.pk})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         order.refresh_from_db()
         assert response.status_code == status.HTTP_201_CREATED
@@ -180,7 +180,7 @@ class TestCreatePreviewOrder(APITestMixin):
             mocked_save.side_effect = Exception()
 
             with pytest.raises(Exception):
-                self.api_client.post(url, format='json')
+                self.api_client.post(url)
 
         order.refresh_from_db()
         assert not order.quote
@@ -202,7 +202,7 @@ class TestCreatePreviewOrder(APITestMixin):
         orig_quote = order.quote
 
         url = reverse('api-v3:omis:quote:preview', kwargs={'order_pk': order.pk})
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert order.reference in response.json()['content']
@@ -231,7 +231,7 @@ class TestGetQuote(APITestMixin):
         quote = order.quote
 
         url = reverse('api-v3:omis:quote:detail', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {
@@ -259,7 +259,7 @@ class TestGetQuote(APITestMixin):
         )
 
         url = reverse('api-v3:omis:quote:detail', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['terms_and_conditions'] == ''
@@ -267,7 +267,7 @@ class TestGetQuote(APITestMixin):
     def test_404_if_order_doesnt_exist(self):
         """Test that if the order doesn't exist, the endpoint returns 404."""
         url = reverse('api-v3:omis:quote:detail', kwargs={'order_pk': uuid.uuid4()})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -277,7 +277,7 @@ class TestGetQuote(APITestMixin):
         assert not order.quote
 
         url = reverse('api-v3:omis:quote:detail', kwargs={'order_pk': order.pk})
-        response = self.api_client.get(url, format='json')
+        response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -291,7 +291,7 @@ class TestCancelOrder(APITestMixin):
             f'api-v3:omis:quote:cancel',
             kwargs={'order_pk': uuid.uuid4()}
         )
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -317,7 +317,7 @@ class TestCancelOrder(APITestMixin):
             f'api-v3:omis:quote:cancel',
             kwargs={'order_pk': order.pk}
         )
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.json() == {
@@ -335,7 +335,7 @@ class TestCancelOrder(APITestMixin):
             f'api-v3:omis:quote:cancel',
             kwargs={'order_pk': order.pk}
         )
-        response = self.api_client.post(url, format='json')
+        response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -349,7 +349,7 @@ class TestCancelOrder(APITestMixin):
             kwargs={'order_pk': order.pk}
         )
         with freeze_time('2017-07-12 13:00') as mocked_now:
-            response = self.api_client.post(url, format='json')
+            response = self.api_client.post(url)
 
             assert response.status_code == status.HTTP_200_OK
             assert response.json() == {

--- a/datahub/search/companieshousecompany/tests/test_views.py
+++ b/datahub/search/companieshousecompany/tests/test_views.py
@@ -133,7 +133,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
         """Test search results."""
         url = reverse('api-v3:search:companieshousecompany')
 
-        response = self.api_client.post(url, data, format='json')
+        response = self.api_client.post(url, data)
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == len(results)
         assert {
@@ -147,7 +147,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
         response = self.api_client.post(url, {
             'incorporation_date_after': 'invalid',
             'incorporation_date_before': 'invalid',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -181,7 +181,6 @@ class TestSearch(APITestMixin):
         response = self.api_client.post(
             url,
             query,
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -275,7 +274,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'country': country,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         if match:
@@ -307,7 +306,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'name': name,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         if match:
@@ -329,7 +328,7 @@ class TestSearch(APITestMixin):
         response = self.api_client.post(url, {
             'original_query': term,
             'trading_address_country': [united_states_id, united_kingdom_id],
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -395,7 +394,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'uk_region': None,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'uk_region': ['This field may not be null.']}
@@ -472,7 +471,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'uk_based': False,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -496,7 +495,7 @@ class TestCompanyExportView(APITestMixin):
         api_client = self.create_api_client(user=user)
 
         url = reverse('api-v3:search:company-export')
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(
@@ -526,7 +525,7 @@ class TestCompanyExportView(APITestMixin):
         url = reverse('api-v3:search:company-export')
 
         with freeze_time('2018-01-01 11:12:13'):
-            response = self.api_client.post(url, format='json', data=data)
+            response = self.api_client.post(url, data=data)
 
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -285,7 +285,7 @@ class TestSearch(APITestMixin):
         request_data = {
             'created_on_exists': created_on_exists,
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -434,7 +434,7 @@ class TestContactExportView(APITestMixin):
         api_client = self.create_api_client(user=user)
 
         url = reverse('api-v3:search:contact-export')
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(
@@ -472,7 +472,7 @@ class TestContactExportView(APITestMixin):
         url = reverse('api-v3:search:contact-export')
 
         with freeze_time('2018-01-01 11:12:13'):
-            response = self.api_client.post(url, format='json', data=data)
+            response = self.api_client.post(url, data=data)
 
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})

--- a/datahub/search/event/tests/test_views.py
+++ b/datahub/search/event/tests/test_views.py
@@ -165,7 +165,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'lead_team': team.id,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 5
@@ -190,7 +190,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'teams': (team_a.id, team_c.id,)
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 6
@@ -218,7 +218,7 @@ class TestSearch(APITestMixin):
                 'exists': False,
                 'after': current_datetime,
             },
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 7
@@ -241,7 +241,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'disabled_on_exists': False,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 5
@@ -262,7 +262,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'disabled_on_exists': True,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         # We should get at least 5 disabled events, as some already exist

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -113,7 +113,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         """
         url = reverse('api-v3:search:interaction')
 
-        response = self.api_client.post(url, {}, format='json')
+        response = self.api_client.post(url, {})
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -134,7 +134,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
 
         api_client = self.create_api_client(user=non_policy_feedback_user)
-        response = api_client.post(url, {}, format='json')
+        response = api_client.post(url, {})
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -152,7 +152,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
 
         api_client = self.create_api_client(user=policy_feedback_user)
-        response = api_client.post(url, {}, format='json')
+        response = api_client.post(url, {})
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -168,7 +168,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'limit': 1
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -181,7 +181,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'offset': 1
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -204,7 +204,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         )
         setup_es.indices.refresh()
 
-        response = self.api_client.post(url, {}, format='json')
+        response = self.api_client.post(url, {})
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -221,7 +221,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'sortby': 'subject:asc'
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -237,7 +237,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'sortby': 'subject:desc'
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -253,7 +253,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'sortby': 'gyratory:backwards'
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -273,7 +273,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'original_query': term
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -343,7 +343,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'kind': Interaction.KINDS.service_delivery,
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -368,7 +368,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'company': companies[5].id
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -394,7 +394,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'company_name': getattr(companies[5], attr)
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -420,7 +420,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'contact': contacts[5].id
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -444,7 +444,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'contact_name': contacts[5].name
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -475,7 +475,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'created_on_exists': created_on_exists,
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -499,7 +499,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'dit_adviser': advisers[5].id
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -526,7 +526,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'dit_adviser_name': advisers[5].name
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -551,7 +551,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'dit_team': dit_team_id
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -580,7 +580,7 @@ class TestInteractionEntitySearchView(APITestMixin):
             'original_query': '',
             'communication_channel': communication_channels[1].pk
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -609,7 +609,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         request_data = {
             'service': service_id
         }
-        response = self.api_client.post(url, request_data, format='json')
+        response = self.api_client.post(url, request_data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -655,7 +655,7 @@ class TestInteractionEntitySearchView(APITestMixin):
     def test_filter_by_date(self, interactions, data, results):
         """Tests filtering interaction by date."""
         url = reverse('api-v3:search:interaction')
-        response = self.api_client.post(url, data, format='json')
+        response = self.api_client.post(url, data)
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -782,7 +782,7 @@ class TestInteractionExportView(APITestMixin):
         api_client = self.create_api_client(user=user)
 
         url = reverse('api-v3:search:interaction-export')
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_policy_feedback_excluded_for_non_policy_feedback_user(
@@ -798,7 +798,7 @@ class TestInteractionExportView(APITestMixin):
 
         api_client = self.create_api_client(user=non_policy_feedback_user)
         url = reverse('api-v3:search:interaction-export')
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
 
         reader = DictReader(StringIO(response.getvalue().decode('utf-8-sig')))
@@ -838,7 +838,7 @@ class TestInteractionExportView(APITestMixin):
         api_client = self.create_api_client(user=policy_feedback_user)
 
         with freeze_time('2018-01-01 11:12:13'):
-            response = api_client.post(url, format='json', data=data)
+            response = api_client.post(url, data=data)
 
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -123,7 +123,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'original_query': 'abc defg',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -164,7 +164,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'adviser': adviser.pk,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -214,7 +214,7 @@ class TestSearch(APITestMixin):
         """Tests detailed investment project search."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, query, format='json')
+        response = self.api_client.post(url, query)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == num_results
@@ -295,7 +295,7 @@ class TestSearch(APITestMixin):
         """Tests the actual land date filter."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, query, format='json')
+        response = self.api_client.post(url, query)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == len(expected_results)
@@ -348,7 +348,7 @@ class TestSearch(APITestMixin):
         """Tests detailed investment project search."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, query, format='json')
+        response = self.api_client.post(url, query)
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == num_results
@@ -370,7 +370,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'estimated_land_date_before': 'this is definitely not a valid date',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -380,7 +380,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'status': ['delayed', 'won'],
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -394,7 +394,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'investor_company_country': constants.Country.japan.value.id,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -407,7 +407,7 @@ class TestSearch(APITestMixin):
 
         response = self.api_client.post(url, {
             'uk_region_location': constants.UKRegion.east_midlands.value.id,
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -499,7 +499,7 @@ class TestSearch(APITestMixin):
                 constants.InvestmentProjectStage.won.value.id,
                 constants.InvestmentProjectStage.active.value.id,
             ],
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -560,7 +560,7 @@ class TestSearch(APITestMixin):
                 constants.InvestmentProjectStage.prospect.value.id,
                 constants.InvestmentProjectStage.active.value.id,
             ],
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 3
@@ -610,7 +610,7 @@ class TestSearchPermissions(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:investment_project')
-        response = api_client.post(url, {}, format='json')
+        response = api_client.post(url, {})
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -637,7 +637,7 @@ class TestSearchPermissions(APITestMixin):
 
         setup_es.indices.refresh()
 
-        response = api_client.post(url, {}, format='json')
+        response = api_client.post(url, {})
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -669,7 +669,7 @@ class TestSearchPermissions(APITestMixin):
 
         setup_es.indices.refresh()
 
-        response = api_client.post(url, {}, format='json')
+        response = api_client.post(url, {})
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -703,7 +703,7 @@ class TestInvestmentProjectExportView(APITestMixin):
         api_client = self.create_api_client(user=user)
 
         url = reverse('api-v3:search:investment_project-export')
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_restricted_users_cannot_see_other_teams_projects(self, setup_es):
@@ -739,7 +739,7 @@ class TestInvestmentProjectExportView(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:investment_project-export')
-        response = api_client.post(url, {}, format='json')
+        response = api_client.post(url, {})
 
         assert response.status_code == status.HTTP_200_OK
 
@@ -777,7 +777,7 @@ class TestInvestmentProjectExportView(APITestMixin):
             data['sortby'] = request_sortby
 
         with freeze_time('2018-01-01 11:12:13'):
-            response = self.api_client.post(url, format='json', data=data)
+            response = self.api_client.post(url, data=data)
 
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Disposition')) == (

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -266,7 +266,7 @@ class TestSearchOrder(APITestMixin):
         """Test search results."""
         url = reverse('api-v3:search:order')
 
-        response = self.api_client.post(url, data, format='json')
+        response = self.api_client.post(url, data)
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == len(results)
@@ -282,7 +282,6 @@ class TestSearchOrder(APITestMixin):
             url, {
                 'company': Company.objects.get(name='Venus Ltd').pk
             },
-            format='json'
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -295,7 +294,7 @@ class TestSearchOrder(APITestMixin):
 
         response = self.api_client.post(url, {
             'created_on_before': 'invalid',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'created_on_before': ['Date is in incorrect format.']}
@@ -309,7 +308,7 @@ class TestSearchOrder(APITestMixin):
 
         response = self.api_client.post(url, {
             'primary_market': 'invalid',
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'primary_market': ['"invalid" is not a valid UUID.']}
@@ -358,7 +357,7 @@ class TestSearchOrder(APITestMixin):
 
         response = self.api_client.post(url, {
             'assigned_to_adviser': assignee.adviser.pk
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == 1
@@ -372,7 +371,7 @@ class TestSearchOrder(APITestMixin):
 
         response = self.api_client.post(url, {
             'assigned_to_team': assignee.adviser.dit_team.pk
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == 1
@@ -395,7 +394,7 @@ class TestOrderExportView(APITestMixin):
         api_client = self.create_api_client(user=user)
 
         url = reverse('api-v3:search:order-export')
-        response = api_client.post(url, format='json')
+        response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(
@@ -456,7 +455,7 @@ class TestOrderExportView(APITestMixin):
         url = reverse('api-v3:search:order-export')
 
         with freeze_time('2018-01-01 11:12:13'):
-            response = self.api_client.post(url, format='json', data=data)
+            response = self.api_client.post(url, data=data)
 
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})
@@ -563,7 +562,7 @@ class TestGlobalSearch(APITestMixin):
             'term': term,
             'sortby': 'created_on:asc',
             'entity': 'order'
-        }, format='json')
+        })
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == len(results)


### PR DESCRIPTION
### Description of change

This sets the default format for DRF's APIClient to `'json'` so that we don't have to pass `format='json'` all the time in tests.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
