### PR TITLE
Add trailing commas to investment sub-apps

### DIFF
--- a/datahub/investment/evidence/models.py
+++ b/datahub/investment/evidence/models.py
@@ -63,7 +63,7 @@ class EvidenceDocument(AbstractEntityDocumentModel):
     investment_project = models.ForeignKey(
         'investment.InvestmentProject',
         on_delete=models.CASCADE,
-        related_name='evidence_documents'
+        related_name='evidence_documents',
     )
     comment = models.TextField(blank=True)
 
@@ -77,19 +77,19 @@ class EvidenceDocument(AbstractEntityDocumentModel):
         permissions = (
             (
                 EvidenceDocumentPermission.add_associated.value,
-                'Can add evidence document for associated investment projects'
+                'Can add evidence document for associated investment projects',
             ),
             (
                 EvidenceDocumentPermission.change_associated.value,
-                'Can change evidence document for associated investment projects'
+                'Can change evidence document for associated investment projects',
             ),
             (
                 EvidenceDocumentPermission.delete_associated.value,
-                'Can delete evidence document for associated investment projects'
+                'Can delete evidence document for associated investment projects',
             ),
             (
                 EvidenceDocumentPermission.view_associated.value,
-                'Can view evidence document for associated investment projects'
+                'Can view evidence document for associated investment projects',
             ),
         )
         default_permissions = (
@@ -106,7 +106,10 @@ class EvidenceDocument(AbstractEntityDocumentModel):
     @property
     def url(self):
         """Returns URL to download endpoint."""
-        return reverse('api-v3:investment:evidence-document:document-item-download', kwargs={
-            'project_pk': self.investment_project.pk,
-            'entity_document_pk': self.pk,
-        })
+        return reverse(
+            'api-v3:investment:evidence-document:document-item-download',
+            kwargs={
+                'project_pk': self.investment_project.pk,
+                'entity_document_pk': self.pk,
+            },
+        )

--- a/datahub/investment/evidence/permissions.py
+++ b/datahub/investment/evidence/permissions.py
@@ -3,7 +3,7 @@ from datahub.core.utils import StrEnum
 from datahub.investment.evidence.models import EvidenceDocument
 from datahub.investment.permissions import (
     InvestmentProjectAssociationCheckerBase,
-    IsAssociatedToInvestmentProjectPermissionMixin
+    IsAssociatedToInvestmentProjectPermissionMixin,
 )
 
 
@@ -25,7 +25,7 @@ class _EvidenceDocumentViewToActionMapping:
 
 class EvidenceDocumentModelPermissions(
     _EvidenceDocumentViewToActionMapping,
-    ViewBasedModelPermissions
+    ViewBasedModelPermissions,
 ):
     """Evidence Document model permissions class."""
 

--- a/datahub/investment/evidence/test/test_views.py
+++ b/datahub/investment/evidence/test/test_views.py
@@ -167,21 +167,27 @@ class TestEvidenceDocumentViews(APITestMixin):
             investment_project.created_by.dit_team = user.dit_team
             investment_project.created_by.save()
 
-        url = reverse('api-v3:investment:evidence-document:document-collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:evidence-document:document-collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
 
         api_client = self.create_api_client(user=user)
-        response = api_client.post(url, data={
-            'original_filename': 'test.txt',
-            'tags': [tag.pk for tag in evidence_tags],
-        })
+        response = api_client.post(
+            url,
+            data={
+                'original_filename': 'test.txt',
+                'tags': [tag.pk for tag in evidence_tags],
+            },
+        )
         response_data = response.json()
 
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response_data == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
@@ -205,7 +211,7 @@ class TestEvidenceDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'modified_by': None,
             'tags': [
@@ -236,7 +242,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-collection',
             kwargs={
                 'project_pk': investment_project.pk,
-            }
+            },
         )
         api_client = self.create_api_client(user=user)
         response = api_client.get(url)
@@ -246,7 +252,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response_data == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
@@ -269,7 +275,7 @@ class TestEvidenceDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'modified_by': None,
             'tags': [
@@ -294,8 +300,8 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-item',
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -305,7 +311,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response_data == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
@@ -325,7 +331,7 @@ class TestEvidenceDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'modified_by': None,
             'tags': [
@@ -352,8 +358,8 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-item',
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -362,22 +368,23 @@ class TestEvidenceDocumentViews(APITestMixin):
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response.json() == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.parametrize(
-        'av_clean,expected_status', (
+        'av_clean,expected_status',
+        (
             (True, status.HTTP_200_OK),
-            (False, status.HTTP_403_FORBIDDEN,)
-        )
+            (False, status.HTTP_403_FORBIDDEN),
+        ),
     )
     @pytest.mark.parametrize('permissions,associated,allowed', VIEW_PERMISSIONS)
     @patch('datahub.documents.models.sign_s3_url')
     def test_document_download(
-        self, sign_s3_url, permissions, associated, allowed, av_clean, expected_status
+        self, sign_s3_url, permissions, associated, allowed, av_clean, expected_status,
     ):
         """Tests download of individual document."""
         sign_s3_url.return_value = 'http://what'
@@ -391,7 +398,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
                 'entity_document_pk': entity_document.pk,
-            }
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -402,7 +409,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response_data == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
@@ -423,7 +430,7 @@ class TestEvidenceDocumentViews(APITestMixin):
                     'id': str(entity_document.created_by.pk),
                     'first_name': entity_document.created_by.first_name,
                     'last_name': entity_document.created_by.last_name,
-                    'name': entity_document.created_by.name
+                    'name': entity_document.created_by.name,
                 },
                 'modified_by': None,
                 'tags': [
@@ -450,7 +457,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
                 'entity_document_pk': entity_document.pk,
-            }
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -460,7 +467,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response_data == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
@@ -473,7 +480,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         virus_scan_document_apply_async,
         permissions,
         associated,
-        allowed
+        allowed,
     ):
         """Tests scheduling virus scan after upload completion.
 
@@ -487,8 +494,8 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-item-callback',
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -498,7 +505,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response_data == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
@@ -519,7 +526,7 @@ class TestEvidenceDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'modified_by': None,
             'tags': [
@@ -534,7 +541,7 @@ class TestEvidenceDocumentViews(APITestMixin):
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
         virus_scan_document_apply_async.assert_called_once_with(
-            args=(str(entity_document.document.pk), )
+            args=(str(entity_document.document.pk), ),
         )
 
     @pytest.mark.parametrize('permissions,associated,allowed', DELETE_PERMISSIONS)
@@ -551,8 +558,8 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-item',
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         document_pk = entity_document.document.pk
@@ -563,7 +570,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response.json() == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
@@ -581,8 +588,8 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-item',
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
         user = create_test_user(permission_codenames=[], dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
@@ -597,7 +604,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         delete_document,
         permissions,
         associated,
-        allowed
+        allowed,
     ):
         """Tests document deletion creates user event log."""
         user = create_test_user(permission_codenames=permissions, dit_team=TeamFactory())
@@ -610,8 +617,8 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-item',
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         document_pk = entity_document.document.pk
@@ -653,7 +660,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         if not allowed:
             assert response.status_code == status.HTTP_403_FORBIDDEN
             assert response.json() == {
-                'detail': 'You do not have permission to perform this action.'
+                'detail': 'You do not have permission to perform this action.',
             }
             return
 
@@ -680,7 +687,7 @@ class TestEvidenceDocumentViews(APITestMixin):
         mark_deletion_pending.side_effect = Exception('No way!')
         user = create_test_user(
             permission_codenames=(EvidenceDocumentPermission.delete_all,),
-            dit_team=TeamFactory()
+            dit_team=TeamFactory(),
         )
         entity_document = create_evidence_document(user, False)
         document = entity_document.document
@@ -691,8 +698,8 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-item',
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -709,8 +716,8 @@ class TestEvidenceDocumentViews(APITestMixin):
             'api-v3:investment:evidence-document:document-item-callback',
             kwargs={
                 'project_pk': entity_document.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         user = create_test_user(permission_codenames=[], dit_team=TeamFactory())
@@ -725,5 +732,5 @@ def _get_document_url(entity_document):
         kwargs={
             'project_pk': entity_document.investment_project.pk,
             'entity_document_pk': entity_document.pk,
-        }
+        },
     )

--- a/datahub/investment/evidence/test/utils.py
+++ b/datahub/investment/evidence/test/utils.py
@@ -8,7 +8,7 @@ def create_evidence_document(user=None, associated=False, investment_project=Non
     evidence_tags = EvidenceTagFactory.create_batch(2)
     if not investment_project:
         investment_project = InvestmentProjectFactory(
-            **{'created_by': user} if associated else {}
+            **{'created_by': user} if associated else {},
         )
     entity_document = EvidenceDocument.objects.create(
         investment_project_id=investment_project.pk,

--- a/datahub/investment/evidence/urls.py
+++ b/datahub/investment/evidence/urls.py
@@ -26,21 +26,21 @@ urlpatterns = [
     path(
         'evidence-document',
         evidence_document_collection,
-        name='document-collection'
+        name='document-collection',
     ),
     path(
         'evidence-document/<uuid:entity_document_pk>',
         evidence_document_item,
-        name='document-item'
+        name='document-item',
     ),
     path(
         'evidence-document/<uuid:entity_document_pk>/upload-callback',
         evidence_document_callback,
-        name='document-item-callback'
+        name='document-item-callback',
     ),
     path(
         'evidence-document/<uuid:entity_document_pk>/download',
         evidence_document_download,
-        name='document-item-download'
+        name='document-item-download',
     ),
 ]

--- a/datahub/investment/evidence/views.py
+++ b/datahub/investment/evidence/views.py
@@ -37,9 +37,9 @@ class EvidenceDocumentViewSet(BaseEntityDocumentModelViewSet):
         self._check_project_exists()
 
         return EvidenceDocument.objects.select_related(
-            'investment_project'
+            'investment_project',
         ).prefetch_related(
-            'tags'
+            'tags',
         ).filter(
             investment_project_id=self.kwargs['project_pk'],
         )

--- a/datahub/investment/proposition/models.py
+++ b/datahub/investment/proposition/models.py
@@ -13,7 +13,7 @@ from datahub.core.utils import StrEnum
 from datahub.documents.models import AbstractEntityDocumentModel, UPLOAD_STATUSES
 from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.investment.proposition.constants import (
-    FEATURE_FLAG_PROPOSITION_DOCUMENT, PropositionStatus
+    FEATURE_FLAG_PROPOSITION_DOCUMENT, PropositionStatus,
 )
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -109,15 +109,15 @@ class Proposition(BaseModel):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     investment_project = models.ForeignKey(
-        'investment.InvestmentProject', on_delete=models.CASCADE, related_name='proposition'
+        'investment.InvestmentProject', on_delete=models.CASCADE, related_name='proposition',
     )
     # adviser to whom a proposition is assigned
     adviser = models.ForeignKey(
-        'company.Advisor', on_delete=models.CASCADE, related_name='+'
+        'company.Advisor', on_delete=models.CASCADE, related_name='+',
     )
     deadline = models.DateField()
     status = models.CharField(
-        max_length=MAX_LENGTH, choices=PropositionStatus, default=PropositionStatus.ongoing
+        max_length=MAX_LENGTH, choices=PropositionStatus, default=PropositionStatus.ongoing,
     )
 
     name = models.CharField(max_length=MAX_LENGTH)
@@ -133,7 +133,7 @@ class Proposition(BaseModel):
         """Change status of a proposition."""
         if self.status != PropositionStatus.ongoing:
             raise APIConflictException(
-                f'The action cannot be performed in the current status {self.status}.'
+                f'The action cannot be performed in the current status {self.status}.',
             )
         self.status = status
         self.modified_by = by
@@ -152,7 +152,7 @@ class Proposition(BaseModel):
         if is_feature_flag_active(FEATURE_FLAG_PROPOSITION_DOCUMENT):
             if self.documents.filter(document__status=UPLOAD_STATUSES.virus_scanned).count() == 0:
                 raise ValidationError({
-                    'non_field_errors': ['Proposition has no documents uploaded.']
+                    'non_field_errors': ['Proposition has no documents uploaded.'],
                 })
         self._change_status(PropositionStatus.completed, by, details)
 
@@ -169,15 +169,15 @@ class Proposition(BaseModel):
         permissions = (
             (
                 PropositionPermission.view_associated.value,
-                'Can view proposition for associated investment projects'
+                'Can view proposition for associated investment projects',
             ),
             (
                 PropositionPermission.add_associated.value,
-                'Can add proposition for associated investment projects'
+                'Can add proposition for associated investment projects',
             ),
             (
                 PropositionPermission.change_associated.value,
-                'Can change proposition for associated investment projects'
+                'Can change proposition for associated investment projects',
             ),
         )
         default_permissions = (
@@ -204,19 +204,19 @@ class PropositionDocument(AbstractEntityDocumentModel):
         permissions = (
             (
                 PropositionDocumentPermission.add_associated.value,
-                'Can add proposition document for associated investment projects'
+                'Can add proposition document for associated investment projects',
             ),
             (
                 PropositionDocumentPermission.change_associated.value,
-                'Can change proposition document for associated investment projects'
+                'Can change proposition document for associated investment projects',
             ),
             (
                 PropositionDocumentPermission.delete_associated.value,
-                'Can delete proposition document for associated investment projects'
+                'Can delete proposition document for associated investment projects',
             ),
             (
                 PropositionDocumentPermission.view_associated.value,
-                'Can view proposition document for associated investment projects'
+                'Can view proposition document for associated investment projects',
             ),
         )
         default_permissions = (
@@ -229,8 +229,11 @@ class PropositionDocument(AbstractEntityDocumentModel):
     @property
     def url(self):
         """Returns URL to download endpoint."""
-        return reverse('api-v3:investment:proposition:document-item-download', kwargs={
-            'proposition_pk': self.proposition.pk,
-            'project_pk': self.proposition.investment_project.pk,
-            'entity_document_pk': self.pk,
-        })
+        return reverse(
+            'api-v3:investment:proposition:document-item-download',
+            kwargs={
+                'proposition_pk': self.proposition.pk,
+                'project_pk': self.proposition.investment_project.pk,
+                'entity_document_pk': self.pk,
+            },
+        )

--- a/datahub/investment/proposition/permissions.py
+++ b/datahub/investment/proposition/permissions.py
@@ -86,7 +86,7 @@ class _PropositionDocumentViewToActionMapping:
 
 class PropositionDocumentModelPermissions(
     _PropositionDocumentViewToActionMapping,
-    ViewBasedModelPermissions
+    ViewBasedModelPermissions,
 ):
     """Proposition Document model permissions class."""
 

--- a/datahub/investment/proposition/serializers.py
+++ b/datahub/investment/proposition/serializers.py
@@ -39,12 +39,12 @@ class CompletePropositionSerializer(serializers.ModelSerializer):
             # if proposition documents are not enabled, "details" field is mandatory
             if self.validated_data['details'] == '':
                 raise ValidationError({
-                    'details': ['This field may not be blank.']
+                    'details': ['This field may not be blank.'],
                 })
 
         self.instance.complete(
             by=self.context['current_user'],
-            details=self.validated_data['details']
+            details=self.validated_data['details'],
         )
         return self.instance
 
@@ -58,14 +58,14 @@ class AbandonPropositionSerializer(serializers.ModelSerializer):
             'details',
         )
         extra_kwargs = {
-            'details': {'allow_blank': False}
+            'details': {'allow_blank': False},
         }
 
     def abandon(self):
         """Abandon a proposition."""
         self.instance.abandon(
             by=self.context['current_user'],
-            details=self.validated_data['details']
+            details=self.validated_data['details'],
         )
         return self.instance
 
@@ -90,7 +90,7 @@ class PropositionDocumentSerializer(serializers.ModelSerializer):
             'url',
             'status',
         )
-        read_only_fields = ('url', 'created_on', )
+        read_only_fields = ('url', 'created_on')
 
     def create(self, validated_data):
         """Create proposition document."""

--- a/datahub/investment/proposition/test/test_views.py
+++ b/datahub/investment/proposition/test/test_views.py
@@ -14,10 +14,10 @@ from datahub.core.test_utils import APITestMixin, create_test_user, format_date_
 from datahub.documents.models import Document, UPLOAD_STATUSES
 from datahub.feature_flag.test.factories import FeatureFlagFactory
 from datahub.investment.proposition.constants import (
-    FEATURE_FLAG_PROPOSITION_DOCUMENT, PropositionStatus
+    FEATURE_FLAG_PROPOSITION_DOCUMENT, PropositionStatus,
 )
 from datahub.investment.proposition.models import (
-    Proposition, PropositionDocument, PropositionDocumentPermission, PropositionPermission
+    Proposition, PropositionDocument, PropositionDocumentPermission, PropositionPermission,
 )
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import TeamFactory
@@ -27,14 +27,14 @@ from .factories import PropositionFactory
 NON_RESTRICTED_VIEW_PERMISSIONS = (
     (
         PropositionPermission.view_all,
-        PropositionDocumentPermission.view_all
+        PropositionDocumentPermission.view_all,
     ),
     (
         PropositionPermission.view_all,
         PropositionDocumentPermission.view_all,
         PropositionPermission.view_associated,
         PropositionDocumentPermission.view_associated,
-    )
+    ),
 )
 
 
@@ -48,7 +48,7 @@ NON_RESTRICTED_ADD_PERMISSIONS = (
         PropositionDocumentPermission.add_all,
         PropositionPermission.add_associated,
         PropositionDocumentPermission.add_associated,
-    )
+    ),
 )
 
 
@@ -62,7 +62,7 @@ NON_RESTRICTED_CHANGE_PERMISSIONS = (
         PropositionDocumentPermission.change_all,
         PropositionPermission.change_associated,
         PropositionDocumentPermission.change_associated,
-    )
+    ),
 )
 
 
@@ -75,7 +75,7 @@ NON_RESTRICTED_DELETE_PERMISSIONS = (
         PropositionPermission.delete_all,
         PropositionDocumentPermission.delete_all,
         PropositionDocumentPermission.delete_associated,
-    )
+    ),
 )
 
 
@@ -93,9 +93,12 @@ class TestCreateProposition(APITestMixin):
         """Test creating proposition."""
         investment_project = InvestmentProjectFactory()
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
 
         adviser = create_test_user(
             permission_codenames=permissions,
@@ -153,9 +156,12 @@ class TestCreateProposition(APITestMixin):
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_ADD_PERMISSIONS)
     def test_cannot_create_proposition_for_non_existent_investment_project(self, permissions):
         """Test user cannot create proposition for non existent investment project."""
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': uuid.uuid4(),
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': uuid.uuid4(),
+            },
+        )
 
         adviser = create_test_user(
             permission_codenames=permissions,
@@ -180,9 +186,12 @@ class TestCreateProposition(APITestMixin):
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(created_by=project_creator)
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
 
         adviser = create_test_user(
             permission_codenames=[PropositionPermission.add_associated],
@@ -242,9 +251,12 @@ class TestCreateProposition(APITestMixin):
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(created_by=project_creator)
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
 
         adviser = create_test_user(
             permission_codenames=[PropositionPermission.add_associated],
@@ -263,16 +275,19 @@ class TestCreateProposition(APITestMixin):
         response_data = response.json()
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response_data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
     def test_cannot_created_with_fields_missing(self):
         """Test that proposition cannot be created without required fields."""
         investment_project = InvestmentProjectFactory()
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
         response = self.api_client.post(url, {})
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
@@ -289,31 +304,40 @@ class TestUpdateProposition(APITestMixin):
     """Tests for the update proposition view."""
 
     @pytest.mark.parametrize(
-        'method', ('put', 'patch',),
+        'method', ('put', 'patch'),
     )
     def test_cannot_update_collection(self, method):
         """Test cannot update proposition."""
         investment_project = InvestmentProjectFactory()
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
         response = getattr(self.api_client, method)(url)
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
     @pytest.mark.parametrize(
-        'method', ('put', 'patch',),
+        'method', ('put', 'patch'),
     )
     def test_cannot_update_item(self, method):
         """Test cannot update given proposition."""
         proposition = PropositionFactory()
         investment_project = InvestmentProjectFactory()
-        url = reverse('api-v3:investment:proposition:item', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': investment_project.pk,
-        })
-        response = getattr(self.api_client, method)(url, {
-            'name': 'hello!',
-        })
+        url = reverse(
+            'api-v3:investment:proposition:item',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': investment_project.pk,
+            },
+        )
+        response = getattr(self.api_client, method)(
+            url,
+            data={
+                'name': 'hello!',
+            },
+        )
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
 
@@ -327,12 +351,15 @@ class TestListPropositions(APITestMixin):
 
         PropositionFactory.create_batch(3)
         propositions = PropositionFactory.create_batch(
-            3, investment_project=investment_project
+            3, investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
 
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -348,9 +375,12 @@ class TestListPropositions(APITestMixin):
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
     def test_user_cannot_list_propositions_for_non_existent_investment_project(self, permissions):
         """Test user cannot list propositions for a non existent investment project."""
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': uuid.uuid4(),
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': uuid.uuid4(),
+            },
+        )
 
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -366,15 +396,18 @@ class TestListPropositions(APITestMixin):
 
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         propositions = PropositionFactory.create_batch(
-            3, investment_project=investment_project
+            3, investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
 
         user = create_test_user(
             permission_codenames=(
@@ -396,15 +429,18 @@ class TestListPropositions(APITestMixin):
         """Restricted user cannot list non associated investment project propositions."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         PropositionFactory.create_batch(
