### PR TITLE
Add trailing commas to dbmaintenance app

### DIFF
--- a/datahub/dbmaintenance/management/base.py
+++ b/datahub/dbmaintenance/management/base.py
@@ -49,7 +49,7 @@ class CSVBaseCommand(BaseCommand):
         s3_client = get_s3_client_for_bucket('default')
         response = s3_client.get_object(
             Bucket=options['bucket'],
-            Key=options['object_key']
+            Key=options['object_key'],
         )['Body']
 
         with closing(response):

--- a/datahub/dbmaintenance/management/commands/update_company_global_hq.py
+++ b/datahub/dbmaintenance/management/commands/update_company_global_hq.py
@@ -16,7 +16,7 @@ class Command(CSVBaseCommand):
             '--overwrite',
             action='store_true',
             default=False,
-            help='If true it will overwrite all provided records.'
+            help='If true it will overwrite all provided records.',
         )
 
     def _should_update(self, company, overwrite=False):
@@ -35,7 +35,7 @@ class Command(CSVBaseCommand):
         if self._should_update(company, overwrite=overwrite):
             global_hq_id = parse_uuid(row['global_hq_id'])
             global_hq = {
-                'id': global_hq_id
+                'id': global_hq_id,
             } if global_hq_id is not None else None
 
             data = {
@@ -45,7 +45,7 @@ class Command(CSVBaseCommand):
             serializer = CompanySerializer(
                 instance=company,
                 data=data,
-                partial=True
+                partial=True,
             )
             serializer.is_valid(raise_exception=True)
             if simulate:

--- a/datahub/dbmaintenance/management/commands/update_company_headquarter_type.py
+++ b/datahub/dbmaintenance/management/commands/update_company_headquarter_type.py
@@ -27,7 +27,7 @@ class Command(CSVBaseCommand):
                 company.save(
                     update_fields=(
                         'headquarter_type',
-                    )
+                    ),
                 )
                 reversion.set_comment('Headquarter type data migration correction.')
 

--- a/datahub/dbmaintenance/management/commands/update_investment_project_actual_land_date.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_actual_land_date.py
@@ -32,8 +32,10 @@ class Command(CSVBaseCommand):
             return
 
         if investment_project.stage_id == UUID(InvestmentProjectStage.won.value.id):
-            logger.warning('Not updating project in Won stage: %s, %s',
-                           investment_project.project_code, investment_project)
+            logger.warning(
+                'Not updating project in Won stage: %s, %s',
+                investment_project.project_code, investment_project,
+            )
             return
 
         investment_project.actual_land_date = new_actual_land_date

--- a/datahub/dbmaintenance/management/commands/update_investment_project_actual_uk_regions.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_actual_uk_regions.py
@@ -20,8 +20,10 @@ class Command(CSVBaseCommand):
         new_actual_uk_regions = parse_uuid_list(row['actual_uk_regions'])
 
         if investment_project.actual_uk_regions.all():
-            logger.warning('Not updating project with existing actual UK regions: %s, %s',
-                           investment_project.project_code, investment_project)
+            logger.warning(
+                'Not updating project with existing actual UK regions: %s, %s',
+                investment_project.project_code, investment_project,
+            )
             return
 
         if not simulate:

--- a/datahub/dbmaintenance/management/commands/update_investment_project_company.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_company.py
@@ -21,12 +21,14 @@ class Command(CSVBaseCommand):
             return None
         return uuid.UUID(company_id)
 
-    def _should_update(self,
-                       investment_project,
-                       investor_company_id,
-                       intermediate_company_id,
-                       uk_company_id,
-                       uk_company_decided):
+    def _should_update(
+        self,
+        investment_project,
+        investor_company_id,
+        intermediate_company_id,
+        uk_company_id,
+        uk_company_decided,
+    ):
         """
         Checks if Investment project should be updated.
 
@@ -80,6 +82,6 @@ class Command(CSVBaseCommand):
                             'intermediate_company',
                             'uk_company',
                             'uk_company_decided',
-                        )
+                        ),
                     )
                     reversion.set_comment('Companies data migration.')

--- a/datahub/dbmaintenance/management/commands/update_investment_project_delivery_partners.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_delivery_partners.py
@@ -20,8 +20,10 @@ class Command(CSVBaseCommand):
         new_delivery_partners = parse_uuid_list(row['delivery_partners'])
 
         if investment_project.delivery_partners.all():
-            logger.warning('Not updating project with existing delivery partners: %s, %s',
-                           investment_project.project_code, investment_project)
+            logger.warning(
+                'Not updating project with existing delivery partners: %s, %s',
+                investment_project.project_code, investment_project,
+            )
             return
 
         if not simulate:

--- a/datahub/dbmaintenance/management/commands/update_investment_project_estimated_land_date.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_estimated_land_date.py
@@ -35,6 +35,6 @@ class Command(CSVBaseCommand):
 
         with reversion.create_revision():
             investment_project.save(
-                update_fields=('estimated_land_date', 'allow_blank_estimated_land_date')
+                update_fields=('estimated_land_date', 'allow_blank_estimated_land_date'),
             )
             reversion.set_comment('Estimated land date migration correction.')

--- a/datahub/dbmaintenance/management/commands/update_investment_project_possible_uk_regions.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_possible_uk_regions.py
@@ -54,7 +54,7 @@ class Command(CSVBaseCommand):
 
         with reversion.create_revision():
             investment_project.save(
-                update_fields=('allow_blank_possible_uk_regions',)
+                update_fields=('allow_blank_possible_uk_regions',),
             )
             investment_project.uk_region_locations.set(uk_region_locations)
             reversion.set_comment('Possible UK regions data migration correction.')

--- a/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_marketing.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_marketing.py
@@ -40,11 +40,12 @@ class Command(CSVBaseCommand):
             return None
         return ReferralSourceMarketing.objects.get(id=referral_source_activity_marketing_id)
 
-    def _should_update(self,
-                       investment_project,
-                       referral_source_activity,
-                       referral_source_activity_marketing
-                       ):
+    def _should_update(
+        self,
+        investment_project,
+        referral_source_activity,
+        referral_source_activity_marketing,
+    ):
         """
         Checks if Investment project should be updated.
 
