### PR TITLE
Add trailing commas to documents app

### DIFF
--- a/datahub/documents/av_scan.py
+++ b/datahub/documents/av_scan.py
@@ -47,8 +47,10 @@ def perform_virus_scan(document_pk: str, download_url: str):
         - unknown response returned by the AV service
     """
     if not settings.AV_V2_SERVICE_URL:
-        raise VirusScanException(f'Cannot scan document with ID {document_pk}; AV V2 service '
-                                 f'URL not configured')
+        raise VirusScanException(
+            f'Cannot scan document with ID {document_pk}; AV V2 service '
+            f'URL not configured',
+        )
 
     logger.info(f'Virus scanning of Document with ID {document_pk} started.')
 
@@ -68,8 +70,10 @@ def perform_virus_scan(document_pk: str, download_url: str):
     is_file_clean = not result['malware']
     document.mark_as_scanned(is_file_clean, result.get('reason') or '')
 
-    logger.info(f'Virus scanning of Document with ID {document_pk} '
-                f'completed (av_clean={is_file_clean}).')
+    logger.info(
+        f'Virus scanning of Document with ID {document_pk} '
+        f'completed (av_clean={is_file_clean}).',
+    )
 
 
 def _download_and_scan_file(document_pk: str, download_url: str):
@@ -80,7 +84,7 @@ def _download_and_scan_file(document_pk: str, download_url: str):
         except HTTPError as exc:
             raise VirusScanException(
                 f'Unable to download the document with ID {document_pk} '
-                f'for scanning (status_code={exc.response.status_code}).'
+                f'for scanning (status_code={exc.response.status_code}).',
             ) from exc
         content = StreamWrapper(response.raw, response.headers['content-length'])
         return _scan_stream(document_pk, content, response.headers['content-type'])
@@ -92,7 +96,7 @@ def _multipart_encoder(document_pk, content, content_type):
             document_pk,
             content,
             content_type,
-        )
+        ),
     }
     encoder = MultipartEncoder(multipart_fields)
     return encoder
@@ -115,5 +119,5 @@ def _scan_stream(document_pk, content, content_type):
 
     raise VirusScanException(
         f'Unexpected response from AV service: {result} '
-        f'when scanning document with ID {document_pk}'
+        f'when scanning document with ID {document_pk}',
     )

--- a/datahub/documents/models.py
+++ b/datahub/documents/models.py
@@ -19,7 +19,7 @@ UPLOAD_STATUSES = Choices(
     ('virus_scanning_in_progress', 'Virus scanning in progress'),
     ('virus_scanning_failed', 'Virus scanning failed.'),
     ('virus_scanned', 'Virus scanned'),
-    ('deletion_pending', 'Deletion pending')
+    ('deletion_pending', 'Deletion pending'),
 )
 
 
@@ -31,7 +31,7 @@ class Document(BaseModel, ArchivableModel):
     path = models.CharField(max_length=settings.CHAR_FIELD_MAX_LENGTH)
 
     uploaded_on = models.DateTimeField(
-        null=True, blank=True
+        null=True, blank=True,
     )
     scan_initiated_on = models.DateTimeField(
         null=True, blank=True,
@@ -51,7 +51,7 @@ class Document(BaseModel, ArchivableModel):
 
     class Meta:
         unique_together = (
-            ('bucket_id', 'path',),
+            ('bucket_id', 'path'),
         )
 
     @property

--- a/datahub/documents/tasks.py
+++ b/datahub/documents/tasks.py
@@ -18,7 +18,7 @@ def delete_document(document_pk):
         perform_delete_document(document_pk)
     except Exception:
         logger.error(
-            f'Deletion from S3 of document with ID {document_pk} failed.'
+            f'Deletion from S3 of document with ID {document_pk} failed.',
         )
         raise
 

--- a/datahub/documents/test/my_entity_document/models.py
+++ b/datahub/documents/test/my_entity_document/models.py
@@ -15,6 +15,9 @@ class MyEntityDocument(AbstractEntityDocumentModel):
     @property
     def url(self):
         """Returns URL to download endpoint."""
-        return reverse('test-document-item-download', kwargs={
-            'entity_document_pk': self.pk,
-        })
+        return reverse(
+            'test-document-item-download',
+            kwargs={
+                'entity_document_pk': self.pk,
+            },
+        )

--- a/datahub/documents/test/my_entity_document/urls.py
+++ b/datahub/documents/test/my_entity_document/urls.py
@@ -26,21 +26,21 @@ urlpatterns = [
     path(
         'test-my-entity-document',
         my_entity_document_collection,
-        name='test-document-collection'
+        name='test-document-collection',
     ),
     path(
         'test-my-entity-document/<uuid:entity_document_pk>',
         my_entity_document_item,
-        name='test-document-item'
+        name='test-document-item',
     ),
     path(
         'test-my-entity-document/<uuid:entity_document_pk>/upload-callback',
         my_entity_document_callback,
-        name='test-document-item-callback'
+        name='test-document-item-callback',
     ),
     path(
         'test-my-entity-document/<uuid:entity_document_pk>/download',
         my_entity_document_download,
-        name='test-document-item-download'
+        name='test-document-item-download',
     ),
 ]

--- a/datahub/documents/test/test_av_scan.py
+++ b/datahub/documents/test/test_av_scan.py
@@ -25,13 +25,16 @@ def test_virus_scan_document_clean(get_signed_url_mock, requests_mock):
         headers={
             'Content-Type': 'application/json',
             'Content-Length': '1000',
-        }
+        },
     )
-    requests_mock.post('http://av-service/', json={
-        'malware': False,
-        'reason': None,
-        'time': 0.2,
-    })
+    requests_mock.post(
+        'http://av-service/',
+        json={
+            'malware': False,
+            'reason': None,
+            'time': 0.2,
+        },
+    )
 
     virus_scan_document.apply(args=(str(document.id), )).get()
     document.refresh_from_db()
@@ -49,13 +52,16 @@ def test_virus_scan_document_infected(get_signed_url_mock, requests_mock):
         headers={
             'Content-Type': 'application/json',
             'Content-Length': '1000',
-        }
+        },
     )
-    requests_mock.post('http://av-service/', json={
-        'malware': True,
-        'reason': 'File contains ransomware.',
-        'time': 0.1,
-    })
+    requests_mock.post(
+        'http://av-service/',
+        json={
+            'malware': True,
+            'reason': 'File contains ransomware.',
+            'time': 0.1,
+        },
+    )
 
     virus_scan_document.apply(args=(str(document.id), )).get()
     document.refresh_from_db()
@@ -73,11 +79,14 @@ def test_virus_scan_document_bad_response_body(get_signed_url_mock, requests_moc
         headers={
             'Content-Type': 'application/json',
             'Content-Length': '1000',
-        }
+        },
     )
-    requests_mock.post('http://av-service/', json={
-        'too_many_cats': 'never',
-    })
+    requests_mock.post(
+        'http://av-service/',
+        json={
+            'too_many_cats': 'never',
+        },
+    )
 
     error_message = (
         f'Unexpected response from AV service: {{\'too_many_cats\': \'never\'}} '
@@ -86,7 +95,7 @@ def test_virus_scan_document_bad_response_body(get_signed_url_mock, requests_moc
 
     with pytest.raises(
         VirusScanException,
-        match=error_message
+        match=error_message,
     ):
         virus_scan_document.apply(args=(str(document.id), )).get()
 
@@ -108,7 +117,7 @@ def test_virus_scan_document_file_not_found(get_signed_url_mock, requests_mock):
     with pytest.raises(
         VirusScanException,
         match=f'Unable to download the document with ID {document.pk} '
-              f'for scanning \(status_code\=404\).'
+              f'for scanning \(status_code\=404\).',
     ):
         virus_scan_document.apply(args=(str(document.id), )).get()
     document.refresh_from_db()
@@ -126,7 +135,7 @@ def test_virus_scan_document_bad_response_status(get_signed_url_mock, requests_m
         headers={
             'Content-Type': 'application/json',
             'Content-Length': '1000',
-        }
+        },
     )
     requests_mock.post(
         'http://av-service/',

--- a/datahub/documents/test/test_tasks.py
+++ b/datahub/documents/test/test_tasks.py
@@ -21,13 +21,16 @@ def test_delete_document(s3_stubber):
 
     bucket_name = get_bucket_name(document.bucket_id)
 
-    s3_stubber.add_response('delete_object', {
-        'ResponseMetadata': {
-            'HTTPStatusCode': 204,
-        }
-    }, expected_params={
-        'Bucket': bucket_name, 'Key': document.path
-    })
+    s3_stubber.add_response(
+        'delete_object',
+        {
+            'ResponseMetadata': {
+                'HTTPStatusCode': 204,
+            },
+        }, expected_params={
+            'Bucket': bucket_name, 'Key': document.path,
+        },
+    )
 
     result = delete_document.apply(args=(document.pk, )).get()
     assert result is None
@@ -55,8 +58,8 @@ def test_delete_document_s3_failure(s3_stubber):
         'delete_object',
         service_error_code=500,
         expected_params={
-            'Bucket': bucket_name, 'Key': document.path
-        }
+            'Bucket': bucket_name, 'Key': document.path,
+        },
     )
 
     with pytest.raises(Exception):

--- a/datahub/documents/test/test_views.py
+++ b/datahub/documents/test/test_views.py
@@ -58,10 +58,13 @@ class TestDocumentViews(APITestMixin):
 
         url = reverse('test-document-collection')
 
-        response = self.api_client.post(url, data={
-            'original_filename': 'test.txt',
-            'my_field': 'cats cannot taste sweet',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_filename': 'test.txt',
+                'my_field': 'cats cannot taste sweet',
+            },
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.data
@@ -85,9 +88,12 @@ class TestDocumentViews(APITestMixin):
             my_field='cats are lactose intolerant',
         )
 
-        url = reverse('test-document-item', kwargs={
-            'entity_document_pk': entity_document.pk
-        })
+        url = reverse(
+            'test-document-item',
+            kwargs={
+                'entity_document_pk': entity_document.pk,
+            },
+        )
 
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
@@ -107,9 +113,12 @@ class TestDocumentViews(APITestMixin):
         )
         entity_document.document.mark_deletion_pending()
 
-        url = reverse('test-document-item', kwargs={
-            'entity_document_pk': entity_document.pk
-        })
+        url = reverse(
+            'test-document-item',
+            kwargs={
+                'entity_document_pk': entity_document.pk,
+            },
+        )
 
         response = self.api_client.get(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -126,16 +135,19 @@ class TestDocumentViews(APITestMixin):
             my_field='cats use whiskers to navigate in the dark',
         )
 
-        url = reverse('test-document-item-callback', kwargs={
-            'entity_document_pk': entity_document.pk
-        })
+        url = reverse(
+            'test-document-item-callback',
+            kwargs={
+                'entity_document_pk': entity_document.pk,
+            },
+        )
 
         response = self.api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['status'] == 'virus_scanning_scheduled'
         virus_scan_document.assert_called_once_with(
-            args=(str(entity_document.document.pk),)
+            args=(str(entity_document.document.pk),),
         )
 
     @patch('datahub.documents.tasks.delete_document.apply_async')

--- a/datahub/documents/utils.py
+++ b/datahub/documents/utils.py
@@ -86,12 +86,12 @@ def perform_delete_document(document_pk):
     document = get_document_by_pk(document_pk)
     if not document:
         raise DocumentDeleteException(
-            f'Document with ID {document_pk} not found.'
+            f'Document with ID {document_pk} not found.',
         )
 
     if document.status != UPLOAD_STATUSES.deletion_pending:
         raise DocumentDeleteException(
-            f'Document with ID {document_pk} is not pending deletion.'
+            f'Document with ID {document_pk} is not pending deletion.',
         )
 
     if document.uploaded_on:


### PR DESCRIPTION
### Description of change

This adds trailing commas to the documents app where they were missing. This includes some related code reformatting and the removal of some incorrect trailing commas.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
