### PR TITLE
Add trailing commas to interaction app

### DIFF
--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -111,14 +111,14 @@ class Interaction(BaseModel):
         related_name="%(class)ss",  # noqa: Q000
         blank=True,
         null=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
     contact = models.ForeignKey(
         'company.Contact',
         related_name="%(class)ss",  # noqa: Q000
         blank=True,
         null=True,
-        on_delete=models.CASCADE
+        on_delete=models.CASCADE,
     )
     event = models.ForeignKey(
         'event.Event',
@@ -126,10 +126,10 @@ class Interaction(BaseModel):
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
-        help_text='For service deliveries only.'
+        help_text='For service deliveries only.',
     )
     service = models.ForeignKey(
-        'metadata.Service', blank=True, null=True, on_delete=models.SET_NULL
+        'metadata.Service', blank=True, null=True, on_delete=models.SET_NULL,
     )
     subject = models.TextField()
     dit_adviser = models.ForeignKey(
@@ -137,11 +137,11 @@ class Interaction(BaseModel):
         related_name="%(class)ss",  # noqa: Q000
         blank=True,
         null=True,
-        on_delete=models.SET_NULL
+        on_delete=models.SET_NULL,
     )
     notes = models.TextField(max_length=settings.CDMS_TEXT_MAX_LENGTH, blank=True)
     dit_team = models.ForeignKey(
-        'metadata.Team', blank=True, null=True, on_delete=models.SET_NULL
+        'metadata.Team', blank=True, null=True, on_delete=models.SET_NULL,
     )
     communication_channel = models.ForeignKey(
         'CommunicationChannel', blank=True, null=True,
@@ -158,12 +158,13 @@ class Interaction(BaseModel):
     )
     archived_documents_url_path = models.CharField(
         max_length=MAX_LENGTH, blank=True,
-        help_text='Legacy field. File browser path to the archived documents for this interaction.'
+        help_text='Legacy field. File browser path to the archived documents for this '
+                  'interaction.',
     )
     service_delivery_status = models.ForeignKey(
         'ServiceDeliveryStatus', blank=True, null=True, on_delete=models.PROTECT,
         verbose_name='status',
-        help_text='For service deliveries only.'
+        help_text='For service deliveries only.',
     )
     grant_amount_offered = models.DecimalField(
         null=True, blank=True, max_digits=19, decimal_places=2,
@@ -206,31 +207,31 @@ class Interaction(BaseModel):
         permissions = (
             (
                 InteractionPermission.view_associated_investmentproject.value,
-                'Can view interaction for associated investment projects'
+                'Can view interaction for associated investment projects',
             ),
             (
                 InteractionPermission.add_associated_investmentproject.value,
-                'Can add interaction for associated investment projects'
+                'Can add interaction for associated investment projects',
             ),
             (
                 InteractionPermission.change_associated_investmentproject.value,
-                'Can change interaction for associated investment projects'
+                'Can change interaction for associated investment projects',
             ),
             (
                 InteractionPermission.view_policy_feedback.value,
-                'Can view policy feedback interaction'
+                'Can view policy feedback interaction',
             ),
             (
                 InteractionPermission.add_policy_feedback.value,
-                'Can add policy feedback interaction'
+                'Can add policy feedback interaction',
             ),
             (
                 InteractionPermission.change_policy_feedback.value,
-                'Can change policy feedback interaction'
+                'Can change policy feedback interaction',
             ),
             (
                 InteractionPermission.export.value,
-                'Can export interaction'
+                'Can export interaction',
             ),
         )
         default_permissions = (

--- a/datahub/interaction/permissions.py
+++ b/datahub/interaction/permissions.py
@@ -3,12 +3,12 @@ from rest_framework.filters import BaseFilterBackend
 from rest_framework.permissions import BasePermission
 
 from datahub.core.permissions import (
-    get_model_action_for_view_action, IsAssociatedToObjectPermission, ViewBasedModelPermissions
+    get_model_action_for_view_action, IsAssociatedToObjectPermission, ViewBasedModelPermissions,
 )
 from datahub.core.utils import StrEnum
 from datahub.interaction.models import Interaction
 from datahub.investment.permissions import (
-    InvestmentProjectAssociationCheckerBase, IsAssociatedToInvestmentProjectFilter
+    InvestmentProjectAssociationCheckerBase, IsAssociatedToInvestmentProjectFilter,
 )
 
 
@@ -26,7 +26,7 @@ class _PermissionTemplate(StrEnum):
 _KIND_PERMISSION_MAPPING = {
     Interaction.KINDS.interaction: None,
     Interaction.KINDS.service_delivery: None,
-    Interaction.KINDS.policy_feedback: _PermissionTemplate.policy_feedback
+    Interaction.KINDS.policy_feedback: _PermissionTemplate.policy_feedback,
 }
 
 
@@ -122,14 +122,20 @@ class HasAssociatedInvestmentProjectValidator:
         investment_project = attrs.get('investment_project')
 
         if investment_project is None:
-            raise ValidationError({
-                'investment_project': self.required_message
-            }, code='null')
+            raise ValidationError(
+                {
+                    'investment_project': self.required_message,
+                },
+                code='null',
+            )
 
         if not checker.is_associated(request, investment_project):
-            raise ValidationError({
-                'investment_project': self.non_associated_investment_project_message
-            }, code='access_denied')
+            raise ValidationError(
+                {
+                    'investment_project': self.non_associated_investment_project_message,
+                },
+                code='access_denied',
+            )
 
     def __repr__(self):
         """Returns the string representation of this object."""
@@ -190,9 +196,12 @@ class KindPermissionValidator:
         allowed_kinds = get_allowed_kinds(request, view.action)
 
         if attrs['kind'] not in allowed_kinds:
-            raise ValidationError({
-                'kind': self.access_denied_message
-            }, code='access_denied')
+            raise ValidationError(
+                {
+                    'kind': self.access_denied_message,
+                },
+                code='access_denied',
+            )
 
     def __repr__(self):
         """Returns the string representation of this object."""
@@ -218,7 +227,7 @@ def _is_kind_allowed(kind, request, view_action):
     format_kwargs = {
         'app_label': Interaction._meta.app_label,
         'model_name': Interaction._meta.model_name,
-        'action': action
+        'action': action,
     }
 
     permission = permission_template.format(**format_kwargs)

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -8,13 +8,22 @@ from datahub.company.serializers import NestedAdviserField
 from datahub.core.serializers import NestedRelatedField
 from datahub.core.validate_utils import is_blank, is_not_blank
 from datahub.core.validators import (
-    EqualsRule, InRule, OperatorRule, RulesBasedValidator, ValidationRule
+    EqualsRule,
+    InRule,
+    OperatorRule,
+    RulesBasedValidator,
+    ValidationRule,
 )
 from datahub.event.models import Event
 from datahub.investment.serializers import NestedInvestmentProjectField
 from datahub.metadata.models import Service, Team
-from .models import (CommunicationChannel, Interaction, PolicyArea, PolicyIssueType,
-                     ServiceDeliveryStatus)
+from .models import (
+    CommunicationChannel,
+    Interaction,
+    PolicyArea,
+    PolicyIssueType,
+    ServiceDeliveryStatus,
+)
 from .permissions import HasAssociatedInvestmentProjectValidator, KindPermissionValidator
 
 
@@ -23,34 +32,40 @@ class InteractionSerializer(serializers.ModelSerializer):
 
     default_error_messages = {
         'invalid_for_non_service_delivery': ugettext_lazy(
-            'This field is only valid for service deliveries.'
+            'This field is only valid for service deliveries.',
         ),
         'invalid_for_service_delivery': ugettext_lazy(
-            'This field is not valid for service deliveries.'
+            'This field is not valid for service deliveries.',
         ),
         'invalid_for_non_interaction': ugettext_lazy(
-            'This field is only valid for interactions.'
+            'This field is only valid for interactions.',
         ),
         'invalid_for_non_event': ugettext_lazy(
-            'This field is only valid for event service deliveries.'
+            'This field is only valid for event service deliveries.',
         ),
         'invalid_for_non_policy_feedback': ugettext_lazy(
-            'This field is only valid for policy feedback.'
+            'This field is only valid for policy feedback.',
         ),
         'one_policy_area_field': ugettext_lazy(
-            'Only one of policy_area and policy_areas should be provided.'
+            'Only one of policy_area and policy_areas should be provided.',
         ),
     }
 
     company = NestedRelatedField(Company)
-    contact = NestedRelatedField(Contact, extra_fields=(
-        'name', 'first_name', 'last_name', 'job_title'
-    ))
+    contact = NestedRelatedField(
+        Contact,
+        extra_fields=(
+            'name',
+            'first_name',
+            'last_name',
+            'job_title',
+        ),
+    )
     dit_adviser = NestedAdviserField()
     created_by = NestedAdviserField(read_only=True)
     dit_team = NestedRelatedField(Team)
     communication_channel = NestedRelatedField(
-        CommunicationChannel, required=False, allow_null=True
+        CommunicationChannel, required=False, allow_null=True,
     )
     is_event = serializers.NullBooleanField(required=False)
     event = NestedRelatedField(Event, required=False, allow_null=True)
@@ -58,11 +73,11 @@ class InteractionSerializer(serializers.ModelSerializer):
     modified_by = NestedAdviserField(read_only=True)
     service = NestedRelatedField(Service)
     service_delivery_status = NestedRelatedField(
-        ServiceDeliveryStatus, required=False, allow_null=True
+        ServiceDeliveryStatus, required=False, allow_null=True,
     )
     policy_areas = NestedRelatedField(PolicyArea, many=True, required=False, allow_empty=True)
     policy_issue_type = NestedRelatedField(
-        PolicyIssueType, required=False, allow_null=True
+        PolicyIssueType, required=False, allow_null=True,
     )
 
     def validate(self, data):
@@ -123,18 +138,24 @@ class InteractionSerializer(serializers.ModelSerializer):
                 ValidationRule(
                     'required',
                     OperatorRule('communication_channel', bool),
-                    when=InRule('kind', [
-                        Interaction.KINDS.interaction,
-                        Interaction.KINDS.policy_feedback
-                    ]),
+                    when=InRule(
+                        'kind',
+                        [
+                            Interaction.KINDS.interaction,
+                            Interaction.KINDS.policy_feedback,
+                        ],
+                    ),
                 ),
                 ValidationRule(
                     'invalid_for_non_interaction',
                     OperatorRule('investment_project', not_),
-                    when=InRule('kind', [
-                        Interaction.KINDS.service_delivery,
-                        Interaction.KINDS.policy_feedback
-                    ]),
+                    when=InRule(
+                        'kind',
+                        [
+                            Interaction.KINDS.service_delivery,
+                            Interaction.KINDS.policy_feedback,
+                        ],
+                    ),
                 ),
                 ValidationRule(
                     'invalid_for_service_delivery',
@@ -148,19 +169,25 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('service_delivery_status', is_blank),
                     OperatorRule('grant_amount_offered', is_blank),
                     OperatorRule('net_company_receipt', is_blank),
-                    when=InRule('kind', [
-                        Interaction.KINDS.interaction,
-                        Interaction.KINDS.policy_feedback
-                    ]),
+                    when=InRule(
+                        'kind',
+                        [
+                            Interaction.KINDS.interaction,
+                            Interaction.KINDS.policy_feedback,
+                        ],
+                    ),
                 ),
                 ValidationRule(
                     'invalid_for_non_policy_feedback',
                     OperatorRule('policy_areas', not_),
                     OperatorRule('policy_issue_type', is_blank),
-                    when=InRule('kind', [
-                        Interaction.KINDS.interaction,
-                        Interaction.KINDS.service_delivery,
-                    ])
+                    when=InRule(
+                        'kind',
+                        [
+                            Interaction.KINDS.interaction,
+                            Interaction.KINDS.service_delivery,
+                        ],
+                    ),
                 ),
                 ValidationRule(
                     'required',

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -7,7 +7,7 @@ from datahub.core.test.factories import to_many_field
 from datahub.core.test_utils import random_obj_for_model
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.models import (
-    CommunicationChannel, Interaction, PolicyArea, PolicyIssueType, ServiceDeliveryStatus
+    CommunicationChannel, Interaction, PolicyArea, PolicyIssueType, ServiceDeliveryStatus,
 )
 from datahub.investment.test.factories import InvestmentProjectFactory
 
@@ -36,7 +36,7 @@ class CompanyInteractionFactory(InteractionFactoryBase):
 
     kind = Interaction.KINDS.interaction
     communication_channel = factory.LazyFunction(
-        lambda: random_obj_for_model(CommunicationChannel)
+        lambda: random_obj_for_model(CommunicationChannel),
     )
 
 
@@ -46,7 +46,7 @@ class InvestmentProjectInteractionFactory(InteractionFactoryBase):
     kind = Interaction.KINDS.interaction
     investment_project = factory.SubFactory(InvestmentProjectFactory)
     communication_channel = factory.LazyFunction(
-        lambda: random_obj_for_model(CommunicationChannel)
+        lambda: random_obj_for_model(CommunicationChannel),
     )
 
 
@@ -55,13 +55,13 @@ class ServiceDeliveryFactory(InteractionFactoryBase):
 
     kind = Interaction.KINDS.service_delivery
     service_delivery_status = factory.LazyFunction(
-        lambda: random_obj_for_model(ServiceDeliveryStatus)
+        lambda: random_obj_for_model(ServiceDeliveryStatus),
     )
     grant_amount_offered = factory.Faker(
-        'pydecimal', left_digits=4, right_digits=2, positive=True
+        'pydecimal', left_digits=4, right_digits=2, positive=True,
     )
     net_company_receipt = factory.Faker(
-        'pydecimal', left_digits=4, right_digits=2, positive=True
+        'pydecimal', left_digits=4, right_digits=2, positive=True,
     )
 
     class Meta:
@@ -80,10 +80,10 @@ class PolicyFeedbackFactory(InteractionFactoryBase):
 
     kind = Interaction.KINDS.policy_feedback
     communication_channel = factory.LazyFunction(
-        lambda: random_obj_for_model(CommunicationChannel)
+        lambda: random_obj_for_model(CommunicationChannel),
     )
     policy_issue_type = factory.LazyFunction(
-        lambda: random_obj_for_model(PolicyIssueType)
+        lambda: random_obj_for_model(PolicyIssueType),
     )
 
     @to_many_field

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -14,7 +14,7 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory, Conta
 from datahub.core.constants import Service, Team
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
 from datahub.core.test_utils import (
-    APITestMixin, create_test_user, format_date_or_datetime, random_obj_for_model
+    APITestMixin, create_test_user, format_date_or_datetime, random_obj_for_model,
 )
 from datahub.event.test.factories import EventFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
@@ -46,9 +46,12 @@ class TestUpdateInteraction(APITestMixin):
         )
 
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = self.api_client.patch(url, data={
-            'archived_documents_url_path': 'new_path'
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'archived_documents_url_path': 'new_path',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['archived_documents_url_path'] == 'old_path'
@@ -58,14 +61,17 @@ class TestUpdateInteraction(APITestMixin):
         interaction = CompanyInteractionFactory()
 
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = self.api_client.patch(url, {
-            'date': 'abcd-de-fe',
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'date': 'abcd-de-fe',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data['date'] == [
-            'Datetime has wrong format. Use one of these formats instead: YYYY-MM-DD.'
+            'Datetime has wrong format. Use one of these formats instead: YYYY-MM-DD.',
         ]
 
 
@@ -81,7 +87,7 @@ class TestListInteractions(APITestMixin):
         interactions = CompanyInteractionFactory.create_batch(2, company=company2)
 
         url = reverse('api-v3:interaction:collection')
-        response = self.api_client.get(url, {'company_id': company2.id})
+        response = self.api_client.get(url, data={'company_id': company2.id})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -96,7 +102,7 @@ class TestListInteractions(APITestMixin):
         interactions = CompanyInteractionFactory.create_batch(2, contact=contact2)
 
         url = reverse('api-v3:interaction:collection')
-        response = self.api_client.get(url, {'contact_id': contact2.id})
+        response = self.api_client.get(url, data={'contact_id': contact2.id})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -111,13 +117,16 @@ class TestListInteractions(APITestMixin):
         CompanyInteractionFactory.create_batch(3, contact=contact)
         CompanyInteractionFactory.create_batch(3, company=company)
         project_interactions = CompanyInteractionFactory.create_batch(
-            2, investment_project=project
+            2, investment_project=project,
         )
 
         url = reverse('api-v3:interaction:collection')
-        response = self.api_client.get(url, {
-            'investment_project_id': project.id
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'investment_project_id': project.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -136,7 +145,7 @@ class TestListInteractions(APITestMixin):
         service_deliveries = EventServiceDeliveryFactory.create_batch(3, event=event)
 
         url = reverse('api-v3:interaction:collection')
-        response = self.api_client.get(url, {'event_id': event.id})
+        response = self.api_client.get(url, data={'event_id': event.id})
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -156,7 +165,7 @@ class TestListInteractions(APITestMixin):
             'dit_adviser.first_name',
             'dit_adviser.last_name',
             'subject',
-        )
+        ),
     )
     def test_sorting(self, field):
         """Test sorting interactions by various fields."""
@@ -168,8 +177,8 @@ class TestListInteractions(APITestMixin):
                     lambda i: ContactFactory(
                         company=i.company,
                         first_name='Holly',
-                        last_name='Taylor'
-                    )
+                        last_name='Taylor',
+                    ),
                 ),
                 'dit_adviser__first_name': 'Elaine',
                 'dit_adviser__last_name': 'Johnston',
@@ -182,8 +191,8 @@ class TestListInteractions(APITestMixin):
                     lambda i: ContactFactory(
                         company=i.company,
                         first_name='Conor',
-                        last_name='Webb'
-                    )
+                        last_name='Webb',
+                    ),
                 ),
                 'dit_adviser__first_name': 'Connor',
                 'dit_adviser__last_name': 'Webb',
@@ -196,8 +205,8 @@ class TestListInteractions(APITestMixin):
                     lambda i: ContactFactory(
                         company=i.company,
                         first_name='Suzanne',
-                        last_name='Palmer'
-                    )
+                        last_name='Palmer',
+                    ),
                 ),
                 'dit_adviser__first_name': 'Hayley',
                 'dit_adviser__last_name': 'Hunt',
