### PR TITLE
Add trailing commas to company app

### DIFF
--- a/datahub/company/admin/adviser.py
+++ b/datahub/company/admin/adviser.py
@@ -10,44 +10,59 @@ class AdviserAdmin(VersionAdmin, UserAdmin):
     """Adviser admin."""
 
     fieldsets = (
-        (None, {
-            'fields': (
-                'email',
-                'password'
-            )
-        }),
-        ('PERSONAL INFO', {
-            'fields': (
-                'first_name',
-                'last_name',
-                'contact_email',
-                'telephone_number',
-                'dit_team'
-            )
-        }),
-        ('PERMISSIONS', {
-            'fields': (
-                'is_active',
-                'is_staff',
-                'is_superuser',
-                'groups',
-                'user_permissions'
-            )
-        }),
-        ('IMPORTANT DATES', {
-            'fields': (
-                'last_login',
-                'date_joined'
-            )
-        }),
+        (
+            None,
+            {
+                'fields': (
+                    'email',
+                    'password',
+                ),
+            },
+        ),
+        (
+            'PERSONAL INFO',
+            {
+                'fields': (
+                    'first_name',
+                    'last_name',
+                    'contact_email',
+                    'telephone_number',
+                    'dit_team',
+                ),
+            },
+        ),
+        (
+            'PERMISSIONS',
+            {
+                'fields': (
+                    'is_active',
+                    'is_staff',
+                    'is_superuser',
+                    'groups',
+                    'user_permissions',
+                ),
+            },
+        ),
+        (
+            'IMPORTANT DATES',
+            {
+                'fields': (
+                    'last_login',
+                    'date_joined',
+                ),
+            },
+        ),
     )
     add_fieldsets = (
-        (None, {
-            'classes': ('wide',),
-            'fields': ('email', 'password1', 'password2'),
-        }),
+        (
+            None,
+            {
+                'classes': ('wide',),
+                'fields': ('email', 'password1', 'password2'),
+            },
+        ),
     )