-            3, investment_project=investment_project
+            3, investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
 
         user = create_test_user(
             permission_codenames=(
@@ -418,7 +454,7 @@ class TestListPropositions(APITestMixin):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         response_data = response.json()
         assert response_data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
     def test_filtered_by_adviser(self):
@@ -427,7 +463,7 @@ class TestListPropositions(APITestMixin):
         investment_project = InvestmentProjectFactory()
 
         PropositionFactory.create_batch(
-            3, investment_project=investment_project
+            3, investment_project=investment_project,
         )
         propositions = PropositionFactory.create_batch(
             3,
@@ -435,12 +471,17 @@ class TestListPropositions(APITestMixin):
             investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
-        response = self.api_client.get(url, {
-            'adviser_id': adviser.id
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
+        response = self.api_client.get(
+            url, {
+                'adviser_id': adviser.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -455,7 +496,7 @@ class TestListPropositions(APITestMixin):
             PropositionStatus.ongoing,
             PropositionStatus.abandoned,
             PropositionStatus.completed,
-        )
+        ),
     )
     def test_filtered_by_status(self, proposition_status):
         """List of propositions filtered by status."""
@@ -471,12 +512,17 @@ class TestListPropositions(APITestMixin):
             investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:collection', kwargs={
-            'project_pk': investment_project.pk,
-        })
-        response = self.api_client.get(url, {
-            'status': proposition_status
-        })
+        url = reverse(
+            'api-v3:investment:proposition:collection',
+            kwargs={
+                'project_pk': investment_project.pk,
+            },
+        )
+        response = self.api_client.get(
+            url, {
+                'status': proposition_status,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -490,10 +536,13 @@ class TestGetProposition(APITestMixin):
     def test_fails_without_permissions(self, api_client):
         """Should return 401"""
         proposition = PropositionFactory()
-        url = reverse('api-v3:investment:proposition:item', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:item',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         response = api_client.get(url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -502,10 +551,13 @@ class TestGetProposition(APITestMixin):
         """Test get proposition by a non restricted user."""
         proposition = PropositionFactory()
 
-        url = reverse('api-v3:investment:proposition:item', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:item',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
         response = api_client.get(url)
@@ -523,7 +575,7 @@ class TestGetProposition(APITestMixin):
                 'first_name': proposition.adviser.first_name,
                 'last_name': proposition.adviser.last_name,
                 'name': proposition.adviser.name,
-                'id': str(proposition.adviser.pk)
+                'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
             'status': PropositionStatus.ongoing,
@@ -550,16 +602,19 @@ class TestGetProposition(APITestMixin):
         """Test get proposition by a restricted user."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:item', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:item',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         user = create_test_user(
             permission_codenames=(
                 PropositionPermission.view_associated,
@@ -582,7 +637,7 @@ class TestGetProposition(APITestMixin):
                 'first_name': proposition.adviser.first_name,
                 'last_name': proposition.adviser.last_name,
                 'name': proposition.adviser.name,
-                'id': str(proposition.adviser.pk)
+                'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
             'status': PropositionStatus.ongoing,
@@ -609,16 +664,19 @@ class TestGetProposition(APITestMixin):
         """Test get non associated ip proposition by a restricted user."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:item', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:item',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         user = create_test_user(
             permission_codenames=(
                 PropositionPermission.view_associated,
@@ -631,7 +689,7 @@ class TestGetProposition(APITestMixin):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         response_data = response.json()
         assert response_data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
@@ -639,10 +697,13 @@ class TestGetProposition(APITestMixin):
         """Test user cannot get proposition by a non restricted user."""
         proposition = PropositionFactory()
 
-        url = reverse('api-v3:investment:proposition:item', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': uuid.uuid4(),
-        })
+        url = reverse(
+            'api-v3:investment:proposition:item',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': uuid.uuid4(),
+            },
+        )
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
         response = api_client.get(url)
@@ -658,10 +719,13 @@ class TestDeleteProposition(APITestMixin):
     def test_fails_without_permissions(self, api_client):
         """Should return 401"""
         proposition = PropositionFactory()
-        url = reverse('api-v3:investment:proposition:item', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:item',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         response = api_client.delete(url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -670,10 +734,13 @@ class TestDeleteProposition(APITestMixin):
         """Test that non restricted user cannot delete proposition."""
         proposition = PropositionFactory()
 
-        url = reverse('api-v3:investment:proposition:item', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:item',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
         response = api_client.delete(url)
@@ -698,10 +765,13 @@ class TestCompleteProposition(APITestMixin):
         )
         entity_document.document.mark_as_scanned(True, '')
 
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         api_client = self.create_api_client(user=user)
         response = api_client.post(url)
@@ -714,13 +784,13 @@ class TestCompleteProposition(APITestMixin):
             'investment_project': {
                 'name': proposition.investment_project.name,
                 'project_code': proposition.investment_project.project_code,
-                'id': str(proposition.investment_project.pk)
+                'id': str(proposition.investment_project.pk),
             },
             'adviser': {
                 'first_name': proposition.adviser.first_name,
                 'last_name': proposition.adviser.last_name,
                 'name': proposition.adviser.name,
-                'id': str(proposition.adviser.pk)
+                'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
             'status': PropositionStatus.completed,
@@ -740,7 +810,7 @@ class TestCompleteProposition(APITestMixin):
                 'last_name': proposition.modified_by.last_name,
                 'name': proposition.modified_by.name,
                 'id': str(proposition.modified_by.pk),
-            }
+            },
         }
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
@@ -754,10 +824,13 @@ class TestCompleteProposition(APITestMixin):
             created_by=user,
         )
         entity_document.document.mark_as_scanned(True, '')
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': uuid.uuid4(),
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': uuid.uuid4(),
+            },
+        )
 
         api_client = self.create_api_client(user=user)
         response = api_client.post(url)
@@ -775,10 +848,10 @@ class TestCompleteProposition(APITestMixin):
             dit_team=project_creator.dit_team,
         )
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -787,10 +860,13 @@ class TestCompleteProposition(APITestMixin):
         )
         entity_document.document.mark_as_scanned(True, '')
 
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         api_client = self.create_api_client(user=user)
         response = api_client.post(url)