@@ -210,15 +219,15 @@ class TestListInteractions(APITestMixin):
             creation_time = data.pop('created_on')
             with freeze_time(creation_time):
                 interactions.append(
-                    EventServiceDeliveryFactory(**data)
+                    EventServiceDeliveryFactory(**data),
                 )
 
         url = reverse('api-v3:interaction:collection')
         response = self.api_client.get(
             url,
             data={
-                'sortby': field.replace('.', '__')
-            }
+                'sortby': field.replace('.', '__'),
+            },
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -233,7 +242,7 @@ class TestListInteractions(APITestMixin):
             reduce(  # get nested items if needed
                 lambda data, key: data.get(key),
                 field.split('.'),
-                result
+                result,
             )
             for result in response_data['results']
         ]
@@ -244,7 +253,7 @@ class TestListInteractions(APITestMixin):
         (
             ('contact', ContactFactory),
             ('dit_adviser', AdviserFactory),
-        )
+        ),
     )
     def test_sort_by_first_and_last_name(self, field, factory_class):
         """Test sorting interactions by first_name with a secondary last_name sort."""
@@ -257,8 +266,8 @@ class TestListInteractions(APITestMixin):
         interactions = EventServiceDeliveryFactory.create_batch(
             len(people),
             **{
-                field: factory.Iterator(sample(people, k=len(people)))
-            }
+                field: factory.Iterator(sample(people, k=len(people))),
+            },
         )
 
         url = reverse('api-v3:interaction:collection')
