### PR TITLE
Add docs README pointing to all docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Development guides
+
+This page contains a non-exhaustive list of documents related to specific development topics. More documentation is always welcome.
+
+* [Document upload architectural design](./Document&#32;upload.md)
+* [How elasticsearch mapping migration works and how to use it](./Elasticsearch&#32;migrations.md)
+* [How to prepare a release](./How&#32;to&#32;prepare&#32;a&#32;release.md)


### PR DESCRIPTION
### Description of change

This adds a docs/README.md pointing to all the docs so that it's easily browsable online. 

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