@@ -803,13 +879,13 @@ class TestCompleteProposition(APITestMixin):
             'investment_project': {
                 'name': proposition.investment_project.name,
                 'project_code': proposition.investment_project.project_code,
-                'id': str(proposition.investment_project.pk)
+                'id': str(proposition.investment_project.pk),
             },
             'adviser': {
                 'first_name': proposition.adviser.first_name,
                 'last_name': proposition.adviser.last_name,
                 'name': proposition.adviser.name,
-                'id': str(proposition.adviser.pk)
+                'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
             'status': PropositionStatus.completed,
@@ -829,7 +905,7 @@ class TestCompleteProposition(APITestMixin):
                 'last_name': proposition.modified_by.last_name,
                 'name': proposition.modified_by.name,
                 'id': str(proposition.modified_by.pk),
-            }
+            },
         }
 
     def test_restricted_user_cannot_complete_non_associated_ip_proposition(self):
@@ -842,10 +918,10 @@ class TestCompleteProposition(APITestMixin):
             dit_team=TeamFactory(),
         )
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -854,16 +930,19 @@ class TestCompleteProposition(APITestMixin):
         )
         entity_document.document.mark_as_scanned(True, '')
 
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         api_client = self.create_api_client(user=user)
         response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         response_data = response.json()
         assert response_data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
         proposition.refresh_from_db()