-    list_display = ('email', 'first_name', 'last_name', 'dit_team', 'is_active', 'is_staff',)
+    list_display = ('email', 'first_name', 'last_name', 'dit_team', 'is_active', 'is_staff')
     search_fields = (
         '=pk',
         'first_name',

--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -11,7 +11,7 @@ class CompanyCoreTeamMemberInline(admin.TabularInline):
     """Inline admin for CompanyCoreTeamMember"""
 
     model = CompanyCoreTeamMember
-    fields = ('id', 'adviser', )
+    fields = ('id', 'adviser')
     extra = 1
     formfield_overrides = {
         models.UUIDField: {'widget': forms.HiddenInput},
@@ -46,8 +46,8 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                     'turnover_range',
                     'classification',
                     'one_list_account_owner',
-                )
-            }
+                ),
+            },
         ),
         (
             'HIERARCHY',
@@ -55,8 +55,8 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                 'fields': (
                     'headquarter_type',
                     'global_headquarters',
-                )
-            }
+                ),
+            },
         ),
         (
             'ADDRESS',
@@ -75,8 +75,8 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                     'trading_address_county',
                     'trading_address_postcode',
                     'trading_address_country',
-                )
-            }
+                ),
+            },
         ),
         (
             'EXPORT',
@@ -85,8 +85,8 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                     'export_experience_category',
                     'export_to_countries',
                     'future_interest_countries',
-                )
-            }
+                ),
+            },
         ),
         (
             'LEGACY FIELDS',
@@ -94,8 +94,8 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                 'fields': (
                     'reference_code',
                     'archived_documents_url_path',
-                )
-            }
+                ),
+            },
         ),
         (
             'ARCHIVE',
@@ -105,9 +105,9 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                     'archived_on',
                     'archived_by',
                     'archived_reason',
-                )
-            }
-        )
+                ),
+            },
+        ),
     )
     search_fields = (
         'name',

--- a/datahub/company/admin_reports.py
+++ b/datahub/company/admin_reports.py
@@ -19,7 +19,7 @@ class AllAdvisersReport(QuerySetReport):
             When(dit_team__disabled_on__isnull=True, dit_team__isnull=False, then=True),
             When(dit_team__disabled_on__isnull=False, then=False),
             default=None,
-            output_field=NullBooleanField()
+            output_field=NullBooleanField(),
         ),
     ).order_by(
         'date_joined',

--- a/datahub/company/constants.py
+++ b/datahub/company/constants.py
@@ -18,11 +18,11 @@ class BusinessTypeConstant(Enum):
     company = Constant('Company', '98d14e94-5d95-e211-a939-e4115bead28a')
     government_dept_or_other_public_body = Constant(
         'Government department or other public body',
-        '9cd14e94-5d95-e211-a939-e4115bead28a'
+        '9cd14e94-5d95-e211-a939-e4115bead28a',
     )
     intermediary = Constant('Intermediary', '9bd14e94-5d95-e211-a939-e4115bead28a')
     limited_partnership = Constant(
-        'Limited partnership', '8b6eaf7e-03e7-e611-bca1-e4115bead28a'
+        'Limited partnership', '8b6eaf7e-03e7-e611-bca1-e4115bead28a',
     )
     limited_liability_partnership = Constant(
         'Limited liability partnership', 'b70764b9-e523-46cf-8297-4c694ecbc5ce',
@@ -30,16 +30,16 @@ class BusinessTypeConstant(Enum):
     partnership = Constant('Partnership', '9ad14e94-5d95-e211-a939-e4115bead28a')
     sole_trader = Constant('Sole Trader', '99d14e94-5d95-e211-a939-e4115bead28a')
     private_limited_company = Constant(
-        'Private limited company', '6f75408b-03e7-e611-bca1-e4115bead28a'
+        'Private limited company', '6f75408b-03e7-e611-bca1-e4115bead28a',
     )
     public_limited_company = Constant(
-        'Public limited company', 'dac8c591-03e7-e611-bca1-e4115bead28a'
+        'Public limited company', 'dac8c591-03e7-e611-bca1-e4115bead28a',
     )
     # These are called UK establishments by Companies House and in law, but we are calling them
     # branches in the front end.
     uk_establishment = Constant(
-        'UK branch of foreign company (BR)', 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98'
+        'UK branch of foreign company (BR)', 'b0730fc6-fcce-4071-bdab-ba8de4f4fc98',
     )
     community_interest_company = Constant(
-        'Community interest company', '34e4cb83-e5e1-421e-ac90-8a52edcc209c'
+        'Community interest company', '34e4cb83-e5e1-421e-ac90-8a52edcc209c',
     )

--- a/datahub/company/management/commands/sync_ch.py
+++ b/datahub/company/management/commands/sync_ch.py
@@ -153,7 +153,7 @@ def transform_ch_row(row):
     # Nasty... copied from korben
     try:
         ret['incorporation_date'] = datetime.strptime(
-            ret['incorporation_date'], '%d/%m/%Y'
+            ret['incorporation_date'], '%d/%m/%Y',
         ).date()
     except (TypeError, ValueError):
         ret['incorporation_date'] = None
@@ -229,7 +229,7 @@ class CHSynchroniser:
             ch_company_rows = iter_ch_csv_from_url(csv_url, tmp_file_creator)
 
             batch_iter = slice_iterable_into_chunks(
-                ch_company_rows, settings.BULK_INSERT_BATCH_SIZE
+                ch_company_rows, settings.BULK_INSERT_BATCH_SIZE,
             )
             with connection.cursor() as cursor:
                 for batch in batch_iter:

--- a/datahub/company/metadata.py
+++ b/datahub/company/metadata.py
@@ -7,7 +7,7 @@ class InteractionFixtures(Fixture):
     """Metadata fixtures (for the loadinitialmetadata command)."""
 
     files = [
-        'fixtures/export_experience_categories.yaml'
+        'fixtures/export_experience_categories.yaml',
     ]
 
 

--- a/datahub/company/models/__init__.py
+++ b/datahub/company/models/__init__.py
@@ -4,7 +4,7 @@ from .company import (
     Company,
     CompanyCoreTeamMember,
     CompanyPermission,
-    ExportExperienceCategory
+    ExportExperienceCategory,
 )
 from .contact import Contact, ContactPermission
 

--- a/datahub/company/models/adviser.py
+++ b/datahub/company/models/adviser.py
@@ -64,7 +64,7 @@ class Advisor(AbstractBaseUser, PermissionsMixin):
     telephone_number = models.CharField(max_length=MAX_LENGTH, blank=True)
     contact_email = models.EmailField(max_length=MAX_LENGTH, blank=True)
     dit_team = models.ForeignKey(
-        metadata_models.Team, blank=True, null=True, on_delete=models.SET_NULL
+        metadata_models.Team, blank=True, null=True, on_delete=models.SET_NULL,
     )
     is_staff = models.BooleanField(
         'staff status',
@@ -83,7 +83,7 @@ class Advisor(AbstractBaseUser, PermissionsMixin):
     # TODO: Remove post-schema freeze
     use_cdms_auth = models.BooleanField(
         default=False,
-        help_text='No longer used'
+        help_text='No longer used',
     )
 
     objects = AdviserManager()

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -44,7 +44,7 @@ class CompanyAbstract(models.Model):
         metadata_models.Country,
         related_name="%(class)ss",  # noqa: Q000
         null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     registered_address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
 
@@ -74,39 +74,39 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
     company_number = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     vat_number = models.CharField(max_length=MAX_LENGTH, blank=True)
     alias = models.CharField(
-        max_length=MAX_LENGTH, blank=True, null=True, help_text='Trading name'
+        max_length=MAX_LENGTH, blank=True, null=True, help_text='Trading name',
     )
     business_type = models.ForeignKey(
         metadata_models.BusinessType, blank=True, null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     sector = TreeForeignKey(
         metadata_models.Sector, blank=True, null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     employee_range = models.ForeignKey(
         metadata_models.EmployeeRange, blank=True, null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     turnover_range = models.ForeignKey(
         metadata_models.TurnoverRange, blank=True, null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     export_to_countries = models.ManyToManyField(
         metadata_models.Country,
         blank=True,
-        related_name='company_export_to_countries'
+        related_name='company_export_to_countries',
     )
     future_interest_countries = models.ManyToManyField(
         metadata_models.Country,
         blank=True,
-        related_name='company_future_interest_countries'
+        related_name='company_future_interest_countries',
     )
     description = models.TextField(blank=True, null=True)
     website = models.URLField(max_length=MAX_LENGTH, blank=True, null=True)
     uk_region = models.ForeignKey(
         metadata_models.UKRegion, blank=True, null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     trading_address_1 = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     trading_address_2 = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
@@ -117,16 +117,16 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
-        related_name='company_trading_address_country'
+        related_name='company_trading_address_country',
     )
     trading_address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     headquarter_type = models.ForeignKey(
         metadata_models.HeadquarterType, blank=True, null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     classification = models.ForeignKey(
         metadata_models.CompanyClassification, blank=True, null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     global_headquarters = models.ForeignKey(
         'self', blank=True, null=True, on_delete=models.SET_NULL,
@@ -135,14 +135,14 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
     one_list_account_owner = models.ForeignKey(
         'Advisor', blank=True, null=True, on_delete=models.SET_NULL,
         related_name='one_list_owned_companies',
-        help_text='Global account manager'
+        help_text='Global account manager',
     )
     export_experience_category = models.ForeignKey(
         ExportExperienceCategory, blank=True, null=True, on_delete=models.SET_NULL,
     )
     archived_documents_url_path = models.CharField(
         max_length=MAX_LENGTH, blank=True,
-        help_text='Legacy field. File browser path to the archived documents for this company.'
+        help_text='Legacy field. File browser path to the archived documents for this company.',
     )
 
     class Meta:
@@ -168,7 +168,7 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
         if self.company_number:
             try:
                 return CompaniesHouseCompany.objects.get(
-                    company_number=self.company_number
+                    company_number=self.company_number,
                 )
             except CompaniesHouseCompany.DoesNotExist:
                 return None
@@ -209,10 +209,10 @@ class CompanyCoreTeamMember(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
 
     company = models.ForeignKey(
-        Company, on_delete=models.CASCADE, related_name='core_team_members'
+        Company, on_delete=models.CASCADE, related_name='core_team_members',
     )
     adviser = models.ForeignKey(
-        'company.Advisor', on_delete=models.CASCADE, related_name='core_team_memberships'
+        'company.Advisor', on_delete=models.CASCADE, related_name='core_team_memberships',
     )
 
     def __str__(self):
@@ -246,7 +246,7 @@ class CompaniesHouseCompany(CompanyAbstract):
     def business_type(self):
         """The business type associated with the company category provided by Companies House."""
         business_type = COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPING.get(
-            self.company_category.lower()
+            self.company_category.lower(),
         )
         if business_type:
             return BusinessType.objects.get(pk=business_type.value.id)

--- a/datahub/company/models/contact.py
+++ b/datahub/company/models/contact.py
@@ -34,18 +34,18 @@ class Contact(ArchivableModel, BaseModel):
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     title = models.ForeignKey(
-        metadata_models.Title, blank=True, null=True, on_delete=models.SET_NULL
+        metadata_models.Title, blank=True, null=True, on_delete=models.SET_NULL,
     )
     first_name = models.CharField(max_length=MAX_LENGTH)
     last_name = models.CharField(max_length=MAX_LENGTH)
     job_title = models.CharField(max_length=MAX_LENGTH, null=True, blank=True)
     company = models.ForeignKey(
         'Company', related_name='contacts', null=True, blank=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
     adviser = models.ForeignKey(
         'Advisor', related_name='contacts', null=True, blank=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     primary = models.BooleanField()
     telephone_countrycode = models.CharField(max_length=MAX_LENGTH)
@@ -58,7 +58,7 @@ class Contact(ArchivableModel, BaseModel):
     address_county = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     address_country = models.ForeignKey(
         metadata_models.Country, null=True, blank=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     telephone_alternative = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
@@ -66,7 +66,7 @@ class Contact(ArchivableModel, BaseModel):
     notes = models.TextField(null=True, blank=True)
     archived_documents_url_path = models.CharField(
         max_length=MAX_LENGTH, blank=True,
-        help_text='Legacy field. File browser path to the archived documents for this contact.'
+        help_text='Legacy field. File browser path to the archived documents for this contact.',
     )
 
     # Marketing preferences

--- a/datahub/company/queryset.py
+++ b/datahub/company/queryset.py
@@ -8,5 +8,5 @@ def get_contact_queryset():
         'company',
         'adviser',
         'address_country',
-        'archived_by'
+        'archived_by',
     )

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -19,7 +19,7 @@ from datahub.company.validators import (
 from datahub.core.constants import Country
 from datahub.core.constants import HeadquarterType
 from datahub.core.serializers import (
-    NestedRelatedField, PermittedFieldsModelSerializer, RelaxedURLField
+    NestedRelatedField, PermittedFieldsModelSerializer, RelaxedURLField,
 )
 from datahub.core.validate_utils import DataCombiner
 from datahub.core.validators import (
@@ -47,7 +47,7 @@ NestedAdviserField = partial(
         'name',
         'first_name',
         'last_name',
-    )
+    ),
 )
 
 
@@ -58,8 +58,8 @@ NestedAdviserWithTeamField = partial(
         'name',
         'first_name',
         'last_name',
-        ('dit_team', NestedRelatedField('metadata.Team'))
-    )
+        ('dit_team', NestedRelatedField('metadata.Team')),
+    ),
 )
 
 # like NestedAdviserField but includes dit_team with uk_region and country
@@ -71,7 +71,7 @@ NestedAdviserWithTeamGeographyField = partial(
         'first_name',
         'last_name',
         ('dit_team', TeamWithGeographyField()),
-    )
+    ),
 )
 
 
@@ -145,25 +145,25 @@ class ContactSerializer(PermittedFieldsModelSerializer):
     default_error_messages = {
         'contact_preferences_required': ugettext_lazy(
             'A contact should have at least one way of being contacted. Please select either '
-            'email or phone, or both.'
+            'email or phone, or both.',
         ),
         'address_same_as_company_and_has_address': ugettext_lazy(
-            'Please select either address_same_as_company or enter an address manually, not both!'
+            'Please select either address_same_as_company or enter an address manually, not both!',
         ),
         'no_address': ugettext_lazy(
-            'Please select either address_same_as_company or enter an address manually.'
+            'Please select either address_same_as_company or enter an address manually.',
         ),
     }
 
     title = NestedRelatedField(
-        meta_models.Title, required=False, allow_null=True
+        meta_models.Title, required=False, allow_null=True,
     )
     company = NestedRelatedField(
-        Company, required=False, allow_null=True
+        Company, required=False, allow_null=True,
     )
     adviser = NestedAdviserField(read_only=True)
     address_country = NestedRelatedField(
-        meta_models.Country, required=False, allow_null=True
+        meta_models.Country, required=False, allow_null=True,
     )
     archived = serializers.BooleanField(read_only=True)
     archived_on = serializers.DateTimeField(read_only=True)
@@ -208,7 +208,7 @@ class ContactSerializer(PermittedFieldsModelSerializer):
             'archived_reason',
             'archived_by',
             'created_on',
-            'modified_on'
+            'modified_on',
         )
         read_only_fields = (
             'archived_documents_url_path',
@@ -239,7 +239,7 @@ class ContactSerializer(PermittedFieldsModelSerializer):
             ),
             # Note: This is deliberately after RulesBasedValidator, so that
             # address_same_as_company rules run first.
-            AddressValidator(lazy=True, fields_mapping=Contact.ADDRESS_VALIDATION_MAPPING)
+            AddressValidator(lazy=True, fields_mapping=Contact.ADDRESS_VALIDATION_MAPPING),
         ]
         extra_kwargs = {
             'contactable_by_email': {'default': True},
@@ -261,20 +261,20 @@ class CompanySerializer(PermittedFieldsModelSerializer):
 
     default_error_messages = {
         'invalid_uk_establishment_number_prefix': ugettext_lazy(
-            'This must be a valid UK establishment number, beginning with BR.'
+            'This must be a valid UK establishment number, beginning with BR.',
         ),
         'invalid_uk_establishment_number_characters': ugettext_lazy(
             'This field can only contain the letters A to Z and numbers (no symbols, punctuation '
-            'or spaces).'
+            'or spaces).',
         ),
         'uk_establishment_not_in_uk': ugettext_lazy(
-            'A UK establishment (branch of non-UK company) must be in the UK.'
+            'A UK establishment (branch of non-UK company) must be in the UK.',
         ),
         'global_headquarters_hq_type_is_not_global_headquarters': ugettext_lazy(
-            'Company to be linked as global headquarters must be a global headquarters.'
+            'Company to be linked as global headquarters must be a global headquarters.',
         ),
         'invalid_global_headquarters': ugettext_lazy(
-            'Global headquarters cannot point to itself.'
+            'Global headquarters cannot point to itself.',
         ),
         'global_headquarters_has_subsidiaries': ugettext_lazy(
             'Subsidiaries have to be unlinked before changing headquarter type.',
@@ -286,47 +286,47 @@ class CompanySerializer(PermittedFieldsModelSerializer):
 
     registered_address_country = NestedRelatedField(meta_models.Country)
     trading_name = serializers.CharField(
-        source='alias', required=False, allow_null=True, allow_blank=True, max_length=MAX_LENGTH
+        source='alias', required=False, allow_null=True, allow_blank=True, max_length=MAX_LENGTH,
     )
     trading_address_country = NestedRelatedField(
-        meta_models.Country, required=False, allow_null=True
+        meta_models.Country, required=False, allow_null=True,
     )
     archived_by = NestedAdviserField(read_only=True)
     business_type = NestedRelatedField(
-        meta_models.BusinessType, required=False, allow_null=True
+        meta_models.BusinessType, required=False, allow_null=True,
     )
     classification = NestedRelatedField(
-        meta_models.CompanyClassification, required=False, allow_null=True
+        meta_models.CompanyClassification, required=False, allow_null=True,
     )
     companies_house_data = NestedCompaniesHouseCompanySerializer(read_only=True)
     contacts = ContactSerializer(many=True, read_only=True)
     employee_range = NestedRelatedField(
-        meta_models.EmployeeRange, required=False, allow_null=True
+        meta_models.EmployeeRange, required=False, allow_null=True,
     )
     export_to_countries = NestedRelatedField(
-        meta_models.Country, many=True, required=False
+        meta_models.Country, many=True, required=False,
     )
     future_interest_countries = NestedRelatedField(
-        meta_models.Country, many=True, required=False
+        meta_models.Country, many=True, required=False,
     )
     headquarter_type = NestedRelatedField(
-        meta_models.HeadquarterType, required=False, allow_null=True
+        meta_models.HeadquarterType, required=False, allow_null=True,
     )
     one_list_account_owner = NestedAdviserWithTeamField(
-        required=False, allow_null=True
+        required=False, allow_null=True,
     )
     global_headquarters = NestedRelatedField(
-        'company.Company', required=False, allow_null=True
+        'company.Company', required=False, allow_null=True,
     )
     sector = NestedRelatedField(meta_models.Sector, required=False, allow_null=True)
     turnover_range = NestedRelatedField(
-        meta_models.TurnoverRange, required=False, allow_null=True
+        meta_models.TurnoverRange, required=False, allow_null=True,
     )
     uk_region = NestedRelatedField(
-        meta_models.UKRegion, required=False, allow_null=True
+        meta_models.UKRegion, required=False, allow_null=True,
     )
     export_experience_category = NestedRelatedField(
-        ExportExperienceCategory, required=False, allow_null=True
+        ExportExperienceCategory, required=False, allow_null=True,
     )
 
     # Use our RelaxedURLField instead to automatically fix URLs without a scheme
@@ -349,7 +349,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             ):
                 message = self.error_messages['subsidiary_cannot_be_a_global_headquarters']
                 raise serializers.ValidationError({
-                    'headquarter_type': message
+                    'headquarter_type': message,
                 })
 
         return data
@@ -367,7 +367,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             and self.instance.subsidiaries.exists()
         ):
             raise serializers.ValidationError(
-                self.error_messages['global_headquarters_has_subsidiaries']
+                self.error_messages['global_headquarters_has_subsidiaries'],
             )
 
         return headquarter_type
@@ -381,7 +381,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             # checks if global_headquarters is not pointing to an instance of the model
             if self.instance == global_headquarters:
                 raise serializers.ValidationError(
-                    self.error_messages['invalid_global_headquarters']
+                    self.error_messages['invalid_global_headquarters'],
                 )
 
             # checks if global_headquarters is global_headquarters
@@ -389,7 +389,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
                 raise serializers.ValidationError(
                     self.error_messages[
                         'global_headquarters_hq_type_is_not_global_headquarters'
-                    ]
+                    ],
                 )
 
         return global_headquarters
@@ -453,32 +453,42 @@ class CompanySerializer(PermittedFieldsModelSerializer):
                 ValidationRule(
                     'required',
                     OperatorRule('uk_region', bool),
-                    when=EqualsRule('registered_address_country',
-                                    Country.united_kingdom.value.id),
+                    when=EqualsRule(
+                        'registered_address_country',
+                        Country.united_kingdom.value.id,
+                    ),
                 ),
                 ValidationRule(
                     'uk_establishment_not_in_uk',
                     EqualsRule('registered_address_country', Country.united_kingdom.value.id),
-                    when=EqualsRule('business_type',
-                                    BusinessTypeConstant.uk_establishment.value.id),
+                    when=EqualsRule(
+                        'business_type',
+                        BusinessTypeConstant.uk_establishment.value.id,
+                    ),
                 ),
                 ValidationRule(
                     'required',
                     OperatorRule('company_number', bool),
-                    when=EqualsRule('business_type',
-                                    BusinessTypeConstant.uk_establishment.value.id),
+                    when=EqualsRule(
+                        'business_type',
+                        BusinessTypeConstant.uk_establishment.value.id,
+                    ),
                 ),
                 ValidationRule(
                     'invalid_uk_establishment_number_characters',
                     OperatorRule('company_number', has_no_invalid_company_number_characters),
-                    when=EqualsRule('business_type',
-                                    BusinessTypeConstant.uk_establishment.value.id),
+                    when=EqualsRule(
+                        'business_type',
+                        BusinessTypeConstant.uk_establishment.value.id,
+                    ),
                 ),
                 ValidationRule(
                     'invalid_uk_establishment_number_prefix',
                     OperatorRule('company_number', has_uk_establishment_number_prefix),
-                    when=EqualsRule('business_type',
-                                    BusinessTypeConstant.uk_establishment.value.id),
+                    when=EqualsRule(
+                        'business_type',
+                        BusinessTypeConstant.uk_establishment.value.id,
+                    ),
                 ),
             ),
             AddressValidator(lazy=True, fields_mapping=Company.TRADING_ADDRESS_VALIDATION_MAPPING),

--- a/datahub/company/test/admin/test_company.py
+++ b/datahub/company/test/admin/test_company.py
@@ -55,7 +55,7 @@ class TestChangeCompanyAdmin(AdminTestMixin):
                 f'initial-core_team_members-{index}-id': team_member_id,
                 f'core_team_members-{index}-id': team_member_id,
                 f'core_team_members-{index}-company': company.pk,
-                f'core_team_members-{index}-adviser': adviser.pk
+                f'core_team_members-{index}-adviser': adviser.pk,
             })
 
         response = self.client.post(url, data, follow=True)
@@ -92,7 +92,7 @@ class TestChangeCompanyAdmin(AdminTestMixin):
                 f'initial-core_team_members-{index}-id': team_member.pk,
                 f'core_team_members-{index}-id': team_member.pk,
                 f'core_team_members-{index}-company': company.pk,
-                f'core_team_members-{index}-adviser': team_member.adviser.pk
+                f'core_team_members-{index}-adviser': team_member.adviser.pk,
 
             })
 
@@ -120,6 +120,6 @@ class TestOneListLink(AdminTestMixin):
 
         one_list_url = reverse(
             'admin-report:download-report',
-            kwargs={'report_id': OneListReport.id}
+            kwargs={'report_id': OneListReport.id},
         )
         assert one_list_url in response.rendered_content

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -49,7 +49,7 @@ class CompanyFactory(factory.django.DjangoModelFactory):
     archived = False
     uk_region_id = constants.UKRegion.england.value.id
     export_experience_category = factory.LazyFunction(
-        ExportExperienceCategory.objects.order_by('?').first
+        ExportExperienceCategory.objects.order_by('?').first,
     )
     turnover_range = factory.LazyFunction(lambda: random_obj_for_model(TurnoverRange))
     employee_range = factory.LazyFunction(lambda: random_obj_for_model(EmployeeRange))

--- a/datahub/company/test/test_admin_report.py
+++ b/datahub/company/test/test_admin_report.py
@@ -86,14 +86,14 @@ class TestReportAdmin(AdminTestMixin):
 def test_adviser_report_generation():
     """Test the generation of the report."""
     disabled_team = TeamFactory(
-        disabled_on=datetime(1980, 1, 1, tzinfo=timezone.utc)
+        disabled_on=datetime(1980, 1, 1, tzinfo=timezone.utc),
     )
     advisers = [
         AdviserFactory(date_joined=datetime(1980, 1, 1, tzinfo=timezone.utc)),
         AdviserFactory(date_joined=datetime(1990, 1, 1, tzinfo=timezone.utc), dit_team=None),
         AdviserFactory(
             date_joined=datetime(2000, 1, 1, tzinfo=timezone.utc),
-            dit_team=disabled_team
+            dit_team=disabled_team,
         ),
     ]
 
@@ -116,7 +116,7 @@ def test_one_list_report_generation():
         2,
         headquarter_type_id=constants.HeadquarterType.ghq.value.id,
         classification=factory.Iterator(
-            CompanyClassification.objects.all()  # keeps the ordering
+            CompanyClassification.objects.all(),  # keeps the ordering
         ),
         one_list_account_owner=AdviserFactory(),
     )

--- a/datahub/company/test/test_advisor_views.py
+++ b/datahub/company/test/test_advisor_views.py
@@ -44,9 +44,12 @@ class TestAdviser(APITestMixin):
         AdviserFactory(first_name='z', last_name='sorted adviser')
         AdviserFactory(first_name='f', last_name='sorted adviser')
         url = reverse('api-v1:advisor-list')
-        response = self.api_client.get(url, data={
-            'last_name__icontains': 'sorted'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'last_name__icontains': 'sorted',
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
         result = response.json()
         assert len(result['results']) == 3

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -12,7 +12,7 @@ from reversion.models import Version
 from datahub.core.constants import Country, HeadquarterType, Sector, UKRegion
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
 from datahub.core.test_utils import (
-    APITestMixin, create_test_user, format_date_or_datetime, random_obj_for_model
+    APITestMixin, create_test_user, format_date_or_datetime, random_obj_for_model,
 )
 from datahub.metadata.models import CompanyClassification
 from datahub.metadata.test.factories import TeamFactory
@@ -53,9 +53,12 @@ class TestListCompanies(APITestMixin):
         CompanyFactory.create_batch(2)
 
         url = reverse('api-v3:company:collection')
-        response = self.api_client.get(url, data={
-            'global_headquarters_id': ghq.pk,
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'global_headquarters_id': ghq.pk,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -74,15 +77,15 @@ class TestListCompanies(APITestMixin):
                     'Venus Ltd',
                     'Mars Components Ltd',
                     'Exports Ltd',
-                    'Lambda Plc'
-                )
-            )
+                    'Lambda Plc',
+                ),
+            ),
         )
 
         url = reverse('api-v3:company:collection')
         response = self.api_client.get(
             url,
-            data={'sortby': 'name'}
+            data={'sortby': 'name'},
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -95,7 +98,7 @@ class TestListCompanies(APITestMixin):
             'Lambda Plc',
             'Mars Components Ltd',
             'Mercury Ltd',
-            'Venus Ltd'
+            'Venus Ltd',
         ]
 
     def test_sort_by_created_on(self):