@@ -266,7 +275,7 @@ class TestListInteractions(APITestMixin):
             url,
             data={
                 'sortby': f'{field}__first_name,{field}__last_name',
-            }
+            },
         )
 
         assert response.status_code == status.HTTP_200_OK
@@ -303,7 +312,7 @@ class TestInteractionVersioning(APITestMixin):
                 'company': CompanyFactory().pk,
                 'contact': ContactFactory().pk,
                 'service': Service.trade_enquiry.value.id,
-                'dit_team': Team.healthcare_uk.value.id
+                'dit_team': Team.healthcare_uk.value.id,
             },
         )
 

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -15,11 +15,11 @@ from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import TeamFactory
 from .utils import resolve_data
 from ..factories import (
-    CompanyInteractionFactory, InvestmentProjectInteractionFactory
+    CompanyInteractionFactory, InvestmentProjectInteractionFactory,
 )
 from ...models import (
     CommunicationChannel, Interaction, InteractionPermission, PolicyArea,
-    PolicyIssueType, ServiceDeliveryStatus
+    PolicyIssueType, ServiceDeliveryStatus,
 )
 
 
@@ -30,7 +30,7 @@ NON_RESTRICTED_VIEW_PERMISSIONS = (
     (
         InteractionPermission.view_all,
         InteractionPermission.view_associated_investmentproject,
-    )
+    ),
 )
 
 
@@ -41,7 +41,7 @@ NON_RESTRICTED_ADD_PERMISSIONS = (
     (
         InteractionPermission.add_all,
         InteractionPermission.add_associated_investmentproject,
-    )
+    ),
 )
 
 
