### PR TITLE
Add trailing commas to event app

### DIFF
--- a/datahub/event/admin.py
+++ b/datahub/event/admin.py
@@ -92,11 +92,11 @@ class EventAdmin(BaseModelAdminMixin, VersionAdmin):
         'organiser',
     )
 
-    actions = ('disable_selected', 'enable_selected',)
+    actions = ('disable_selected', 'enable_selected')
 
     @confirm_action(
         title='Disable selected events',
-        action_message='disable the selected events'
+        action_message='disable the selected events',
     )
     def disable_selected(self, request, queryset):
         """Disables selected objects."""
@@ -111,7 +111,7 @@ class EventAdmin(BaseModelAdminMixin, VersionAdmin):
 
     @confirm_action(
         title='Enable selected events',
-        action_message='enable the selected events'
+        action_message='enable the selected events',
     )
     def enable_selected(self, request, queryset):
         """Enables selected objects."""

--- a/datahub/event/models.py
+++ b/datahub/event/models.py
@@ -19,7 +19,7 @@ class Event(BaseModel, DisableableModel):
     start_date = models.DateField(null=True, blank=True)
     end_date = models.DateField(null=True, blank=True)
     location_type = models.ForeignKey(
-        'LocationType', on_delete=models.deletion.SET_NULL, null=True, blank=True
+        'LocationType', on_delete=models.deletion.SET_NULL, null=True, blank=True,
     )
     address_1 = models.CharField(max_length=MAX_LENGTH)
     address_2 = models.CharField(max_length=MAX_LENGTH, blank=True)
@@ -27,26 +27,26 @@ class Event(BaseModel, DisableableModel):
     address_county = models.CharField(max_length=MAX_LENGTH, blank=True)
     address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True)
     address_country = models.ForeignKey(
-        'metadata.Country', on_delete=models.PROTECT, related_name='+'
+        'metadata.Country', on_delete=models.PROTECT, related_name='+',
     )
     uk_region = models.ForeignKey(
-        'metadata.UKRegion', blank=True, null=True, on_delete=models.SET_NULL
+        'metadata.UKRegion', blank=True, null=True, on_delete=models.SET_NULL,
     )
     notes = models.TextField(blank=True)
     organiser = models.ForeignKey(
-        'company.Advisor', on_delete=models.deletion.SET_NULL, null=True, blank=True
+        'company.Advisor', on_delete=models.deletion.SET_NULL, null=True, blank=True,
     )
     lead_team = models.ForeignKey(
-        'metadata.Team', on_delete=models.PROTECT, null=True, blank=True, related_name='+'
+        'metadata.Team', on_delete=models.PROTECT, null=True, blank=True, related_name='+',
     )
     teams = models.ManyToManyField('metadata.Team', blank=True, related_name='+')
     related_programmes = models.ManyToManyField('Programme', blank=True)
     service = models.ForeignKey(
-        'metadata.Service', null=True, blank=True, on_delete=models.PROTECT
+        'metadata.Service', null=True, blank=True, on_delete=models.PROTECT,
     )
     archived_documents_url_path = models.CharField(
         max_length=MAX_LENGTH, blank=True,
-        help_text='Legacy field. File browser path to the archived documents for this event.'
+        help_text='Legacy field. File browser path to the archived documents for this event.',
     )
 
     def __str__(self):

--- a/datahub/event/serializers.py
+++ b/datahub/event/serializers.py
@@ -14,8 +14,9 @@ class EventSerializer(serializers.ModelSerializer):
     default_error_messages = {
         'lead_team_not_in_teams': ugettext_lazy('Lead team must be in teams array.'),
         'end_date_before_start_date': ugettext_lazy('End date cannot be before start date.'),
-        'uk_region_non_uk_country': ugettext_lazy('Cannot specify a UK region for a non-UK '
-                                                  'country.')
+        'uk_region_non_uk_country': ugettext_lazy(
+            'Cannot specify a UK region for a non-UK country.',
+        ),
     }
     end_date = serializers.DateField()
     event_type = NestedRelatedField('event.EventType')
@@ -26,7 +27,7 @@ class EventSerializer(serializers.ModelSerializer):
     address_country = NestedRelatedField('metadata.Country')
     uk_region = NestedRelatedField('metadata.UKRegion', required=False, allow_null=True)
     related_programmes = NestedRelatedField(
-        'event.Programme', many=True, required=False, allow_empty=True
+        'event.Programme', many=True, required=False, allow_empty=True,
     )
     service = NestedRelatedField('metadata.Service')
     start_date = serializers.DateField()

--- a/datahub/event/test/test_admin.py
+++ b/datahub/event/test/test_admin.py
@@ -19,7 +19,7 @@ class TestEventAdmin(AdminTestMixin):
         url = reverse('admin:event_event_changelist')
         data = {
             'action': 'disable_selected',
-            helpers.ACTION_CHECKBOX_NAME: ids
+            helpers.ACTION_CHECKBOX_NAME: ids,
         }
         response = self.client.post(url, data)
 
@@ -50,8 +50,8 @@ class TestEventAdmin(AdminTestMixin):
         for _ in range(5):
             events.append(
                 EventFactory(
-                    disabled_on=now()
-                )
+                    disabled_on=now(),
+                ),
             )
 
         ids = [event.id for event in events]