@@ -112,9 +115,12 @@ class TestListCompanies(APITestMixin):
                 CompanyFactory()
 
         url = reverse('api-v3:company:collection')
-        response = self.api_client.get(url, data={
-            'sortby': 'created_on',
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'sortby': 'created_on',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -133,7 +139,7 @@ class TestListCompanies(APITestMixin):
         user = create_test_user(
             permission_codenames=(
                 'view_company',
-            )
+            ),
         )
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:company:collection')
@@ -154,7 +160,7 @@ class TestListCompanies(APITestMixin):
             permission_codenames=(
                 'view_company',
                 'view_company_document',
-            )
+            ),
         )
         api_client = self.create_api_client(user=user)
         url = reverse('api-v3:company:collection')
@@ -179,7 +185,7 @@ class TestGetCompany(APITestMixin):
         user = create_test_user(
             permission_codenames=(
                 'view_company',
-            )
+            ),
         )
         api_client = self.create_api_client(user=user)
 
@@ -196,7 +202,7 @@ class TestGetCompany(APITestMixin):
             name='Foo Ltd',
             registered_address_1='Hello St',
             registered_address_town='Fooland',
-            registered_address_country_id=Country.united_states.value.id
+            registered_address_country_id=Country.united_states.value.id,
         )
         company = CompanyFactory(
             company_number=123,
@@ -206,13 +212,13 @@ class TestGetCompany(APITestMixin):
             registered_address_1='Goodbye St',
             registered_address_town='Barland',
             registered_address_country_id=Country.united_kingdom.value.id,
-            one_list_account_owner=AdviserFactory()
+            one_list_account_owner=AdviserFactory(),
         )
         user = create_test_user(
             permission_codenames=(
                 'view_company',
                 'view_company_document',
-            )
+            ),
         )
         api_client = self.create_api_client(user=user)
 
@@ -301,7 +307,7 @@ class TestGetCompany(APITestMixin):
             'trading_address_2': None,
             'trading_address_country': {
                 'id': str(company.trading_address_country.id),
-                'name': company.trading_address_country.name
+                'name': company.trading_address_country.name,
             },
             'trading_address_county': None,
             'trading_address_postcode': None,
@@ -331,7 +337,7 @@ class TestGetCompany(APITestMixin):
             registered_address_town='Fooland',
             registered_address_country_id=Country.united_states.value.id,
             headquarter_type_id=HeadquarterType.ukhq.value.id,
-            classification=random_obj_for_model(CompanyClassification)
+            classification=random_obj_for_model(CompanyClassification),
         )
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.id})
@@ -348,7 +354,7 @@ class TestGetCompany(APITestMixin):
                 company.registered_address_town)
         assert response.data['registered_address_country'] == {
             'name': company.registered_address_country.name,
-            'id': str(company.registered_address_country.pk)
+            'id': str(company.registered_address_country.pk),
         }
         assert response.data['registered_address_county'] is None
         assert response.data['registered_address_postcode'] is None
@@ -356,7 +362,7 @@ class TestGetCompany(APITestMixin):
                 HeadquarterType.ukhq.value.id)
         assert response.data['classification'] == {
             'id': str(company.classification.pk),
-            'name': company.classification.name
+            'name': company.classification.name,
         }
 
     def test_get_company_without_registered_country(self):
@@ -383,13 +389,14 @@ class TestGetCompany(APITestMixin):
         assert response.data['uk_based'] is None
 
     @pytest.mark.parametrize(
-        'input_website,expected_website', (
+        'input_website,expected_website',
+        (
             ('www.google.com', 'http://www.google.com'),
             ('http://www.google.com', 'http://www.google.com'),
             ('https://www.google.com', 'https://www.google.com'),
             ('', ''),
             (None, None),
-        )
+        ),
     )
     def test_get_company_with_website(self, input_website, expected_website):
         """
@@ -397,7 +404,7 @@ class TestGetCompany(APITestMixin):
         specified, the endpoint adds it automatically.
         """
         company = CompanyFactory(
-            website=input_website
+            website=input_website,
         )
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
         response = self.api_client.get(url)
@@ -415,14 +422,17 @@ class TestUpdateCompany(APITestMixin):
             name='Foo ltd.',
             registered_address_1='Hello st.',
             registered_address_town='Fooland',
-            registered_address_country_id=Country.united_states.value.id
+            registered_address_country_id=Country.united_states.value.id,
         )
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'name': 'Acme',
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'name': 'Acme',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['name'] == 'Acme'
@@ -438,7 +448,7 @@ class TestUpdateCompany(APITestMixin):
             name='Foo Ltd',
             registered_address_1='Hello St',
             registered_address_town='Fooland',
-            registered_address_country_id=Country.united_states.value.id
+            registered_address_country_id=Country.united_states.value.id,
         )
         company = CompanyFactory(
             company_number=123,
@@ -447,7 +457,7 @@ class TestUpdateCompany(APITestMixin):
             vat_number='009485769',
             registered_address_1='Goodbye St',
             registered_address_town='Barland',
-            registered_address_country_id=Country.united_kingdom.value.id
+            registered_address_country_id=Country.united_kingdom.value.id,
         )
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
@@ -479,10 +489,13 @@ class TestUpdateCompany(APITestMixin):
         )
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'reference_code': 'XYZ',
-            'archived_documents_url_path': 'new_path'
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'reference_code': 'XYZ',
+                'archived_documents_url_path': 'new_path',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['reference_code'] == 'ORG-345645'
@@ -494,22 +507,28 @@ class TestUpdateCompany(APITestMixin):
             name='Foo ltd.',
             registered_address_1='Hello st.',
             registered_address_town='Fooland',
-            registered_address_country_id=Country.united_states.value.id
+            registered_address_country_id=Country.united_states.value.id,
         )
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'trading_name': 'a' * 600,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'trading_name': 'a' * 600,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            'trading_name': ['Ensure this field has no more than 255 characters.']
+            'trading_name': ['Ensure this field has no more than 255 characters.'],
         }
 
-    @pytest.mark.parametrize('field,value', (
-        ('sector', Sector.aerospace_assembly_aircraft.value.id),
-    ))
+    @pytest.mark.parametrize(
+        'field,value',
+        (
+            ('sector', Sector.aerospace_assembly_aircraft.value.id),
+        ),
+    )
     def test_update_non_null_field_to_null(self, field, value):
         """
         Tests setting fields to null that are currently non-null, and are allowed to be null
@@ -520,14 +539,17 @@ class TestUpdateCompany(APITestMixin):
             'registered_address_1': 'Hello st.',
             'registered_address_town': 'Fooland',
             'registered_address_country_id': Country.united_states.value.id,
-            f'{field}_id': value
+            f'{field}_id': value,
         }
         company = CompanyFactory(**creation_data)
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, {
-            field: None,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                field: None,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -545,24 +567,30 @@ class TestUpdateCompany(APITestMixin):
             'registered_address_1': 'Hello st.',
             'registered_address_town': 'Fooland',
             'registered_address_country_id': Country.united_states.value.id,
-            f'{field}_id': None
+            f'{field}_id': None,
         }
         company = CompanyFactory(**creation_data)
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, {
-            field: None,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                field: None,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()[field] is None
 
-    @pytest.mark.parametrize('hq,is_valid', (
-        (HeadquarterType.ehq.value.id, False),
-        (HeadquarterType.ukhq.value.id, False),
-        (HeadquarterType.ghq.value.id, True),
-        (None, False),
-    ))
+    @pytest.mark.parametrize(
+        'hq,is_valid',
+        (
+            (HeadquarterType.ehq.value.id, False),
+            (HeadquarterType.ukhq.value.id, False),
+            (HeadquarterType.ghq.value.id, True),
+            (None, False),
+        ),
+    )
     def test_update_company_global_headquarters_with_not_a_global_headquarters(self, hq, is_valid):
         """Tests if adding company that is not a Global HQ as a Global HQ
         will fail or if added company is a Global HQ then it will pass.