@@ -884,7 +963,7 @@ class TestCompleteProposition(APITestMixin):
             dit_team=TeamFactory(),
         )
         proposition = PropositionFactory(
-            status=proposition_status
+            status=proposition_status,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -892,10 +971,13 @@ class TestCompleteProposition(APITestMixin):
             created_by=user,
         )
         entity_document.document.mark_as_scanned(True, '')
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         api_client = self.create_api_client(user=user)
         response = api_client.post(url)
         response_data = response.json()
@@ -910,10 +992,13 @@ class TestCompleteProposition(APITestMixin):
     def test_cannot_complete_proposition_without_uploading_documents(self):
         """Test cannot complete proposition without uploading documents."""
         proposition = PropositionFactory()
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         response = self.api_client.post(url)
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
@@ -930,10 +1015,13 @@ class TestLegacyCompleteProposition(APITestMixin):
         """Test completing proposition by non restricted user."""
         proposition = PropositionFactory()
 
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -952,13 +1040,13 @@ class TestLegacyCompleteProposition(APITestMixin):
             'investment_project': {
                 'name': proposition.investment_project.name,
                 'project_code': proposition.investment_project.project_code,
-                'id': str(proposition.investment_project.pk)
+                'id': str(proposition.investment_project.pk),
             },
             'adviser': {
                 'first_name': proposition.adviser.first_name,
                 'last_name': proposition.adviser.last_name,
                 'name': proposition.adviser.name,
-                'id': str(proposition.adviser.pk)
+                'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
             'status': PropositionStatus.completed,
@@ -978,7 +1066,7 @@ class TestLegacyCompleteProposition(APITestMixin):
                 'last_name': proposition.modified_by.last_name,
                 'name': proposition.modified_by.name,
                 'id': str(proposition.modified_by.pk),
-            }
+            },
         }
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_CHANGE_PERMISSIONS)
@@ -986,10 +1074,13 @@ class TestLegacyCompleteProposition(APITestMixin):
         """Test user cannot complete proposition for non existent investment project."""
         proposition = PropositionFactory()
 
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': uuid.uuid4(),
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': uuid.uuid4(),
+            },
+        )
 
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -1007,16 +1098,19 @@ class TestLegacyCompleteProposition(APITestMixin):
         """Test completing proposition by a restricted user."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         user = create_test_user(
             permission_codenames=(
@@ -1040,13 +1134,13 @@ class TestLegacyCompleteProposition(APITestMixin):
             'investment_project': {
                 'name': proposition.investment_project.name,
                 'project_code': proposition.investment_project.project_code,
-                'id': str(proposition.investment_project.pk)
+                'id': str(proposition.investment_project.pk),
             },
             'adviser': {
                 'first_name': proposition.adviser.first_name,
                 'last_name': proposition.adviser.last_name,
                 'name': proposition.adviser.name,
-                'id': str(proposition.adviser.pk)
+                'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
             'status': PropositionStatus.completed,
@@ -1066,23 +1160,26 @@ class TestLegacyCompleteProposition(APITestMixin):
                 'last_name': proposition.modified_by.last_name,
                 'name': proposition.modified_by.name,
                 'id': str(proposition.modified_by.pk),
-            }
+            },
         }
 
     def test_restricted_user_cannot_complete_non_associated_ip_proposition(self):
         """Test restricted user cannot complete non associated investment project proposition."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         user = create_test_user(
             permission_codenames=(
@@ -1100,7 +1197,7 @@ class TestLegacyCompleteProposition(APITestMixin):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         response_data = response.json()
         assert response_data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
         proposition.refresh_from_db()
@@ -1115,12 +1212,15 @@ class TestLegacyCompleteProposition(APITestMixin):
     def test_cannot_complete_proposition_without_ongoing_status(self, proposition_status):
         """Test cannot complete proposition that doesn't have ongoing status."""
         proposition = PropositionFactory(
-            status=proposition_status
+            status=proposition_status,
         )
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         response = self.api_client.post(
             url,
             {
@@ -1139,10 +1239,13 @@ class TestLegacyCompleteProposition(APITestMixin):
     def test_cannot_complete_proposition_without_details(self):
         """Test cannot complete proposition without giving details."""
         proposition = PropositionFactory()
-        url = reverse('api-v3:investment:proposition:complete', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:complete',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         response = self.api_client.post(
             url,
             {
@@ -1164,10 +1267,13 @@ class TestAbandonProposition(APITestMixin):
         """Test abandoning proposition by non restricted user."""
         proposition = PropositionFactory()
 
-        url = reverse('api-v3:investment:proposition:abandon', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:abandon',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -1192,7 +1298,7 @@ class TestAbandonProposition(APITestMixin):
                 'first_name': proposition.adviser.first_name,
                 'last_name': proposition.adviser.last_name,
                 'name': proposition.adviser.name,
-                'id': str(proposition.adviser.pk)
+                'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
             'status': PropositionStatus.abandoned,
@@ -1220,10 +1326,13 @@ class TestAbandonProposition(APITestMixin):
         """Test user cannot abandon proposition for non existent investment project."""
         proposition = PropositionFactory()
 
-        url = reverse('api-v3:investment:proposition:abandon', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': uuid.uuid4(),
-        })
+        url = reverse(
+            'api-v3:investment:proposition:abandon',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': uuid.uuid4(),
+            },
+        )
 
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -1241,16 +1350,19 @@ class TestAbandonProposition(APITestMixin):
         """Test abandoning proposition by restricted user."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:abandon', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:abandon',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         user = create_test_user(
             permission_codenames=(
@@ -1280,7 +1392,7 @@ class TestAbandonProposition(APITestMixin):
                 'first_name': proposition.adviser.first_name,
                 'last_name': proposition.adviser.last_name,
                 'name': proposition.adviser.name,
-                'id': str(proposition.adviser.pk)
+                'id': str(proposition.adviser.pk),
             },
             'deadline': proposition.deadline.isoformat(),
             'status': PropositionStatus.abandoned,
@@ -1307,16 +1419,19 @@ class TestAbandonProposition(APITestMixin):
         """Test restricted user cannot abandon non associated investment project proposition."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:abandon', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:abandon',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         user = create_test_user(
             permission_codenames=(
@@ -1334,7 +1449,7 @@ class TestAbandonProposition(APITestMixin):
         assert response.status_code == status.HTTP_403_FORBIDDEN
         response_data = response.json()
         assert response_data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
         proposition.refresh_from_db()
@@ -1349,12 +1464,15 @@ class TestAbandonProposition(APITestMixin):
     def test_cannot_abandon_proposition_without_ongoing_status(self, proposition_status):
         """Test cannot abandon proposition that doesn't have ongoing status."""
         proposition = PropositionFactory(
-            status=proposition_status
+            status=proposition_status,
         )
-        url = reverse('api-v3:investment:proposition:abandon', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:abandon',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         response = self.api_client.post(
             url,
             {
@@ -1373,10 +1491,13 @@ class TestAbandonProposition(APITestMixin):
     def test_cannot_abandon_proposition_without_details(self):
         """Test cannot abandon proposition without giving details."""
         proposition = PropositionFactory()
-        url = reverse('api-v3:investment:proposition:abandon', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:abandon',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
         response = self.api_client.post(
             url,
             {
@@ -1401,17 +1522,23 @@ class TestPropositionDocumentViews(APITestMixin):
 
         proposition = PropositionFactory()
 
-        url = reverse('api-v3:investment:proposition:document-collection', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:document-collection',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
 
-        response = api_client.post(url, data={
-            'original_filename': 'test.txt',
-        })
+        response = api_client.post(
+            url,
+            data={
+                'original_filename': 'test.txt',
+            },
+        )
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.data
 
@@ -1426,7 +1553,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
@@ -1446,22 +1573,28 @@ class TestPropositionDocumentViews(APITestMixin):
             dit_team=TeamFactory(),
         )
         investment_project = InvestmentProjectFactory(
-            created_by=user
+            created_by=user,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:document-collection', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:document-collection',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         api_client = self.create_api_client(user=user)
 
-        response = api_client.post(url, data={
-            'original_filename': 'test.txt',
-        })
+        response = api_client.post(
+            url,
+            data={
+                'original_filename': 'test.txt',
+            },
+        )
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.data
 
@@ -1476,7 +1609,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
@@ -1490,16 +1623,19 @@ class TestPropositionDocumentViews(APITestMixin):
         """Test that restricted user cannot create non associated document."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
-        url = reverse('api-v3:investment:proposition:document-collection', kwargs={
-            'proposition_pk': proposition.pk,
-            'project_pk': proposition.investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:document-collection',
+            kwargs={
+                'proposition_pk': proposition.pk,
+                'project_pk': proposition.investment_project.pk,
+            },
+        )
 
         user = create_test_user(
             permission_codenames=(PropositionDocumentPermission.add_associated,),
@@ -1507,29 +1643,38 @@ class TestPropositionDocumentViews(APITestMixin):
         )
         api_client = self.create_api_client(user=user)
 
-        response = api_client.post(url, data={
-            'original_filename': 'test.txt',
-        })
+        response = api_client.post(
+            url,
+            data={
+                'original_filename': 'test.txt',
+            },
+        )
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
     def test_cannot_create_document_for_non_existent_proposition(self):
         """Test that user cannot create document for non existent proposition."""
         investment_project = InvestmentProjectFactory()
 
-        url = reverse('api-v3:investment:proposition:document-collection', kwargs={
-            'proposition_pk': uuid.uuid4(),
-            'project_pk': investment_project.pk,
-        })
+        url = reverse(
+            'api-v3:investment:proposition:document-collection',
+            kwargs={
+                'proposition_pk': uuid.uuid4(),
+                'project_pk': investment_project.pk,
+            },
+        )
 
         user = create_test_user(permission_codenames=(PropositionDocumentPermission.add_all,))
         api_client = self.create_api_client(user=user)
 
-        response = api_client.post(url, data={
-            'original_filename': 'test.txt',
-        })
+        response = api_client.post(
+            url,
+            data={
+                'original_filename': 'test.txt',
+            },
+        )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
@@ -1556,7 +1701,7 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-            }
+            },
         )
         user = create_test_user(permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -1573,7 +1718,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'av_clean': True,
             'original_filename': 'test.txt',
@@ -1590,10 +1735,10 @@ class TestPropositionDocumentViews(APITestMixin):
             dit_team=TeamFactory(),
         )
         investment_project = InvestmentProjectFactory(
-            created_by=user
+            created_by=user,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -1614,7 +1759,7 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-            }
+            },
         )
         api_client = self.create_api_client(user=user)
         response = api_client.get(url)
@@ -1629,7 +1774,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'av_clean': True,
             'original_filename': 'test.txt',
@@ -1643,10 +1788,10 @@ class TestPropositionDocumentViews(APITestMixin):
         """Tests that restricted user cannot list non associated documents."""
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -1660,7 +1805,7 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-            }
+            },
         )
         user = create_test_user(
             permission_codenames=(PropositionDocumentPermission.view_associated,),
@@ -1671,7 +1816,7 @@ class TestPropositionDocumentViews(APITestMixin):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
@@ -1690,8 +1835,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -1705,7 +1850,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
@@ -1721,10 +1866,10 @@ class TestPropositionDocumentViews(APITestMixin):
             dit_team=TeamFactory(),
         )
         investment_project = InvestmentProjectFactory(
-            created_by=user
+            created_by=user,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -1737,8 +1882,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -1751,7 +1896,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
             'original_filename': 'test.txt',
             'url': _get_document_url(entity_document.proposition, entity_document),
@@ -1768,10 +1913,10 @@ class TestPropositionDocumentViews(APITestMixin):
         )
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -1785,15 +1930,15 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
         response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
@@ -1801,7 +1946,7 @@ class TestPropositionDocumentViews(APITestMixin):
         """Tests retrieval of individual document that is pending deletion."""
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
-            proposition_id=proposition.pk, original_filename='test.txt'
+            proposition_id=proposition.pk, original_filename='test.txt',
         )
         entity_document.document.mark_deletion_pending()
 
@@ -1810,8 +1955,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         user = create_test_user(permission_codenames=permissions)
@@ -1823,8 +1968,8 @@ class TestPropositionDocumentViews(APITestMixin):
     @pytest.mark.parametrize(
         'av_clean,expected_status', (
             (True, status.HTTP_200_OK),
-            (False, status.HTTP_403_FORBIDDEN,)
-        )
+            (False, status.HTTP_403_FORBIDDEN),
+        ),
     )
     @patch('datahub.documents.models.sign_s3_url')
     def test_document_download(self, sign_s3_url, av_clean, expected_status):
@@ -1832,7 +1977,7 @@ class TestPropositionDocumentViews(APITestMixin):
         sign_s3_url.return_value = 'http://what'
 
         user = create_test_user(
-            permission_codenames=(PropositionDocumentPermission.view_all,)
+            permission_codenames=(PropositionDocumentPermission.view_all,),
         )
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
@@ -1848,7 +1993,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
                 'entity_document_pk': entity_document.pk,
-            }
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -1862,7 +2007,7 @@ class TestPropositionDocumentViews(APITestMixin):
                     'id': str(entity_document.created_by.pk),
                     'first_name': entity_document.created_by.first_name,
                     'last_name': entity_document.created_by.last_name,
-                    'name': entity_document.created_by.name
+                    'name': entity_document.created_by.name,
                 },
                 'original_filename': 'test.txt',
                 'url': _get_document_url(entity_document.proposition, entity_document),
@@ -1877,7 +2022,7 @@ class TestPropositionDocumentViews(APITestMixin):
         """Tests download of individual document when not yet virus scanned."""
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
-            proposition_id=proposition.pk, original_filename='test.txt'
+            proposition_id=proposition.pk, original_filename='test.txt',
         )
 
         url = reverse(
@@ -1886,7 +2031,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
                 'entity_document_pk': entity_document.pk,
-            }
+            },
         )
 
         user = create_test_user(permission_codenames=permissions)
@@ -1900,7 +2045,7 @@ class TestPropositionDocumentViews(APITestMixin):
     def test_document_upload_schedule_virus_scan(
         self,
         virus_scan_document_apply_async,
-        permissions
+        permissions,
     ):
         """Tests scheduling virus scan after upload completion.
 
@@ -1920,8 +2065,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -1937,7 +2082,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
 
             'original_filename': 'test.txt',
@@ -1947,7 +2092,7 @@ class TestPropositionDocumentViews(APITestMixin):
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
         virus_scan_document_apply_async.assert_called_once_with(
-            args=(str(entity_document.document.pk), )
+            args=(str(entity_document.document.pk), ),
         )
 
     @patch('datahub.documents.tasks.virus_scan_document.apply_async')
@@ -1963,10 +2108,10 @@ class TestPropositionDocumentViews(APITestMixin):
             dit_team=TeamFactory(),
         )
         investment_project = InvestmentProjectFactory(
-            created_by=user
+            created_by=user,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -1979,8 +2124,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
@@ -1996,7 +2141,7 @@ class TestPropositionDocumentViews(APITestMixin):
                 'id': str(entity_document.created_by.pk),
                 'first_name': entity_document.created_by.first_name,
                 'last_name': entity_document.created_by.last_name,
-                'name': entity_document.created_by.name
+                'name': entity_document.created_by.name,
             },
 
             'original_filename': 'test.txt',
@@ -2006,7 +2151,7 @@ class TestPropositionDocumentViews(APITestMixin):
             'uploaded_on': format_date_or_datetime(entity_document.document.uploaded_on),
         }
         virus_scan_document_apply_async.assert_called_once_with(
-            args=(str(entity_document.document.pk), )
+            args=(str(entity_document.document.pk), ),
         )
 
     def test_restricted_user_cannot_schedule_virus_scan_for_non_associated_document(self):
@@ -2017,10 +2162,10 @@ class TestPropositionDocumentViews(APITestMixin):
         )
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -2034,14 +2179,14 @@ class TestPropositionDocumentViews(APITestMixin):
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
                 'entity_document_pk': entity_document.pk,
-            }
+            },
         )
 
         api_client = self.create_api_client(user=user)
         response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
         entity_document.document.refresh_from_db()
@@ -2053,7 +2198,7 @@ class TestPropositionDocumentViews(APITestMixin):
         """Tests document deletion."""
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
-            proposition_id=proposition.pk, original_filename='test.txt'
+            proposition_id=proposition.pk, original_filename='test.txt',
         )
         document = entity_document.document
         document.mark_scan_scheduled()
@@ -2064,8 +2209,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         document_pk = entity_document.document.pk
@@ -2085,10 +2230,10 @@ class TestPropositionDocumentViews(APITestMixin):
             dit_team=TeamFactory(),
         )
         investment_project = InvestmentProjectFactory(
-            created_by=user
+            created_by=user,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -2104,8 +2249,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         document_pk = entity_document.document.pk
@@ -2124,10 +2269,10 @@ class TestPropositionDocumentViews(APITestMixin):
         )
         project_creator = AdviserFactory()
         investment_project = InvestmentProjectFactory(
-            created_by=project_creator
+            created_by=project_creator,
         )
         proposition = PropositionFactory(
-            investment_project=investment_project
+            investment_project=investment_project,
         )
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk,
@@ -2143,15 +2288,15 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         api_client = self.create_api_client(user=user)
         response = api_client.delete(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.data == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
         entity_document.document.refresh_from_db()
@@ -2163,7 +2308,7 @@ class TestPropositionDocumentViews(APITestMixin):
         """Tests user can't delete document without permissions."""
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
-            proposition_id=proposition.pk, original_filename='test.txt'
+            proposition_id=proposition.pk, original_filename='test.txt',
         )
         entity_document.document.mark_scan_scheduled()
         entity_document.document.mark_as_scanned(True, 'reason')
@@ -2173,8 +2318,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
         response = self.api_client.delete(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -2186,7 +2331,7 @@ class TestPropositionDocumentViews(APITestMixin):
         """Tests document deletion creates user event log."""
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
-            proposition_id=proposition.pk, original_filename='test.txt'
+            proposition_id=proposition.pk, original_filename='test.txt',
         )
         document = entity_document.document
         document.mark_scan_scheduled()
@@ -2197,8 +2342,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         document_pk = entity_document.document.pk
@@ -2240,7 +2385,7 @@ class TestPropositionDocumentViews(APITestMixin):
         mark_deletion_pending.side_effect = Exception('No way!')
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
-            proposition_id=proposition.pk, original_filename='test.txt'
+            proposition_id=proposition.pk, original_filename='test.txt',
         )
         document = entity_document.document
         document.mark_scan_scheduled()
@@ -2251,12 +2396,12 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
         user = create_test_user(
             permission_codenames=(PropositionDocumentPermission.delete_all,),
-            dit_team=TeamFactory()
+            dit_team=TeamFactory(),
         )
         api_client = self.create_api_client(user=user)
         with pytest.raises(Exception):
@@ -2268,7 +2413,7 @@ class TestPropositionDocumentViews(APITestMixin):
         """Tests user without permission can't call upload status endpoint."""
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
-            proposition_id=proposition.pk, original_filename='test.txt'
+            proposition_id=proposition.pk, original_filename='test.txt',
         )
 
         url = reverse(
@@ -2276,8 +2421,8 @@ class TestPropositionDocumentViews(APITestMixin):
             kwargs={
                 'proposition_pk': proposition.pk,
                 'project_pk': proposition.investment_project.pk,
-                'entity_document_pk': entity_document.pk
-            }
+                'entity_document_pk': entity_document.pk,
+            },
         )
 
         response = self.api_client.post(url, data={})
