### PR TITLE
Add trailing commas to investment app

### DIFF
--- a/datahub/investment/admin.py
+++ b/datahub/investment/admin.py
@@ -76,9 +76,12 @@ class InvestmentProjectTeamMemberAdmin(VersionAdmin):
     )
 
 
-admin.site.register((
-    InvestmentDeliveryPartner,
-    InvestorType,
-    Involvement,
-    SpecificProgramme,
-), DisableableMetadataAdmin)
+admin.site.register(
+    (
+        InvestmentDeliveryPartner,
+        InvestorType,
+        Involvement,
+        SpecificProgramme,
+    ),
+    DisableableMetadataAdmin,
+)

--- a/datahub/investment/constants.py
+++ b/datahub/investment/constants.py
@@ -10,7 +10,7 @@ class SpecificProgramme(Enum):
     space = Constant('Space', '1c91dd94-cae4-4ea4-b37e-8ef88cb10e7f')
     advanced_engineering_supply_chain = Constant(
         'Advanced Engineering Supply Chain',
-        '6513f918-4263-4516-8abb-8e4a6a4de857'
+        '6513f918-4263-4516-8abb-8e4a6a4de857',
     )
 
 

--- a/datahub/investment/models.py
+++ b/datahub/investment/models.py
@@ -98,12 +98,12 @@ class IProjectAbstract(models.Model):
         default=False,
         help_text='Controls whether estimated land date is a required field. Intended for '
                   'projects migrated from CDMS in the verify win and won stages where legacy '
-                  'data for estimated land date does not exist.'
+                  'data for estimated land date does not exist.',
     )
     estimated_land_date = models.DateField(null=True, blank=True)
     investment_type = models.ForeignKey(
         'metadata.InvestmentType', on_delete=models.PROTECT,
-        related_name='investment_projects'
+        related_name='investment_projects',
     )
 
     cdms_project_code = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
@@ -122,10 +122,10 @@ class IProjectAbstract(models.Model):
     stage = models.ForeignKey(
         'metadata.InvestmentProjectStage', on_delete=models.PROTECT,
         related_name='investment_projects',
-        default=InvestmentProjectStage.prospect.value.id
+        default=InvestmentProjectStage.prospect.value.id,
     )
     status = models.CharField(
-        max_length=MAX_LENGTH, choices=STATUSES, default=STATUSES.ongoing
+        max_length=MAX_LENGTH, choices=STATUSES, default=STATUSES.ongoing,
     )
     reason_delayed = models.TextField(blank=True, null=True)
     reason_abandoned = models.TextField(blank=True, null=True)