@@ -572,9 +600,12 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'global_headquarters': headquarter.id,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'global_headquarters': headquarter.id,
+            },
+        )
         if is_valid:
             assert response.status_code == status.HTTP_200_OK
             if hq is not None:
@@ -587,7 +618,7 @@ class TestUpdateCompany(APITestMixin):
     def test_remove_global_headquarters_link(self):
         """Tests that we can remove global headquarter link."""
         global_headquarters = CompanyFactory(
-            headquarter_type_id=HeadquarterType.ghq.value.id
+            headquarter_type_id=HeadquarterType.ghq.value.id,
         )
         company = CompanyFactory(global_headquarters=global_headquarters)
 
@@ -595,9 +626,12 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'global_headquarters': None,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'global_headquarters': None,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['global_headquarters'] is None
@@ -607,14 +641,17 @@ class TestUpdateCompany(APITestMixin):
     def test_cannot_point_company_to_itself_as_global_headquarters(self):
         """Test that you cannot point company as its own global headquarters."""
         company = CompanyFactory(
-            headquarter_type_id=HeadquarterType.ghq.value.id
+            headquarter_type_id=HeadquarterType.ghq.value.id,
         )
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'global_headquarters': company.id,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'global_headquarters': company.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         error = ['Global headquarters cannot point to itself.']
@@ -623,7 +660,7 @@ class TestUpdateCompany(APITestMixin):
     def test_subsidiary_cannot_become_a_global_headquarters(self):
         """Tests that subsidiary cannot become a global headquarter."""
         global_headquarters = CompanyFactory(
-            headquarter_type_id=HeadquarterType.ghq.value.id
+            headquarter_type_id=HeadquarterType.ghq.value.id,
         )
         company = CompanyFactory(
             headquarter_type_id=None,
@@ -634,29 +671,35 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'headquarter_type': HeadquarterType.ghq.value.id,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'headquarter_type': HeadquarterType.ghq.value.id,
+            },
+        )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         error = ['A company cannot both be and have a global headquarters.']
         assert response.data['headquarter_type'] == error
 
-    @pytest.mark.parametrize('headquarter_type_id,changed_to,has_subsidiaries,is_valid', (
-        (HeadquarterType.ghq.value.id, None, True, False),
-        (HeadquarterType.ghq.value.id, HeadquarterType.ehq.value.id, True, False),
-        (HeadquarterType.ghq.value.id, HeadquarterType.ehq.value.id, False, True),
-        (HeadquarterType.ghq.value.id, None, False, True),
-    ))
+    @pytest.mark.parametrize(
+        'headquarter_type_id,changed_to,has_subsidiaries,is_valid',
+        (
+            (HeadquarterType.ghq.value.id, None, True, False),
+            (HeadquarterType.ghq.value.id, HeadquarterType.ehq.value.id, True, False),
+            (HeadquarterType.ghq.value.id, HeadquarterType.ehq.value.id, False, True),
+            (HeadquarterType.ghq.value.id, None, False, True),
+        ),
+    )
     def test_update_headquarter_type(
         self,
         headquarter_type_id,
         changed_to,
         has_subsidiaries,
-        is_valid
+        is_valid,
     ):
         """Test updating headquarter type."""
         company = CompanyFactory(
-            headquarter_type_id=headquarter_type_id
+            headquarter_type_id=headquarter_type_id,
         )
         if has_subsidiaries:
             CompanyFactory(global_headquarters=company)
@@ -664,9 +707,12 @@ class TestUpdateCompany(APITestMixin):
 
         # now update it
         url = reverse('api-v3:company:item', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'headquarter_type': changed_to,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'headquarter_type': changed_to,
+            },
+        )
 
         if is_valid:
             assert response.status_code == status.HTTP_200_OK
@@ -685,20 +731,23 @@ class TestAddCompany(APITestMixin):
     def test_add_uk_company(self):
         """Test add new UK company."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': 'Trading name',
-            'business_type': {'id': BusinessTypeConstant.company.value.id},
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': 'Trading name',
+                'business_type': {'id': BusinessTypeConstant.company.value.id},
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'uk_region': {'id': UKRegion.england.value.id},
+                'headquarter_type': {'id': HeadquarterType.ghq.value.id},
+                'classification': {'id': random_obj_for_model(CompanyClassification).pk},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'uk_region': {'id': UKRegion.england.value.id},
-            'headquarter_type': {'id': HeadquarterType.ghq.value.id},
-            'classification': {'id': random_obj_for_model(CompanyClassification).pk},
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data['name'] == 'Acme'
@@ -709,36 +758,42 @@ class TestAddCompany(APITestMixin):
         CompaniesHouseCompanyFactory(company_number=1234567890)
 
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, {
-            'name': 'Acme',
-            'company_number': 1234567890,
-            'business_type': BusinessTypeConstant.company.value.id,
-            'sector': Sector.aerospace_assembly_aircraft.value.id,
-            'registered_address_country': Country.united_kingdom.value.id,
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'trading_address_country': Country.ireland.value.id,
-            'trading_address_1': '1 Hello st.',
-            'trading_address_town': 'Dublin',
-            'uk_region': UKRegion.england.value.id
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'company_number': 1234567890,
+                'business_type': BusinessTypeConstant.company.value.id,
+                'sector': Sector.aerospace_assembly_aircraft.value.id,
+                'registered_address_country': Country.united_kingdom.value.id,
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'trading_address_country': Country.ireland.value.id,
+                'trading_address_1': '1 Hello st.',
+                'trading_address_town': 'Dublin',
+                'uk_region': UKRegion.england.value.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
 
     def test_add_uk_company_without_uk_region(self):
         """Test add new UK without UK region company."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': None,
-            'business_type': {'id': BusinessTypeConstant.company.value.id},
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': None,
+                'business_type': {'id': BusinessTypeConstant.company.value.id},
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {'uk_region': ['This field is required.']}
@@ -746,17 +801,20 @@ class TestAddCompany(APITestMixin):
     def test_add_not_uk_company(self):
         """Test add new not UK company."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': None,
-            'business_type': {'id': BusinessTypeConstant.company.value.id},
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_states.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': None,
+                'business_type': {'id': BusinessTypeConstant.company.value.id},
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_states.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.data['name'] == 'Acme'
@@ -764,54 +822,63 @@ class TestAddCompany(APITestMixin):
     def test_add_company_partial_trading_address(self):
         """Test add new company with partial trading address."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'business_type': {'id': BusinessTypeConstant.company.value.id},
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'business_type': {'id': BusinessTypeConstant.company.value.id},
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'trading_address_1': 'test',
+                'uk_region': {'id': UKRegion.england.value.id},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'trading_address_1': 'test',
-            'uk_region': {'id': UKRegion.england.value.id}
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
             'trading_address_town': ['This field is required.'],
-            'trading_address_country': ['This field is required.']
+            'trading_address_country': ['This field is required.'],
         }
 
     def test_add_company_with_trading_address(self):
         """Test add new company with trading_address."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'business_type': {'id': BusinessTypeConstant.company.value.id},
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'business_type': {'id': BusinessTypeConstant.company.value.id},
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'trading_address_country': {'id': Country.ireland.value.id},
+                'trading_address_1': '1 Hello st.',
+                'trading_address_town': 'Dublin',
+                'uk_region': {'id': UKRegion.england.value.id},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'trading_address_country': {'id': Country.ireland.value.id},
-            'trading_address_1': '1 Hello st.',
-            'trading_address_town': 'Dublin',
-            'uk_region': {'id': UKRegion.england.value.id}
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
 
     def test_add_company_without_address(self):
         """Tests adding a company without a country."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, {
-            'name': 'Acme',
-            'trading_name': None,
-            'business_type': BusinessTypeConstant.company.value.id,
-            'sector': Sector.aerospace_assembly_aircraft.value.id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': None,
+                'business_type': BusinessTypeConstant.company.value.id,
+                'sector': Sector.aerospace_assembly_aircraft.value.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -823,15 +890,18 @@ class TestAddCompany(APITestMixin):
     def test_add_company_with_null_address(self):
         """Tests adding a company without a country."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, {
-            'name': 'Acme',
-            'trading_name': None,
-            'business_type': BusinessTypeConstant.company.value.id,
-            'sector': Sector.aerospace_assembly_aircraft.value.id,
-            'registered_address_1': None,
-            'registered_address_town': None,
-            'registered_address_country': None
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': None,
+                'business_type': BusinessTypeConstant.company.value.id,
+                'sector': Sector.aerospace_assembly_aircraft.value.id,
+                'registered_address_1': None,
+                'registered_address_town': None,
+                'registered_address_country': None,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
@@ -843,21 +913,24 @@ class TestAddCompany(APITestMixin):
     def test_add_company_with_blank_address(self):
         """Tests adding a company without a country."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, {
-            'name': 'Acme',
-            'trading_name': None,
-            'business_type': BusinessTypeConstant.company.value.id,
-            'sector': Sector.aerospace_assembly_aircraft.value.id,
-            'registered_address_1': '',
-            'registered_address_town': '',
-            'registered_address_country': None,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': None,
+                'business_type': BusinessTypeConstant.company.value.id,
+                'sector': Sector.aerospace_assembly_aircraft.value.id,
+                'registered_address_1': '',
+                'registered_address_town': '',
+                'registered_address_country': None,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
             'registered_address_1': ['This field may not be blank.'],
             'registered_address_town': ['This field may not be blank.'],
-            'registered_address_country': ['This field may not be null.']
+            'registered_address_country': ['This field may not be null.'],
         }
 
     @pytest.mark.parametrize('field', ('sector',))
@@ -867,46 +940,53 @@ class TestAddCompany(APITestMixin):
         updates) when already null.
         """
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, {
-            'name': 'Acme',
-            'alias': None,
-            'business_type': BusinessTypeConstant.company.value.id,
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'registered_address_country': Country.united_kingdom.value.id,
-            'uk_region': UKRegion.england.value.id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'alias': None,
+                'business_type': BusinessTypeConstant.company.value.id,
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'registered_address_country': Country.united_kingdom.value.id,
+                'uk_region': UKRegion.england.value.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()[field] == ['This field is required.']
 
     @pytest.mark.parametrize(
-        'input_website,expected_website', (
+        'input_website,expected_website',
+        (
             ('www.google.com', 'http://www.google.com'),
             ('http://www.google.com', 'http://www.google.com'),
             ('https://www.google.com', 'https://www.google.com'),
             ('', ''),
             (None, None),
-        )
+        ),
     )
     def test_add_company_with_website(self, input_website, expected_website):
         """Test add new company with trading_address."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'business_type': {'id': BusinessTypeConstant.company.value.id},
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'business_type': {'id': BusinessTypeConstant.company.value.id},
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'trading_address_country': {'id': Country.ireland.value.id},
+                'trading_address_1': '1 Hello st.',
+                'trading_address_town': 'Dublin',
+                'uk_region': {'id': UKRegion.england.value.id},
+                'website': input_website,
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'trading_address_country': {'id': Country.ireland.value.id},
-            'trading_address_1': '1 Hello st.',
-            'trading_address_town': 'Dublin',
-            'uk_region': {'id': UKRegion.england.value.id},
-            'website': input_website,
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()['website'] == expected_website
@@ -914,21 +994,24 @@ class TestAddCompany(APITestMixin):
     def test_add_uk_establishment(self):
         """Test adding a UK establishment."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': 'Trading name',
-            'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
-            'company_number': 'BR000006',
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': 'Trading name',
+                'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                'company_number': 'BR000006',
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'uk_region': {'id': UKRegion.england.value.id},
+                'headquarter_type': {'id': HeadquarterType.ghq.value.id},
+                'classification': {'id': random_obj_for_model(CompanyClassification).pk},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'uk_region': {'id': UKRegion.england.value.id},
-            'headquarter_type': {'id': HeadquarterType.ghq.value.id},
-            'classification': {'id': random_obj_for_model(CompanyClassification).pk},
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()['company_number'] == 'BR000006'
@@ -936,50 +1019,56 @@ class TestAddCompany(APITestMixin):
     def test_cannot_add_uk_establishment_without_number(self):
         """Test that a UK establishment cannot be added without a company number."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': 'Trading name',