@@ -52,7 +52,7 @@ NON_RESTRICTED_CHANGE_PERMISSIONS = (
     (
         InteractionPermission.change_all,
         InteractionPermission.change_associated_investmentproject,
-    )
+    ),
 )
 
 
@@ -69,9 +69,9 @@ class TestAddInteraction(APITestMixin):
             # investment project interaction
             {
                 'investment_project': InvestmentProjectFactory,
-            }
+            },
 
-        )
+        ),
     )
     def test_add(self, extra_data, permissions):
         """Test add a new interaction."""
@@ -112,7 +112,7 @@ class TestAddInteraction(APITestMixin):
             'policy_issue_type': None,
             'communication_channel': {
                 'id': str(communication_channel.pk),
-                'name': communication_channel.name
+                'name': communication_channel.name,
             },
             'subject': 'whatever',
             'date': '2017-04-18',
@@ -120,12 +120,12 @@ class TestAddInteraction(APITestMixin):
                 'id': str(adviser.pk),
                 'first_name': adviser.first_name,
                 'last_name': adviser.last_name,
-                'name': adviser.name
+                'name': adviser.name,
             },
             'notes': 'hello',
             'company': {
                 'id': str(company.pk),
-                'name': company.name
+                'name': company.name,
             },
             'contact': {
                 'id': str(contact.pk),
@@ -149,13 +149,13 @@ class TestAddInteraction(APITestMixin):
                 'id': str(adviser.pk),
                 'first_name': adviser.first_name,
                 'last_name': adviser.last_name,
-                'name': adviser.name
+                'name': adviser.name,
             },
             'modified_by': {
                 'id': str(adviser.pk),
                 'first_name': adviser.first_name,
                 'last_name': adviser.last_name,
-                'name': adviser.name
+                'name': adviser.name,
             },
             'created_on': '2017-04-18T13:25:30.986208Z',
             'modified_on': '2017-04-18T13:25:30.986208Z',
@@ -177,7 +177,7 @@ class TestAddInteraction(APITestMixin):
                     'dit_adviser': ['This field is required.'],
                     'service': ['This field is required.'],
                     'dit_team': ['This field is required.'],
-                }
+                },
             ),
 
             # interaction fields required
@@ -195,7 +195,7 @@ class TestAddInteraction(APITestMixin):
                 {
                     'notes': ['This field is required.'],
                     'communication_channel': ['This field is required.'],
-                }
+                },
             ),
 
             # fields not allowed
@@ -216,7 +216,7 @@ class TestAddInteraction(APITestMixin):
                     'is_event': True,
                     'event': EventFactory,
                     'service_delivery_status': partial(
-                        random_obj_for_model, ServiceDeliveryStatus
+                        random_obj_for_model, ServiceDeliveryStatus,
                     ),
                     'grant_amount_offered': '1111.11',
                     'net_company_receipt': '8888.11',
@@ -227,15 +227,15 @@ class TestAddInteraction(APITestMixin):
                     'is_event': ['This field is only valid for service deliveries.'],
                     'event': ['This field is only valid for service deliveries.'],
                     'service_delivery_status': [
-                        'This field is only valid for service deliveries.'
+                        'This field is only valid for service deliveries.',
                     ],
                     'grant_amount_offered': ['This field is only valid for service deliveries.'],
                     'net_company_receipt': ['This field is only valid for service deliveries.'],
                     'policy_areas': ['This field is only valid for policy feedback.'],
-                    'policy_issue_type': ['This field is only valid for policy feedback.']
-                }
+                    'policy_issue_type': ['This field is only valid for policy feedback.'],
+                },
             ),
-        )
+        ),
     )
     def test_validation(self, data, errors):
         """Test validation errors."""
@@ -261,19 +261,22 @@ class TestAddInteraction(APITestMixin):
         contact = ContactFactory()
         url = reverse('api-v3:interaction:collection')
         api_client = self.create_api_client(user=requester)
-        response = api_client.post(url, {
-            'kind': Interaction.KINDS.interaction,
-            'company': company.pk,
-            'contact': contact.pk,
-            'communication_channel': random_obj_for_model(CommunicationChannel).pk,
-            'subject': 'whatever',
-            'date': date.today().isoformat(),
-            'dit_adviser': requester.pk,
-            'notes': 'hello',
-            'investment_project': project.pk,
-            'service': Service.trade_enquiry.value.id,
-            'dit_team': Team.healthcare_uk.value.id
-        })
+        response = api_client.post(
+            url,
+            data={
+                'kind': Interaction.KINDS.interaction,
+                'company': company.pk,
+                'contact': contact.pk,
+                'communication_channel': random_obj_for_model(CommunicationChannel).pk,
+                'subject': 'whatever',
+                'date': date.today().isoformat(),
+                'dit_adviser': requester.pk,
+                'notes': 'hello',
+                'investment_project': project.pk,
+                'service': Service.trade_enquiry.value.id,
+                'dit_team': Team.healthcare_uk.value.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_201_CREATED
         response_data = response.json()
@@ -295,49 +298,57 @@ class TestAddInteraction(APITestMixin):
         )
         url = reverse('api-v3:interaction:collection')
         api_client = self.create_api_client(user=requester)
-        response = api_client.post(url, {
-            'kind': Interaction.KINDS.interaction,
-            'company': CompanyFactory().pk,
-            'contact': ContactFactory().pk,
-            'communication_channel': random_obj_for_model(CommunicationChannel).pk,
-            'subject': 'whatever',
-            'date': date.today().isoformat(),
-            'dit_adviser': requester.pk,
-            'notes': 'hello',
-            'investment_project': project.pk,
-            'service': Service.trade_enquiry.value.id,
-            'dit_team': Team.healthcare_uk.value.id
-        })
+        response = api_client.post(
+            url,
+            data={
+                'kind': Interaction.KINDS.interaction,
+                'company': CompanyFactory().pk,
+                'contact': ContactFactory().pk,
+                'communication_channel': random_obj_for_model(CommunicationChannel).pk,
+                'subject': 'whatever',
+                'date': date.today().isoformat(),
+                'dit_adviser': requester.pk,
+                'notes': 'hello',
+                'investment_project': project.pk,
+                'service': Service.trade_enquiry.value.id,
+                'dit_team': Team.healthcare_uk.value.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            'investment_project': ["You don't have permission to add an interaction for this "
-                                   'investment project.']
+            'investment_project': [
+                "You don't have permission to add an interaction for this "
+                'investment project.',
+            ],
         }
 
     def test_restricted_user_cannot_add_company_interaction(self):
         """Test that a restricted user cannot add a company interaction."""
         requester = create_test_user(
-            permission_codenames=[InteractionPermission.add_associated_investmentproject]
+            permission_codenames=[InteractionPermission.add_associated_investmentproject],
         )
         url = reverse('api-v3:interaction:collection')
         api_client = self.create_api_client(user=requester)
-        response = api_client.post(url, {
-            'kind': Interaction.KINDS.interaction,
-            'company': CompanyFactory().pk,
-            'contact': ContactFactory().pk,
-            'communication_channel': random_obj_for_model(CommunicationChannel).pk,
-            'subject': 'whatever',
-            'date': date.today().isoformat(),
-            'dit_adviser': requester.pk,
-            'notes': 'hello',
-            'service': Service.trade_enquiry.value.id,
-            'dit_team': Team.healthcare_uk.value.id
-        })
+        response = api_client.post(
+            url,
+            data={
+                'kind': Interaction.KINDS.interaction,
+                'company': CompanyFactory().pk,
+                'contact': ContactFactory().pk,
+                'communication_channel': random_obj_for_model(CommunicationChannel).pk,
+                'subject': 'whatever',
+                'date': date.today().isoformat(),
+                'dit_adviser': requester.pk,
+                'notes': 'hello',
+                'service': Service.trade_enquiry.value.id,
+                'dit_team': Team.healthcare_uk.value.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            'investment_project': ['This field is required.']
+            'investment_project': ['This field is required.'],
         }
 
 
@@ -367,7 +378,7 @@ class TestGetInteraction(APITestMixin):
             'policy_issue_type': None,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),
-                'name': interaction.communication_channel.name
+                'name': interaction.communication_channel.name,
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),
@@ -375,12 +386,12 @@ class TestGetInteraction(APITestMixin):
                 'id': str(interaction.dit_adviser.pk),
                 'first_name': interaction.dit_adviser.first_name,
                 'last_name': interaction.dit_adviser.last_name,
-                'name': interaction.dit_adviser.name
+                'name': interaction.dit_adviser.name,
             },
             'notes': interaction.notes,
             'company': {
                 'id': str(interaction.company.pk),
-                'name': interaction.company.name
+                'name': interaction.company.name,
             },
             'contact': {
                 'id': str(interaction.contact.pk),
@@ -404,16 +415,16 @@ class TestGetInteraction(APITestMixin):
                 'id': str(interaction.created_by.pk),
                 'first_name': interaction.created_by.first_name,
                 'last_name': interaction.created_by.last_name,
-                'name': interaction.created_by.name
+                'name': interaction.created_by.name,
             },
             'modified_by': {
                 'id': str(interaction.modified_by.pk),
                 'first_name': interaction.modified_by.first_name,
                 'last_name': interaction.modified_by.last_name,
-                'name': interaction.modified_by.name
+                'name': interaction.modified_by.name,
             },
             'created_on': '2017-04-18T13:25:30.986208Z',