@@ -133,68 +133,68 @@ class IProjectAbstract(models.Model):
     reason_lost = models.TextField(blank=True, null=True)
     date_lost = models.DateField(blank=True, null=True)
     country_lost_to = models.ForeignKey(
-        'metadata.Country', related_name='+', null=True, blank=True, on_delete=models.SET_NULL
+        'metadata.Country', related_name='+', null=True, blank=True, on_delete=models.SET_NULL,
     )
 
     investor_company = models.ForeignKey(
         'company.Company', related_name='investor_investment_projects',
-        null=True, blank=True, on_delete=models.CASCADE
+        null=True, blank=True, on_delete=models.CASCADE,
     )
     investor_type = models.ForeignKey(
         'investment.InvestorType', related_name='+',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     intermediate_company = models.ForeignKey(
         'company.Company', related_name='intermediate_investment_projects',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     level_of_involvement = models.ForeignKey(
         'investment.Involvement', related_name='+',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     specific_programme = models.ForeignKey(
         'investment.SpecificProgramme', related_name='+',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     client_contacts = models.ManyToManyField(
-        'company.Contact', related_name='investment_projects', blank=True
+        'company.Contact', related_name='investment_projects', blank=True,
     )
     client_relationship_manager = models.ForeignKey(
         'company.Advisor', related_name='investment_projects', null=True,
-        blank=True, on_delete=models.SET_NULL
+        blank=True, on_delete=models.SET_NULL,
     )
     referral_source_adviser = models.ForeignKey(
         'company.Advisor', related_name='referred_investment_projects',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     referral_source_activity = models.ForeignKey(
         'metadata.ReferralSourceActivity', related_name='investment_projects',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     referral_source_activity_website = models.ForeignKey(
         'metadata.ReferralSourceWebsite', related_name='investment_projects',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     referral_source_activity_marketing = models.ForeignKey(
         'metadata.ReferralSourceMarketing', related_name='investment_projects',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     referral_source_activity_event = models.CharField(max_length=MAX_LENGTH, null=True, blank=True)
     fdi_type = models.ForeignKey(
         'metadata.FDIType', related_name='investment_projects', null=True,
-        blank=True, on_delete=models.SET_NULL
+        blank=True, on_delete=models.SET_NULL,
     )
     sector = TreeForeignKey(
         'metadata.Sector', related_name='+', null=True, blank=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     business_activities = models.ManyToManyField(
         'metadata.InvestmentBusinessActivity',
         related_name='+',
-        blank=True
+        blank=True,
     )
     other_business_activity = models.CharField(
-        max_length=MAX_LENGTH, null=True, blank=True
+        max_length=MAX_LENGTH, null=True, blank=True,
     )
 
     @property
@@ -235,14 +235,16 @@ class IProjectValueAbstract(models.Model):
 
     fdi_value = models.ForeignKey(
         'metadata.FDIValue', related_name='investment_projects', null=True, blank=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     client_cannot_provide_total_investment = models.NullBooleanField()
-    total_investment = models.DecimalField(null=True, max_digits=19,
-                                           decimal_places=0, blank=True)
+    total_investment = models.DecimalField(
+        null=True, max_digits=19,
+        decimal_places=0, blank=True,
+    )
     client_cannot_provide_foreign_investment = models.NullBooleanField()
     foreign_equity_investment = models.DecimalField(
-        null=True, max_digits=19, decimal_places=0, blank=True
+        null=True, max_digits=19, decimal_places=0, blank=True,
     )
     government_assistance = models.NullBooleanField()
     some_new_jobs = models.NullBooleanField()
@@ -250,12 +252,12 @@ class IProjectValueAbstract(models.Model):
     will_new_jobs_last_two_years = models.NullBooleanField()
     average_salary = models.ForeignKey(
         'metadata.SalaryRange', related_name='+', null=True, blank=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     number_safeguarded_jobs = models.IntegerField(null=True, blank=True)
     r_and_d_budget = models.NullBooleanField()
     non_fdi_r_and_d_budget = models.NullBooleanField(
-        verbose_name='has associated non-FDI R&D project'
+        verbose_name='has associated non-FDI R&D project',
     )
     associated_non_fdi_r_and_d_project = models.ForeignKey(
         'InvestmentProject', related_name='+', null=True, blank=True, on_delete=models.SET_NULL,
@@ -282,14 +284,14 @@ class IProjectRequirementsAbstract(models.Model):
     uk_company_decided = models.NullBooleanField()
     uk_company = models.ForeignKey(
         'company.Company', related_name='investee_projects',
-        null=True, blank=True, on_delete=models.SET_NULL
+        null=True, blank=True, on_delete=models.SET_NULL,
     )
     competitor_countries = models.ManyToManyField('metadata.Country', related_name='+', blank=True)
     allow_blank_possible_uk_regions = models.BooleanField(
         default=False,
         help_text='Controls whether possible UK regions is a required field (after the prospect '
                   'stage). Intended for projects migrated from CDMS in the verify win and won '
-                  'stages where legacy data for possible UK regions does not exist.'
+                  'stages where legacy data for possible UK regions does not exist.',
     )
     uk_region_locations = models.ManyToManyField(
         'metadata.UKRegion', related_name='+', blank=True,
@@ -306,12 +308,12 @@ class IProjectRequirementsAbstract(models.Model):
     )
     strategic_drivers = models.ManyToManyField(
         'metadata.InvestmentStrategicDriver',
-        related_name='investment_projects', blank=True
+        related_name='investment_projects', blank=True,
     )
     archived_documents_url_path = models.CharField(
         max_length=MAX_LENGTH, blank=True,
         help_text='Legacy field. File browser path to the archived documents for this '
-                  'investment project.'
+                  'investment project.',
     )
 
 
@@ -322,13 +324,13 @@ class IProjectTeamAbstract(models.Model):
         abstract = True
 
     project_manager = models.ForeignKey(
-        'company.Advisor', null=True, related_name='+', blank=True, on_delete=models.SET_NULL
+        'company.Advisor', null=True, related_name='+', blank=True, on_delete=models.SET_NULL,
     )
     # field project_manager_first_assigned_on is being used for SPI reporting
     # it contains a datetime when first time a project manager has been assigned
     project_manager_first_assigned_on = models.DateTimeField(null=True, blank=True)
     project_assurance_adviser = models.ForeignKey(
-        'company.Advisor', null=True, related_name='+', blank=True, on_delete=models.SET_NULL
+        'company.Advisor', null=True, related_name='+', blank=True, on_delete=models.SET_NULL,
     )
 
     @property
@@ -361,14 +363,20 @@ class IProjectSPIAbstract(models.Model):
 
 
 _AssociatedToManyField = namedtuple(
-    '_AssociatedToManyField', ('field_name', 'subfield_name', 'es_field_name')
+    '_AssociatedToManyField', ('field_name', 'subfield_name', 'es_field_name'),
 )
 
 
 @reversion.register_base_model()
-class InvestmentProject(ArchivableModel, IProjectAbstract,
-                        IProjectValueAbstract, IProjectRequirementsAbstract,
-                        IProjectTeamAbstract, IProjectSPIAbstract, BaseModel):
+class InvestmentProject(
+    ArchivableModel,
+    IProjectAbstract,
+    IProjectValueAbstract,
+    IProjectRequirementsAbstract,
+    IProjectTeamAbstract,
+    IProjectSPIAbstract,
+    BaseModel,
+):
     """An investment project."""
 
     _ASSOCIATED_ADVISER_TO_ONE_FIELDS = (
@@ -380,7 +388,7 @@ class InvestmentProject(ArchivableModel, IProjectAbstract,
 
     _ASSOCIATED_ADVISER_TO_MANY_FIELDS = (
         _AssociatedToManyField(
-            field_name='team_members', subfield_name='adviser', es_field_name='team_members'
+            field_name='team_members', subfield_name='adviser', es_field_name='team_members',
         ),
     )
 
@@ -437,24 +445,24 @@ class InvestmentProject(ArchivableModel, IProjectAbstract,
         permissions = (
             (
                 InvestmentProjectPermission.view_associated.value,
-                'Can view associated investment project'
+                'Can view associated investment project',
             ),
             (
                 InvestmentProjectPermission.change_associated.value,
-                'Can change associated investment project'
+                'Can change associated investment project',
             ),
             (
                 InvestmentProjectPermission.export.value,
-                'Can export investment project'
+                'Can export investment project',
             ),
             (
                 InvestmentProjectPermission.view_investmentproject_document.value,
-                'Can view investment project document'
+                'Can view investment project document',
             ),
             (
                 InvestmentProjectPermission.change_stage_to_won.value,
                 'Can change investment project stage to won',
-            )
+            ),
         )
         default_permissions = (
             'add',
@@ -509,7 +517,7 @@ class InvestmentProjectTeamMember(models.Model):
     """
 
     investment_project = models.ForeignKey(
-        InvestmentProject, on_delete=models.CASCADE, related_name='team_members'
+        InvestmentProject, on_delete=models.CASCADE, related_name='team_members',
     )
     adviser = models.ForeignKey('company.Advisor', on_delete=models.CASCADE, related_name='+')
     role = models.CharField(max_length=MAX_LENGTH)
@@ -530,7 +538,7 @@ class InvestmentProjectStageLog(models.Model):
     """
 
     investment_project = models.ForeignKey(
-        InvestmentProject, on_delete=models.CASCADE, related_name='stage_log'
+        InvestmentProject, on_delete=models.CASCADE, related_name='stage_log',
     )
     stage = models.ForeignKey(
         'metadata.InvestmentProjectStage', on_delete=models.PROTECT,

--- a/datahub/investment/permissions.py
+++ b/datahub/investment/permissions.py
@@ -87,7 +87,7 @@ class InvestmentProjectAssociationCheckerBase(ObjectAssociationCheckerBase):
         format_kwargs = {
             'app_label': self.model._meta.app_label,
             'model_name': self.model._meta.model_name,
-            'action': action
+            'action': action,
         }
 
         if request.user.has_perm(self.all_permission_template.format(**format_kwargs)):
@@ -134,7 +134,7 @@ class IsAssociatedToInvestmentProjectPermissionMixin:
         """Returns whether the user has permissions for a view."""
         if self.checker.should_apply_restrictions(request, view.action):
             investment_project = InvestmentProject.objects.get(
-                pk=request.parser_context['kwargs']['project_pk']
+                pk=request.parser_context['kwargs']['project_pk'],
             )
             if not self.checker.is_associated(request, investment_project):
                 return False

--- a/datahub/investment/serializers.py
+++ b/datahub/investment/serializers.py
@@ -19,7 +19,7 @@ from datahub.investment.models import (
     InvestmentProjectTeamMember,
     InvestorType,
     Involvement,
-    SpecificProgramme
+    SpecificProgramme,
 )
 from datahub.investment.validate import validate
 
@@ -167,11 +167,11 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
     default_error_messages = {
         'only_pm_or_paa_can_move_to_verify_win': ugettext_lazy(
             'Only the Project Manager or Project Assurance Adviser can move the project'
-            ' to the ‘Verify win’ stage.'
+            ' to the ‘Verify win’ stage.',
         ),
         'only_ivt_can_move_to_won': ugettext_lazy(
-            'Only the Investment Verification Team can move the project to the ‘Won’ stage.'
-        )
+            'Only the Investment Verification Team can move the project to the ‘Won’ stage.',
+        ),
     }
 
     incomplete_fields = serializers.SerializerMethodField()
@@ -186,37 +186,37 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
     level_of_involvement = NestedRelatedField(Involvement, required=False, allow_null=True)
     specific_programme = NestedRelatedField(SpecificProgramme, required=False, allow_null=True)
     client_contacts = NestedRelatedField(
-        Contact, many=True, required=True, allow_null=False, allow_empty=False
+        Contact, many=True, required=True, allow_null=False, allow_empty=False,
     )
 
     client_relationship_manager = NestedAdviserField(required=True, allow_null=False)
     client_relationship_manager_team = NestedRelatedField(meta_models.Team, read_only=True)
     referral_source_adviser = NestedAdviserField(required=True, allow_null=False)
     referral_source_activity = NestedRelatedField(
-        meta_models.ReferralSourceActivity, required=True, allow_null=False
+        meta_models.ReferralSourceActivity, required=True, allow_null=False,
     )
     referral_source_activity_website = NestedRelatedField(
-        meta_models.ReferralSourceWebsite, required=False, allow_null=True
+        meta_models.ReferralSourceWebsite, required=False, allow_null=True,
     )
     referral_source_activity_marketing = NestedRelatedField(
-        meta_models.ReferralSourceMarketing, required=False, allow_null=True
+        meta_models.ReferralSourceMarketing, required=False, allow_null=True,
     )
     fdi_type = NestedRelatedField(meta_models.FDIType, required=False, allow_null=True)
     sector = NestedRelatedField(meta_models.Sector, required=True, allow_null=False)
     business_activities = NestedRelatedField(
         meta_models.InvestmentBusinessActivity, many=True, required=True,
-        allow_null=False, allow_empty=False
+        allow_null=False, allow_empty=False,
     )
     archived_by = NestedAdviserField(read_only=True)
 
     # Value fields
     fdi_value = NestedRelatedField(meta_models.FDIValue, required=False, allow_null=True)
     average_salary = NestedRelatedField(
-        meta_models.SalaryRange, required=False, allow_null=True
+        meta_models.SalaryRange, required=False, allow_null=True,
     )
     value_complete = serializers.SerializerMethodField()
     associated_non_fdi_r_and_d_project = NestedRelatedField(
-        InvestmentProject, required=False, allow_null=True, extra_fields=('name', 'project_code')
+        InvestmentProject, required=False, allow_null=True, extra_fields=('name', 'project_code'),
     )
 
     # Requirements fields
@@ -227,7 +227,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
     actual_uk_regions = NestedRelatedField(meta_models.UKRegion, many=True, required=False)
     delivery_partners = NestedRelatedField(InvestmentDeliveryPartner, many=True, required=False)
     strategic_drivers = NestedRelatedField(
-        meta_models.InvestmentStrategicDriver, many=True, required=False
+        meta_models.InvestmentStrategicDriver, many=True, required=False,
     )
     uk_company = NestedRelatedField(Company, required=False, allow_null=True)
     requirements_complete = serializers.SerializerMethodField()
@@ -288,7 +288,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
                 and current_user_id not in allowed_users_ids
             ):
                 errors = {
-                    'stage': self.default_error_messages['only_pm_or_paa_can_move_to_verify_win']
+                    'stage': self.default_error_messages['only_pm_or_paa_can_move_to_verify_win'],
                 }
                 raise serializers.ValidationError(errors)
 
@@ -303,7 +303,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
                 and not current_user.has_perm(permission_name)
             ):
                 errors = {
-                    'stage': self.default_error_messages['only_ivt_can_move_to_won']
+                    'stage': self.default_error_messages['only_ivt_can_move_to_won'],
                 }
                 raise serializers.ValidationError(errors)
 
@@ -316,19 +316,19 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
     def get_value_complete(self, instance):
         """Whether the value fields required to move to the next stage are complete."""
         return not validate(
-            instance=instance, fields=VALUE_FIELDS, next_stage=True
+            instance=instance, fields=VALUE_FIELDS, next_stage=True,
         )
 
     def get_requirements_complete(self, instance):
         """Whether the requirements fields required to move to the next stage are complete."""
         return not validate(
-            instance=instance, fields=REQUIREMENTS_FIELDS, next_stage=True
+            instance=instance, fields=REQUIREMENTS_FIELDS, next_stage=True,
         )
 
     def get_team_complete(self, instance):
         """Whether the team fields required to move to the next stage are complete."""
         return not validate(
-            instance=instance, fields=TEAM_FIELDS, next_stage=True
+            instance=instance, fields=TEAM_FIELDS, next_stage=True,
         )
 
     def _update_status(self, data):
@@ -357,7 +357,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
         }
         permissions = {
             f'investment.{InvestmentProjectPermission.view_investmentproject_document}':
-                'archived_documents_url_path'
+                'archived_documents_url_path',
         }
         read_only_fields = (
             'allow_blank_estimated_land_date',
@@ -372,7 +372,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
 
 NestedInvestmentProjectField = partial(
     NestedRelatedField, InvestmentProject,
-    extra_fields=('name', 'project_code')
+    extra_fields=('name', 'project_code'),
 )
 
 
@@ -381,8 +381,8 @@ class IProjectTeamMemberListSerializer(serializers.ListSerializer):
 
     default_error_messages = {
         'duplicate_adviser': ugettext_lazy(
-            'You cannot add the same adviser as a team member more than once.'
-        )
+            'You cannot add the same adviser as a team member more than once.',
+        ),
     }
 
     def update(self, instances, validated_data):

--- a/datahub/investment/test/factories.py
+++ b/datahub/investment/test/factories.py
@@ -9,12 +9,12 @@ from django.utils.timezone import now
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core.constants import (
     InvestmentBusinessActivity, InvestmentProjectStage, InvestmentStrategicDriver,
-    InvestmentType, ReferralSourceActivity, SalaryRange, Sector
+    InvestmentType, ReferralSourceActivity, SalaryRange, Sector,
 )
 from datahub.core.test.factories import to_many_field
 from datahub.core.test_utils import random_obj_for_model
 from datahub.investment.constants import (
-    InvestorType, Involvement, SpecificProgramme
+    InvestorType, Involvement, SpecificProgramme,
 )
 from datahub.investment.models import InvestmentDeliveryPartner, InvestmentProject
 from datahub.metadata.models import UKRegion

--- a/datahub/investment/test/test_models.py
+++ b/datahub/investment/test/test_models.py
@@ -11,7 +11,7 @@ from freezegun import freeze_time
 from datahub.company.test.factories import AdviserFactory
 from datahub.core import constants
 from datahub.investment.test.factories import (
-    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory
+    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -106,17 +106,20 @@ def test_project_assurance_team_valid():
     assert str(project.project_assurance_team.id) == huk_team.id
 
 
-@pytest.mark.parametrize('field', (
-    'client_relationship_manager',
-    'project_assurance_adviser',
-    'project_manager',
-    'created_by',
-))
+@pytest.mark.parametrize(
+    'field',
+    (
+        'client_relationship_manager',
+        'project_assurance_adviser',
+        'project_manager',
+        'created_by',
+    ),
+)
 def test_associated_advisers_specific_roles(field):
     """Tests that get_associated_advisers() includes advisers in specific roles."""
     adviser = AdviserFactory()
     factory_kwargs = {
-        field: adviser
+        field: adviser,
     }
     project = InvestmentProjectFactory(**factory_kwargs)
     assert adviser in tuple(project.get_associated_advisers())
@@ -152,10 +155,10 @@ def test_creates_stage_log_if_stage_was_modified():
 
     date_iter = iter(dates)
     assert [
-        (entry.stage.id, entry.created_on,) for entry in project.stage_log.order_by('created_on')
+        (entry.stage.id, entry.created_on) for entry in project.stage_log.order_by('created_on')
     ] == [
-        (UUID(constants.InvestmentProjectStage.prospect.value.id), next(date_iter),),
-        (UUID(constants.InvestmentProjectStage.assign_pm.value.id), next(date_iter),)
+        (UUID(constants.InvestmentProjectStage.prospect.value.id), next(date_iter)),
+        (UUID(constants.InvestmentProjectStage.assign_pm.value.id), next(date_iter)),
     ]
 
 
@@ -172,10 +175,10 @@ def test_stage_log_added_when_investment_project_is_created():
     """Tests that stage is being logged when Investment Projects is created."""
     project = InvestmentProjectFactory()
     assert [
-        (entry.stage.id, entry.created_on,) for entry in project.stage_log.all()
+        (entry.stage.id, entry.created_on) for entry in project.stage_log.all()
     ] == [
         (
             UUID(constants.InvestmentProjectStage.prospect.value.id),
             datetime(2017, 4, 28, 17, 35, tzinfo=utc),
-        )
+        ),
     ]

--- a/datahub/investment/test/test_serializers.py
+++ b/datahub/investment/test/test_serializers.py
@@ -2,7 +2,7 @@ import pytest
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.investment.serializers import (
-    IProjectTeamMemberListSerializer, IProjectTeamMemberSerializer
+    IProjectTeamMemberListSerializer, IProjectTeamMemberSerializer,
 )
 from .factories import InvestmentProjectFactory, InvestmentProjectTeamMemberFactory
 
@@ -15,7 +15,7 @@ def test_team_member_list_update_remove_all():
     project = InvestmentProjectFactory()
 
     team_members = InvestmentProjectTeamMemberFactory.create_batch(
-        2, investment_project=project
+        2, investment_project=project,
     )
 
     child_serializer = IProjectTeamMemberSerializer()
@@ -30,19 +30,22 @@ def test_team_member_list_update_mixed_changes():
     project = InvestmentProjectFactory()
 
     team_members = InvestmentProjectTeamMemberFactory.create_batch(
-        2, investment_project=project, role='old role'
+        2, investment_project=project, role='old role',
     )
     adviser = AdviserFactory()
 
-    new_team_member_data = [{
-        'investment_project': project,
-        'adviser': team_members[1].adviser,
-        'role': 'new role'
-    }, {
-        'investment_project': project,
-        'adviser': adviser,
-        'role': 'new team member'
-    }]
+    new_team_member_data = [
+        {
+            'investment_project': project,
+            'adviser': team_members[1].adviser,
+            'role': 'new role',
+        },
+        {
+            'investment_project': project,
+            'adviser': adviser,
+            'role': 'new team member',
+        },
+    ]
 
     child_serializer = IProjectTeamMemberSerializer()
     serializer = IProjectTeamMemberListSerializer(child=child_serializer)
@@ -63,18 +66,21 @@ def test_team_member_list_update_change_only():
     project = InvestmentProjectFactory()
 
     team_members = InvestmentProjectTeamMemberFactory.create_batch(
-        2, investment_project=project, role='old role'
+        2, investment_project=project, role='old role',
     )
 
-    new_team_member_data = [{
-        'investment_project': project,
-        'adviser': team_members[0].adviser,
-        'role': 'new role'
-    }, {
-        'investment_project': project,
-        'adviser': team_members[1].adviser,
-        'role': 'new role'
-    }]
+    new_team_member_data = [
+        {
+            'investment_project': project,
+            'adviser': team_members[0].adviser,
+            'role': 'new role',
+        },
+        {
+            'investment_project': project,
+            'adviser': team_members[1].adviser,
+            'role': 'new role',
+        },
+    ]
 
     child_serializer = IProjectTeamMemberSerializer()
     serializer = IProjectTeamMemberListSerializer(child=child_serializer)
@@ -94,15 +100,18 @@ def test_team_member_list_update_add_only():
     """Tests updating adding team members when none previously existed."""
     project = InvestmentProjectFactory()
 
-    new_team_member_data = [{
-        'investment_project': project,
-        'adviser': AdviserFactory(),
-        'role': 'new role'
-    }, {
-        'investment_project': project,
-        'adviser': AdviserFactory(),
-        'role': 'new team member'
-    }]
+    new_team_member_data = [
+        {
+            'investment_project': project,
+            'adviser': AdviserFactory(),
+            'role': 'new role',
+        },
+        {
+            'investment_project': project,
+            'adviser': AdviserFactory(),
+            'role': 'new team member',
+        },
+    ]
 
     child_serializer = IProjectTeamMemberSerializer()
     serializer = IProjectTeamMemberListSerializer(child=child_serializer)

--- a/datahub/investment/test/test_validate.py
+++ b/datahub/investment/test/test_validate.py
@@ -5,7 +5,7 @@ from datahub.core import constants
 from datahub.core.test_utils import random_obj_for_model
 from datahub.investment.models import InvestmentDeliveryPartner
 from datahub.investment.serializers import (
-    CORE_FIELDS, REQUIREMENTS_FIELDS, TEAM_FIELDS, VALUE_FIELDS
+    CORE_FIELDS, REQUIREMENTS_FIELDS, TEAM_FIELDS, VALUE_FIELDS,
 )
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.investment.validate import validate
@@ -18,18 +18,18 @@ def test_validate_project_fail():
     """Tests validating an incomplete project section."""
     project = InvestmentProjectFactory(
         investment_type_id=constants.InvestmentType.fdi.value.id,
-        fdi_type_id=None
+        fdi_type_id=None,
     )
     errors = validate(instance=project, fields=CORE_FIELDS)
     assert errors == {
-        'fdi_type': 'This field is required.'
+        'fdi_type': 'This field is required.',
     }
 
 
 def test_validate_project_instance_success():
     """Tests validating a complete project section using a model instance."""
     project = InvestmentProjectFactory(
-        client_contacts=[ContactFactory().id, ContactFactory().id]
+        client_contacts=[ContactFactory().id, ContactFactory().id],
     )
     errors = validate(instance=project, fields=CORE_FIELDS)
     assert not errors
@@ -39,16 +39,19 @@ def test_validate_fdi_type():
     """Tests fdi_type conditional validation."""
     investment_type_id = constants.InvestmentType.fdi.value.id
     project = InvestmentProjectFactory(
-        investment_type_id=investment_type_id
+        investment_type_id=investment_type_id,
     )
     errors = validate(instance=project, fields=CORE_FIELDS)
     assert 'fdi_type' in errors
 
 
-@pytest.mark.parametrize('allow_blank_estimated_land_date,is_error', (
-    (True, False),
-    (False, True),
-))
+@pytest.mark.parametrize(
+    'allow_blank_estimated_land_date,is_error',
+    (
+        (True, False),
+        (False, True),
+    ),
+)
 def test_validate_estimated_land_date(allow_blank_estimated_land_date, is_error):
     """Tests estimated_land_date conditional validation."""
     investment_type_id = constants.InvestmentType.fdi.value.id
@@ -64,11 +67,11 @@ def test_validate_estimated_land_date(allow_blank_estimated_land_date, is_error)
 def test_validate_business_activity_other_instance():
     """Tests other_business_activity conditional validation for a model instance."""
     project = InvestmentProjectFactory(
-        business_activities=[constants.InvestmentBusinessActivity.other.value.id]
+        business_activities=[constants.InvestmentBusinessActivity.other.value.id],
     )
     errors = validate(instance=project, fields=CORE_FIELDS)
     assert errors == {
-        'other_business_activity': 'This field is required.'
+        'other_business_activity': 'This field is required.',
     }
 
 
@@ -76,12 +79,14 @@ def test_validate_business_activity_other_update_data():
     """Tests other_business_activity conditional validation for update data."""
     project = InvestmentProjectFactory()
     data = {
-        'business_activities': [constants.InvestmentBusinessActivity.other.value.id]
+        'business_activities': [constants.InvestmentBusinessActivity.other.value.id],
     }
-    errors = validate(instance=project, update_data=data,
-                      fields=CORE_FIELDS)
+    errors = validate(
+        instance=project, update_data=data,
+        fields=CORE_FIELDS,
+    )
     assert errors == {
-        'other_business_activity': 'This field is required.'
+        'other_business_activity': 'This field is required.',
     }
 
 
@@ -89,7 +94,7 @@ def test_validate_project_referral_website():
     """Tests referral_source_activity_website conditional validation."""
     referral_source_id = constants.ReferralSourceActivity.website.value.id
     project = InvestmentProjectFactory(
-        referral_source_activity_id=referral_source_id
+        referral_source_activity_id=referral_source_id,
     )
     errors = validate(instance=project, fields=CORE_FIELDS)
     assert 'referral_source_activity_website' in errors
@@ -101,7 +106,7 @@ def test_validate_project_referral_event():
     """Tests referral_source_activity_event conditional validation."""
     referral_source_id = constants.ReferralSourceActivity.event.value.id
     project = InvestmentProjectFactory(
-        referral_source_activity_id=referral_source_id
+        referral_source_activity_id=referral_source_id,
     )
     errors = validate(instance=project, fields=CORE_FIELDS)
     assert 'referral_source_activity_event' in errors
@@ -113,7 +118,7 @@ def test_validate_project_referral_marketing():
     """Tests referral_source_activity_marketing conditional validation."""
     referral_source_id = constants.ReferralSourceActivity.marketing.value.id
     project = InvestmentProjectFactory(
-        referral_source_activity_id=referral_source_id
+        referral_source_activity_id=referral_source_id,
     )
     errors = validate(instance=project, fields=CORE_FIELDS)
     assert 'referral_source_activity_marketing' in errors
@@ -127,10 +132,12 @@ def test_validate_project_update_data():
     project = InvestmentProjectFactory()
     referral_source = ReferralSourceActivity.objects.get(pk=referral_source_id)
     update_data = {
-        'referral_source_activity': referral_source
+        'referral_source_activity': referral_source,
     }
-    errors = validate(instance=project, update_data=update_data,
-                      fields=CORE_FIELDS)
+    errors = validate(
+        instance=project, update_data=update_data,
+        fields=CORE_FIELDS,
+    )
     assert 'referral_source_activity_marketing' in errors
     assert 'referral_source_activity_website' not in errors
     assert 'referral_source_activity_event' not in errors
@@ -139,13 +146,13 @@ def test_validate_project_update_data():
 def test_validate_value_fail():
     """Tests validating an incomplete value section."""
     project = InvestmentProjectFactory(
-        sector_id=None, stage_id=constants.InvestmentProjectStage.assign_pm.value.id
+        sector_id=None, stage_id=constants.InvestmentProjectStage.assign_pm.value.id,
     )
     errors = validate(instance=project, fields=VALUE_FIELDS)
     assert errors == {
         'client_cannot_provide_total_investment': 'This field is required.',
         'total_investment': 'This field is required.',
-        'number_new_jobs': 'This field is required.'
+        'number_new_jobs': 'This field is required.',
     }
 
 
@@ -155,7 +162,7 @@ def test_validate_value_instance_success():
         stage_id=constants.InvestmentProjectStage.assign_pm.value.id,
         client_cannot_provide_total_investment=False,
         total_investment=100,
-        number_new_jobs=0
+        number_new_jobs=0,
     )
     errors = validate(instance=project, fields=VALUE_FIELDS)
     assert not errors
@@ -165,21 +172,21 @@ def test_validate_reqs_fail():
     """Tests validating an incomplete reqs section."""
     project = InvestmentProjectFactory(
         stage_id=constants.InvestmentProjectStage.assign_pm.value.id,
-        sector_id=None
+        sector_id=None,
     )
     errors = validate(instance=project, fields=REQUIREMENTS_FIELDS)
     assert errors == {
         'client_considering_other_countries': 'This field is required.',
         'client_requirements': 'This field is required.',
         'strategic_drivers': 'This field is required.',
-        'uk_region_locations': 'This field is required.'
+        'uk_region_locations': 'This field is required.',
     }
 
 
 def test_validate_reqs_instance_success():
     """Tests validating a complete reqs section using a model instance."""
     strategic_drivers = [
-        constants.InvestmentStrategicDriver.access_to_market.value.id
+        constants.InvestmentStrategicDriver.access_to_market.value.id,
     ]
     uk_region_locations = [random_obj_for_model(UKRegion)]
     project = InvestmentProjectFactory(
@@ -188,7 +195,7 @@ def test_validate_reqs_instance_success():
         client_requirements='client reqs',
         site_decided=False,
         strategic_drivers=strategic_drivers,
-        uk_region_locations=uk_region_locations
+        uk_region_locations=uk_region_locations,
     )
     errors = validate(instance=project, fields=REQUIREMENTS_FIELDS)
     assert not errors
@@ -198,7 +205,7 @@ def test_validate_reqs_competitor_countries_missing():
     """Tests missing competitor countries conditional validation."""
     project = InvestmentProjectFactory(
         stage_id=constants.InvestmentProjectStage.assign_pm.value.id,
-        client_considering_other_countries=True
+        client_considering_other_countries=True,
     )
     errors = validate(instance=project, fields=REQUIREMENTS_FIELDS)
     assert 'competitor_countries' in errors
@@ -209,16 +216,19 @@ def test_validate_reqs_competitor_countries_present():
     project = InvestmentProjectFactory(
         stage_id=constants.InvestmentProjectStage.assign_pm.value.id,
         client_considering_other_countries=True,
-        competitor_countries=[constants.Country.united_states.value.id]
+        competitor_countries=[constants.Country.united_states.value.id],
     )
     errors = validate(instance=project, fields=REQUIREMENTS_FIELDS)
     assert 'competitor_countries' not in errors
 
 
-@pytest.mark.parametrize('allow_blank_possible_uk_regions,is_error', (
-    (True, False),
-    (False, True),
-))
+@pytest.mark.parametrize(
+    'allow_blank_possible_uk_regions,is_error',
+    (
+        (True, False),
+        (False, True),
+    ),
+)
 def test_validate_possible_uk_regions(allow_blank_possible_uk_regions, is_error):
     """Tests uk_region_locations (possible UK regions) conditional validation."""
     project = InvestmentProjectFactory(
@@ -234,12 +244,12 @@ def test_validate_team_fail():
     """Tests validating an incomplete team section."""
     project = InvestmentProjectFactory(
         stage_id=constants.InvestmentProjectStage.active.value.id,
-        sector_id=None
+        sector_id=None,
     )
     errors = validate(instance=project, fields=TEAM_FIELDS)
     assert errors == {
         'project_assurance_adviser': 'This field is required.',
-        'project_manager': 'This field is required.'
+        'project_manager': 'This field is required.',
     }
 
 
@@ -249,7 +259,7 @@ def test_validate_team_instance_success():
     project = InvestmentProjectFactory(
         stage_id=constants.InvestmentProjectStage.active.value.id,
         project_manager=adviser,
-        project_assurance_adviser=adviser
+        project_assurance_adviser=adviser,
     )
     errors = validate(instance=project, fields=TEAM_FIELDS)
     assert not errors
@@ -259,7 +269,7 @@ def test_validate_verify_win_instance_failure():
     """Tests validation for the verify win stage for an incomplete project instance."""
     adviser = AdviserFactory()
     strategic_drivers = [
-        constants.InvestmentStrategicDriver.access_to_market.value.id
+        constants.InvestmentStrategicDriver.access_to_market.value.id,
     ]
     project = InvestmentProjectFactory(
         stage_id=constants.InvestmentProjectStage.verify_win.value.id,
@@ -273,7 +283,7 @@ def test_validate_verify_win_instance_failure():
         strategic_drivers=strategic_drivers,
         uk_region_locations=[random_obj_for_model(UKRegion)],
         project_assurance_adviser=adviser,
-        project_manager=adviser
+        project_manager=adviser,
     )
     errors = validate(instance=project)
     assert errors == {
@@ -301,7 +311,7 @@ def test_validate_verify_win_instance_cond_validation():
         client_cannot_provide_total_investment=True,
         client_cannot_provide_foreign_investment=True,
         non_fdi_r_and_d_budget=False,
-        number_new_jobs=0
+        number_new_jobs=0,
     )
     errors = validate(instance=project)
     assert 'total_investment' not in errors
@@ -325,7 +335,7 @@ def test_validate_verify_win_instance_with_cond_fields():
     """Tests validation for the verify win stage for a complete project instance."""
     adviser = AdviserFactory()
     strategic_drivers = [
-        constants.InvestmentStrategicDriver.access_to_market.value.id
+        constants.InvestmentStrategicDriver.access_to_market.value.id,
     ]
     project = InvestmentProjectFactory(
         stage_id=constants.InvestmentProjectStage.verify_win.value.id,

--- a/datahub/investment/urls.py
+++ b/datahub/investment/urls.py
@@ -6,17 +6,17 @@ from datahub.investment.evidence.urls import urlpatterns as evidence_urlpatterns
 from datahub.investment.proposition.urls import urlpatterns as proposition_urlpatterns
 from datahub.investment.views import (
     IProjectAuditViewSet, IProjectModifiedSinceViewSet,
-    IProjectTeamMembersViewSet, IProjectViewSet
+    IProjectTeamMembersViewSet, IProjectViewSet,
 )
 
 project_collection = IProjectViewSet.as_view({
     'get': 'list',
-    'post': 'create'
+    'post': 'create',
 })
 
 project_item = IProjectViewSet.as_view({
     'get': 'retrieve',
-    'patch': 'partial_update'
+    'patch': 'partial_update',
 })
 
 project_team_member_collection = IProjectTeamMembersViewSet.as_view({
@@ -28,7 +28,7 @@ project_team_member_collection = IProjectTeamMembersViewSet.as_view({
 project_team_member_item = IProjectTeamMembersViewSet.as_view({
     'get': 'retrieve',
     'patch': 'partial_update',
-    'delete': 'destroy'
+    'delete': 'destroy',
 })
 
 project_modified_since_collection = IProjectModifiedSinceViewSet.as_view({
@@ -52,55 +52,55 @@ urlpatterns = [
     path(
         'investment',
         project_collection,
-        name='investment-collection'
+        name='investment-collection',
     ),
     path(
         'investment/from',
         project_modified_since_collection,
-        name='investment-modified-since-collection'
+        name='investment-modified-since-collection',
     ),
     path(
         'investment/<uuid:pk>',
         project_item,
-        name='investment-item'
+        name='investment-item',
     ),
     path(
         'investment/<uuid:pk>/archive',
         archive_item,
-        name='archive-item'
+        name='archive-item',
     ),
     path(
         'investment/<uuid:project_pk>/team-member',
         project_team_member_collection,
-        name='team-member-collection'
+        name='team-member-collection',
     ),
     path(
         'investment/<uuid:project_pk>/team-member/<uuid:adviser_pk>',
         project_team_member_item,
-        name='team-member-item'
+        name='team-member-item',
     ),
     path(
         'investment/<uuid:pk>/unarchive',
         unarchive_item,
-        name='unarchive-item'
+        name='unarchive-item',
     ),
     path(
         'investment/<uuid:pk>/audit',
         audit_item,
-        name='audit-item'
+        name='audit-item',
     ),
     path(
         'investment/<uuid:project_pk>/',
         include(
-            (proposition_urlpatterns, 'proposition',),
-            namespace='proposition'
-        )
+            (proposition_urlpatterns, 'proposition'),
+            namespace='proposition',
+        ),
     ),
     path(
         'investment/<uuid:project_pk>/',
         include(
-            (evidence_urlpatterns, 'evidence-document',),
-            namespace='evidence-document'
-        )
+            (evidence_urlpatterns, 'evidence-document'),
+            namespace='evidence-document',
+        ),
     ),
 ]

--- a/datahub/investment/validate.py
+++ b/datahub/investment/validate.py
@@ -8,7 +8,7 @@ from datahub.core.constants import (
     InvestmentBusinessActivity as BusinessActivity,
     InvestmentProjectStage as Stage,
     InvestmentType,
-    ReferralSourceActivity as Activity
+    ReferralSourceActivity as Activity,
 )
 from datahub.core.validate_utils import DataCombiner
 from datahub.investment.models import InvestmentProject
@@ -64,8 +64,10 @@ CONDITIONAL_VALIDATION_MAPPING = {
     'referral_source_activity_event':
         CondValRule('referral_source_activity', Activity.event.value.id, Stage.prospect.value),
     'other_business_activity':
-        CondValRule('business_activities', partial(_contains_id, BusinessActivity.other.value.id),
-                    Stage.prospect.value),
+        CondValRule(
+            'business_activities', partial(_contains_id, BusinessActivity.other.value.id),
+            Stage.prospect.value,
+        ),
     'referral_source_activity_marketing':
         CondValRule('referral_source_activity', Activity.marketing.value.id, Stage.prospect.value),
     'referral_source_activity_website':

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -47,8 +47,11 @@ class IProjectViewSet(ArchivableViewSetMixin, CoreViewSet):
     This replaces the previous project, value, team and requirements endpoints.
     """
 
-    permission_classes = (IsAuthenticatedOrTokenHasScope, InvestmentProjectModelPermissions,
-                          IsAssociatedToInvestmentProjectPermission)
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        InvestmentProjectModelPermissions,
+        IsAssociatedToInvestmentProjectPermission,
+    )
     required_scopes = (Scope.internal_front_end,)
     serializer_class = IProjectSerializer
     queryset = InvestmentProject.objects.select_related(
@@ -89,9 +92,11 @@ class IProjectViewSet(ArchivableViewSetMixin, CoreViewSet):
         'strategic_drivers',
         Prefetch('team_members', queryset=_team_member_queryset),
     )
-    filter_backends = (DjangoFilterBackend,
-                       OrderingFilter,
-                       IsAssociatedToInvestmentProjectFilter)
+    filter_backends = (
+        DjangoFilterBackend,
+        OrderingFilter,
+        IsAssociatedToInvestmentProjectFilter,
+    )
     filterset_fields = ('investor_company_id',)
     ordering = ('-created_on',)
 
@@ -131,7 +136,7 @@ class _SinglePagePaginator(BasePagination):
     def get_paginated_response(self, data):
         return Response({
             'count': len(data),
-            'results': data
+            'results': data,
         })
 
 
@@ -166,7 +171,7 @@ class IProjectTeamMembersViewSet(CoreViewSet):
         """Filters the query set to the specified project."""
         self._check_project_exists()
         return self.queryset.filter(
-            investment_project_id=self.kwargs['project_pk']
+            investment_project_id=self.kwargs['project_pk'],
         ).all()
 
     def get_serializer(self, *args, **kwargs):


### PR DESCRIPTION
### Description of change

This adds trailing commas where missing to the investment app. This includes some related code reformatting and the removal of some incorrect trailing commas.

The sub-apps are done separately in https://github.com/uktrade/data-hub-leeloo/pull/1127.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