-            'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
-            'company_number': '',
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': 'Trading name',
+                'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                'company_number': '',
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'uk_region': {'id': UKRegion.england.value.id},
+                'headquarter_type': {'id': HeadquarterType.ghq.value.id},
+                'classification': {'id': random_obj_for_model(CompanyClassification).pk},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'uk_region': {'id': UKRegion.england.value.id},
-            'headquarter_type': {'id': HeadquarterType.ghq.value.id},
-            'classification': {'id': random_obj_for_model(CompanyClassification).pk},
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            'company_number': ['This field is required.']
+            'company_number': ['This field is required.'],
         }
 
     def test_cannot_add_uk_establishment_as_foreign_company(self):
         """Test that adding a UK establishment fails if its country is not UK."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': 'Trading name',
-            'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
-            'company_number': 'BR000006',
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_states.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': 'Trading name',
+                'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                'company_number': 'BR000006',
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_states.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'uk_region': {'id': UKRegion.england.value.id},
+                'headquarter_type': {'id': HeadquarterType.ghq.value.id},
+                'classification': {'id': random_obj_for_model(CompanyClassification).pk},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'uk_region': {'id': UKRegion.england.value.id},
-            'headquarter_type': {'id': HeadquarterType.ghq.value.id},
-            'classification': {'id': random_obj_for_model(CompanyClassification).pk},
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             'registered_address_country':
-                ['A UK establishment (branch of non-UK company) must be in the UK.']
+                ['A UK establishment (branch of non-UK company) must be in the UK.'],
         }
 
     def test_cannot_add_uk_establishment_invalid_prefix(self):
@@ -987,26 +1076,29 @@ class TestAddCompany(APITestMixin):
         Test that adding a UK establishment fails if its company number does not start with BR.
         """
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': 'Trading name',
-            'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
-            'company_number': 'SC000006',
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': 'Trading name',
+                'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                'company_number': 'SC000006',
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'uk_region': {'id': UKRegion.england.value.id},
+                'headquarter_type': {'id': HeadquarterType.ghq.value.id},
+                'classification': {'id': random_obj_for_model(CompanyClassification).pk},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'uk_region': {'id': UKRegion.england.value.id},
-            'headquarter_type': {'id': HeadquarterType.ghq.value.id},
-            'classification': {'id': random_obj_for_model(CompanyClassification).pk},
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             'company_number':
-                ['This must be a valid UK establishment number, beginning with BR.']
+                ['This must be a valid UK establishment number, beginning with BR.'],
         }
 
     def test_cannot_add_uk_establishment_invalid_characters(self):
@@ -1015,47 +1107,55 @@ class TestAddCompany(APITestMixin):
         characters.
         """
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': 'Trading name',
-            'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
-            'company_number': 'BR000444é',
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': 'Trading name',
+                'business_type': {'id': BusinessTypeConstant.uk_establishment.value.id},
+                'company_number': 'BR000444é',
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'uk_region': {'id': UKRegion.england.value.id},
+                'headquarter_type': {'id': HeadquarterType.ghq.value.id},
+                'classification': {'id': random_obj_for_model(CompanyClassification).pk},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'uk_region': {'id': UKRegion.england.value.id},
-            'headquarter_type': {'id': HeadquarterType.ghq.value.id},
-            'classification': {'id': random_obj_for_model(CompanyClassification).pk},
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             'company_number':
-                ['This field can only contain the letters A to Z and numbers (no symbols, '
-                 'punctuation or spaces).']
+                [
+                    'This field can only contain the letters A to Z and numbers (no symbols, '
+                    'punctuation or spaces).',
+                ],
         }
 
     def test_no_company_number_validation_for_normal_uk_companies(self):
         """Test that no validation is done on company number for normal companies."""
         url = reverse('api-v3:company:collection')
-        response = self.api_client.post(url, data={
-            'name': 'Acme',
-            'trading_name': 'Trading name',
-            'business_type': {'id': BusinessTypeConstant.private_limited_company.value.id},
-            'company_number': 'sc000444é',
-            'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
-            'registered_address_country': {
-                'id': Country.united_kingdom.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'name': 'Acme',
+                'trading_name': 'Trading name',
+                'business_type': {'id': BusinessTypeConstant.private_limited_company.value.id},
+                'company_number': 'sc000444é',
+                'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
+                'registered_address_country': {
+                    'id': Country.united_kingdom.value.id,
+                },
+                'registered_address_1': '75 Stramford Road',
+                'registered_address_town': 'London',
+                'uk_region': {'id': UKRegion.england.value.id},
+                'headquarter_type': {'id': HeadquarterType.ghq.value.id},
+                'classification': {'id': random_obj_for_model(CompanyClassification).pk},
             },
-            'registered_address_1': '75 Stramford Road',
-            'registered_address_town': 'London',
-            'uk_region': {'id': UKRegion.england.value.id},
-            'headquarter_type': {'id': HeadquarterType.ghq.value.id},
-            'classification': {'id': random_obj_for_model(CompanyClassification).pk},
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()['company_number'] == 'sc000444é'
@@ -1072,14 +1172,14 @@ class TestArchiveCompany(APITestMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
-            'reason': ['This field is required.']
+            'reason': ['This field is required.'],
         }
 
     def test_archive_company_reason(self):
         """Test company archive."""
         company = CompanyFactory()
         url = reverse('api-v3:company:archive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, {'reason': 'foo'})
+        response = self.api_client.post(url, data={'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -1097,7 +1197,7 @@ class TestArchiveCompany(APITestMixin):
             uk_region_id=None,
         )
         url = reverse('api-v3:company:archive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, {'reason': 'foo'})
+        response = self.api_client.post(url, data={'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -1128,7 +1228,7 @@ class TestUnarchiveCompany(APITestMixin):
     def test_unarchive_company(self):
         """Unarchive a company."""
         company = CompanyFactory(
-            archived=True, archived_on=now(), archived_reason='foo'
+            archived=True, archived_on=now(), archived_reason='foo',
         )
         url = reverse('api-v3:company:unarchive', kwargs={'pk': company.id})
         response = self.api_client.post(url)
@@ -1156,7 +1256,7 @@ class TestCompanyVersioning(APITestMixin):
                 'business_type': {'id': BusinessTypeConstant.company.value.id},
                 'sector': {'id': Sector.aerospace_assembly_aircraft.value.id},
                 'registered_address_country': {
-                    'id': Country.united_kingdom.value.id
+                    'id': Country.united_kingdom.value.id,
                 },
                 'registered_address_1': '75 Stramford Road',
                 'registered_address_town': 'London',
@@ -1193,7 +1293,7 @@ class TestCompanyVersioning(APITestMixin):
                 'registered_address_country': Country.united_kingdom.value.id,
                 'registered_address_1': '75 Stramford Road',
                 'registered_address_town': 'London',
-                'uk_region': UKRegion.england.value.id
+                'uk_region': UKRegion.england.value.id,
             },
         )
 
@@ -1256,7 +1356,7 @@ class TestCompanyVersioning(APITestMixin):
         assert Version.objects.get_for_object(company).count() == 0
 
         url = reverse('api-v3:company:archive', kwargs={'pk': company.id})
-        response = self.api_client.post(url, {'reason': 'foo'})
+        response = self.api_client.post(url, data={'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -1283,7 +1383,7 @@ class TestCompanyVersioning(APITestMixin):
     def test_unarchive_creates_a_new_version(self):
         """Test that unarchiving a company creates a new version."""
         company = CompanyFactory(
-            archived=True, archived_on=now(), archived_reason='foo'
+            archived=True, archived_on=now(), archived_reason='foo',
         )
         assert Version.objects.get_for_object(company).count() == 0
 
@@ -1362,7 +1462,7 @@ class TestCHCompany(APITestMixin):
         """Test retrieving a single CH company."""
         ch_company = CompaniesHouseCompanyFactory()
         url = reverse(
-            'api-v3:ch-company:item', kwargs={'company_number': ch_company.company_number}
+            'api-v3:ch-company:item', kwargs={'company_number': ch_company.company_number},
         )
         response = self.api_client.get(url)
 
@@ -1399,7 +1499,7 @@ class TestCHCompany(APITestMixin):
         """Test retrieving a single CH company where the company number contains letters."""
         CompaniesHouseCompanyFactory(company_number='SC00001234')
         url = reverse(
-            'api-v3:ch-company:item', kwargs={'company_number': 'SC00001234'}
+            'api-v3:ch-company:item', kwargs={'company_number': 'SC00001234'},
         )
         response = self.api_client.get(url)
 
@@ -1427,7 +1527,7 @@ class TestCompanyCoreTeam(APITestMixin):
 
         url = reverse(
             'api-v3:company:core-team',
-            kwargs={'pk': company.pk}
+            kwargs={'pk': company.pk},
         )
         response = self.api_client.get(url)
 
@@ -1444,7 +1544,7 @@ class TestCompanyCoreTeam(APITestMixin):
 
         url = reverse(
             'api-v3:company:core-team',
-            kwargs={'pk': company.pk}
+            kwargs={'pk': company.pk},
         )
         response = self.api_client.get(url)
 
@@ -1461,22 +1561,22 @@ class TestCompanyCoreTeam(APITestMixin):
                         'name': global_account_manager.dit_team.name,
                         'uk_region': {
                             'id': str(global_account_manager.dit_team.uk_region.pk),
-                            'name': global_account_manager.dit_team.uk_region.name
+                            'name': global_account_manager.dit_team.uk_region.name,
                         },
                         'country': {
                             'id': str(global_account_manager.dit_team.country.pk),
-                            'name': global_account_manager.dit_team.country.name
+                            'name': global_account_manager.dit_team.country.name,
                         },
-                    }
+                    },
                 },
-                'is_global_account_manager': True
-            }
+                'is_global_account_manager': True,
+            },
         ]
 
     @pytest.mark.parametrize(
         'with_global_account_manager',
         (True, False),
-        ids=lambda val: f'{"With" if val else "Without"} global account manager'
+        ids=lambda val: f'{"With" if val else "Without"} global account manager',
     )
     def test_with_core_team_members(self, with_global_account_manager):
         """
@@ -1488,8 +1588,8 @@ class TestCompanyCoreTeam(APITestMixin):
         team_member_advisers = AdviserFactory.create_batch(
             3,
             first_name=factory.Iterator(
-                ('Adam', 'Barbara', 'Chris')
-            )
+                ('Adam', 'Barbara', 'Chris'),
+            ),
         )
         global_account_manager = team_member_advisers[0] if with_global_account_manager else None
 
@@ -1497,12 +1597,12 @@ class TestCompanyCoreTeam(APITestMixin):
         CompanyCoreTeamMemberFactory.create_batch(
             len(team_member_advisers),
             company=company,
-            adviser=factory.Iterator(team_member_advisers)
+            adviser=factory.Iterator(team_member_advisers),
         )
 
         url = reverse(
             'api-v3:company:core-team',
-            kwargs={'pk': company.pk}
+            kwargs={'pk': company.pk},
         )
         response = self.api_client.get(url)
 
@@ -1519,15 +1619,15 @@ class TestCompanyCoreTeam(APITestMixin):
                         'name': adviser.dit_team.name,
                         'uk_region': {
                             'id': str(adviser.dit_team.uk_region.pk),
-                            'name': adviser.dit_team.uk_region.name
+                            'name': adviser.dit_team.uk_region.name,
                         },
                         'country': {
                             'id': str(adviser.dit_team.country.pk),
-                            'name': adviser.dit_team.country.name
+                            'name': adviser.dit_team.country.name,
                         },
-                    }
+                    },
                 },
-                'is_global_account_manager': adviser is global_account_manager
+                'is_global_account_manager': adviser is global_account_manager,
             }
             for adviser in team_member_advisers
         ]