@@ -66,11 +67,11 @@ class Command(CSVBaseCommand):
         investment_project = InvestmentProject.objects.get(pk=row['id'])
 
         referral_source_activity = self.get_referral_source_activity(
-            row['referral_source_activity_id']
+            row['referral_source_activity_id'],
         )
 
         referral_source_activity_marketing = self.get_referral_source_activity_marketing(
-            row['referral_source_activity_marketing_id']
+            row['referral_source_activity_marketing_id'],
         )
 
         if self._should_update(
@@ -89,6 +90,6 @@ class Command(CSVBaseCommand):
                         update_fields=(
                             'referral_source_activity',
                             'referral_source_activity_marketing',
-                        )
+                        ),
                     )
                     reversion.set_comment('ReferralSourceActivityMarketing migration.')

--- a/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_website.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_website.py
@@ -40,11 +40,12 @@ class Command(CSVBaseCommand):
             return None
         return ReferralSourceWebsite.objects.get(id=referral_source_activity_website_id)
 
-    def _should_update(self,
-                       investment_project,
-                       referral_source_activity,
-                       referral_source_activity_website
-                       ):
+    def _should_update(
+        self,
+        investment_project,
+        referral_source_activity,
+        referral_source_activity_website,
+    ):
         """
         Checks if Investment project should be updated.
 
@@ -66,11 +67,11 @@ class Command(CSVBaseCommand):
         investment_project = InvestmentProject.objects.get(pk=row['id'])
 
         referral_source_activity = self.get_referral_source_activity(
-            row['referral_source_activity_id']
+            row['referral_source_activity_id'],
         )
 
         referral_source_activity_website = self.get_referral_source_activity_website(
-            row['referral_source_activity_website_id']
+            row['referral_source_activity_website_id'],
         )
 
         if self._should_update(
@@ -87,6 +88,6 @@ class Command(CSVBaseCommand):
                         update_fields=(
                             'referral_source_activity',
                             'referral_source_activity_website',
-                        )
+                        ),
                     )
                     reversion.set_comment('ReferralSourceActivityWebsite migration.')

--- a/datahub/dbmaintenance/management/commands/update_investment_project_sector.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_sector.py
@@ -21,10 +21,11 @@ class Command(CSVBaseCommand):
             return None
         return Sector.objects.get(id=sector_id)
 
-    def _should_update(self,
-                       investment_project,
-                       old_sector,
-                       ):
+    def _should_update(
+        self,
+        investment_project,
+        old_sector,
+    ):
         """
         Checks if Investment project should be updated.
 
@@ -51,6 +52,6 @@ class Command(CSVBaseCommand):
                     investment_project.save(
                         update_fields=(
                             'sector',
-                        )
+                        ),
                     )
                     reversion.set_comment('Sector migration.')

--- a/datahub/dbmaintenance/management/commands/update_one_list_fields.py
+++ b/datahub/dbmaintenance/management/commands/update_one_list_fields.py
@@ -33,7 +33,7 @@ class Command(CSVBaseCommand):
             help=(
                 'If true, Data Hub records not present '
                 'in the CSV will have classification and one_list_account_owner set to None.'
-            )
+            ),
         )
 
     def _handle(self, *args, simulate=False, reset_unmatched=False, **options):
@@ -47,7 +47,7 @@ class Command(CSVBaseCommand):
         # as we process them and reset the remaining items.
         if reset_unmatched:
             qs = Company.objects.filter(
-                Q(classification_id__isnull=False) | Q(one_list_account_owner_id__isnull=False)
+                Q(classification_id__isnull=False) | Q(one_list_account_owner_id__isnull=False),
             )
             self.companies_to_reset = {company.id: company for company in qs}
         else:
@@ -58,7 +58,7 @@ class Command(CSVBaseCommand):
             *args,
             reset_unmatched=reset_unmatched,
             simulate=simulate,
-            **options
+            **options,
         )
 
         # reset all remaining unmatched companies
@@ -82,7 +82,7 @@ class Command(CSVBaseCommand):
                 company,
                 new_classification_id=None,
                 new_one_list_account_owner_id=None,