-            'modified_on': '2017-04-18T13:25:30.986208Z'
+            'modified_on': '2017-04-18T13:25:30.986208Z',
         }
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
@@ -439,7 +450,7 @@ class TestGetInteraction(APITestMixin):
             'policy_issue_type': None,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),
-                'name': interaction.communication_channel.name
+                'name': interaction.communication_channel.name,
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),
@@ -447,12 +458,12 @@ class TestGetInteraction(APITestMixin):
                 'id': str(interaction.dit_adviser.pk),
                 'first_name': interaction.dit_adviser.first_name,
                 'last_name': interaction.dit_adviser.last_name,
-                'name': interaction.dit_adviser.name
+                'name': interaction.dit_adviser.name,
             },
             'notes': interaction.notes,
             'company': {
                 'id': str(interaction.company.pk),
-                'name': interaction.company.name
+                'name': interaction.company.name,
             },
             'contact': {
                 'id': str(interaction.contact.pk),
@@ -480,16 +491,16 @@ class TestGetInteraction(APITestMixin):
                 'id': str(interaction.created_by.pk),
                 'first_name': interaction.created_by.first_name,
                 'last_name': interaction.created_by.last_name,
-                'name': interaction.created_by.name
+                'name': interaction.created_by.name,
             },
             'modified_by': {
                 'id': str(interaction.modified_by.pk),
                 'first_name': interaction.modified_by.first_name,
                 'last_name': interaction.modified_by.last_name,
-                'name': interaction.modified_by.name
+                'name': interaction.modified_by.name,
             },
             'created_on': '2017-04-18T13:25:30.986208Z',
-            'modified_on': '2017-04-18T13:25:30.986208Z'
+            'modified_on': '2017-04-18T13:25:30.986208Z',
         }
 
     @freeze_time('2017-04-18 13:25:30.986208')
@@ -519,7 +530,7 @@ class TestGetInteraction(APITestMixin):
             'policy_issue_type': None,
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),
-                'name': interaction.communication_channel.name
+                'name': interaction.communication_channel.name,
             },
             'subject': interaction.subject,
             'date': interaction.date.date().isoformat(),
@@ -527,12 +538,12 @@ class TestGetInteraction(APITestMixin):
                 'id': str(interaction.dit_adviser.pk),
                 'first_name': interaction.dit_adviser.first_name,
                 'last_name': interaction.dit_adviser.last_name,
-                'name': interaction.dit_adviser.name
+                'name': interaction.dit_adviser.name,
             },
             'notes': interaction.notes,
             'company': {
                 'id': str(interaction.company.pk),
-                'name': interaction.company.name
+                'name': interaction.company.name,
             },
             'contact': {
                 'id': str(interaction.contact.pk),
@@ -560,16 +571,16 @@ class TestGetInteraction(APITestMixin):
                 'id': str(interaction.created_by.pk),
                 'first_name': interaction.created_by.first_name,
                 'last_name': interaction.created_by.last_name,
-                'name': interaction.created_by.name
+                'name': interaction.created_by.name,
             },
             'modified_by': {
                 'id': str(interaction.modified_by.pk),
                 'first_name': interaction.modified_by.first_name,
                 'last_name': interaction.modified_by.last_name,
-                'name': interaction.modified_by.name
+                'name': interaction.modified_by.name,
             },
             'created_on': '2017-04-18T13:25:30.986208Z',
-            'modified_on': '2017-04-18T13:25:30.986208Z'
+            'modified_on': '2017-04-18T13:25:30.986208Z',
         }
 
     def test_restricted_user_cannot_get_non_associated_investment_project_interaction(self):