@@ -1538,7 +1638,7 @@ class TestCompanyCoreTeam(APITestMixin):
         """
         url = reverse(
             'api-v3:company:core-team',
-            kwargs={'pk': '00000000-0000-0000-0000-000000000000'}
+            kwargs={'pk': '00000000-0000-0000-0000-000000000000'},
         )
         response = self.api_client.get(url)
 

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -28,46 +28,49 @@ class TestAddContact(APITestMixin):
         company = CompanyFactory()
 
         url = reverse('api-v3:contact:list')
-        response = self.api_client.post(url, {
-            'title': {
-                'id': constants.Title.admiral_of_the_fleet.value.id
+        response = self.api_client.post(
+            url,
+            data={
+                'title': {
+                    'id': constants.Title.admiral_of_the_fleet.value.id,
+                },
+                'first_name': 'Oratio',
+                'last_name': 'Nelson',
+                'job_title': 'Head of Sales',
+                'company': {
+                    'id': str(company.pk),
+                },
+                'email': 'foo@bar.com',
+                'email_alternative': 'foo2@bar.com',
+                'primary': True,
+                'telephone_countrycode': '+44',
+                'telephone_number': '123456789',
+                'telephone_alternative': '987654321',
+                'address_same_as_company': False,
+                'address_1': 'Foo st.',
+                'address_2': 'adr 2',
+                'address_town': 'London',
+                'address_county': 'London',
+                'address_country': {
+                    'id': constants.Country.united_kingdom.value.id,
+                },
+                'address_postcode': 'SW1A1AA',
+                'notes': 'lorem ipsum',
+                'contactable_by_dit': True,
+                'contactable_by_uk_dit_partners': True,
+                'contactable_by_overseas_dit_partners': True,
+                'accepts_dit_email_marketing': True,
+                'contactable_by_email': True,
+                'contactable_by_phone': True,
             },
-            'first_name': 'Oratio',
-            'last_name': 'Nelson',
-            'job_title': 'Head of Sales',
-            'company': {
-                'id': str(company.pk)
-            },
-            'email': 'foo@bar.com',
-            'email_alternative': 'foo2@bar.com',
-            'primary': True,
-            'telephone_countrycode': '+44',
-            'telephone_number': '123456789',
-            'telephone_alternative': '987654321',
-            'address_same_as_company': False,
-            'address_1': 'Foo st.',
-            'address_2': 'adr 2',
-            'address_town': 'London',
-            'address_county': 'London',
-            'address_country': {
-                'id': constants.Country.united_kingdom.value.id
-            },
-            'address_postcode': 'SW1A1AA',
-            'notes': 'lorem ipsum',
-            'contactable_by_dit': True,
-            'contactable_by_uk_dit_partners': True,
-            'contactable_by_overseas_dit_partners': True,
-            'accepts_dit_email_marketing': True,
-            'contactable_by_email': True,
-            'contactable_by_phone': True
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json() == {
             'id': response.json()['id'],
             'title': {
                 'id': constants.Title.admiral_of_the_fleet.value.id,
-                'name': constants.Title.admiral_of_the_fleet.value.name
+                'name': constants.Title.admiral_of_the_fleet.value.name,
             },
             'first_name': 'Oratio',
             'last_name': 'Nelson',
@@ -75,13 +78,13 @@ class TestAddContact(APITestMixin):
             'job_title': 'Head of Sales',
             'company': {
                 'id': str(company.pk),
-                'name': company.name
+                'name': company.name,
             },
             'adviser': {
                 'id': str(self.user.pk),
                 'first_name': self.user.first_name,
                 'last_name': self.user.last_name,
-                'name': self.user.name
+                'name': self.user.name,
             },
             'email': 'foo@bar.com',
             'email_alternative': 'foo2@bar.com',
@@ -96,7 +99,7 @@ class TestAddContact(APITestMixin):
             'address_county': 'London',
             'address_country': {
                 'id': constants.Country.united_kingdom.value.id,
-                'name': constants.Country.united_kingdom.value.name
+                'name': constants.Country.united_kingdom.value.name,
             },
             'address_postcode': 'SW1A1AA',
             'notes': 'lorem ipsum',
@@ -118,18 +121,21 @@ class TestAddContact(APITestMixin):
     def test_with_address_same_as_company(self):
         """Test add new contact with same address as company."""
         url = reverse('api-v3:contact:list')
-        response = self.api_client.post(url, {
-            'first_name': 'Oratio',
-            'last_name': 'Nelson',
-            'company': {
-                'id': CompanyFactory().pk
+        response = self.api_client.post(
+            url,
+            data={
+                'first_name': 'Oratio',
+                'last_name': 'Nelson',
+                'company': {
+                    'id': CompanyFactory().pk,
+                },
+                'email': 'foo@bar.com',
+                'telephone_countrycode': '+44',
+                'telephone_number': '123456789',
+                'address_same_as_company': True,
+                'primary': True,
             },
-            'email': 'foo@bar.com',
-            'telephone_countrycode': '+44',
-            'telephone_number': '123456789',
-            'address_same_as_company': True,
-            'primary': True
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -145,18 +151,21 @@ class TestAddContact(APITestMixin):
     def test_defaults(self):
         """Test defaults when adding an item."""
         url = reverse('api-v3:contact:list')
-        response = self.api_client.post(url, {
-            'first_name': 'Oratio',
-            'last_name': 'Nelson',
-            'company': {
-                'id': CompanyFactory().pk
+        response = self.api_client.post(
+            url,
+            data={
+                'first_name': 'Oratio',
+                'last_name': 'Nelson',
+                'company': {
+                    'id': CompanyFactory().pk,
+                },
+                'email': 'foo@bar.com',
+                'telephone_countrycode': '+44',
+                'telephone_number': '123456789',
+                'address_same_as_company': True,
+                'primary': True,
             },
-            'email': 'foo@bar.com',
-            'telephone_countrycode': '+44',
-            'telephone_number': '123456789',
-            'address_same_as_company': True,
-            'primary': True
-        })
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.data
@@ -181,116 +190,131 @@ class TestAddContact(APITestMixin):
     def test_fails_with_invalid_email_address(self):
         """Test that fails if the email address is invalid."""
         url = reverse('api-v3:contact:list')
-        response = self.api_client.post(url, {
-            'first_name': 'Oratio',
-            'last_name': 'Nelson',
-            'company': {
-                'id': CompanyFactory().pk
+        response = self.api_client.post(
+            url,
+            data={
+                'first_name': 'Oratio',
+                'last_name': 'Nelson',
+                'company': {
+                    'id': CompanyFactory().pk,
+                },
+                'email': 'invalid dot com',
+                'telephone_countrycode': '+44',
+                'telephone_number': '123456789',
+                'address_same_as_company': True,
+                'primary': True,
             },
-            'email': 'invalid dot com',
-            'telephone_countrycode': '+44',
-            'telephone_number': '123456789',
-            'address_same_as_company': True,
-            'primary': True
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
-            'email': ['Enter a valid email address.']
+            'email': ['Enter a valid email address.'],
         }
 
     def test_fails_without_address(self):
         """Test that fails without any address."""
         url = reverse('api-v3:contact:list')
-        response = self.api_client.post(url, {
-            'first_name': 'Oratio',
-            'last_name': 'Nelson',
-            'company': {
-                'id': CompanyFactory().pk
+        response = self.api_client.post(
+            url,
+            data={
+                'first_name': 'Oratio',
+                'last_name': 'Nelson',
+                'company': {
+                    'id': CompanyFactory().pk,
+                },
+                'email': 'foo@bar.com',
+                'telephone_countrycode': '+44',
+                'telephone_number': '123456789',
+                'primary': True,
             },
-            'email': 'foo@bar.com',
-            'telephone_countrycode': '+44',
-            'telephone_number': '123456789',
-            'primary': True
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
             'address_same_as_company': [
-                'Please select either address_same_as_company or enter an address manually.'
-            ]
+                'Please select either address_same_as_company or enter an address manually.',
+            ],
         }
 
     def test_fails_with_only_partial_manual_address(self):
         """Test that fails if only partial manual address supplied."""
         url = reverse('api-v3:contact:list')
-        response = self.api_client.post(url, {
-            'first_name': 'Oratio',
-            'last_name': 'Nelson',
-            'company': {
-                'id': CompanyFactory().pk
+        response = self.api_client.post(
+            url,
+            data={
+                'first_name': 'Oratio',
+                'last_name': 'Nelson',
+                'company': {
+                    'id': CompanyFactory().pk,
+                },
+                'email': 'foo@bar.com',
+                'telephone_countrycode': '+44',
+                'telephone_number': '123456789',
+                'address_1': 'test',
+                'primary': True,
             },
-            'email': 'foo@bar.com',
-            'telephone_countrycode': '+44',
-            'telephone_number': '123456789',
-            'address_1': 'test',
-            'primary': True
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
             'address_country': ['This field is required.'],
-            'address_town': ['This field is required.']
+            'address_town': ['This field is required.'],
         }
 
     def test_fails_with_contact_preferences_not_set(self):
         """Test that fails without any contact preference."""
         url = reverse('api-v3:contact:list')
-        response = self.api_client.post(url, {
-            'first_name': 'Oratio',
-            'last_name': 'Nelson',
-            'company': {
-                'id': CompanyFactory().pk
+        response = self.api_client.post(
+            url,
+            data={
+                'first_name': 'Oratio',
+                'last_name': 'Nelson',
+                'company': {
+                    'id': CompanyFactory().pk,
+                },
+                'email': 'foo@bar.com',
+                'telephone_countrycode': '+44',
+                'telephone_number': '123456789',
+                'address_same_as_company': True,
+                'contactable_by_email': False,
+                'contactable_by_phone': False,
+                'primary': True,
             },
-            'email': 'foo@bar.com',
-            'telephone_countrycode': '+44',
-            'telephone_number': '123456789',
-            'address_same_as_company': True,
-            'contactable_by_email': False,
-            'contactable_by_phone': False,
-            'primary': True
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
             'contactable_by_email': [
                 'A contact should have at least one way of being contacted. '
-                'Please select either email or phone, or both.'
+                'Please select either email or phone, or both.',
             ],
             'contactable_by_phone': [
                 'A contact should have at least one way of being contacted. '
-                'Please select either email or phone, or both.'
-            ]
+                'Please select either email or phone, or both.',
+            ],
         }
 
     def test_fails_without_primary_specified(self):
         """Test that fails if primary is not specified."""
         url = reverse('api-v3:contact:list')
-        response = self.api_client.post(url, {
-            'first_name': 'Oratio',
-            'last_name': 'Nelson',
-            'company': {
-                'id': CompanyFactory().pk
+        response = self.api_client.post(
+            url,
+            data={
+                'first_name': 'Oratio',
+                'last_name': 'Nelson',
+                'company': {
+                    'id': CompanyFactory().pk,
+                },
+                'email': 'foo@bar.com',
+                'telephone_countrycode': '+44',
+                'telephone_number': '123456789',
+                'address_same_as_company': True,
             },
-            'email': 'foo@bar.com',
-            'telephone_countrycode': '+44',
-            'telephone_number': '123456789',
-            'address_same_as_company': True,
-        })
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
-            'primary': ['This field is required.']
+            'primary': ['This field is required.'],
         }
 
 
@@ -328,21 +352,24 @@ class TestEditContact(APITestMixin):
                 contactable_by_overseas_dit_partners=False,
                 accepts_dit_email_marketing=False,
                 contactable_by_email=True,
-                contactable_by_phone=True
+                contactable_by_phone=True,
             )
 
         url = reverse('api-v3:contact:detail', kwargs={'pk': contact.pk})
         with freeze_time('2017-04-19 13:25:30.986208'):
-            response = self.api_client.patch(url, {
-                'first_name': 'New Oratio',
-            })
+            response = self.api_client.patch(
+                url,
+                data={
+                    'first_name': 'New Oratio',
+                },
+            )
 
         assert response.status_code == status.HTTP_200_OK, response.data
         assert response.json() == {
             'id': response.json()['id'],
             'title': {
                 'id': constants.Title.admiral_of_the_fleet.value.id,
-                'name': constants.Title.admiral_of_the_fleet.value.name
+                'name': constants.Title.admiral_of_the_fleet.value.name,
             },
             'first_name': 'New Oratio',
             'last_name': 'Nelson',
@@ -350,7 +377,7 @@ class TestEditContact(APITestMixin):
             'job_title': 'Head of Sales',
             'company': {
                 'id': str(company.pk),
-                'name': company.name
+                'name': company.name,
             },
             'email': 'foo@bar.com',
             'email_alternative': 'foo2@bar.com',
@@ -359,7 +386,7 @@ class TestEditContact(APITestMixin):
                 'id': str(self.user.pk),
                 'first_name': self.user.first_name,
                 'last_name': self.user.last_name,
-                'name': self.user.name
+                'name': self.user.name,
             },
             'telephone_countrycode': '+44',
             'telephone_number': '123456789',
@@ -371,7 +398,7 @@ class TestEditContact(APITestMixin):
             'address_county': 'London',
             'address_country': {
                 'id': constants.Country.united_kingdom.value.id,
-                'name': constants.Country.united_kingdom.value.name
+                'name': constants.Country.united_kingdom.value.name,
             },
             'address_postcode': 'SW1A1AA',
             'notes': 'lorem ipsum',
@@ -395,9 +422,12 @@ class TestEditContact(APITestMixin):
         company = ArchivedContactFactory()
 
         url = reverse('api-v3:contact:detail', kwargs={'pk': company.pk})
-        response = self.api_client.patch(url, data={
-            'first_name': 'new name',
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'first_name': 'new name',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
@@ -411,9 +441,12 @@ class TestEditContact(APITestMixin):
         )
 
         url = reverse('api-v3:contact:detail', kwargs={'pk': contact.pk})
-        response = self.api_client.patch(url, data={
-            'archived_documents_url_path': 'new_path'
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'archived_documents_url_path': 'new_path',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived_documents_url_path'] == 'old_path'
@@ -430,14 +463,14 @@ class TestArchiveContact(APITestMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.data == {
-            'reason': ['This field is required.']
+            'reason': ['This field is required.'],
         }
 
     def test_archive_with_reason(self):
         """Test archive contact providing a reason."""
         contact = ContactFactory()
         url = reverse('api-v3:contact:archive', kwargs={'pk': contact.pk})
-        response = self.api_client.post(url, {'reason': 'foo'})
+        response = self.api_client.post(url, data={'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -445,7 +478,7 @@ class TestArchiveContact(APITestMixin):
             'id': str(self.user.pk),
             'first_name': self.user.first_name,
             'last_name': self.user.last_name,
-            'name': self.user.name
+            'name': self.user.name,
         }
         assert response.data['archived_reason'] == 'foo'
         assert response.data['id'] == str(contact.pk)
@@ -457,7 +490,7 @@ class TestArchiveContact(APITestMixin):
             address_1='',
         )
         url = reverse('api-v3:contact:archive', kwargs={'pk': contact.pk})
-        response = self.api_client.post(url, {'reason': 'foo'})
+        response = self.api_client.post(url, data={'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -517,7 +550,7 @@ class TestViewContact(APITestMixin):
             contactable_by_overseas_dit_partners=False,
             accepts_dit_email_marketing=False,
             contactable_by_email=True,
-            contactable_by_phone=True
+            contactable_by_phone=True,
         )
         url = reverse('api-v3:contact:detail', kwargs={'pk': contact.pk})
         response = self.api_client.get(url)
@@ -527,7 +560,7 @@ class TestViewContact(APITestMixin):
             'id': response.json()['id'],
             'title': {
                 'id': constants.Title.admiral_of_the_fleet.value.id,
-                'name': constants.Title.admiral_of_the_fleet.value.name
+                'name': constants.Title.admiral_of_the_fleet.value.name,
             },
             'first_name': 'Oratio',
             'last_name': 'Nelson',
@@ -535,13 +568,13 @@ class TestViewContact(APITestMixin):
             'job_title': 'Head of Sales',
             'company': {
                 'id': str(company.pk),
-                'name': company.name
+                'name': company.name,
             },
             'adviser': {
                 'id': str(self.user.pk),
                 'first_name': self.user.first_name,
                 'last_name': self.user.last_name,
-                'name': self.user.name
+                'name': self.user.name,
             },
             'email': 'foo@bar.com',
             'email_alternative': 'foo2@bar.com',
@@ -556,7 +589,7 @@ class TestViewContact(APITestMixin):
             'address_county': 'London',
             'address_country': {
                 'id': constants.Country.united_kingdom.value.id,
-                'name': constants.Country.united_kingdom.value.name
+                'name': constants.Country.united_kingdom.value.name,
             },
             'address_postcode': 'SW1A1AA',
             'notes': 'lorem ipsum',
@@ -583,7 +616,7 @@ class TestViewContact(APITestMixin):
         user = create_test_user(
             permission_codenames=(
                 'view_contact',
-            )
+            ),
         )
         api_client = self.create_api_client(user=user)
 
@@ -622,7 +655,7 @@ class TestContactList(APITestMixin):
         user = create_test_user(
             permission_codenames=(
                 'view_contact',
-            )
+            ),
         )
         api_client = self.create_api_client(user=user)
 
@@ -644,7 +677,7 @@ class TestContactList(APITestMixin):
             permission_codenames=(
                 'view_contact',
                 'view_contact_document',
-            )
+            ),
         )
         api_client = self.create_api_client(user=user)
 
@@ -666,7 +699,7 @@ class TestContactList(APITestMixin):
         for creation_datetime in datetimes:
             with freeze_time(creation_datetime):
                 contacts.append(
-                    ContactFactory()
+                    ContactFactory(),
                 )
 
         url = reverse('api-v3:contact:list')
@@ -689,7 +722,7 @@ class TestContactList(APITestMixin):
         contacts = ContactFactory.create_batch(2, company=company2)
 
         url = reverse('api-v3:contact:list')
-        response = self.api_client.get(url, {'company_id': company2.id})
+        response = self.api_client.get(url, data={'company_id': company2.id})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -716,7 +749,7 @@ class TestContactVersioning(APITestMixin):
                 'telephone_countrycode': '+44',
                 'telephone_number': '123456789',
                 'address_same_as_company': True,
-                'primary': True
+                'primary': True,
             },
         )
 
@@ -753,7 +786,7 @@ class TestContactVersioning(APITestMixin):
         """Test that updating a contact creates a new version."""
         contact = ContactFactory(
             first_name='Oratio',
-            last_name='Nelson'
+            last_name='Nelson',
         )
 
         response = self.api_client.patch(
@@ -774,7 +807,7 @@ class TestContactVersioning(APITestMixin):
         """Test that if the endpoint returns 400, no version is created."""
         contact = ContactFactory(
             first_name='Oratio',
-            last_name='Nelson'
+            last_name='Nelson',
         )
 
         response = self.api_client.patch(
@@ -791,7 +824,7 @@ class TestContactVersioning(APITestMixin):
         assert Version.objects.get_for_object(contact).count() == 0
 
         url = reverse('api-v3:contact:archive', kwargs={'pk': contact.id})
-        response = self.api_client.post(url, {'reason': 'foo'})
+        response = self.api_client.post(url, data={'reason': 'foo'})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived']
@@ -818,7 +851,7 @@ class TestContactVersioning(APITestMixin):
     def test_unarchive_creates_a_new_version(self):
         """Test that unarchiving a contact creates a new version."""
         contact = ContactFactory(
-            archived=True, archived_on=now(), archived_reason='foo'
+            archived=True, archived_on=now(), archived_reason='foo',
         )
         assert Version.objects.get_for_object(contact).count() == 0
 

--- a/datahub/company/test/test_sync_ch_command.py
+++ b/datahub/company/test/test_sync_ch_command.py
@@ -71,7 +71,7 @@ def test_empty_registered_address_town():
 def test_present_registered_address_town():
     """Test present registered address town."""
     test_dict = {
-        'registered_address_town': 'Meow town'
+        'registered_address_town': 'Meow town',
     }
 
     result = sync_ch.transform_ch_row(test_dict)
@@ -104,11 +104,14 @@ def test_unzip_and_csv_read_on_the_fly():
             assert len(result) == 201
 
 
-@pytest.mark.parametrize('row,num_results', (
-    ({'company_category': 'Private Limited Company'}, 1),
-    ({'company_category': 'public limited company'}, 1),
-    ({'company_category': 'registered society'}, 0),
-))
+@pytest.mark.parametrize(
+    'row,num_results',
+    (
+        ({'company_category': 'Private Limited Company'}, 1),
+        ({'company_category': 'public limited company'}, 1),
+        ({'company_category': 'registered society'}, 0),
+    ),
+)
 def test_process_row_company_filtering(row, num_results):
     """Tests filtering of companies with an irrelevant type."""
     processed = list(sync_ch.process_row(row))
@@ -169,7 +172,7 @@ def test_process_rows_record():
     }
 
     new_ch_company = CompaniesHouseCompany.objects.get(
-        company_number=new_record_data['company_number']
+        company_number=new_record_data['company_number'],
     )
     actual_new_data = {
         field: getattr(new_ch_company, field) for field in new_record_data

--- a/datahub/company/test/test_validators.py
+++ b/datahub/company/test/test_validators.py
@@ -6,23 +6,29 @@ from datahub.company.validators import (
 )
 
 
-@pytest.mark.parametrize('company_number,is_valid', (
-    ('BR000555', True),
-    ('BR000555%^', False),
-    ('BR000555é', False),
-    ('br000555', False),
-    ('BR000555 ', False),
-))
+@pytest.mark.parametrize(
+    'company_number,is_valid',
+    (
+        ('BR000555', True),
+        ('BR000555%^', False),
+        ('BR000555é', False),
+        ('br000555', False),
+        ('BR000555 ', False),
+    ),
+)
 def test_has_no_invalid_company_number_characters(company_number, is_valid):
     """Tests validation of company number characters."""
     assert has_no_invalid_company_number_characters(company_number) == is_valid
 
 
-@pytest.mark.parametrize('company_number,is_valid', (
-    ('BR000555', True),
-    ('SC000555', False),
-    ('br000555', False),
-))
+@pytest.mark.parametrize(
+    'company_number,is_valid',
+    (
+        ('BR000555', True),
+        ('SC000555', False),
+        ('br000555', False),
+    ),
+)
 def test_has_uk_establishment_number_prefix(company_number, is_valid):
     """Tests validation of UK establishment prefix."""
     assert has_uk_establishment_number_prefix(company_number) == is_valid

--- a/datahub/company/test/timeline/test_client.py
+++ b/datahub/company/test/timeline/test_client.py
@@ -14,29 +14,32 @@ from datahub.company.timeline.exceptions import InvalidCompanyNumberError
 FAKE_RESPONSES = {
     '/api/v1/company/events/?companies_house_id=125694': {
         'json': {
-            'events': [{
-                'data_source': 'companies_house.companies',
-                'datetime': 'Mon, 31 Dec 2018 00:00:00 GMT',
-                'description': 'Accounts next due date',
-            }, {
-                'data_source': 'companies_house.companies',
-                'datetime': 'Mon, 31 Dec 2017 00:00:00 GMT',
-                'description': 'Accounts filed',
-            }]
-        }
+            'events': [
+                {
+                    'data_source': 'companies_house.companies',
+                    'datetime': 'Mon, 31 Dec 2018 00:00:00 GMT',
+                    'description': 'Accounts next due date',
+                },
+                {
+                    'data_source': 'companies_house.companies',
+                    'datetime': 'Mon, 31 Dec 2017 00:00:00 GMT',
+                    'description': 'Accounts filed',
+                },
+            ],
+        },
     },
     '/api/v1/company/events/?companies_house_id=989087': {
         'json': {
             'events': [{
                 'invalid_response': 'Accounts filed',
-            }]
-        }
+            }],
+        },
     },
     '/api/v1/company/events/?companies_house_id=356812': {
-        'status_code': status.HTTP_404_NOT_FOUND
+        'status_code': status.HTTP_404_NOT_FOUND,
     },
     '/api/v1/company/events/?companies_house_id=886423': {
-        'status_code': status.HTTP_500_INTERNAL_SERVER_ERROR
+        'status_code': status.HTTP_500_INTERNAL_SERVER_ERROR,
     },
 }
 
@@ -57,7 +60,7 @@ class TestDataScienceCompanyAPIClient:
             ('', 'api-id', 'api-key'),
             ('api-url', '', 'api-key'),
             ('api-url', 'api-id', ''),
-        )
+        ),
     )
     def test_raises_an_error_on_invalid_configuration(self, monkeypatch, api_url, api_id, api_key):
         """Test that ImproperlyConfigured if the API connection details are not configured."""
@@ -68,7 +71,7 @@ class TestDataScienceCompanyAPIClient:
         with pytest.raises(ImproperlyConfigured):
             DataScienceCompanyAPIClient()
 
-    @pytest.mark.parametrize('company_number', (None, '', '00', ))
+    @pytest.mark.parametrize('company_number', (None, '', '00'))
     def test_raises_an_error_on_blank_like_company_numbers(self, company_number):
         """Test that an error is raised for company numbers that are blank or only zeroes."""
         client = DataScienceCompanyAPIClient()
@@ -99,12 +102,15 @@ class TestDataScienceCompanyAPIClient:
     def test_transforms_the_api_response(self, company_number):
         """Test the re-formatting of the API response."""
         client = DataScienceCompanyAPIClient()
-        assert client.get_timeline_events_by_company_number(company_number) == [{
-            'data_source': 'companies_house.companies',
-            'datetime': datetime(2018, 12, 31, tzinfo=utc),
-            'description': 'Accounts next due date',
-        }, {
-            'data_source': 'companies_house.companies',
-            'datetime': datetime(2017, 12, 31, tzinfo=utc),
-            'description': 'Accounts filed',
-        }]
+        assert client.get_timeline_events_by_company_number(company_number) == [
+            {
+                'data_source': 'companies_house.companies',
+                'datetime': datetime(2018, 12, 31, tzinfo=utc),
+                'description': 'Accounts next due date',
+            },
+            {
+                'data_source': 'companies_house.companies',
+                'datetime': datetime(2017, 12, 31, tzinfo=utc),
+                'description': 'Accounts filed',
+            },
+        ]

--- a/datahub/company/test/timeline/test_views.py
+++ b/datahub/company/test/timeline/test_views.py
@@ -21,15 +21,18 @@ class TestCompanyTimelineViews(APITestMixin):
             '/api/v1/company/events/?companies_house_id=125694',
         )
         stubbed_response_data = {
-            'events': [{
-                'data_source': 'companies_house.companies',
-                'datetime': 'Mon, 31 Dec 2018 00:00:00 GMT',
-                'description': 'Accounts next due date',
-            }, {
-                'data_source': 'companies_house.companies',
-                'datetime': 'Mon, 31 Dec 2017 00:00:00 GMT',
-                'description': 'Accounts filed',
-            }]
+            'events': [
+                {
+                    'data_source': 'companies_house.companies',
+                    'datetime': 'Mon, 31 Dec 2018 00:00:00 GMT',
+                    'description': 'Accounts next due date',
+                },
+                {
+                    'data_source': 'companies_house.companies',
+                    'datetime': 'Mon, 31 Dec 2017 00:00:00 GMT',
+                    'description': 'Accounts filed',
+                },
+            ],
         }
 
         requests_mock.get(
@@ -49,15 +52,18 @@ class TestCompanyTimelineViews(APITestMixin):
             'count': 2,
             'next': None,
             'previous': None,
-            'results': [{
-                'data_source': 'companies_house.companies',
-                'datetime': '2018-12-31T00:00:00Z',
-                'description': 'Accounts next due date',
-            }, {
-                'data_source': 'companies_house.companies',
-                'datetime': '2017-12-31T00:00:00Z',
-                'description': 'Accounts filed',
-            }],
+            'results': [
+                {
+                    'data_source': 'companies_house.companies',
+                    'datetime': '2018-12-31T00:00:00Z',
+                    'description': 'Accounts next due date',
+                },
+                {
+                    'data_source': 'companies_house.companies',
+                    'datetime': '2017-12-31T00:00:00Z',
+                    'description': 'Accounts filed',
+                },
+            ],
         }
 
     def test_list_with_no_matching_company_in_reporting_service(self, requests_mock):
@@ -102,10 +108,13 @@ class TestCompanyTimelineViews(APITestMixin):
             'results': [],
         }
 
-    @pytest.mark.parametrize('status_code', (
-        status.HTTP_400_BAD_REQUEST,
-        status.HTTP_500_INTERNAL_SERVER_ERROR,
-    ))
+    @pytest.mark.parametrize(
+        'status_code',
+        (
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
     def test_list_with_error_from_upstream_server(
             self,
             monkeypatch,
@@ -133,14 +142,14 @@ class TestCompanyTimelineViews(APITestMixin):
 
         assert response_data == {
             'detail': f'Error communicating with the company timeline API. Error reference: '
-                      f'{error_reference}.'
+                      f'{error_reference}.',
         }
 
     def test_list_with_invalid_upstream_response(
             self,
             monkeypatch,
             requests_mock,
-            response_signature
+            response_signature,
     ):
         """
         Test the behaviour when an data is returned in an unexpected format from the