-                simulate=simulate
+                simulate=simulate,
             )
         except Exception as e:
             logger.exception(f'Resetting company {company} - Failed')
@@ -112,7 +112,7 @@ class Command(CSVBaseCommand):
         return Advisor.objects.get(pk=pk)
 
     def _update_company(
-        self, company, new_classification_id, new_one_list_account_owner_id, simulate
+        self, company, new_classification_id, new_one_list_account_owner_id, simulate,
     ):
         """
         Update `company` with the new values.
@@ -132,7 +132,7 @@ class Command(CSVBaseCommand):
                 update_fields=(
                     'classification_id',
                     'one_list_account_owner_id',
-                )
+                ),
             )
             reversion.set_comment('Classification and One List account owner correction.')
 

--- a/datahub/dbmaintenance/management/commands/update_service_delivery_grant_fields.py
+++ b/datahub/dbmaintenance/management/commands/update_service_delivery_grant_fields.py
@@ -26,15 +26,18 @@ class Command(CSVBaseCommand):
         interaction = Interaction.objects.get(pk=pk)
 
         something_updated = _update_fields(
-            interaction, status_id, grant_amount_offered, net_company_receipt, overwrite
+            interaction, status_id, grant_amount_offered, net_company_receipt, overwrite,
         )
 
         if simulate or not something_updated:
             return
 
         interaction.save(
-            update_fields=('service_delivery_status', 'grant_amount_offered',
-                           'net_company_receipt')
+            update_fields=(
+                'service_delivery_status',
+                'grant_amount_offered',
+                'net_company_receipt',
+            ),
         )
 
 
@@ -43,13 +46,13 @@ def _update_fields(interaction, status_id, grant_amount_offered, net_company_rec
         raise ValueError('Cannot set grant fields on interactions without kind==service_delivery')
 
     status_updated = _update_field(
-        interaction, 'service_delivery_status_id', status_id, overwrite
+        interaction, 'service_delivery_status_id', status_id, overwrite,
     )
     grant_amount_offered_updated = _update_field(
-        interaction, 'grant_amount_offered', grant_amount_offered, overwrite
+        interaction, 'grant_amount_offered', grant_amount_offered, overwrite,
     )
     net_company_receipt_updated = _update_field(
-        interaction, 'net_company_receipt', net_company_receipt, overwrite
+        interaction, 'net_company_receipt', net_company_receipt, overwrite,
     )
 
     return status_updated or grant_amount_offered_updated or net_company_receipt_updated

--- a/datahub/dbmaintenance/test/commands/test_update_adviser_contact_email.py
+++ b/datahub/dbmaintenance/test/commands/test_update_adviser_contact_email.py
@@ -35,12 +35,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_adviser_contact_email', bucket, object_key)
@@ -85,12 +85,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_adviser_contact_email', bucket, object_key, simulate=True)
@@ -128,12 +128,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_adviser_contact_email', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_adviser_telephone_number.py
+++ b/datahub/dbmaintenance/test/commands/test_update_adviser_telephone_number.py
@@ -33,12 +33,12 @@ def test_run(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_adviser_telephone_number', bucket, object_key)
@@ -67,12 +67,12 @@ def test_simulate(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_adviser_telephone_number', bucket, object_key, simulate=True)
@@ -96,12 +96,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_adviser_telephone_number', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_company_alias.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_alias.py
@@ -35,12 +35,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_alias', bucket, object_key)
@@ -52,7 +52,7 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert [company.alias for company in companies] == [
-        'xyz100', 'xyz102', 'ghi', 'xyz104', 'xyz105'
+        'xyz100', 'xyz102', 'ghi', 'xyz104', 'xyz105',
     ]
 
 
@@ -81,12 +81,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_alias', bucket, object_key, simulate=True)
@@ -119,12 +119,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_alias', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_company_company_number.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_company_number.py
@@ -39,12 +39,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     with freeze_time('2018-11-11 00:00:00'):
@@ -57,7 +57,7 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert [company.company_number for company in companies] == [
-        '012345', '456', '', '087891', '087892'
+        '012345', '456', '', '087891', '087892',
     ]
     assert all(company.modified_on == original_datetime for company in companies)
 
@@ -86,12 +86,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_company_number', bucket, object_key, simulate=True)
@@ -124,12 +124,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_company_number', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_global_hq.py
@@ -23,17 +23,17 @@ def test_run(s3_stubber, caplog):
     )
     other_global_hq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
 
     company_needs_global_hq = CompanyFactory(
-        global_headquarters=None
+        global_headquarters=None,
     )
     company_should_keep_current_global_hq = CompanyFactory(
-        global_headquarters=other_global_hq
+        global_headquarters=other_global_hq,
     )
     company_should_also_keep_global_hq = CompanyFactory(
-        global_headquarters=other_global_hq
+        global_headquarters=other_global_hq,
     )
 
     companies = [
@@ -56,12 +56,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_global_hq', bucket, object_key)
@@ -88,21 +88,21 @@ def test_overwrite(s3_stubber, caplog):
     caplog.set_level('ERROR')
     global_hq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
     other_global_hq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
 
     company_needs_global_hq = CompanyFactory(
-        global_headquarters=None
+        global_headquarters=None,
     )
     company_should_get_new_global_hq = CompanyFactory(
-        global_headquarters=other_global_hq
+        global_headquarters=other_global_hq,
     )
     company_should_have_global_hq_removed = CompanyFactory(
-        global_headquarters=other_global_hq
+        global_headquarters=other_global_hq,
     )
 
     companies = [
@@ -125,12 +125,12 @@ def test_overwrite(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_global_hq', bucket, object_key, overwrite=True)
@@ -152,28 +152,28 @@ def test_overwrite(s3_stubber, caplog):
 
 @pytest.mark.parametrize(
     'overwrite',
-    (True, False)
+    (True, False),
 )
 def test_simulate(s3_stubber, caplog, overwrite):
     """Test that the command simulates updates if --simulate is passed in."""
     caplog.set_level('ERROR')
     global_hq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
     other_global_hq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
 
     company_needs_global_hq = CompanyFactory(
-        global_headquarters=None
+        global_headquarters=None,
     )
     company_should_get_new_global_hq = CompanyFactory(
-        global_headquarters=other_global_hq
+        global_headquarters=other_global_hq,
     )
     company_should_have_global_hq_removed = CompanyFactory(
-        global_headquarters=other_global_hq
+        global_headquarters=other_global_hq,
     )
 
     companies = [
@@ -196,12 +196,12 @@ def test_simulate(s3_stubber, caplog, overwrite):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
@@ -209,7 +209,7 @@ def test_simulate(s3_stubber, caplog, overwrite):
         bucket,
         object_key,
         simulate=True,
-        overwrite=overwrite
+        overwrite=overwrite,
     )
 
     for company in companies:
@@ -231,14 +231,14 @@ def test_audit_log(s3_stubber):
     """Test that reversion revisions are created."""
     company_ghq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
     company_needs_global_hq = CompanyFactory(
-        global_headquarters=None
+        global_headquarters=None,
     )
     # Should not change
     company_ghq_set_already = CompanyFactory(
-        global_headquarters=company_ghq
+        global_headquarters=company_ghq,
     )
 
     bucket = 'test_bucket'
@@ -251,12 +251,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_global_hq', bucket, object_key)
@@ -273,13 +273,13 @@ def test_override_audit_log(s3_stubber):
     """Test that reversion revisions are created."""
     company_ghq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
     company_needs_global_hq = CompanyFactory(
-        global_headquarters=None
+        global_headquarters=None,
     )
     company_ghq_set_already = CompanyFactory(
-        global_headquarters=company_ghq
+        global_headquarters=company_ghq,
     )
 
     bucket = 'test_bucket'
@@ -292,12 +292,12 @@ def test_override_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_global_hq', bucket, object_key, overwrite=True)
@@ -319,15 +319,15 @@ def test_validation(s3_stubber, caplog):
     )
     valid_global_hq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
     other_valid_global_hq = CompanyFactory(
         headquarter_type_id=HeadquarterType.ghq.value.id,
-        global_headquarters=None
+        global_headquarters=None,
     )
 
     company_needs_global_hq = CompanyFactory(
-        global_headquarters=None
+        global_headquarters=None,
     )
 
     companies = [
@@ -348,12 +348,12 @@ def test_validation(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_global_hq', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_company_headquarter_type.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_headquarter_type.py
@@ -16,16 +16,16 @@ def test_run(s3_stubber, caplog):
     caplog.set_level('ERROR')
 
     company_no_hq_type = CompanyFactory(
-        headquarter_type_id=None
+        headquarter_type_id=None,
     )
     company_ghq = CompanyFactory(
-        headquarter_type_id=HeadquarterType.ghq.value.id
+        headquarter_type_id=HeadquarterType.ghq.value.id,
     )
     company_ukhq = CompanyFactory(
-        headquarter_type_id=HeadquarterType.ukhq.value.id
+        headquarter_type_id=HeadquarterType.ukhq.value.id,
     )
     company_ehq = CompanyFactory(
-        headquarter_type_id=HeadquarterType.ehq.value.id
+        headquarter_type_id=HeadquarterType.ehq.value.id,
     )
     companies = [
         company_no_hq_type,
@@ -46,12 +46,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_headquarter_type', bucket, object_key)
@@ -73,16 +73,16 @@ def test_simulate(s3_stubber, caplog):
     caplog.set_level('ERROR')
 
     company_no_hq_type = CompanyFactory(
-        headquarter_type_id=None
+        headquarter_type_id=None,
     )
     company_ghq = CompanyFactory(
-        headquarter_type_id=HeadquarterType.ghq.value.id
+        headquarter_type_id=HeadquarterType.ghq.value.id,
     )
     company_ukhq = CompanyFactory(
-        headquarter_type_id=HeadquarterType.ukhq.value.id
+        headquarter_type_id=HeadquarterType.ukhq.value.id,
     )
     company_ehq = CompanyFactory(
-        headquarter_type_id=HeadquarterType.ehq.value.id
+        headquarter_type_id=HeadquarterType.ehq.value.id,
     )
     companies = [
         company_no_hq_type,
@@ -103,12 +103,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_headquarter_type', bucket, object_key, simulate=True)
@@ -128,10 +128,10 @@ def test_simulate(s3_stubber, caplog):
 def test_audit_log(s3_stubber):
     """Test that reversion revisions are created."""
     company_no_hq_type = CompanyFactory(
-        headquarter_type_id=None
+        headquarter_type_id=None,
     )
     company_ehq = CompanyFactory(
-        headquarter_type_id=HeadquarterType.ehq.value.id
+        headquarter_type_id=HeadquarterType.ehq.value.id,
     )
 
     bucket = 'test_bucket'
@@ -144,12 +144,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_headquarter_type', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_company_name.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_name.py
@@ -35,12 +35,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_name', bucket, object_key)
@@ -52,7 +52,7 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert [company.name for company in companies] == [
-        'xyz100', 'xyz102', 'ghi', 'xyz104', 'xyz105'
+        'xyz100', 'xyz102', 'ghi', 'xyz104', 'xyz105',
     ]
 
 
@@ -81,12 +81,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_name', bucket, object_key, simulate=True)
@@ -119,12 +119,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_company_name', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_contact_accepts_dit_email_marketing.py
+++ b/datahub/dbmaintenance/test/commands/test_update_contact_accepts_dit_email_marketing.py
@@ -37,12 +37,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     with freeze_time('2018-11-11 00:00:00'):
@@ -89,17 +89,17 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     with freeze_time('2018-11-11 00:00:00'):
         call_command(
-            'update_contact_accepts_dit_email_marketing', bucket, object_key, simulate=True
+            'update_contact_accepts_dit_email_marketing', bucket, object_key, simulate=True,
         )
 
     for contact in contacts:
@@ -133,12 +133,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_contact_accepts_dit_email_marketing', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_actual_land_date.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_actual_land_date.py
@@ -27,7 +27,7 @@ def test_run(s3_stubber, caplog):
     investment_projects = InvestmentProjectFactory.create_batch(
         5,
         stage_id=factory.Iterator(stages),
-        actual_land_date=factory.Iterator(old_dates)
+        actual_land_date=factory.Iterator(old_dates),
     )
 
     bucket = 'test_bucket'
@@ -44,12 +44,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_actual_land_date', bucket, object_key)
@@ -62,7 +62,7 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 2
 
     assert [project.actual_land_date for project in investment_projects] == [
-        None, None, None, date(2016, 8, 24), date(2016, 8, 23)
+        None, None, None, date(2016, 8, 24), date(2016, 8, 23),
     ]
 
 
@@ -72,7 +72,7 @@ def test_simulate(s3_stubber, caplog):
 
     old_dates = [date(2016, 2, 20), None, date(2013, 6, 13), date(2016, 8, 23)]
     investment_projects = InvestmentProjectFactory.create_batch(
-        4, actual_land_date=factory.Iterator(old_dates)
+        4, actual_land_date=factory.Iterator(old_dates),
     )
 
     bucket = 'test_bucket'
@@ -88,12 +88,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_actual_land_date', bucket, object_key, simulate=True)
@@ -122,12 +122,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_actual_land_date', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_actual_uk_regions.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_actual_uk_regions.py
@@ -38,12 +38,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_actual_uk_regions', bucket, object_key)
@@ -55,7 +55,7 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert [list(project.actual_uk_regions.all()) for project in investment_projects] == [
-        [], regions[2:3], regions[0:1], regions[1:2], regions[3:5]
+        [], regions[2:3], regions[0:1], regions[1:2], regions[3:5],
     ]
 
 
@@ -87,12 +87,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_actual_uk_regions', bucket, object_key, simulate=True)
@@ -105,7 +105,7 @@ def test_simulate(s3_stubber, caplog):
     assert len(caplog.records) == 2
 
     assert [list(project.actual_uk_regions.all()) for project in investment_projects] == [
-        [], [], regions[0:1], regions[1:2], []
+        [], [], regions[0:1], regions[1:2], [],
     ]
 
 
@@ -126,12 +126,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_actual_uk_regions', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_business_activities.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_business_activities.py
@@ -37,12 +37,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
             'Key': object_key,
-        }
+        },
     )
 
     call_command('update_investment_project_business_activities', bucket, object_key)
@@ -85,12 +85,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
             'Key': object_key,
-        }
+        },
     )
 
     call_command(
@@ -117,7 +117,7 @@ def test_audit_log(s3_stubber):
     project_without_change = InvestmentProjectFactory(business_activities=business_activities[0:1])
     project_with_change = InvestmentProjectFactory(business_activities=[])
     project_already_updated = InvestmentProjectFactory(
-        business_activities=business_activities[0:1]
+        business_activities=business_activities[0:1],
     )
 
     bucket = 'test_bucket'
@@ -131,12 +131,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
             'Key': object_key,
-        }
+        },
     )
 
     call_command('update_investment_project_business_activities', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_comments.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_comments.py
@@ -33,12 +33,12 @@ New Line :)"
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_comments', bucket, object_key)
@@ -64,12 +64,12 @@ def test_simulate(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_comments', bucket, object_key, simulate=True)
@@ -93,12 +93,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_comments', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_company.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_company.py
@@ -86,12 +86,12 @@ def test_run(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_company', bucket, object_key)
@@ -150,12 +150,12 @@ def test_simulate(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_company', bucket, object_key, simulate=True)
@@ -186,12 +186,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_company', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_created_on.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_created_on.py
@@ -37,12 +37,12 @@ def test_run(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_created_on', bucket, object_key)
@@ -69,12 +69,12 @@ def test_simulate(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_created_on', bucket, object_key, simulate=True)
@@ -98,12 +98,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_created_on', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_delivery_partners.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_delivery_partners.py
@@ -38,12 +38,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_delivery_partners', bucket, object_key)
@@ -91,12 +91,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_delivery_partners', bucket, object_key, simulate=True)
@@ -109,7 +109,7 @@ def test_simulate(s3_stubber, caplog):
     assert len(caplog.records) == 2
 
     assert [list(project.delivery_partners.all()) for project in investment_projects] == [
-        [], [], delivery_partners[0:1], delivery_partners[1:2], []
+        [], [], delivery_partners[0:1], delivery_partners[1:2], [],
     ]
 
 
@@ -130,12 +130,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_delivery_partners', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_estimated_land_date.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_estimated_land_date.py
@@ -20,7 +20,7 @@ def test_run(s3_stubber, caplog):
     investment_projects = InvestmentProjectFactory.create_batch(
         4,
         allow_blank_estimated_land_date=factory.Iterator(allow_blank_estimated_land_date),
-        estimated_land_date=factory.Iterator(estimated_land_date)
+        estimated_land_date=factory.Iterator(estimated_land_date),
     )
 
     bucket = 'test_bucket'
@@ -36,12 +36,12 @@ def test_run(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_estimated_land_date', bucket, object_key)
@@ -53,10 +53,10 @@ def test_run(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert [project.allow_blank_estimated_land_date for project in investment_projects] == [
-        True, False, False, True
+        True, False, False, True,
     ]
     assert [project.estimated_land_date for project in investment_projects] == [
-        None, date(2018, 1, 1), date(2017, 1, 5), date(2016, 8, 23)
+        None, date(2018, 1, 1), date(2017, 1, 5), date(2016, 8, 23),
     ]
 
 
@@ -69,7 +69,7 @@ def test_simulate(s3_stubber, caplog):
     investment_projects = InvestmentProjectFactory.create_batch(
         4,
         allow_blank_estimated_land_date=factory.Iterator(allow_blank_estimated_land_date),
-        estimated_land_date=factory.Iterator(estimated_land_date)
+        estimated_land_date=factory.Iterator(estimated_land_date),
     )
 
     bucket = 'test_bucket'
@@ -85,16 +85,16 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
-        'update_investment_project_estimated_land_date', bucket, object_key, simulate=True
+        'update_investment_project_estimated_land_date', bucket, object_key, simulate=True,
     )
 
     for project in investment_projects:
@@ -129,12 +129,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_estimated_land_date', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_possible_uk_regions.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_possible_uk_regions.py
@@ -25,7 +25,7 @@ def test_run_with_old_regions(s3_stubber, caplog):
 
     investment_projects = InvestmentProjectFactory.create_batch(
         4,
-        allow_blank_possible_uk_regions=factory.Iterator(old_allow_blank_possible_uk_regions)
+        allow_blank_possible_uk_regions=factory.Iterator(old_allow_blank_possible_uk_regions),
     )
 
     for project, project_regions in zip(investment_projects, old_uk_region_locations):
@@ -44,12 +44,12 @@ def test_run_with_old_regions(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
@@ -65,7 +65,7 @@ def test_run_with_old_regions(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert [project.allow_blank_possible_uk_regions for project in investment_projects] == [
-        True, False, False, True
+        True, False, False, True,
     ]
     assert [list(project.uk_region_locations.all()) for project in investment_projects] == [
         [],
@@ -88,7 +88,7 @@ def test_run_ignore_old_regions(s3_stubber, caplog):
 
     investment_projects = InvestmentProjectFactory.create_batch(
         4,
-        allow_blank_possible_uk_regions=factory.Iterator(old_allow_blank_possible_uk_regions)
+        allow_blank_possible_uk_regions=factory.Iterator(old_allow_blank_possible_uk_regions),
     )
 
     for project, project_regions in zip(investment_projects, old_uk_region_locations):
@@ -107,12 +107,12 @@ def test_run_ignore_old_regions(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
@@ -129,10 +129,10 @@ def test_run_ignore_old_regions(s3_stubber, caplog):
     assert len(caplog.records) == 1
 
     assert [project.allow_blank_possible_uk_regions for project in investment_projects] == [
-        True, False, False, True
+        True, False, False, True,
     ]
     assert [list(project.uk_region_locations.all()) for project in investment_projects] == [
-        [], regions[2:3], regions[0:2], regions[0:4]
+        [], regions[2:3], regions[0:2], regions[0:4],
     ]
 
 
@@ -147,7 +147,7 @@ def test_simulate(s3_stubber, caplog):
 
     investment_projects = InvestmentProjectFactory.create_batch(
         4,
-        allow_blank_possible_uk_regions=factory.Iterator(old_allow_blank_possible_uk_regions)
+        allow_blank_possible_uk_regions=factory.Iterator(old_allow_blank_possible_uk_regions),
     )
 
     for project, project_regions in zip(investment_projects, old_uk_region_locations):
@@ -166,12 +166,12 @@ def test_simulate(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
@@ -217,12 +217,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_marketing.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_marketing.py
@@ -8,7 +8,7 @@ from reversion.models import Version
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import (
     ReferralSourceActivityFactory,
-    ReferralSourceMarketingFactory
+    ReferralSourceMarketingFactory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -25,27 +25,27 @@ def test_run(s3_stubber):
         # referral_source_activity and referral_source_marketing should get updated
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[0].id,
-            referral_source_activity_marketing=referral_source_marketings[0]
+            referral_source_activity_marketing=referral_source_marketings[0],
         ),
         # referral_source_activity and referral_source_marketing should get updated
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[1].id,
-            referral_source_activity_marketing=referral_source_marketings[1]
+            referral_source_activity_marketing=referral_source_marketings[1],
         ),
         # should be ignored
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[2].id,
-            referral_source_activity_marketing=referral_source_marketings[2]
+            referral_source_activity_marketing=referral_source_marketings[2],
         ),
         # referral_source_activity is invalid so it should fail
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[3].id,
-            referral_source_activity_marketing=referral_source_marketings[3]
+            referral_source_activity_marketing=referral_source_marketings[3],
         ),
         # referral_source_marketing is invalid so it should fail
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[4].id,
-            referral_source_activity_marketing=referral_source_marketings[4]
+            referral_source_activity_marketing=referral_source_marketings[4],
         ),
     ]
 
@@ -65,18 +65,18 @@ def test_run(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
         'update_investment_project_referral_source_activity_marketing',
         bucket,
-        object_key
+        object_key,
     )
 
     for investment_project in investment_projects:
@@ -138,19 +138,19 @@ def test_simulate(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
         'update_investment_project_referral_source_activity_marketing',
         bucket,
         object_key,
-        simulate=True
+        simulate=True,
     )
 
     for investment_project in investment_projects:
@@ -180,12 +180,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_website.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_website.py
@@ -8,7 +8,7 @@ from reversion.models import Version
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import (
     ReferralSourceActivityFactory,
-    ReferralSourceWebsiteFactory
+    ReferralSourceWebsiteFactory,
 )
 
 pytestmark = pytest.mark.django_db
@@ -25,27 +25,27 @@ def test_run(s3_stubber):
         # referral_source_activity and referral_source_website should get updated
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[0].id,
-            referral_source_activity_website=referral_source_websites[0]
+            referral_source_activity_website=referral_source_websites[0],
         ),
         # referral_source_activity and referral_source_website should get updated
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[1].id,
-            referral_source_activity_website=referral_source_websites[1]
+            referral_source_activity_website=referral_source_websites[1],
         ),
         # should be ignored
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[2].id,
-            referral_source_activity_website=referral_source_websites[2]
+            referral_source_activity_website=referral_source_websites[2],
         ),
         # referral_source_activity is invalid so it should fail
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[3].id,
-            referral_source_activity_website=referral_source_websites[3]
+            referral_source_activity_website=referral_source_websites[3],
         ),
         # referral_source_website is invalid so it should fail
         InvestmentProjectFactory(
             referral_source_activity_id=referral_source_activities[4].id,
-            referral_source_activity_website=referral_source_websites[4]
+            referral_source_activity_website=referral_source_websites[4],
         ),
     ]
 
@@ -65,12 +65,12 @@ def test_run(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_referral_source_activity_website', bucket, object_key)
@@ -114,19 +114,19 @@ def test_simulate(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
         'update_investment_project_referral_source_activity_website',
         bucket,
         object_key,
-        simulate=True
+        simulate=True,
     )
 
     for investment_project in investment_projects:
@@ -155,12 +155,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_sector.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_sector.py
@@ -44,12 +44,12 @@ def test_run(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_sector', bucket, object_key)
@@ -79,12 +79,12 @@ def test_simulate(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_sector', bucket, object_key, simulate=True)
@@ -110,12 +110,12 @@ def test_audit_log(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_investment_project_sector', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_omis_uk_regions.py
+++ b/datahub/dbmaintenance/test/commands/test_update_omis_uk_regions.py
@@ -40,7 +40,7 @@ def test_run(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {'Body': BytesIO(bytes(csv_content, encoding='utf-8'))},
-        expected_params={'Bucket': bucket, 'Key': object_key}
+        expected_params={'Bucket': bucket, 'Key': object_key},
     )
 
     call_command('update_omis_uk_regions', bucket, object_key)
@@ -71,7 +71,7 @@ def test_simulate(s3_stubber):
     s3_stubber.add_response(
         'get_object',
         {'Body': BytesIO(bytes(csv_content, encoding='utf-8'))},
-        expected_params={'Bucket': bucket, 'Key': object_key}
+        expected_params={'Bucket': bucket, 'Key': object_key},
     )
 
     call_command('update_omis_uk_regions', bucket, object_key, simulate=True)

--- a/datahub/dbmaintenance/test/commands/test_update_one_list_fields.py
+++ b/datahub/dbmaintenance/test/commands/test_update_one_list_fields.py
@@ -54,15 +54,15 @@ def test_run(s3_stubber, caplog, reset_unmatched):
         8,
         classification=factory.LazyFunction(
             lambda: random_obj_for_queryset(
-                CompanyClassification.objects.exclude(pk=new_classification.pk)
-            )
+                CompanyClassification.objects.exclude(pk=new_classification.pk),
+            ),
         ),
-        one_list_account_owner=factory.SubFactory(AdviserFactory)
+        one_list_account_owner=factory.SubFactory(AdviserFactory),
     )
     non_one_list_companies = CompanyFactory.create_batch(
         3,
         classification=None,
-        one_list_account_owner=None
+        one_list_account_owner=None,
     )
 
     for company in chain(one_list_companies, non_one_list_companies):
@@ -90,8 +90,8 @@ def test_run(s3_stubber, caplog, reset_unmatched):
         {'Body': BytesIO(csv_content.encode(encoding='utf-8'))},
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_one_list_fields', bucket, object_key, reset_unmatched=reset_unmatched)
@@ -138,12 +138,12 @@ def test_run(s3_stubber, caplog, reset_unmatched):
 
     # non_one_list_companies[1]: nothing changed
     assert_did_not_change(
-        non_one_list_companies[1], 'classification_id', 'one_list_account_owner_id'
+        non_one_list_companies[1], 'classification_id', 'one_list_account_owner_id',
     )
 
     # non_one_list_companies[2]: nothing changed
     assert_did_not_change(
-        non_one_list_companies[2], 'classification_id', 'one_list_account_owner_id'
+        non_one_list_companies[2], 'classification_id', 'one_list_account_owner_id',
     )
 
     # one_list_companies[6] / [7]: if reset_unmatched == False => nothing changed else all changed
@@ -157,10 +157,10 @@ def test_run(s3_stubber, caplog, reset_unmatched):
         assert one_list_companies[7].one_list_account_owner is None
     else:
         assert_did_not_change(
-            one_list_companies[6], 'classification_id', 'one_list_account_owner_id'
+            one_list_companies[6], 'classification_id', 'one_list_account_owner_id',
         )
         assert_did_not_change(
-            one_list_companies[7], 'classification_id', 'one_list_account_owner_id'
+            one_list_companies[7], 'classification_id', 'one_list_account_owner_id',
         )
 
 
@@ -174,15 +174,15 @@ def test_simulate(s3_stubber, caplog, reset_unmatched):
         8,
         classification=factory.LazyFunction(
             lambda: random_obj_for_queryset(
-                CompanyClassification.objects.exclude(pk=new_classification.pk)
-            )
+                CompanyClassification.objects.exclude(pk=new_classification.pk),
+            ),
         ),
-        one_list_account_owner=factory.SubFactory(AdviserFactory)
+        one_list_account_owner=factory.SubFactory(AdviserFactory),
     )
     non_one_list_companies = CompanyFactory.create_batch(
         3,
         classification=None,
-        one_list_account_owner=None
+        one_list_account_owner=None,
     )
 
     for company in chain(one_list_companies, non_one_list_companies):
@@ -210,8 +210,8 @@ def test_simulate(s3_stubber, caplog, reset_unmatched):
         {'Body': BytesIO(csv_content.encode(encoding='utf-8'))},
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command(
@@ -219,7 +219,7 @@ def test_simulate(s3_stubber, caplog, reset_unmatched):
         bucket,
         object_key,
         reset_unmatched=reset_unmatched,
-        simulate=True
+        simulate=True,
     )
 
     for company in chain(one_list_companies, non_one_list_companies):
@@ -244,7 +244,7 @@ def test_audit_log(s3_stubber, caplog):
     company_without_change, company_with_change = CompanyFactory.create_batch(
         2,
         classification=classifications[0],
-        one_list_account_owner=AdviserFactory()
+        one_list_account_owner=AdviserFactory(),
     )
 
     bucket = 'test_bucket'
@@ -257,12 +257,12 @@ def test_audit_log(s3_stubber, caplog):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(csv_content.encode(encoding='utf-8'))
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
 
     call_command('update_one_list_fields', bucket, object_key)

--- a/datahub/dbmaintenance/test/commands/test_update_service_delivery_grant_fields.py
+++ b/datahub/dbmaintenance/test/commands/test_update_service_delivery_grant_fields.py
@@ -63,12 +63,12 @@ def s3_csv_object(s3_stubber, statuses, interactions):
     s3_stubber.add_response(
         'get_object',
         {
-            'Body': BytesIO(bytes(csv_content, encoding='utf-8'))
+            'Body': BytesIO(bytes(csv_content, encoding='utf-8')),
         },
         expected_params={
             'Bucket': bucket,
-            'Key': object_key
-        }
+            'Key': object_key,
+        },
     )
     return bucket, object_key
 


### PR DESCRIPTION
### Description of change

This adds trailing commas to the dbmaintenance app where they were missing. This includes some related code reformatting and the removal of some incorrect trailing commas.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