@@ -580,7 +591,7 @@ class TestGetInteraction(APITestMixin):
         interaction = InvestmentProjectInteractionFactory()
         requester = create_test_user(
             permission_codenames=[InteractionPermission.view_associated_investmentproject],
-            dit_team=TeamFactory()
+            dit_team=TeamFactory(),
         )
         api_client = self.create_api_client(user=requester)
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
@@ -593,7 +604,7 @@ class TestGetInteraction(APITestMixin):
         interaction = CompanyInteractionFactory()
         requester = create_test_user(
             permission_codenames=[InteractionPermission.view_associated_investmentproject],
-            dit_team=TeamFactory()
+            dit_team=TeamFactory(),
         )
         api_client = self.create_api_client(user=requester)
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
@@ -613,9 +624,12 @@ class TestUpdateInteraction(APITestMixin):
 
         api_client = self.create_api_client(user=requester)
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = api_client.patch(url, {
-            'subject': 'I am another subject',
-        })
+        response = api_client.patch(
+            url,
+            data={
+                'subject': 'I am another subject',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['subject'] == 'I am another subject'
@@ -623,15 +637,18 @@ class TestUpdateInteraction(APITestMixin):
     def test_restricted_user_cannot_update_company_interaction(self):
         """Test that a restricted user cannot update a company interaction."""
         requester = create_test_user(
-            permission_codenames=[InteractionPermission.change_associated_investmentproject]
+            permission_codenames=[InteractionPermission.change_associated_investmentproject],
         )
         interaction = CompanyInteractionFactory(subject='I am a subject')
 
         api_client = self.create_api_client(user=requester)
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = api_client.patch(url, {
-            'subject': 'I am another subject',
-        })
+        response = api_client.patch(
+            url,
+            data={
+                'subject': 'I am another subject',
+            },
+        )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -643,14 +660,17 @@ class TestUpdateInteraction(APITestMixin):
             subject='I am a subject',
         )
         requester = create_test_user(
-            permission_codenames=[InteractionPermission.change_associated_investmentproject]
+            permission_codenames=[InteractionPermission.change_associated_investmentproject],
         )
 
         api_client = self.create_api_client(user=requester)
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = api_client.patch(url, {
-            'subject': 'I am another subject',
-        })
+        response = api_client.patch(
+            url,
+            data={
+                'subject': 'I am another subject',
+            },
+        )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -662,20 +682,23 @@ class TestUpdateInteraction(APITestMixin):
         project = InvestmentProjectFactory(created_by=project_creator)
         interaction = CompanyInteractionFactory(
             subject='I am a subject',
-            investment_project=project
+            investment_project=project,
         )
         requester = create_test_user(
             permission_codenames=[
-                InteractionPermission.change_associated_investmentproject
+                InteractionPermission.change_associated_investmentproject,
             ],
-            dit_team=project_creator.dit_team
+            dit_team=project_creator.dit_team,
         )
 
         api_client = self.create_api_client(user=requester)
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = api_client.patch(url, {
-            'subject': 'I am another subject',
-        })
+        response = api_client.patch(
+            url,
+            data={
+                'subject': 'I am another subject',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['subject'] == 'I am another subject'
@@ -694,7 +717,7 @@ class TestListInteractions(APITestMixin):
         company = CompanyFactory()
         company_interactions = CompanyInteractionFactory.create_batch(3, company=company)
         project_interactions = CompanyInteractionFactory.create_batch(
-            3, investment_project=project
+            3, investment_project=project,
         )
 
         url = reverse('api-v3:interaction:collection')
@@ -715,7 +738,7 @@ class TestListInteractions(APITestMixin):
         creator = AdviserFactory()
         requester = create_test_user(
             permission_codenames=[InteractionPermission.view_associated_investmentproject],
-            dit_team=creator.dit_team
+            dit_team=creator.dit_team,
         )
         api_client = self.create_api_client(user=requester)
 
@@ -725,10 +748,10 @@ class TestListInteractions(APITestMixin):
 
         CompanyInteractionFactory.create_batch(3, company=company)
         CompanyInteractionFactory.create_batch(
-            3, investment_project=non_associated_project
+            3, investment_project=non_associated_project,
         )
         associated_project_interactions = CompanyInteractionFactory.create_batch(
-            2, investment_project=associated_project
+            2, investment_project=associated_project,
         )
 
         url = reverse('api-v3:interaction:collection')

--- a/datahub/interaction/test/views/test_policy_feedback.py
+++ b/datahub/interaction/test/views/test_policy_feedback.py
@@ -10,7 +10,7 @@ from rest_framework.reverse import reverse
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core.constants import Service, Team
 from datahub.core.test_utils import (
-    APITestMixin, format_date_or_datetime, random_obj_for_model
+    APITestMixin, format_date_or_datetime, random_obj_for_model,
 )
 from datahub.event.test.factories import EventFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
@@ -58,7 +58,7 @@ class TestAddPolicyFeedback(APITestMixin):
             'service': Service.trade_enquiry.value.id,
             'dit_team': Team.healthcare_uk.value.id,
             'policy_areas': [policy_area.pk for policy_area in policy_areas],
-            'policy_issue_type': policy_issue_type.pk
+            'policy_issue_type': policy_issue_type.pk,
         }
 
         user = create_add_policy_feedback_user()
@@ -85,7 +85,7 @@ class TestAddPolicyFeedback(APITestMixin):
             },
             'communication_channel': {
                 'id': str(communication_channel.pk),
-                'name': communication_channel.name
+                'name': communication_channel.name,
             },
             'subject': 'whatever',
             'date': '2017-04-18',
@@ -93,12 +93,12 @@ class TestAddPolicyFeedback(APITestMixin):
                 'id': str(adviser.pk),
                 'first_name': adviser.first_name,
                 'last_name': adviser.last_name,
-                'name': adviser.name
+                'name': adviser.name,
             },
             'notes': 'hello',
             'company': {
                 'id': str(company.pk),
-                'name': company.name
+                'name': company.name,
             },
             'contact': {
                 'id': str(contact.pk),
@@ -122,13 +122,13 @@ class TestAddPolicyFeedback(APITestMixin):
                 'id': str(user.pk),
                 'first_name': user.first_name,
                 'last_name': user.last_name,
-                'name': user.name
+                'name': user.name,
             },
             'modified_by': {
                 'id': str(user.pk),
                 'first_name': user.first_name,
                 'last_name': user.last_name,
-                'name': user.name
+                'name': user.name,
             },
             'created_on': '2017-04-18T13:25:30.986208Z',
             'modified_on': '2017-04-18T13:25:30.986208Z',
@@ -150,7 +150,7 @@ class TestAddPolicyFeedback(APITestMixin):
                     'dit_adviser': ['This field is required.'],
                     'service': ['This field is required.'],
                     'dit_team': ['This field is required.'],
-                }
+                },
             ),
 
             # policy fields required
@@ -170,7 +170,7 @@ class TestAddPolicyFeedback(APITestMixin):
                     'policy_areas': ['This field is required.'],
                     'policy_issue_type': ['This field is required.'],
                     'communication_channel': ['This field is required.'],
-                }
+                },
             ),
 
             # policy fields cannot be blank
@@ -193,7 +193,7 @@ class TestAddPolicyFeedback(APITestMixin):
                     'policy_areas': ['This field is required.'],
                     'policy_issue_type': ['This field is required.'],
                     'communication_channel': ['This field is required.'],
-                }
+                },
             ),
 
             # fields not allowed
@@ -217,7 +217,7 @@ class TestAddPolicyFeedback(APITestMixin):
                     'is_event': True,
                     'event': EventFactory,
                     'service_delivery_status': partial(
-                        random_obj_for_model, ServiceDeliveryStatus
+                        random_obj_for_model, ServiceDeliveryStatus,
                     ),
                     'grant_amount_offered': '1111.11',
                     'net_company_receipt': '8888.11',
@@ -227,14 +227,14 @@ class TestAddPolicyFeedback(APITestMixin):
                     'is_event': ['This field is only valid for service deliveries.'],
                     'event': ['This field is only valid for service deliveries.'],
                     'service_delivery_status': [
-                        'This field is only valid for service deliveries.'
+                        'This field is only valid for service deliveries.',
                     ],
                     'grant_amount_offered': ['This field is only valid for service deliveries.'],
                     'net_company_receipt': ['This field is only valid for service deliveries.'],
-                    'investment_project': ['This field is only valid for interactions.']
-                }
+                    'investment_project': ['This field is only valid for interactions.'],
+                },
             ),