@@ -157,15 +166,18 @@ class TestCompanyTimelineViews(APITestMixin):
             '/api/v1/company/events/?companies_house_id=1000',
         )
         stubbed_response_data = {
-            'events': [{
-                'data_source_wrong': 'companies_house.companies',
-                'datetime_wrong': 'Mon, 31 Dec 2018 00:00:00 GMT',
-                'description_wrong': 'Accounts next due date',
-            }, {
-                'data_source_wrong': 'companies_house.companies',
-                'datetime_wrong': 'Mon, 31 Dec 2017 00:00:00 GMT',
-                'description_wrong': 'Accounts filed',
-            }]
+            'events': [
+                {
+                    'data_source_wrong': 'companies_house.companies',
+                    'datetime_wrong': 'Mon, 31 Dec 2018 00:00:00 GMT',
+                    'description_wrong': 'Accounts next due date',
+                },
+                {
+                    'data_source_wrong': 'companies_house.companies',
+                    'datetime_wrong': 'Mon, 31 Dec 2017 00:00:00 GMT',
+                    'description_wrong': 'Accounts filed',
+                },
+            ],
         }
 
         requests_mock.get(stubbed_url, json=stubbed_response_data, headers=response_signature)
@@ -179,7 +191,7 @@ class TestCompanyTimelineViews(APITestMixin):
 
         assert response_data == {
             'detail': f'Unexpected response data format received from the company timeline API. '
-                      f'Error reference: {error_reference}.'
+                      f'Error reference: {error_reference}.',
         }
 
     @pytest.mark.parametrize(
@@ -188,7 +200,7 @@ class TestCompanyTimelineViews(APITestMixin):
             (CompanyPermission.view_company,),
             (CompanyPermission.view_company_timeline,),
             (),
-        )
+        ),
     )
     def test_permission_is_denied(self, permission_codenames):
         """Test that a 403 is returned for users without the correct permissions."""