@@ -2291,5 +2436,5 @@ def _get_document_url(proposition, entity_document):
             'proposition_pk': proposition.pk,
             'project_pk': proposition.investment_project.pk,
             'entity_document_pk': entity_document.pk,
-        }
+        },
     )

--- a/datahub/investment/proposition/urls.py
+++ b/datahub/investment/proposition/urls.py
@@ -6,7 +6,7 @@ from datahub.investment.proposition.views import PropositionDocumentViewSet, Pro
 
 proposition_collection = PropositionViewSet.as_view({
     'get': 'list',
-    'post': 'create'
+    'post': 'create',
 })
 
 proposition_item = PropositionViewSet.as_view({
@@ -47,21 +47,21 @@ urlpatterns = [
     path(
         'proposition/<uuid:proposition_pk>/document',
         proposition_document_collection,
-        name='document-collection'
+        name='document-collection',
     ),
     path(
         'proposition/<uuid:proposition_pk>/document/<uuid:entity_document_pk>',
         proposition_document_item,
-        name='document-item'
+        name='document-item',
     ),
     path(
         'proposition/<uuid:proposition_pk>/document/<uuid:entity_document_pk>/upload-callback',
         proposition_document_callback,
-        name='document-item-callback'
+        name='document-item-callback',
     ),
     path(
         'proposition/<uuid:proposition_pk>/document/<uuid:entity_document_pk>/download',
         proposition_document_download,
-        name='document-item-download'
+        name='document-item-download',
     ),
 ]

--- a/datahub/investment/proposition/views.py
+++ b/datahub/investment/proposition/views.py
@@ -53,19 +53,19 @@ class PropositionViewSet(CoreViewSet):
         DjangoFilterBackend,
         OrderingFilter,
     )
-    filterset_fields = ('adviser_id', 'status',)
+    filterset_fields = ('adviser_id', 'status')
 
     lookup_url_kwarg = 'proposition_pk'
 
-    ordering_fields = ('deadline', 'created_on',)
-    ordering = ('-deadline', '-created_on',)
+    ordering_fields = ('deadline', 'created_on')
+    ordering = ('-deadline', '-created_on')
 
     def get_queryset(self):
         """Filters the query set to the specified project."""
         self._check_project_exists()
 
         return self.queryset.filter(
-            investment_project_id=self.kwargs['project_pk']
+            investment_project_id=self.kwargs['project_pk'],
         )
 
     def create(self, request, *args, **kwargs):
@@ -80,7 +80,7 @@ class PropositionViewSet(CoreViewSet):
         instance = serializer.save(**self.get_additional_data(True))
         return Response(
             self.get_serializer(instance=instance).data,
-            status=status.HTTP_201_CREATED
+            status=status.HTTP_201_CREATED,
         )
 
     def _action(self, method, action_serializer, request, *args, **kwargs):
@@ -101,7 +101,7 @@ class PropositionViewSet(CoreViewSet):
         instance = getattr(serializer, method)()
         return Response(
             self.get_serializer(instance=instance).data,
-            status=status.HTTP_200_OK
+            status=status.HTTP_200_OK,
         )
 
     def complete(self, request, *args, **kwargs):
@@ -157,7 +157,7 @@ class PropositionDocumentViewSet(BaseEntityDocumentModelViewSet):
     def get_queryset(self):
         """Returns proposition documents queryset."""
         return PropositionDocument.objects.select_related(
-            'proposition__investment_project'
+            'proposition__investment_project',
         ).filter(
             proposition_id=self.kwargs['proposition_pk'],
             proposition__investment_project_id=self.kwargs['project_pk'],

--- a/datahub/investment/report/admin.py
+++ b/datahub/investment/report/admin.py
@@ -9,7 +9,7 @@ from datahub.investment.report.models import SPIReport
 class SPIReportAdmin(admin.ModelAdmin):
     """SPI Report admin."""
 
-    fields = ('id', 'created_on',)
+    fields = ('id', 'created_on')
     readonly_fields = fields
 
     list_display = (
@@ -22,12 +22,15 @@ class SPIReportAdmin(admin.ModelAdmin):
 
     def report(self, instance):
         """URL to the report download."""
-        href = reverse('investment-report:download-spi-report', kwargs={
-            'pk': instance.pk,
-        })
+        href = reverse(
+            'investment-report:download-spi-report',
+            kwargs={
+                'pk': instance.pk,
+            },
+        )
         return format_html(
             '<a href="{href}">Click to download.</a>',
-            href=href
+            href=href,
         )
 
     def has_add_permission(self, request):

--- a/datahub/investment/report/spi.py
+++ b/datahub/investment/report/spi.py
@@ -132,7 +132,7 @@ class SPIReport:
         Earliest date counts.
         """
         stage_log = investment_project.stage_log.filter(
-            stage_id=Stage.won.value.id
+            stage_id=Stage.won.value.id,
         ).order_by('created_on').first()
 
         return stage_log.created_on if stage_log else None
@@ -141,12 +141,12 @@ class SPIReport:
         """Gets project's propositions."""
         qs = investment_project.proposition.select_related(
             'adviser',
-            'created_by__dit_team'
+            'created_by__dit_team',
         )
         if ist_only:
             # Only teams tagged with investment services team
             qs = qs.filter(
-                created_by__dit_team__tags__overlap=[Team.TAGS.investment_services_team]
+                created_by__dit_team__tags__overlap=[Team.TAGS.investment_services_team],
             )
         return qs.order_by('created_on')
 

--- a/datahub/investment/report/tasks.py
+++ b/datahub/investment/report/tasks.py
@@ -29,11 +29,11 @@ def generate_spi_report():
             get_bucket_name('report'),
             report_key,
             ExtraArgs={
-                'ServerSideEncryption': 'AES256'
-            }
+                'ServerSideEncryption': 'AES256',
+            },
         )
 
         report = SPIReport(
-            s3_key=report_key
+            s3_key=report_key,
         )
         report.save()

--- a/datahub/investment/report/test/test_spi.py
+++ b/datahub/investment/report/test/test_spi.py
@@ -10,7 +10,7 @@ from datahub.investment.proposition.models import PropositionDocument
 from datahub.investment.proposition.test.factories import PropositionFactory
 from datahub.investment.report.spi import SPIReport
 from datahub.investment.test.factories import (
-    InvestmentProjectFactory, VerifyWinInvestmentProjectFactory
+    InvestmentProjectFactory, VerifyWinInvestmentProjectFactory,
 )
 from datahub.metadata.models import Team
 
@@ -89,18 +89,21 @@ def test_can_see_spi1_start(spi_report):
     assert 'Enquiry processed' not in rows[0]
 
 
-@pytest.mark.parametrize('service_id,visible', (
-    (Service.investment_enquiry_requested_more_information.value.id, True),
-    (Service.investment_enquiry_confirmed_prospect.value.id, True),
-    (Service.investment_enquiry_assigned_to_ist_cmc.value.id, True),
-    (Service.investment_enquiry_assigned_to_ist_sas.value.id, True),
-    (Service.investment_enquiry_assigned_to_hq.value.id, True),
-    (Service.investment_enquiry_transferred_to_lep.value.id, True),
-    (Service.investment_enquiry_transferred_to_da.value.id, True),
-    (Service.investment_enquiry_transferred_to_lp.value.id, True),
-    (Service.trade_enquiry.value.id, False),
-    (Service.account_management.value.id, False),
-))
+@pytest.mark.parametrize(
+    'service_id,visible',
+    (
+        (Service.investment_enquiry_requested_more_information.value.id, True),
+        (Service.investment_enquiry_confirmed_prospect.value.id, True),
+        (Service.investment_enquiry_assigned_to_ist_cmc.value.id, True),
+        (Service.investment_enquiry_assigned_to_ist_sas.value.id, True),
+        (Service.investment_enquiry_assigned_to_hq.value.id, True),
+        (Service.investment_enquiry_transferred_to_lep.value.id, True),
+        (Service.investment_enquiry_transferred_to_da.value.id, True),
+        (Service.investment_enquiry_transferred_to_lp.value.id, True),
+        (Service.trade_enquiry.value.id, False),
+        (Service.account_management.value.id, False),
+    ),
+)
 def test_interaction_would_end_spi1_or_not(spi_report, service_id, visible):
     """Checks if specified interaction ends spi1 or not."""
     investment_project = InvestmentProjectFactory()
@@ -119,18 +122,21 @@ def test_interaction_would_end_spi1_or_not(spi_report, service_id, visible):
         assert 'Enquiry processed' not in rows[0]
 
 
-@pytest.mark.parametrize('service_id,visible', (
-    (Service.investment_enquiry_requested_more_information.value.id, False),
-    (Service.investment_enquiry_confirmed_prospect.value.id, False),
-    (Service.investment_enquiry_assigned_to_ist_cmc.value.id, True),
-    (Service.investment_enquiry_assigned_to_ist_sas.value.id, True),
-    (Service.investment_enquiry_assigned_to_hq.value.id, False),
-    (Service.investment_enquiry_transferred_to_lep.value.id, False),
-    (Service.investment_enquiry_transferred_to_da.value.id, False),
-    (Service.investment_enquiry_transferred_to_lp.value.id, False),
-    (Service.trade_enquiry.value.id, False),
-    (Service.account_management.value.id, False),
-))
+@pytest.mark.parametrize(
+    'service_id,visible',
+    (
+        (Service.investment_enquiry_requested_more_information.value.id, False),
+        (Service.investment_enquiry_confirmed_prospect.value.id, False),
+        (Service.investment_enquiry_assigned_to_ist_cmc.value.id, True),
+        (Service.investment_enquiry_assigned_to_ist_sas.value.id, True),
+        (Service.investment_enquiry_assigned_to_hq.value.id, False),
+        (Service.investment_enquiry_transferred_to_lep.value.id, False),
+        (Service.investment_enquiry_transferred_to_da.value.id, False),
+        (Service.investment_enquiry_transferred_to_lp.value.id, False),
+        (Service.trade_enquiry.value.id, False),
+        (Service.account_management.value.id, False),
+    ),
+)
 def test_interaction_would_start_spi2_or_not(spi_report, ist_adviser, service_id, visible):
     """Checks if specified interaction starts spi2 or not."""
     investment_project = InvestmentProjectFactory(
@@ -236,7 +242,7 @@ def test_can_get_spi5_start_and_end(spi_report, ist_adviser):
     with freeze_time('2017-01-15'):
         InvestmentProjectInteractionFactory(
             service_id=Service.investment_ist_aftercare_offered.value.id,
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
     rows = list(spi_report.rows())
@@ -247,7 +253,7 @@ def test_can_get_spi5_start_and_end(spi_report, ist_adviser):
 
 def test_cannot_get_spi5_start_and_end_for_non_new_investor(
     spi_report,
-    ist_adviser
+    ist_adviser,
 ):
     """Tests if we are not going to see spi5 start and end dates if investor is not new."""
     investment_project = VerifyWinInvestmentProjectFactory(
@@ -262,7 +268,7 @@ def test_cannot_get_spi5_start_and_end_for_non_new_investor(
     with freeze_time('2017-01-15'):
         InvestmentProjectInteractionFactory(
             service_id=Service.investment_ist_aftercare_offered.value.id,
-            investment_project=investment_project
+            investment_project=investment_project,
         )
 
     rows = list(spi_report.rows())

--- a/datahub/investment/report/test/test_views.py
+++ b/datahub/investment/report/test/test_views.py
@@ -14,9 +14,12 @@ class TestGetSPIReport(AdminTestMixin):
     def test_fails_without_permissions(self, api_client):
         """Should redirect to login page."""
         report = SPIReportFactory()
-        url = reverse('investment-report:download-spi-report', kwargs={
-            'pk': report.pk,
-        })
+        url = reverse(
+            'investment-report:download-spi-report',
+            kwargs={
+                'pk': report.pk,
+            },
+        )
         response = api_client.get(url, follow=True)
         assert response.status_code == status.HTTP_200_OK
         assert len(response.redirect_chain) == 1
@@ -26,9 +29,12 @@ class TestGetSPIReport(AdminTestMixin):
         """Test get report by a user with permission."""
         report = SPIReportFactory()
 
-        url = reverse('investment-report:download-spi-report', kwargs={
-            'pk': report.pk,
-        })
+        url = reverse(
+            'investment-report:download-spi-report',
+            kwargs={
+                'pk': report.pk,
+            },
+        )
         user = create_test_user(
             is_staff=True,
             password=self.PASSWORD,
@@ -45,9 +51,12 @@ class TestGetSPIReport(AdminTestMixin):
     def test_user_without_permission_cannot_get_report(self):
         """Test that user without permission cannot get a report."""
         report = SPIReportFactory()
-        url = reverse('investment-report:download-spi-report', kwargs={
-            'pk': report.pk,
-        })
+        url = reverse(
+            'investment-report:download-spi-report',
+            kwargs={
+                'pk': report.pk,
+            },
+        )
         user = create_test_user(
             is_staff=True,
             password=self.PASSWORD,
@@ -59,9 +68,12 @@ class TestGetSPIReport(AdminTestMixin):
 
     def test_non_restricted_user_cannot_get_non_existent_report(self):
         """Test user cannot get a report that doesn't exist."""
-        url = reverse('investment-report:download-spi-report', kwargs={
-            'pk': uuid4(),
-        })
+        url = reverse(
+            'investment-report:download-spi-report',
+            kwargs={
+                'pk': uuid4(),
+            },
+        )
         user = create_test_user(
             is_staff=True,
             password=self.PASSWORD,

--- a/datahub/investment/report/urls.py
+++ b/datahub/investment/report/urls.py
@@ -10,6 +10,6 @@ urlpatterns = [
     path(
         'admin/investment-report/spi/<uuid:pk>',
         site.admin_view(download_spi_report),
-        name='download-spi-report'
+        name='download-spi-report',
     ),
 ]

--- a/datahub/investment/report/views.py
+++ b/datahub/investment/report/views.py
@@ -8,7 +8,7 @@ from datahub.investment.report.models import SPIReport, SPIReportPermission
 def download_spi_report(request, pk=None):
     """Downloads SPI report."""
     if not request.user or not request.user.has_perm(
-        f'report.{SPIReportPermission.change}'
+        f'report.{SPIReportPermission.change}',
     ):
         raise PermissionDenied
 


### PR DESCRIPTION
### Description of change

This adds trailing commas where missing to the investment sub-apps. This includes some related code reformatting and the removal of some incorrect trailing commas.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