-        )
+        ),
     )
     def test_validation(self, data, errors):
         """Test validation errors."""
@@ -252,7 +252,7 @@ class TestAddPolicyFeedback(APITestMixin):
         (
             create_interaction_user_without_policy_feedback,
             create_restricted_investment_project_user,
-        )
+        ),
     )
     def test_add_without_permission(self, create_user):
         """Test adding a policy feedback interaction without the required permissions."""
@@ -276,7 +276,7 @@ class TestAddPolicyFeedback(APITestMixin):
             'service': Service.trade_enquiry.value.id,
             'dit_team': Team.healthcare_uk.value.id,
             'policy_areas': [policy_area.pk],
-            'policy_issue_type': policy_issue_type.pk
+            'policy_issue_type': policy_issue_type.pk,
         }
         user = create_user()
         api_client = self.create_api_client(user=user)
@@ -284,7 +284,7 @@ class TestAddPolicyFeedback(APITestMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
-            'kind': ['You don’t have permission to add this type of interaction.']
+            'kind': ['You don’t have permission to add this type of interaction.'],
         }
 
 
@@ -316,11 +316,11 @@ class TestUpdatePolicyFeedback(APITestMixin):
             }],
             'policy_issue_type': {
                 'id': str(interaction.policy_issue_type.pk),
-                'name': interaction.policy_issue_type.name
+                'name': interaction.policy_issue_type.name,
             },
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),
-                'name': interaction.communication_channel.name
+                'name': interaction.communication_channel.name,
             },
             'subject': interaction.subject,
             'date': format_date_or_datetime(interaction.date.date()),
@@ -328,12 +328,12 @@ class TestUpdatePolicyFeedback(APITestMixin):
                 'id': str(interaction.dit_adviser.pk),
                 'first_name': interaction.dit_adviser.first_name,
                 'last_name': interaction.dit_adviser.last_name,
-                'name': interaction.dit_adviser.name
+                'name': interaction.dit_adviser.name,
             },
             'notes': 'updated notes',
             'company': {
                 'id': str(interaction.company.pk),
-                'name': interaction.company.name
+                'name': interaction.company.name,
             },
             'contact': {
                 'id': str(interaction.contact.pk),
@@ -357,13 +357,13 @@ class TestUpdatePolicyFeedback(APITestMixin):
                 'id': str(interaction.created_by.pk),
                 'first_name': interaction.created_by.first_name,
                 'last_name': interaction.created_by.last_name,
-                'name': interaction.created_by.name
+                'name': interaction.created_by.name,
             },
             'modified_by': {
                 'id': str(user.pk),
                 'first_name': user.first_name,
                 'last_name': user.last_name,
-                'name': user.name
+                'name': user.name,
             },
             'created_on': '2017-04-18T13:25:30.986208Z',
             'modified_on': '2017-04-18T13:25:30.986208Z',
@@ -374,7 +374,7 @@ class TestUpdatePolicyFeedback(APITestMixin):
         (
             create_interaction_user_without_policy_feedback,
             create_restricted_investment_project_user,
-        )
+        ),
     )
     def test_update_without_permission(self, create_user):
         """Test updating a policy feedback interaction without the required permissions."""
@@ -386,7 +386,7 @@ class TestUpdatePolicyFeedback(APITestMixin):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }
 
 
@@ -418,11 +418,11 @@ class TestGetPolicyFeedback(APITestMixin):
             }],
             'policy_issue_type': {
                 'id': str(interaction.policy_issue_type.pk),
-                'name': interaction.policy_issue_type.name
+                'name': interaction.policy_issue_type.name,
             },
             'communication_channel': {
                 'id': str(interaction.communication_channel.pk),
-                'name': interaction.communication_channel.name
+                'name': interaction.communication_channel.name,
             },
             'subject': interaction.subject,
             'date': format_date_or_datetime(interaction.date.date()),
@@ -430,12 +430,12 @@ class TestGetPolicyFeedback(APITestMixin):
                 'id': str(interaction.dit_adviser.pk),
                 'first_name': interaction.dit_adviser.first_name,
                 'last_name': interaction.dit_adviser.last_name,
-                'name': interaction.dit_adviser.name
+                'name': interaction.dit_adviser.name,
             },
             'notes': interaction.notes,
             'company': {
                 'id': str(interaction.company.pk),
-                'name': interaction.company.name
+                'name': interaction.company.name,
             },
             'contact': {
                 'id': str(interaction.contact.pk),
@@ -459,13 +459,13 @@ class TestGetPolicyFeedback(APITestMixin):
                 'id': str(interaction.created_by.pk),
                 'first_name': interaction.created_by.first_name,
                 'last_name': interaction.created_by.last_name,
-                'name': interaction.created_by.name
+                'name': interaction.created_by.name,
             },
             'modified_by': {
                 'id': str(interaction.modified_by.pk),
                 'first_name': interaction.modified_by.first_name,
                 'last_name': interaction.modified_by.last_name,
-                'name': interaction.modified_by.name
+                'name': interaction.modified_by.name,
             },
             'created_on': '2017-04-18T13:25:30.986208Z',
             'modified_on': '2017-04-18T13:25:30.986208Z',
@@ -476,7 +476,7 @@ class TestGetPolicyFeedback(APITestMixin):
         (
             create_interaction_user_without_policy_feedback,
             create_restricted_investment_project_user,
-        )
+        ),
     )
     def test_get_without_permission(self, create_user):
         """Test retrieving a policy feedback interaction without the required permissions."""
@@ -488,5 +488,5 @@ class TestGetPolicyFeedback(APITestMixin):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert response.json() == {
-            'detail': 'You do not have permission to perform this action.'
+            'detail': 'You do not have permission to perform this action.',
         }

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -13,10 +13,10 @@ from datahub.event.test.factories import EventFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
 from .utils import resolve_data
 from ..factories import (
-    EventServiceDeliveryFactory, ServiceDeliveryFactory
+    EventServiceDeliveryFactory, ServiceDeliveryFactory,
 )
 from ...models import (
-    CommunicationChannel, Interaction, PolicyArea, PolicyIssueType, ServiceDeliveryStatus
+    CommunicationChannel, Interaction, PolicyArea, PolicyIssueType, ServiceDeliveryStatus,
 )
 
 
@@ -44,8 +44,8 @@ class TestAddServiceDelivery(APITestMixin):
                 'service_delivery_status': partial(random_obj_for_model, ServiceDeliveryStatus),
                 'grant_amount_offered': '9999.99',
                 'net_company_receipt': '8888.99',
-            }
-        )
+            },
+        ),
     )
     def test_add(self, extra_data):
         """Test add a new service delivery."""
@@ -63,7 +63,7 @@ class TestAddServiceDelivery(APITestMixin):
             'service': Service.trade_enquiry.value.id,
             'dit_team': Team.healthcare_uk.value.id,
 
-            **resolve_data(extra_data)
+            **resolve_data(extra_data),
         }
         response = self.api_client.post(url, request_data)
 
@@ -86,12 +86,12 @@ class TestAddServiceDelivery(APITestMixin):
                 'id': str(adviser.pk),
                 'first_name': adviser.first_name,
                 'last_name': adviser.last_name,