--- a/datahub/company/timeline/client.py
+++ b/datahub/company/timeline/client.py
@@ -31,7 +31,7 @@ class DataScienceCompanyAPIClient:
 
         if not all((api_url, api_id, api_key)):
             raise ImproperlyConfigured(
-                'Data science company API connection details not configured'
+                'Data science company API connection details not configured',
             )
 
         timeout = settings.DATA_SCIENCE_COMPANY_API_TIMEOUT
@@ -46,9 +46,12 @@ class DataScienceCompanyAPIClient:
         if not transformed_company_number:
             raise InvalidCompanyNumberError
 
-        data = self._request('/api/v1/company/events/', params={
-            'companies_house_id': transformed_company_number,
-        })
+        data = self._request(
+            '/api/v1/company/events/',
+            params={
+                'companies_house_id': transformed_company_number,
+            },
+        )
 
         return _transform_events_response(data)
 
@@ -58,8 +61,10 @@ class DataScienceCompanyAPIClient:
         except HTTPError as exc:
             if exc.response.status_code != status.HTTP_404_NOT_FOUND:
                 event_id = client.captureException()
-                raise APIException(f'Error communicating with the company timeline API. Error '
-                                   f'reference: {event_id}.') from exc
+                raise APIException(
+                    f'Error communicating with the company timeline API. Error '
+                    f'reference: {event_id}.',
+                ) from exc
             return {}
         else:
             return response.json()
@@ -71,8 +76,10 @@ def _transform_events_response(data):
         serializer.is_valid(raise_exception=True)
     except ValidationError as exc:
         event_id = client.captureException()
-        raise APIException(f'Unexpected response data format received from the company '
-                           f'timeline API. Error reference: {event_id}.') from exc
+        raise APIException(
+            f'Unexpected response data format received from the company '
+            f'timeline API. Error reference: {event_id}.',
+        ) from exc
 
     return serializer.validated_data
 

--- a/datahub/company/urls.py
+++ b/datahub/company/urls.py
@@ -5,23 +5,23 @@ from django.urls import path
 from datahub.company.timeline.views import CompanyTimelineViewSet
 from datahub.company.views import (
     CompaniesHouseCompanyViewSet, CompanyAuditViewSet, CompanyCoreTeamViewSet,
-    CompanyViewSet, ContactAuditViewSet, ContactViewSet
+    CompanyViewSet, ContactAuditViewSet, ContactViewSet,
 )
 
 # CONTACT
 
 contact_collection = ContactViewSet.as_view({
     'get': 'list',
-    'post': 'create'
+    'post': 'create',
 })
 
 contact_item = ContactViewSet.as_view({
     'get': 'retrieve',
-    'patch': 'partial_update'
+    'patch': 'partial_update',
 })
 
 contact_archive = ContactViewSet.as_view({
-    'post': 'archive'
+    'post': 'archive',
 })
 
 contact_unarchive = ContactViewSet.as_view({
@@ -44,12 +44,12 @@ contact_urls = [
 
 company_collection = CompanyViewSet.as_view({
     'get': 'list',
-    'post': 'create'
+    'post': 'create',
 })
 
 company_item = CompanyViewSet.as_view({
     'get': 'retrieve',
-    'patch': 'partial_update'
+    'patch': 'partial_update',
 })
 
 company_audit = CompanyAuditViewSet.as_view({
@@ -61,7 +61,7 @@ company_timeline = CompanyTimelineViewSet.as_view({
 })
 
 company_archive = CompanyViewSet.as_view({
-    'post': 'archive'
+    'post': 'archive',
 })
 
 company_unarchive = CompanyViewSet.as_view({
@@ -69,15 +69,15 @@ company_unarchive = CompanyViewSet.as_view({
 })
 
 company_core_team = CompanyCoreTeamViewSet.as_view({
-    'get': 'list'
+    'get': 'list',
 })
 
 ch_company_list = CompaniesHouseCompanyViewSet.as_view({
-    'get': 'list'
+    'get': 'list',
 })
 
 ch_company_item = CompaniesHouseCompanyViewSet.as_view({
-    'get': 'retrieve'
+    'get': 'retrieve',
 })
 
 company_urls = [

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -89,14 +89,14 @@ class CompanyCoreTeamViewSet(CoreViewSet):
             objs.append(
                 {
                     'adviser': global_account_manager,
-                    'is_global_account_manager': True
-                }
+                    'is_global_account_manager': True,
+                },
             )
 
         # add all other core members excluding the global account manager
         # who might have already been added
         team_members = company.core_team_members.exclude(
-            adviser=global_account_manager
+            adviser=global_account_manager,
         ).select_related(
             'adviser',
             'adviser__dit_team',
@@ -110,7 +110,7 @@ class CompanyCoreTeamViewSet(CoreViewSet):
         objs.extend(
             {
                 'adviser': team_member.adviser,
-                'is_global_account_manager': False
+                'is_global_account_manager': False,
             }
             for team_member in team_members
         )
@@ -127,7 +127,8 @@ class CompanyAuditViewSet(AuditViewSet):
 
 
 class CompaniesHouseCompanyViewSet(
-        mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+        mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet,
+):
     """Companies House company read-only GET only views."""
 
     required_scopes = (Scope.internal_front_end,)
@@ -143,7 +144,7 @@ class ContactViewSet(ArchivableViewSetMixin, CoreViewSet):
     serializer_class = ContactSerializer
     queryset = get_contact_queryset()
     filter_backends = (
-        DjangoFilterBackend, OrderingFilter
+        DjangoFilterBackend, OrderingFilter,
     )
     filterset_fields = ['company_id']
     ordering = ('-created_on',)
@@ -176,7 +177,8 @@ class AdviserFilter(FilterSet):
 
 
 class AdviserReadOnlyViewSetV1(
-        mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet):
+        mixins.ListModelMixin, mixins.RetrieveModelMixin, viewsets.GenericViewSet,
+):
     """Adviser GET only views."""
 
     required_scopes = (Scope.internal_front_end,)


### PR DESCRIPTION
### Description of change

This adds trailing commas to the company app where they were missing. This includes some related code reformatting and the removal of some incorrect trailing commas.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