@@ -59,7 +59,7 @@ class TestEventAdmin(AdminTestMixin):
         url = reverse('admin:event_event_changelist')
         data = {
             'action': 'enable_selected',
-            helpers.ACTION_CHECKBOX_NAME: ids
+            helpers.ACTION_CHECKBOX_NAME: ids,
         }
         response = self.client.post(url, data)
 

--- a/datahub/event/test/test_views.py
+++ b/datahub/event/test/test_views.py
@@ -80,13 +80,16 @@ class TestGetEventView(APITestMixin):
                 'id': str(event.lead_team.id),
                 'name': event.lead_team.name,
             },
-            'teams': [{
-                'id': Team.healthcare_uk.value.id,
-                'name': Team.healthcare_uk.value.name,
-            }, {
-                'id': Team.crm.value.id,
-                'name': Team.crm.value.name,
-            }],
+            'teams': [
+                {
+                    'id': Team.healthcare_uk.value.id,
+                    'name': Team.healthcare_uk.value.name,
+                },
+                {
+                    'id': Team.crm.value.id,
+                    'name': Team.crm.value.name,
+                },
+            ],
             'related_programmes': [{
                 'id': Programme.great_branded.value.id,
                 'name': Programme.great_branded.value.name,
@@ -94,7 +97,7 @@ class TestGetEventView(APITestMixin):
             'service': {
                 'id': Service.trade_enquiry.value.id,
                 'name': Service.trade_enquiry.value.name,
-            }
+            },
         })
 
         assert response_data == expected_response_data
@@ -252,13 +255,16 @@ class TestCreateEventView(APITestMixin):
                 'id': Team.crm.value.id,
                 'name': Team.crm.value.name,
             },
-            'teams': [{
-                'id': Team.healthcare_uk.value.id,
-                'name': Team.healthcare_uk.value.name,
-            }, {
-                'id': Team.crm.value.id,
-                'name': Team.crm.value.name,
-            }],
+            'teams': [
+                {
+                    'id': Team.healthcare_uk.value.id,
+                    'name': Team.healthcare_uk.value.name,
+                },
+                {
+                    'id': Team.crm.value.id,
+                    'name': Team.crm.value.name,
+                },
+            ],
             'related_programmes': [{
                 'id': Programme.great_branded.value.id,
                 'name': Programme.great_branded.value.name,
@@ -291,7 +297,7 @@ class TestCreateEventView(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'lead_team': ['Lead team must be in teams array.']
+            'lead_team': ['Lead team must be in teams array.'],
         }
 
     def test_create_uk_no_uk_region(self):
@@ -315,7 +321,7 @@ class TestCreateEventView(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'uk_region': ['This field is required.']
+            'uk_region': ['This field is required.'],
         }
 
     def test_create_non_uk_with_uk_region(self):
@@ -340,7 +346,7 @@ class TestCreateEventView(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'uk_region': ['Cannot specify a UK region for a non-UK country.']
+            'uk_region': ['Cannot specify a UK region for a non-UK country.'],
         }
 
     def test_create_end_date_without_start_date(self):
@@ -364,7 +370,7 @@ class TestCreateEventView(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'start_date': ['This field is required.']
+            'start_date': ['This field is required.'],
         }
 
     def test_create_end_date_before_start_date(self):
@@ -389,7 +395,7 @@ class TestCreateEventView(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'end_date': ['End date cannot be before start date.']
+            'end_date': ['End date cannot be before start date.'],
         }
 
     def test_create_omitted_failure(self):
@@ -426,7 +432,7 @@ class TestCreateEventView(APITestMixin):
             'name': '',
             'service': None,
             'start_date': None,
-            'teams': []
+            'teams': [],
         }
         response = self.api_client.post(url, data=request_data)
 
@@ -515,13 +521,16 @@ class TestUpdateEventView(APITestMixin):
                 'id': Team.food_from_britain.value.id,
                 'name': Team.food_from_britain.value.name,
             },
-            'teams': [{
-                'id': Team.healthcare_uk.value.id,
-                'name': Team.healthcare_uk.value.name,
-            }, {
-                'id': Team.food_from_britain.value.id,
-                'name': Team.food_from_britain.value.name,
-            }],
+            'teams': [
+                {
+                    'id': Team.healthcare_uk.value.id,
+                    'name': Team.healthcare_uk.value.name,
+                },
+                {
+                    'id': Team.food_from_britain.value.id,
+                    'name': Team.food_from_britain.value.name,
+                },
+            ],
             'related_programmes': [{
                 'id': Programme.great_challenge_fund.value.id,
                 'name': Programme.great_challenge_fund.value.name,
@@ -574,7 +583,7 @@ class TestUpdateEventView(APITestMixin):
 
         response_data = response.json()
         assert response_data == {
-            'lead_team': ['Lead team must be in teams array.']
+            'lead_team': ['Lead team must be in teams array.'],
         }
 
     def test_update_read_only_fields(self):
@@ -582,10 +591,13 @@ class TestUpdateEventView(APITestMixin):
         event = DisabledEventFactory(archived_documents_url_path='old_path')
 
         url = reverse('api-v3:event:item', kwargs={'pk': event.pk})
-        response = self.api_client.patch(url, data={
-            'archived_documents_url_path': 'new_path',
-            'disabled_on': None,
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'archived_documents_url_path': 'new_path',
+                'disabled_on': None,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived_documents_url_path'] == 'old_path'


### PR DESCRIPTION
### Description of change

This adds trailing commas to the event app where they were missing. This includes some related code reformatting and the removal of some incorrect trailing commas.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