-                'name': adviser.name
+                'name': adviser.name,
             },
             'notes': request_data.get('notes', ''),
             'company': {
                 'id': str(company.pk),
-                'name': company.name
+                'name': company.name,
             },
             'contact': {
                 'id': str(contact.pk),
@@ -115,16 +115,16 @@ class TestAddServiceDelivery(APITestMixin):
                 'id': str(self.user.pk),
                 'first_name': self.user.first_name,
                 'last_name': self.user.last_name,
-                'name': self.user.name
+                'name': self.user.name,
             },
             'modified_by': {
                 'id': str(self.user.pk),
                 'first_name': self.user.first_name,
                 'last_name': self.user.last_name,
-                'name': self.user.name
+                'name': self.user.name,
             },
             'created_on': '2017-04-18T13:25:30.986208Z',
-            'modified_on': '2017-04-18T13:25:30.986208Z'
+            'modified_on': '2017-04-18T13:25:30.986208Z',
         }
 
     @pytest.mark.parametrize(
@@ -133,7 +133,7 @@ class TestAddServiceDelivery(APITestMixin):
             # required fields
             (
                 {
-                    'kind': Interaction.KINDS.service_delivery
+                    'kind': Interaction.KINDS.service_delivery,
                 },
                 {
                     'date': ['This field is required.'],
@@ -143,7 +143,7 @@ class TestAddServiceDelivery(APITestMixin):
                     'dit_adviser': ['This field is required.'],
                     'service': ['This field is required.'],
                     'dit_team': ['This field is required.'],
-                }
+                },
             ),
 
             # required fields for service delivery
@@ -161,7 +161,7 @@ class TestAddServiceDelivery(APITestMixin):
                 {
                     'is_event': ['This field is required.'],
                     'notes': ['This field is required.'],
-                }
+                },
             ),
 
             # fields not allowed
@@ -179,7 +179,7 @@ class TestAddServiceDelivery(APITestMixin):
                     'is_event': True,
                     'event': EventFactory,
                     'service_delivery_status': partial(
-                        random_obj_for_model, ServiceDeliveryStatus
+                        random_obj_for_model, ServiceDeliveryStatus,
                     ),
                     'grant_amount_offered': '1111.11',
                     'net_company_receipt': '8888.11',
@@ -194,8 +194,8 @@ class TestAddServiceDelivery(APITestMixin):
                     'communication_channel': ['This field is not valid for service deliveries.'],
                     'policy_areas': ['This field is only valid for policy feedback.'],
                     'policy_issue_type': ['This field is only valid for policy feedback.'],
-                    'investment_project': ['This field is only valid for interactions.']
-                }
+                    'investment_project': ['This field is only valid for interactions.'],
+                },
             ),
 
             # event field not allowed for non-event service delivery
@@ -211,7 +211,7 @@ class TestAddServiceDelivery(APITestMixin):
                     'service': Service.trade_enquiry.value.id,
                     'dit_team': Team.healthcare_uk.value.id,
                     'service_delivery_status': partial(
-                        random_obj_for_model, ServiceDeliveryStatus
+                        random_obj_for_model, ServiceDeliveryStatus,
                     ),
                     'grant_amount_offered': '1111.11',
                     'net_company_receipt': '8888.11',
@@ -221,8 +221,8 @@ class TestAddServiceDelivery(APITestMixin):
                     'event': EventFactory,
                 },
                 {
-                    'event': ['This field is only valid for event service deliveries.']
-                }
+                    'event': ['This field is only valid for event service deliveries.'],
+                },
             ),
 
             # event field required for event service delivery
@@ -237,7 +237,7 @@ class TestAddServiceDelivery(APITestMixin):
                     'service': Service.trade_enquiry.value.id,
                     'dit_team': Team.healthcare_uk.value.id,
                     'service_delivery_status': partial(
-                        random_obj_for_model, ServiceDeliveryStatus
+                        random_obj_for_model, ServiceDeliveryStatus,
                     ),
                     'grant_amount_offered': '1111.11',
                     'net_company_receipt': '8888.11',
@@ -246,10 +246,10 @@ class TestAddServiceDelivery(APITestMixin):
                     'is_event': True,
                 },
                 {
-                    'event': ['This field is required.']
-                }
+                    'event': ['This field is required.'],
+                },
             ),
-        )
+        ),
     )
     def test_validation(self, data, errors):
         """Test validation errors."""
@@ -270,10 +270,13 @@ class TestUpdateServiceDelivery(APITestMixin):
         event = EventFactory()
 
         url = reverse('api-v3:interaction:item', kwargs={'pk': service_delivery.pk})
-        response = self.api_client.patch(url, {
-            'is_event': True,
-            'event': event.pk
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'is_event': True,
+                'event': event.pk,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -288,10 +291,13 @@ class TestUpdateServiceDelivery(APITestMixin):
         service_delivery = EventServiceDeliveryFactory()
 
         url = reverse('api-v3:interaction:item', kwargs={'pk': service_delivery.pk})
-        response = self.api_client.patch(url, {
-            'is_event': False,
-            'event': None
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'is_event': False,
+                'event': None,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -303,14 +309,17 @@ class TestUpdateServiceDelivery(APITestMixin):
         interaction = ServiceDeliveryFactory()
 
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = self.api_client.patch(url, {
-            'grant_amount_offered': '-100.00',
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'grant_amount_offered': '-100.00',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data['grant_amount_offered'] == [
-            'Ensure this value is greater than or equal to 0.'
+            'Ensure this value is greater than or equal to 0.',
         ]
 
     def test_fails_with_negative_net_company_receipt(self):
@@ -318,12 +327,15 @@ class TestUpdateServiceDelivery(APITestMixin):
         interaction = ServiceDeliveryFactory()
 
         url = reverse('api-v3:interaction:item', kwargs={'pk': interaction.pk})
-        response = self.api_client.patch(url, {
-            'net_company_receipt': '-100.00',
-        })
+        response = self.api_client.patch(
+            url,
+            data={
+                'net_company_receipt': '-100.00',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data['net_company_receipt'] == [
-            'Ensure this value is greater than or equal to 0.'
+            'Ensure this value is greater than or equal to 0.',
         ]

--- a/datahub/interaction/test/views/utils.py
+++ b/datahub/interaction/test/views/utils.py
@@ -32,7 +32,7 @@ def _resolve_single_value(value):
         obj_value = resolved_value
         resolved_value = {
             'id': str(obj_value.id),
-            'name': obj_value.name
+            'name': obj_value.name,
         }
 
         # this is here because of inconsistent endpoint :(

--- a/datahub/interaction/urls.py
+++ b/datahub/interaction/urls.py
@@ -4,12 +4,12 @@ from datahub.interaction.views import InteractionViewSet
 
 collection = InteractionViewSet.as_view({
     'get': 'list',
-    'post': 'create'
+    'post': 'create',
 })
 
 item = InteractionViewSet.as_view({
     'get': 'retrieve',
-    'patch': 'partial_update'
+    'patch': 'partial_update',
 })
 
 urlpatterns = [


### PR DESCRIPTION
### Description of change

This adds trailing commas to the interaction app where they were missing. This includes some related code reformatting and the removal of some incorrect trailing commas.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
