### PR TITLE
Add trailing commas to search app

### DIFF
--- a/datahub/search/bulk_sync.py
+++ b/datahub/search/bulk_sync.py
@@ -39,8 +39,10 @@ def sync_app(search_app, batch_size=None, post_batch_callback=None):
         rows_processed += num_actions
 
         if emit_progress:
-            logger.info(f'{model_name} rows processed: {rows_processed}/{total_rows} '
-                        f'{rows_processed*100//total_rows}%')
+            logger.info(
+                f'{model_name} rows processed: {rows_processed}/{total_rows} '
+                f'{rows_processed*100//total_rows}%',
+            )
 
     logger.info(f'{model_name} rows processed: {rows_processed}/{total_rows} 100%.')
 
@@ -48,7 +50,7 @@ def sync_app(search_app, batch_size=None, post_batch_callback=None):
 def sync_objects(es_model, model_objects, read_indices, write_index, post_batch_callback=None):
     """Syncs an iterable of model instances to Elasticsearch."""
     actions = list(
-        es_model.db_objects_to_es_documents(model_objects, index=write_index)
+        es_model.db_objects_to_es_documents(model_objects, index=write_index),
     )
     num_actions = len(actions)
     bulk(

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -14,8 +14,8 @@ class CompaniesHouseCompany(BaseESModel):
     incorporation_date = Date()
     name = fields.SortableText(
         copy_to=[
-            'name_keyword', 'name_trigram'
-        ]
+            'name_keyword', 'name_trigram',
+        ],
     )
     name_keyword = fields.SortableCaseInsensitiveKeywordText()
     name_trigram = fields.TrigramText()

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -2,7 +2,7 @@ import pytest
 from elasticsearch_dsl import Mapping
 
 from datahub.company.test.factories import (
-    CompaniesHouseCompanyFactory
+    CompaniesHouseCompanyFactory,
 )
 from datahub.core.test_utils import format_date_or_datetime
 from .. import CompaniesHouseCompanySearchApp
@@ -26,91 +26,91 @@ def test_mapping(setup_es):
                 'company_category': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'company_number': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'company_status': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'id': {
-                    'type': 'keyword'
+                    'type': 'keyword',
                 },
                 'incorporation_date': {
-                    'type': 'date'
+                    'type': 'date',
                 },
                 'name': {
                     'copy_to': ['name_keyword', 'name_trigram'],
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'name_keyword': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'name_trigram': {
                     'analyzer': 'trigram_analyzer',
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'registered_address_1': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'registered_address_2': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'registered_address_country': {
                     'include_in_parent': True,
                     'properties': {
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'registered_address_county': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'registered_address_postcode': {
                     'copy_to': ['registered_address_postcode_trigram'],
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'registered_address_postcode_trigram': {
                     'analyzer': 'trigram_analyzer',
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'registered_address_town': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'sic_code_1': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'sic_code_2': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'sic_code_3': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'sic_code_4': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'uri': {
-                    'type': 'text'
-                }
-            }
-        }
+                    'type': 'text',
+                },
+            },
+        },
     }
 
 
@@ -126,7 +126,7 @@ def test_indexed_doc(setup_es):
     indexed_ch_company = setup_es.get(
         index=ESCompaniesHouseCompany.get_write_index(),
         doc_type=CompaniesHouseCompanySearchApp.name,
-        id=ch_company.pk
+        id=ch_company.pk,
     )
 
     assert indexed_ch_company == {
@@ -145,7 +145,7 @@ def test_indexed_doc(setup_es):
             'registered_address_postcode': ch_company.registered_address_postcode,
             'registered_address_country': {
                 'id': str(ch_company.registered_address_country.pk),
-                'name': ch_company.registered_address_country.name
+                'name': ch_company.registered_address_country.name,
             },
             'company_number': ch_company.company_number,
             'company_category': ch_company.company_category,
@@ -156,5 +156,5 @@ def test_indexed_doc(setup_es):
             'sic_code_4': ch_company.sic_code_4,
             'uri': ch_company.uri,
             'incorporation_date': format_date_or_datetime(ch_company.incorporation_date),
-        }
+        },
     }

--- a/datahub/search/companieshousecompany/tests/test_views.py
+++ b/datahub/search/companieshousecompany/tests/test_views.py
@@ -8,7 +8,7 @@ from datahub.company.test.factories import CompaniesHouseCompanyFactory
 from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 from datahub.search.companieshousecompany.models import (
-    CompaniesHouseCompany as ESCompaniesHouseCompany
+    CompaniesHouseCompany as ESCompaniesHouseCompany,
 )
 from datahub.search.sync_async import sync_object_async
 
@@ -61,7 +61,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
         (
             (  # no filter => return all records
                 {},
-                {'111', '222', '333'}
+                {'111', '222', '333'},
             ),
             (  # pagination
                 {
@@ -69,37 +69,37 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
                     'offset': 1,
                     'sortby': 'name:asc',
                 },
-                {'222'}
+                {'222'},
             ),
             (  # company number filter
                 {
-                    'company_number': '222'
+                    'company_number': '222',
                 },
                 {'222'},
             ),
             (  # incorporation date filter
                 {
-                    'incorporation_date_after': '2014'
+                    'incorporation_date_after': '2014',
                 },
                 {'222', '333'},
             ),
             (  # incorporation date filter
                 {
-                    'incorporation_date_before': '2014'
+                    'incorporation_date_before': '2014',
                 },
                 {'111'},
             ),
             (  # incorporation date filter
                 {
                     'incorporation_date_after': '2014',
-                    'incorporation_date_before': '2017'
+                    'incorporation_date_before': '2017',
                 },
                 {'222', '333'},
             ),
             (  # incorporation date filter
                 {
                     'incorporation_date_after': '2010',
-                    'incorporation_date_before': '2015-10-01'
+                    'incorporation_date_before': '2015-10-01',
                 },
                 {'111', '222'},
             ),
@@ -127,7 +127,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
                 },
                 {'222'},
             ),
-        )
+        ),
     )
     def test_search(self, setup_data, data, results):
         """Test search results."""
@@ -144,13 +144,16 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
         """Test that if the date is not in a valid format, the API return a validation error."""
         url = reverse('api-v3:search:companieshousecompany')
 
-        response = self.api_client.post(url, {
-            'incorporation_date_after': 'invalid',
-            'incorporation_date_before': 'invalid',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'incorporation_date_after': 'invalid',
+                'incorporation_date_before': 'invalid',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {
             'incorporation_date_after': ['Date is in incorrect format.'],
-            'incorporation_date_before': ['Date is in incorrect format.']
+            'incorporation_date_before': ['Date is in incorrect format.'],
         }

--- a/datahub/search/companieshousecompany/views.py
+++ b/datahub/search/companieshousecompany/views.py
@@ -26,6 +26,6 @@ class SearchCompaniesHouseCompanyParams:
 
 class SearchCompaniesHouseCompanyAPIView(
     SearchCompaniesHouseCompanyParams,
-    SearchAPIView
+    SearchAPIView,
 ):
     """Filtered company search view."""

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -39,12 +39,12 @@ class Company(BaseESModel):
     registered_address_town = fields.SortableCaseInsensitiveKeywordText()
     registered_address_county = Text()
     registered_address_country = fields.nested_id_name_partial_field(
-        'registered_address_country'
+        'registered_address_country',
     )
     registered_address_postcode = Text(
         copy_to=[
-            'registered_address_postcode_trigram'
-        ]
+            'registered_address_postcode_trigram',
+        ],
     )
     registered_address_postcode_trigram = fields.TrigramText()
     sector = fields.nested_sector_field()
@@ -53,17 +53,17 @@ class Company(BaseESModel):
     trading_address_town = fields.SortableCaseInsensitiveKeywordText()
     trading_address_county = Text()
     trading_address_postcode = Text(
-        copy_to=['trading_address_postcode_trigram']
+        copy_to=['trading_address_postcode_trigram'],
     )
     trading_address_postcode_trigram = fields.TrigramText()
     trading_address_country = fields.nested_id_name_partial_field(
-        'trading_address_country'
+        'trading_address_country',
     )
     trading_name = fields.SortableText(
         copy_to=[
             'trading_name_keyword',
             'trading_name_trigram',
-        ]
+        ],
     )
     trading_name_keyword = fields.SortableCaseInsensitiveKeywordText()
     trading_name_trigram = fields.TrigramText()
@@ -74,7 +74,7 @@ class Company(BaseESModel):
     website = Text()
 
     COMPUTED_MAPPINGS = {
-        'trading_name': attrgetter('alias')
+        'trading_name': attrgetter('alias'),
     }
 
     MAPPINGS = {
@@ -110,7 +110,7 @@ class Company(BaseESModel):
         'registered_address_postcode_trigram',
         'trading_address_country.name_trigram',
         'trading_address_postcode_trigram',
-        'uk_region.name_trigram'
+        'uk_region.name_trigram',
     )
 
     class Meta:

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -15,7 +15,7 @@ class SearchCompanySerializer(SearchSerializer):
     headquarter_type = SingleOrListField(
         child=StringUUIDField(allow_null=True),
         required=False,
-        allow_null=True
+        allow_null=True,
     )
     name = serializers.CharField(required=False)
     sector = SingleOrListField(child=StringUUIDField(), required=False)
@@ -44,5 +44,5 @@ class SearchCompanySerializer(SearchSerializer):
         'trading_address_town',
         'turnover_range.name',
         'uk_based',
-        'uk_region.name'
+        'uk_region.name',
     )

--- a/datahub/search/company/signals.py
+++ b/datahub/search/company/signals.py
@@ -10,7 +10,7 @@ from ..sync_async import sync_object_async
 def company_sync_es(sender, instance, **kwargs):
     """Sync company to the Elasticsearch."""
     transaction.on_commit(
-        lambda: sync_object_async(ESCompany, DBCompany, str(instance.pk))
+        lambda: sync_object_async(ESCompany, DBCompany, str(instance.pk)),
     )
 
 

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -18,14 +18,16 @@ def test_get_basic_search_query():
                         'match_phrase': {
                             'name_keyword': {
                                 'query': 'test',
-                                'boost': 2
-                            }
-                        }
-                    }, {
+                                'boost': 2,
+                            },
+                        },
+                    },
+                    {
                         'match_phrase': {
-                            'id': 'test'
-                        }
-                    }, {
+                            'id': 'test',
+                        },
+                    },
+                    {
                         'multi_match': {
                             'query': 'test',
                             'fields': [
@@ -67,39 +69,39 @@ def test_get_basic_search_query():
                                 'trading_name_trigram',
                                 'uk_company.name',
                                 'uk_company.name_trigram',
-                                'uk_region.name_trigram'
+                                'uk_region.name_trigram',
                             ],
                             'type': 'cross_fields',
-                            'operator': 'and'
-                        }
-                    }
-                ]
-            }
+                            'operator': 'and',
+                        },
+                    },
+                ],
+            },
         },
         'post_filter': {
             'bool': {
                 'should': [
                     {
                         'term': {
-                            '_type': 'company'
-                        }
-                    }
-                ]
-            }
+                            '_type': 'company',
+                        },
+                    },
+                ],
+            },
         },
         'aggs': {
             'count_by_type': {
                 'terms': {
-                    'field': '_type'
-                }
-            }
+                    'field': '_type',
+                },
+            },
         },
         'from': 5,
         'size': 5,
         'sort': [
             '_score',
-            'id'
-        ]
+            'id',
+        ],
     }
 
 
@@ -120,7 +122,7 @@ def test_limited_get_search_by_entity_query():
     query = limit_search_query(
         query,
         offset=5,
-        limit=5
+        limit=5,
     )
 
     assert query.to_dict() == {
@@ -129,23 +131,26 @@ def test_limited_get_search_by_entity_query():
                 'must': [
                     {
                         'term': {
-                            '_type': 'company'
-                        }
-                    }, {
+                            '_type': 'company',
+                        },
+                    },
+                    {
                         'bool': {
                             'should': [
                                 {
                                     'match_phrase': {
                                         'name_keyword': {
                                             'query': 'test',
-                                            'boost': 2
-                                        }
-                                    }
-                                }, {
+                                            'boost': 2,
+                                        },
+                                    },
+                                },
+                                {
                                     'match_phrase': {
-                                        'id': 'test'
-                                    }
-                                }, {
+                                        'id': 'test',
+                                    },
+                                },
+                                {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
@@ -159,60 +164,64 @@ def test_limited_get_search_by_entity_query():
                                             'registered_address_postcode_trigram',
                                             'trading_address_country.name_trigram',
                                             'trading_address_postcode_trigram',
-                                            'uk_region.name_trigram'
+                                            'uk_region.name_trigram',
                                         ),
                                         'type': 'cross_fields',
-                                        'operator': 'and'
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
+                                        'operator': 'and',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
         },
         'post_filter': {
             'bool': {
-                'must': [{
-                    'bool': {
-                        'should': [
-                            {
-                                'match': {
-                                    'address_town': {
-                                        'query': 'Woodside',
-                                        'operator': 'and'
-                                    }
-                                }
-                            }
-                        ],
-                        'minimum_should_match': 1
-                    }
-                }, {
-                    'bool': {
-                        'should': [
-                            {
-                                'match_phrase': {
-                                    'trading_address_country.id':
-                                        '80756b9a-5d95-e211-a939-e4115bead28a'
-                                }
-                            }
-                        ],
-                        'minimum_should_match': 1
-                    }
-                }, {
-                    'range': {
-                        'estimated_land_date': {
-                            'gte': '2017-06-13T09:44:31.062870',
-                            'lte': '2017-06-13T09:44:31.062870'
-                        }
-                    }
-                }]
-            }
+                'must': [
+                    {
+                        'bool': {
+                            'should': [
+                                {
+                                    'match': {
+                                        'address_town': {
+                                            'query': 'Woodside',
+                                            'operator': 'and',
+                                        },
+                                    },
+                                },
+                            ],
+                            'minimum_should_match': 1,
+                        },
+                    },
+                    {
+                        'bool': {
+                            'should': [
+                                {
+                                    'match_phrase': {
+                                        'trading_address_country.id':
+                                            '80756b9a-5d95-e211-a939-e4115bead28a',
+                                    },
+                                },
+                            ],
+                            'minimum_should_match': 1,
+                        },
+                    },
+                    {
+                        'range': {
+                            'estimated_land_date': {
+                                'gte': '2017-06-13T09:44:31.062870',
+                                'lte': '2017-06-13T09:44:31.062870',
+                            },
+                        },
+                    },
+                ],
+            },
         },
         'from': 5,
         'size': 5,
         'sort': [
             '_score',
-            'id'
-        ]
+            'id',
+        ],
     }

--- a/datahub/search/company/test/test_signals.py
+++ b/datahub/search/company/test/test_signals.py
@@ -11,7 +11,7 @@ def test_company_auto_sync_to_es(setup_es):
     """Tests if company gets synced to Elasticsearch."""
     test_name = 'very_hard_to_find_company'
     CompanyFactory(
-        name=test_name
+        name=test_name,
     )
     setup_es.indices.refresh()
 
@@ -24,7 +24,7 @@ def test_company_auto_updates_to_es(setup_es):
     """Tests if company gets updated in Elasticsearch."""
     test_name = 'very_hard_to_find_company_international'
     company = CompanyFactory(
-        name=test_name
+        name=test_name,
     )
     new_test_name = 'very_hard_to_find_company_local'
     company.name = new_test_name

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -47,7 +47,7 @@ def setup_data(setup_es):
         trading_address_1='1 Fake Lane',
         trading_address_town='Downtown',
         trading_address_country_id=country_us,
-        registered_address_country_id=country_us
+        registered_address_country_id=country_us,
     )
     setup_es.indices.refresh()
 
@@ -86,10 +86,11 @@ class TestSearch(APITestMixin):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     @pytest.mark.parametrize(
-        'archived', (
+        'archived',
+        (
             True,
             False,
-        )
+        ),
     )
     def test_archived_filter(self, setup_es, archived):
         """Tests filtering by archived."""
@@ -100,9 +101,12 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:company')
 
-        response = self.api_client.post(url, {
-            'archived': archived,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'archived': archived,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -117,9 +121,12 @@ class TestSearch(APITestMixin):
         url = reverse('api-v3:search:company')
         united_states_id = constants.Country.united_states.value.id
 
-        response = self.api_client.post(url, {
-            'trading_address_country': united_states_id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'trading_address_country': united_states_id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -131,9 +138,12 @@ class TestSearch(APITestMixin):
         url = reverse('api-v3:search:company')
         uk_region = constants.UKRegion.south_east.value.id
 
-        response = self.api_client.post(url, {
-            'uk_region': uk_region,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'uk_region': uk_region,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -141,7 +151,8 @@ class TestSearch(APITestMixin):
         assert response.data['results'][0]['uk_region']['id'] == uk_region
 
     @pytest.mark.parametrize(
-        'query,results', (
+        'query,results',
+        (
             (
                 {
                     'headquarter_type': None,
@@ -150,7 +161,7 @@ class TestSearch(APITestMixin):
             ),
             (
                 {
-                    'headquarter_type': constants.HeadquarterType.ghq.value.id
+                    'headquarter_type': constants.HeadquarterType.ghq.value.id,
                 },
                 {'ghq'},
             ),
@@ -173,7 +184,7 @@ class TestSearch(APITestMixin):
                 },
                 {'ehq', 'ghq', 'none'},
             ),
-        )
+        ),
     )
     def test_headquarter_type_filter(self, setup_headquarters_data, query, results):
         """Test headquarter type filter."""
@@ -206,8 +217,8 @@ class TestSearch(APITestMixin):
         response = self.api_client.post(
             url,
             {
-                'global_headquarters': ghq1.id
-            }
+                'global_headquarters': ghq1.id,
+            },
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -228,20 +239,20 @@ class TestSearch(APITestMixin):
 
         companies = CompanyFactory.create_batch(
             num_sectors,
-            sector_id=factory.Iterator(sectors_ids)
+            sector_id=factory.Iterator(sectors_ids),
         )
         CompanyFactory.create_batch(
             3,
             sector=factory.LazyFunction(lambda: random_obj_for_queryset(
-                Sector.objects.exclude(pk__in=sectors_ids)
-            ))
+                Sector.objects.exclude(pk__in=sectors_ids),
+            )),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:company')
         body = {
-            'sector_descends': hierarchical_sectors[sector_level].pk
+            'sector_descends': hierarchical_sectors[sector_level].pk,
         }
         response = self.api_client.post(url, body)
         assert response.status_code == status.HTTP_200_OK
@@ -260,7 +271,7 @@ class TestSearch(APITestMixin):
             (constants.Country.montserrat.value.id, True),
             (constants.Country.st_helena.value.id, False),
             (constants.Country.anguilla.value.id, False),
-        )
+        ),
     )
     def test_composite_country_filter(self, setup_es, country, match):
         """Tests composite country filter."""
@@ -272,9 +283,12 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:company')
 
-        response = self.api_client.post(url, {
-            'country': country,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'country': country,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         if match:
@@ -292,7 +306,7 @@ class TestSearch(APITestMixin):
             ('house lion', True),
             ('tiger', False),
             ('panda', False),
-        )
+        ),
     )
     def test_composite_name_filter(self, setup_es, name, match):
         """Tests composite name filter."""
@@ -304,9 +318,12 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:company')
 
-        response = self.api_client.post(url, {
-            'name': name,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'name': name,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         if match:
@@ -325,10 +342,13 @@ class TestSearch(APITestMixin):
         united_states_id = constants.Country.united_states.value.id
         united_kingdom_id = constants.Country.united_kingdom.value.id
 
-        response = self.api_client.post(url, {
-            'original_query': term,
-            'trading_address_country': [united_states_id, united_kingdom_id],
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': term,
+                'trading_address_country': [united_states_id, united_kingdom_id],
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -362,21 +382,24 @@ class TestSearch(APITestMixin):
             ('Pallas Hiding', 'Pallas Hid', True),
             ('Pallas Hiding', 'Pallas Hi', True),
             ('A & B', 'A & B', True),
-            ('A&B Properties Limited', 'a&b', True)
-        )
+            ('A&B Properties Limited', 'a&b', True),
+        ),
     )
     def test_name_filter_match(self, setup_es, company_name, search_name, match):
         """Tests company name partial search."""
         company = CompanyFactory(
-            name=company_name
+            name=company_name,
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:company')
 
-        response = self.api_client.post(url, {
-            'name': search_name,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'name': search_name,
+            },
+        )
         assert response.status_code == status.HTTP_200_OK
 
         if match:
@@ -392,18 +415,24 @@ class TestSearch(APITestMixin):
         """Tests filter with null value."""
         url = reverse('api-v3:search:company')
 
-        response = self.api_client.post(url, {
-            'uk_region': None,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'uk_region': None,
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'uk_region': ['This field may not be null.']}
 
-    @pytest.mark.parametrize('sortby', (
-        {},
-        {'sortby': 'name:asc'},
-        {'sortby': 'created_on:asc'},
-    ))
+    @pytest.mark.parametrize(
+        'sortby',
+        (
+            {},
+            {'sortby': 'name:asc'},
+            {'sortby': 'created_on:asc'},
+        ),
+    )
     def test_company_search_paging(self, setup_es, sortby):
         """Tests if content placement is consistent between pages."""
         ids = sorted((uuid4() for _ in range(9)))
@@ -423,13 +452,16 @@ class TestSearch(APITestMixin):
 
         for page in range((len(ids) + page_size - 1) // page_size):
             url = reverse('api-v3:search:company')
-            response = self.api_client.post(url, {
-                'original_query': name,
-                'entity': 'company',
-                'offset': page * page_size,
-                'limit': page_size,
-                **sortby
-            })
+            response = self.api_client.post(
+                url,
+                data={
+                    'original_query': name,
+                    'entity': 'company',
+                    'offset': page * page_size,
+                    'limit': page_size,
+                    **sortby,
+                },
+            )
 
             assert response.status_code == status.HTTP_200_OK
 
@@ -469,9 +501,12 @@ class TestSearch(APITestMixin):
         """Tests detailed company search."""
         url = reverse('api-v3:search:company')
 
-        response = self.api_client.post(url, {
-            'uk_based': False,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'uk_based': False,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -483,11 +518,12 @@ class TestCompanyExportView(APITestMixin):
     """Tests the company export view."""
 
     @pytest.mark.parametrize(
-        'permissions', (
+        'permissions',
+        (
             (),
             (CompanyPermission.view_company,),
             (CompanyPermission.export_company,),
-        )
+        ),
     )
     def test_user_without_permission_cannot_export(self, setup_es, permissions):
         """Test that a user without the correct permissions cannot export data."""
@@ -504,7 +540,7 @@ class TestCompanyExportView(APITestMixin):
             ('name', 'name'),
             ('modified_on', 'modified_on'),
             ('modified_on:desc', '-modified_on'),
-        )
+        ),
     )
     def test_export(
         self,
@@ -530,7 +566,7 @@ class TestCompanyExportView(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})
         assert parse_header(response.get('Content-Disposition')) == (
-            'attachment', {'filename': 'Data Hub - Companies - 2018-01-01-11-12-13.csv'}
+            'attachment', {'filename': 'Data Hub - Companies - 2018-01-01-11-12-13.csv'},
         )
 
         sorted_company = Company.objects.order_by(orm_ordering, 'pk')
@@ -564,10 +600,13 @@ class TestBasicSearch(APITestMixin):
     def test_all_companies(self, setup_data):
         """Tests basic aggregate all companies query."""
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': '',
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] > 0
@@ -577,10 +616,13 @@ class TestBasicSearch(APITestMixin):
         term = 'abc defg'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -594,10 +636,13 @@ class TestBasicSearch(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -611,7 +656,7 @@ class TestBasicSearch(APITestMixin):
             ('trading_address_postcode', 'SW1A 1AA', 'SW1A 1AB', False),
             ('registered_address_postcode', 'SW1A 1AA', 'SW1A 1AA', True),
             ('registered_address_postcode', 'SW1A 1AA', 'SW1A 1AB', False),
-        )
+        ),
     )
     def test_search_in_field(self, setup_es, field, value, term, match):
         """Tests basic aggregate companies query."""
@@ -620,10 +665,13 @@ class TestBasicSearch(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         if match:
@@ -637,10 +685,13 @@ class TestBasicSearch(APITestMixin):
         term = 'there-should-be-no-match'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.data['count'] == 0
 

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -35,7 +35,7 @@ class Contact(BaseESModel):
             'name',
             'name_keyword',
             'name_trigram',
-        ]
+        ],
     )
     job_title = fields.SortableCaseInsensitiveKeywordText()
     last_name = fields.SortableText(
@@ -43,7 +43,8 @@ class Contact(BaseESModel):
             'name',
             'name_keyword',
             'name_trigram',
-        ])
+        ],
+    )
     modified_on = Date()
     name = fields.SortableText()
     name_keyword = fields.SortableCaseInsensitiveKeywordText()

--- a/datahub/search/contact/signals.py
+++ b/datahub/search/contact/signals.py
@@ -10,7 +10,7 @@ from ..sync_async import sync_object_async
 def contact_sync_es(sender, instance, **kwargs):
     """Sync contact to the Elasticsearch."""
     transaction.on_commit(
-        lambda: sync_object_async(ESContact, DBContact, str(instance.pk))
+        lambda: sync_object_async(ESContact, DBContact, str(instance.pk)),
     )
 
 

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -18,14 +18,16 @@ def test_get_basic_search_query():
                         'match_phrase': {
                             'name_keyword': {
                                 'query': 'test',
-                                'boost': 2
-                            }
-                        }
-                    }, {
+                                'boost': 2,
+                            },
+                        },
+                    },
+                    {
                         'match_phrase': {
-                            'id': 'test'
-                        }
-                    }, {
+                            'id': 'test',
+                        },
+                    },
+                    {
                         'multi_match': {
                             'query': 'test',
                             'fields': [
@@ -67,39 +69,39 @@ def test_get_basic_search_query():
                                 'trading_name_trigram',
                                 'uk_company.name',
                                 'uk_company.name_trigram',
-                                'uk_region.name_trigram'
+                                'uk_region.name_trigram',
                             ],
                             'type': 'cross_fields',
-                            'operator': 'and'
-                        }
-                    }
-                ]
-            }
+                            'operator': 'and',
+                        },
+                    },
+                ],
+            },
         },
         'post_filter': {
             'bool': {
                 'should': [
                     {
                         'term': {
-                            '_type': 'contact'
-                        }
-                    }
-                ]
-            }
+                            '_type': 'contact',
+                        },
+                    },
+                ],
+            },
         },
         'aggs': {
             'count_by_type': {
                 'terms': {
-                    'field': '_type'
-                }
-            }
+                    'field': '_type',
+                },
+            },
         },
         'from': 5,
         'size': 5,
         'sort': [
             '_score',
-            'id'
-        ]
+            'id',
+        ],
     }
 
 
@@ -129,23 +131,26 @@ def test_get_limited_search_by_entity_query():
                 'must': [
                     {
                         'term': {
-                            '_type': 'contact'
-                        }
-                    }, {
+                            '_type': 'contact',
+                        },
+                    },
+                    {
                         'bool': {
                             'should': [
                                 {
                                     'match_phrase': {
                                         'name_keyword': {
                                             'query': 'test',
-                                            'boost': 2
-                                        }
-                                    }
-                                }, {
+                                            'boost': 2,
+                                        },
+                                    },
+                                },
+                                {
                                     'match_phrase': {
-                                        'id': 'test'
-                                    }
-                                }, {
+                                        'id': 'test',
+                                    },
+                                },
+                                {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
@@ -154,17 +159,17 @@ def test_get_limited_search_by_entity_query():
                                             'email',
                                             'email_alternative',
                                             'company.name',
-                                            'company.name_trigram'
+                                            'company.name_trigram',
                                         ),
                                         'type': 'cross_fields',
-                                        'operator': 'and'
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
+                                        'operator': 'and',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
         },
         'post_filter': {
             'bool': {
@@ -176,38 +181,40 @@ def test_get_limited_search_by_entity_query():
                                     'match': {
                                         'address_town': {
                                             'query': 'Woodside',
-                                            'operator': 'and'
-                                        }
-                                    }
-                                }
+                                            'operator': 'and',
+                                        },
+                                    },
+                                },
                             ],
-                            'minimum_should_match': 1
-                        }
-                    }, {
+                            'minimum_should_match': 1,
+                        },
+                    },
+                    {
                         'bool': {
                             'should': [{
                                 'match_phrase': {
                                     'trading_address_country.id':
-                                        '80756b9a-5d95-e211-a939-e4115bead28a'
-                                }
+                                        '80756b9a-5d95-e211-a939-e4115bead28a',
+                                },
                             }],
-                            'minimum_should_match': 1
-                        }
-                    }, {
+                            'minimum_should_match': 1,
+                        },
+                    },
+                    {
                         'range': {
                             'estimated_land_date': {
                                 'gte': '2017-06-13T09:44:31.062870',
-                                'lte': '2017-06-13T09:44:31.062870'
-                            }
-                        }
-                    }
-                ]
-            }
+                                'lte': '2017-06-13T09:44:31.062870',
+                            },
+                        },
+                    },
+                ],
+            },
         },
         'from': 5,
         'size': 5,
         'sort': [
             '_score',
-            'id'
-        ]
+            'id',
+        ],
     }

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -44,7 +44,7 @@ def test_contact_dbmodel_to_dict(setup_es):
         'notes',
         'accepts_dit_email_marketing',
         'company_sector',
-        'company_uk_region'
+        'company_uk_region',
     }
 
     assert set(result.keys()) == keys
@@ -67,7 +67,7 @@ def test_contact_dbmodels_to_es_documents_without_country(setup_es):
     # We want to bypass any validation
     contact = Contact(
         address_same_as_company=False,
-        address_country=None
+        address_country=None,
     )
     result = ESContact.es_document(contact)
 

--- a/datahub/search/contact/test/test_signals.py
+++ b/datahub/search/contact/test/test_signals.py
@@ -11,7 +11,7 @@ def test_contact_auto_sync_to_es(setup_es):
     """Tests if contact gets synced to Elasticsearch."""
     test_name = 'very_hard_to_find_contact'
     ContactFactory(
-        first_name=test_name
+        first_name=test_name,
     )
     setup_es.indices.refresh()
 
@@ -24,7 +24,7 @@ def test_contact_auto_updates_to_es(setup_es):
     """Tests if contact gets updated in Elasticsearch."""
     test_name = 'very_hard_to_find_contact_ii'
     contact = ContactFactory(
-        first_name=test_name
+        first_name=test_name,
     )
     contact.save()
 

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -48,7 +48,7 @@ class SearchContactParams:
     COMPOSITE_FILTERS = {
         'name': [
             'name',
-            'name_trigram'
+            'name_trigram',
         ],
         'company_name': [
             'company.name',
@@ -98,7 +98,7 @@ class SearchContactExportAPIView(SearchContactParams, SearchExportAPIView):
         team_of_latest_interaction=get_top_related_expression_subquery(
             DBInteraction.contact.field,
             F('dit_team__name'),
-            ('-date',)
+            ('-date',),
         ),
     )
     field_titles = {

--- a/datahub/search/dashboard/test/test_views.py
+++ b/datahub/search/dashboard/test/test_views.py
@@ -56,9 +56,12 @@ class TestDashboard(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('dashboard:intelligent-homepage')
-        response = self.api_client.get(url, data={
-            'limit': 10
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'limit': 10,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -68,7 +71,7 @@ class TestDashboard(APITestMixin):
     def test_contact_permission(self, setup_es):
         """Test that the contact view permission is enforced."""
         requester = create_test_user(
-            permission_codenames=(InteractionPermission.view_all,)
+            permission_codenames=(InteractionPermission.view_all,),
         )
         CompanyInteractionFactory.create_batch(5, dit_adviser=requester)
         ContactFactory.create_batch(5, created_by=requester)
@@ -78,9 +81,12 @@ class TestDashboard(APITestMixin):
         api_client = self.create_api_client(user=requester)
 
         url = reverse('dashboard:intelligent-homepage')
-        response = api_client.get(url, data={
-            'limit': 10
-        })
+        response = api_client.get(
+            url,
+            data={
+                'limit': 10,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -90,7 +96,7 @@ class TestDashboard(APITestMixin):
     def test_interaction_permission(self, setup_es):
         """Test that the interaction view permission is enforced."""
         requester = create_test_user(
-            permission_codenames=('view_contact',)
+            permission_codenames=('view_contact',),
         )
         CompanyInteractionFactory.create_batch(5, dit_adviser=requester)
         ContactFactory.create_batch(5, created_by=requester)
@@ -100,9 +106,12 @@ class TestDashboard(APITestMixin):
         api_client = self.create_api_client(user=requester)
 
         url = reverse('dashboard:intelligent-homepage')
-        response = api_client.get(url, data={
-            'limit': 10
-        })
+        response = api_client.get(
+            url,
+            data={
+                'limit': 10,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()

--- a/datahub/search/dashboard/urls.py
+++ b/datahub/search/dashboard/urls.py
@@ -3,5 +3,5 @@ from django.urls import path
 from .views import IntelligentHomepageView
 
 urlpatterns = [
-    path('homepage/', IntelligentHomepageView.as_view(), name='intelligent-homepage')
+    path('homepage/', IntelligentHomepageView.as_view(), name='intelligent-homepage'),
 ]

--- a/datahub/search/deletion.py
+++ b/datahub/search/deletion.py
@@ -36,7 +36,7 @@ def delete_documents(index, es_docs):
     if non_404_errors:
         raise DataHubException(
             f'One or more errors during an Elasticsearch bulk deletion operation: '
-            f'{non_404_errors!r}'
+            f'{non_404_errors!r}',
         )
 
 
@@ -85,7 +85,7 @@ class Collector:
 
             # set up the receivers to add when collecting the deleted objects
             self.signal_receivers_to_add.append(
-                SignalReceiver(post_delete, model, self._collect)
+                SignalReceiver(post_delete, model, self._collect),
             )
 
             # get the existing post/pre_delete receivers that need to be

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -16,7 +16,7 @@ def id_type_dict(obj):
 
     return {
         'id': str(obj.id),
-        'type': obj.type
+        'type': obj.type,
     }
 
 
@@ -27,7 +27,7 @@ def id_uri_dict(obj):
 
     return {
         'id': str(obj.id),
-        'uri': obj.uri
+        'uri': obj.uri,
     }
 
 

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -16,7 +16,7 @@ logger = getLogger(__name__)
 lowercase_keyword_analyzer = analysis.CustomAnalyzer(
     'lowercase_keyword_analyzer',
     tokenizer='keyword',
-    filter=('lowercase',)
+    filter=('lowercase',),
 )
 
 # Trigram tokenizer enables us to support partial matching
@@ -25,7 +25,7 @@ trigram = analysis.tokenizer(
     'nGram',
     min_gram=3,
     max_gram=3,
-    token_chars=('letter', 'digit',)
+    token_chars=('letter', 'digit'),
 )
 
 # Filters out "-" so that t-shirt and tshirt can be matched
@@ -40,19 +40,19 @@ trigram_analyzer = analysis.CustomAnalyzer(
 english_possessive_stemmer = analysis.token_filter(
     'english_possessive_stemmer',
     type='stemmer',
-    language='possessive_english'
+    language='possessive_english',
 )
 
 english_stemmer = analysis.token_filter(
     'english_stemmer',
     type='stemmer',
-    language='english'
+    language='english',
 )
 
 english_stop = analysis.token_filter(
     'english_stop',
     type='stop',
-    stopwords='_english_'
+    stopwords='_english_',
 )
 
 english_analyzer = analysis.CustomAnalyzer(
@@ -63,13 +63,13 @@ english_analyzer = analysis.CustomAnalyzer(
         'lowercase',
         english_stop,
         english_stemmer,
-    ]
+    ],
 )
 
 lowercase_analyzer = analysis.CustomAnalyzer(
     'lowercase_analyzer',
     tokenizer='standard',
-    filter=('lowercase',)
+    filter=('lowercase',),
 )
 
 
@@ -86,7 +86,7 @@ def configure_connection():
     if settings.ES_USE_AWS_AUTH:
         es_protocol = {
             'http': 80,
-            'https': 443
+            'https': 443,
         }
         es_host = urlparse(settings.ES_URL)
         es_port = es_host.port if es_host.port else es_protocol.get(es_host.scheme)
@@ -95,7 +95,7 @@ def configure_connection():
             aws_secret_access_key=settings.AWS_ELASTICSEARCH_SECRET,
             aws_host=es_host.netloc,
             aws_region=settings.AWS_ELASTICSEARCH_REGION,
-            aws_service='es'
+            aws_service='es',
         )
         connections_default = {
             'hosts': [es_host.netloc],
@@ -103,16 +103,16 @@ def configure_connection():
             'use_ssl': settings.ES_USE_SSL,
             'verify_certs': settings.ES_VERIFY_CERTS,
             'http_auth': auth,
-            'connection_class': RequestsHttpConnection
+            'connection_class': RequestsHttpConnection,
         }
     else:
         connections_default = {
             'hosts': [settings.ES_URL],
-            'verify_certs': settings.ES_VERIFY_CERTS
+            'verify_certs': settings.ES_VERIFY_CERTS,
         }
 
     connections.configure(
-        default=connections_default
+        default=connections_default,
     )
 
 
@@ -201,8 +201,8 @@ class _AliasUpdater:
         self.actions.append({
             'add': {
                 'alias': alias_name,
-                'indices': list(index_names)
-            }
+                'indices': list(index_names),
+            },
         })
 
     def dissociate_indices_from_alias(self, alias_name, index_names):
@@ -210,15 +210,15 @@ class _AliasUpdater:
         self.actions.append({
             'remove': {
                 'alias': alias_name,
-                'indices': list(index_names)
-            }
+                'indices': list(index_names),
+            },
         })
 
     def commit(self):
         """Commits (flushes) pending operations."""
         client = get_client()
         client.indices.update_aliases(body={
-            'actions': self.actions
+            'actions': self.actions,
         })
         self.actions = []
 
@@ -261,7 +261,7 @@ def bulk(
     actions=None,
     chunk_size=500,
     max_chunk_bytes=settings.ES_BULK_MAX_CHUNK_BYTES,
-    **kwargs
+    **kwargs,
 ):
     """Send data in bulk to Elasticsearch."""
     return es_bulk(
@@ -269,5 +269,5 @@ def bulk(
         actions=actions,
         chunk_size=chunk_size,
         max_chunk_bytes=max_chunk_bytes,
-        **kwargs
+        **kwargs,
     )

--- a/datahub/search/event/signals.py
+++ b/datahub/search/event/signals.py
@@ -10,7 +10,7 @@ from .models import Event as ESEvent
 def sync_event_to_es(sender, instance, **kwargs):
     """Sync event to the Elasticsearch."""
     transaction.on_commit(
-        lambda: sync_object_async(ESEvent, DBEvent, str(instance.pk))
+        lambda: sync_object_async(ESEvent, DBEvent, str(instance.pk)),
     )
 
 

--- a/datahub/search/event/tests/test_signals.py
+++ b/datahub/search/event/tests/test_signals.py
@@ -14,7 +14,7 @@ def test_new_event_synced(setup_es):
     assert setup_es.get(
         index=EventSearchApp.es_model.get_write_index(),
         doc_type=EventSearchApp.name,
-        id=event.pk
+        id=event.pk,
     )
 
 
@@ -29,6 +29,6 @@ def test_updated_event_synced(setup_es):
     result = setup_es.get(
         index=EventSearchApp.es_model.get_write_index(),
         doc_type=EventSearchApp.name,
-        id=event.pk
+        id=event.pk,
     )
     assert result['_source']['name'] == new_name

--- a/datahub/search/event/tests/test_views.py
+++ b/datahub/search/event/tests/test_views.py
@@ -36,15 +36,18 @@ class TestSearch(APITestMixin):
         """Tests detailed event search."""
         event_name = '012345catsinspace'
         EventFactory(
-            name=event_name
+            name=event_name,
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'original_query': event_name,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': event_name,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -56,10 +59,13 @@ class TestSearch(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:event')
-        response = self.api_client.post(url, {
-            'offset': 1,
-            'limit': 1,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'offset': 1,
+                'limit': 1,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] > 1
@@ -79,15 +85,18 @@ class TestSearch(APITestMixin):
         """Tests event_name filter."""
         event_name = '0000000000'
         EventFactory(
-            name=event_name
+            name=event_name,
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'name': event_name[:5],
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'name': event_name[:5],
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -98,15 +107,18 @@ class TestSearch(APITestMixin):
         """Tests organiser filter."""
         organiser = AdviserFactory()
         EventFactory(
-            organiser=organiser
+            organiser=organiser,
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'organiser': organiser.id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'organiser': organiser.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -120,15 +132,18 @@ class TestSearch(APITestMixin):
             organiser=AdviserFactory(
                 first_name=organiser_name.split(' ', maxsplit=1)[0],
                 last_name=organiser_name.split(' ', maxsplit=1)[1],
-            )
+            ),
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'organiser_name': '00000',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'organiser_name': '00000',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -145,9 +160,12 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'address_country': country_id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'address_country': country_id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -163,9 +181,12 @@ class TestSearch(APITestMixin):
         EventFactory.create_batch(5, lead_team_id=team.id)
         setup_es.indices.refresh()
 
-        response = self.api_client.post(url, {
-            'lead_team': team.id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'lead_team': team.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 5
@@ -183,14 +204,17 @@ class TestSearch(APITestMixin):
         team_b = TeamFactory()
         team_c = TeamFactory()
         EventFactory(teams=(team_c,))
-        EventFactory.create_batch(5, teams=(team_a, team_b,))
+        EventFactory.create_batch(5, teams=(team_a, team_b))
         EventFactory.create_batch(5, teams=(team_b,))
 
         setup_es.indices.refresh()
 
-        response = self.api_client.post(url, {
-            'teams': (team_a.id, team_c.id,)
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'teams': (team_a.id, team_c.id),
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 6
@@ -213,21 +237,25 @@ class TestSearch(APITestMixin):
 
         setup_es.indices.refresh()
 
-        response = self.api_client.post(url, {
-            'disabled_on': {
-                'exists': False,
-                'after': current_datetime,
+        response = self.api_client.post(
+            url,
+            data={
+                'disabled_on': {
+                    'exists': False,
+                    'after': current_datetime,
+                },
             },
-        })
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 7
         assert len(response.data['results']) == 7
 
         disabled_ons = [result['disabled_on'] for result in response.data['results']]
-        assert all(disabled_on is None or disabled_on == current_datetime.isoformat()
-                   for disabled_on in disabled_ons
-                   )
+        assert all(
+            disabled_on is None or disabled_on == current_datetime.isoformat()
+            for disabled_on in disabled_ons
+        )
 
     def test_search_event_disabled_on_doesnt_exist(self, setup_es):
         """Tests disabled_on is null filter."""
@@ -239,9 +267,12 @@ class TestSearch(APITestMixin):
 
         setup_es.indices.refresh()
 
-        response = self.api_client.post(url, {
-            'disabled_on_exists': False,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'disabled_on_exists': False,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 5
@@ -260,9 +291,12 @@ class TestSearch(APITestMixin):
 
         setup_es.indices.refresh()
 
-        response = self.api_client.post(url, {
-            'disabled_on_exists': True,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'disabled_on_exists': True,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         # We should get at least 5 disabled events, as some already exist
@@ -284,9 +318,12 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'uk_region': uk_region_id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'uk_region': uk_region_id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -304,11 +341,14 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'original_query': '',
-            'start_date_after': start_date,
-            'start_date_before': start_date,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': '',
+                'start_date_after': start_date,
+                'start_date_before': start_date,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -325,11 +365,14 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'start_date_after': start_date_a,
-            'start_date_before': start_date_b,
-            'sortby': 'start_date:desc',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'start_date_after': start_date_a,
+                'start_date_before': start_date_b,
+                'sortby': 'start_date:desc',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -348,12 +391,15 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'original_query': '',
-            'start_date_after': start_date,
-            'start_date_before': start_date,
-            'sortby': 'end_date:desc',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': '',
+                'start_date_after': start_date,
+                'start_date_before': start_date,
+                'sortby': 'end_date:desc',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -372,11 +418,14 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:event')
 
-        response = self.api_client.post(url, {
-            'start_date_after': start_date,
-            'start_date_before': start_date,
-            'sortby': 'modified_on:desc',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'start_date_after': start_date,
+                'start_date_before': start_date,
+                'sortby': 'modified_on:desc',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -395,10 +444,13 @@ class TestBasicSearch(APITestMixin):
         term = ''
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'event'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'event',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] > 0
@@ -410,10 +462,13 @@ class TestBasicSearch(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': 'abcdefg',
-            'entity': 'event'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': 'abcdefg',
+                'entity': 'event',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -427,9 +482,12 @@ class TestBasicSearch(APITestMixin):
         term = 'there-should-be-no-match'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'event'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'event',
+            },
+        )
 
         assert response.data['count'] == 0

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -5,7 +5,7 @@ from elasticsearch_dsl import Keyword, Nested, Object, Text
 SortableCaseInsensitiveKeywordText = partial(
     Text,
     analyzer='lowercase_keyword_analyzer',
-    fielddata=True
+    fielddata=True,
 )
 TrigramText = partial(Text, analyzer='trigram_analyzer')
 SortableTrigramText = partial(Text, analyzer='trigram_analyzer', fielddata=True)
@@ -27,9 +27,13 @@ class TextWithKeyword(Text):
 
     def __init__(self, *args, **kwargs):
         """Initialises the field, creating a keyword sub-field."""
-        super().__init__(*args, **kwargs, fields={
-            'keyword': Keyword(ignore_above=self.ES_DEFAULT_IGNORE_ABOVE)
-        })
+        super().__init__(
+            *args,
+            **kwargs,
+            fields={
+                'keyword': Keyword(ignore_above=self.ES_DEFAULT_IGNORE_ABOVE),
+            },
+        )
 
 
 def nested_contact_or_adviser_field(field, include_dit_team=False):
@@ -84,7 +88,7 @@ def nested_company_field(field):
             'name': SortableCaseInsensitiveKeywordText(copy_to=f'{field}.name_trigram'),
             'name_trigram': TrigramText(),
             'trading_name': SortableCaseInsensitiveKeywordText(
-                copy_to=f'{field}.trading_name_trigram'
+                copy_to=f'{field}.trading_name_trigram',
             ),
             'trading_name_trigram': TrigramText(),
         },
@@ -96,7 +100,7 @@ def nested_ch_company_field():
     """Nested field for lists of objects with id and company_number sub-fields."""
     return Nested(properties={
         'id': Keyword(),
-        'company_number': SortableCaseInsensitiveKeywordText()
+        'company_number': SortableCaseInsensitiveKeywordText(),
     })
 
 
@@ -115,7 +119,7 @@ def nested_sector_field():
 def object_field(*fields):
     """This is a mapping that reflects how Elasticsearch auto-creates mappings for objects."""
     return Object(
-        properties={field: TextWithKeyword() for field in fields}
+        properties={field: TextWithKeyword() for field in fields},
     )
 
 

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -2,8 +2,10 @@ from datahub.interaction.models import Interaction as DBInteraction, Interaction
 from datahub.interaction.permissions import get_allowed_kinds
 from datahub.search.apps import SearchApp
 from datahub.search.interaction.models import Interaction
-from datahub.search.interaction.views import (SearchInteractionAPIView,
-                                              SearchInteractionExportAPIView)
+from datahub.search.interaction.views import (
+    SearchInteractionAPIView,
+    SearchInteractionExportAPIView,
+)
 
 
 class InteractionSearchApp(SearchApp):

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -30,7 +30,7 @@ class Interaction(BaseESModel):
     service = fields.nested_id_name_field()
     service_delivery_status = fields.nested_id_name_field()
     subject = fields.SortableCaseInsensitiveKeywordText(
-        copy_to=['subject_english']
+        copy_to=['subject_english'],
     )
     subject_english = fields.EnglishText()
 
@@ -50,7 +50,7 @@ class Interaction(BaseESModel):
     COMPUTED_MAPPINGS = {
         'company_sector': dict_utils.computed_nested_sector_dict('company.sector'),
         'investment_project_sector': dict_utils.computed_nested_sector_dict(
-            'investment_project.sector'
+            'investment_project.sector',
         ),
         'is_event': attrgetter('is_event'),
     }

--- a/datahub/search/interaction/signals.py
+++ b/datahub/search/interaction/signals.py
@@ -13,14 +13,14 @@ from .models import Interaction as ESInteraction
 def sync_interaction_to_es(sender, instance, **kwargs):
     """Sync interaction to the Elasticsearch."""
     transaction.on_commit(
-        lambda: sync_object_async(ESInteraction, DBInteraction, str(instance.pk))
+        lambda: sync_object_async(ESInteraction, DBInteraction, str(instance.pk)),
     )
 
 
 def remove_interaction_from_es(sender, instance, **kwargs):
     """Remove interaction from es."""
     transaction.on_commit(
-        lambda pk=instance.pk: delete_document(ESInteraction, str(pk))
+        lambda pk=instance.pk: delete_document(ESInteraction, str(pk)),
     )
 
 

--- a/datahub/search/interaction/tests/test_signals.py
+++ b/datahub/search/interaction/tests/test_signals.py
@@ -2,7 +2,7 @@ import pytest
 from elasticsearch.exceptions import NotFoundError
 
 from datahub.interaction.test.factories import (
-    CompanyInteractionFactory, InvestmentProjectInteractionFactory
+    CompanyInteractionFactory, InvestmentProjectInteractionFactory,
 )
 from datahub.search.interaction.apps import InteractionSearchApp
 
@@ -17,7 +17,7 @@ def test_new_interaction_synced(setup_es):
     assert setup_es.get(
         index=InteractionSearchApp.es_model.get_write_index(),
         doc_type=InteractionSearchApp.name,
-        id=interaction.pk
+        id=interaction.pk,
     )
 
 
@@ -32,7 +32,7 @@ def test_updated_interaction_synced(setup_es):
     result = setup_es.get(
         index=InteractionSearchApp.es_model.get_write_index(),
         doc_type=InteractionSearchApp.name,
-        id=interaction.pk
+        id=interaction.pk,
     )
     assert result['_source']['subject'] == new_subject
 
@@ -48,7 +48,7 @@ def test_deleted_interaction_deleted_from_es(setup_es):
     assert setup_es.get(
         index=InteractionSearchApp.es_model.get_write_index(),
         doc_type=InteractionSearchApp.name,
-        id=interaction.pk
+        id=interaction.pk,
     )
 
     interaction_id = interaction.pk
@@ -59,7 +59,7 @@ def test_deleted_interaction_deleted_from_es(setup_es):
         assert setup_es.get(
             index=InteractionSearchApp.es_model.get_write_index(),
             doc_type=InteractionSearchApp.name,
-            id=interaction_id
+            id=interaction_id,
         ) is None
 
 
@@ -74,7 +74,7 @@ def test_updating_company_name_updates_interaction(setup_es):
     result = setup_es.get(
         index=InteractionSearchApp.es_model.get_write_index(),
         doc_type=InteractionSearchApp.name,
-        id=interaction.pk
+        id=interaction.pk,
     )
     assert result['_source']['company']['name'] == new_company_name
 
@@ -92,7 +92,7 @@ def test_updating_contact_name_updates_interaction(setup_es):
     result = setup_es.get(
         index=InteractionSearchApp.es_model.get_write_index(),
         doc_type=InteractionSearchApp.name,
-        id=interaction.pk
+        id=interaction.pk,
     )
     assert result['_source']['contact'] == {
         'id': str(interaction.contact.id),
@@ -116,6 +116,6 @@ def test_updating_project_name_updates_interaction(setup_es):
     result = setup_es.get(
         index=InteractionSearchApp.es_model.get_write_index(),
         doc_type=InteractionSearchApp.name,
-        id=interaction.pk
+        id=interaction.pk,
     )
     assert result['_source']['investment_project']['name'] == new_project_name

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -63,23 +63,23 @@ def interactions(setup_es):
         data.extend([
             CompanyInteractionFactory(
                 subject='Exports meeting',
-                date=dateutil_parse('2017-10-30T00:00:00Z')
+                date=dateutil_parse('2017-10-30T00:00:00Z'),
             ),
             CompanyInteractionFactory(
                 subject='a coffee',
-                date=dateutil_parse('2017-04-05T00:00:00Z')
+                date=dateutil_parse('2017-04-05T00:00:00Z'),
             ),
             CompanyInteractionFactory(
                 subject='Email about exhibition',
-                date=dateutil_parse('2016-09-02T00:00:00Z')
+                date=dateutil_parse('2016-09-02T00:00:00Z'),
             ),
             CompanyInteractionFactory(
                 subject='talking about cats',
-                date=dateutil_parse('2018-02-01T00:00:00Z')
+                date=dateutil_parse('2018-02-01T00:00:00Z'),
             ),
             CompanyInteractionFactory(
                 subject='Event at HQ',
-                date=dateutil_parse('2018-01-01T00:00:00Z')
+                date=dateutil_parse('2018-01-01T00:00:00Z'),
             ),
         ])
 
@@ -166,7 +166,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
 
         request_data = {
-            'limit': 1
+            'limit': 1,
         }
         response = self.api_client.post(url, request_data)
 
@@ -179,7 +179,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
 
         request_data = {
-            'offset': 1
+            'offset': 1,
         }
         response = self.api_client.post(url, request_data)
 
@@ -200,7 +200,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         )
         CompanyInteractionFactory.create_batch(
             len(dates),
-            date=factory.Iterator(dates)
+            date=factory.Iterator(dates),
         )
         setup_es.indices.refresh()
 
@@ -219,7 +219,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
 
         request_data = {
-            'sortby': 'subject:asc'
+            'sortby': 'subject:asc',
         }
         response = self.api_client.post(url, request_data)
 
@@ -235,7 +235,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
 
         request_data = {
-            'sortby': 'subject:desc'
+            'sortby': 'subject:desc',
         }
         response = self.api_client.post(url, request_data)
 
@@ -251,7 +251,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
 
         request_data = {
-            'sortby': 'gyratory:backwards'
+            'sortby': 'gyratory:backwards',
         }
         response = self.api_client.post(url, request_data)
 
@@ -262,7 +262,7 @@ class TestInteractionEntitySearchView(APITestMixin):
                 "'sortby' field is not one of ('company.name', 'contact.name', 'date'"
                 ", 'dit_adviser.name', 'dit_team.name', 'id', 'subject').",
                 "Invalid sort direction 'backwards', must be one of ('asc', 'desc')",
-            ]
+            ],
         }
 
     @pytest.mark.parametrize('term', ('exports', 'meeting', 'exports meeting'))
@@ -271,7 +271,7 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
 
         request_data = {
-            'original_query': term
+            'original_query': term,
         }
         response = self.api_client.post(url, request_data)
 
@@ -334,7 +334,7 @@ class TestInteractionEntitySearchView(APITestMixin):
 
     def test_filter_by_kind(self, setup_es):
         """Tests filtering interaction by kind."""
-        CompanyInteractionFactory.create_batch(10),
+        CompanyInteractionFactory.create_batch(10)
         service_deliveries = ServiceDeliveryFactory.create_batch(10)
 
         setup_es.indices.refresh()
@@ -360,13 +360,13 @@ class TestInteractionEntitySearchView(APITestMixin):
         companies = CompanyFactory.create_batch(10)
         CompanyInteractionFactory.create_batch(
             len(companies),
-            company=factory.Iterator(companies)
+            company=factory.Iterator(companies),
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'company': companies[5].id
+            'company': companies[5].id,
         }
         response = self.api_client.post(url, request_data)
 
@@ -385,14 +385,14 @@ class TestInteractionEntitySearchView(APITestMixin):
         companies = CompanyFactory.create_batch(10)
         CompanyInteractionFactory.create_batch(
             len(companies),
-            company=factory.Iterator(companies)
+            company=factory.Iterator(companies),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'company_name': getattr(companies[5], attr)
+            'company_name': getattr(companies[5], attr),
         }
         response = self.api_client.post(url, request_data)
 
@@ -411,14 +411,14 @@ class TestInteractionEntitySearchView(APITestMixin):
         contacts = ContactFactory.create_batch(10)
         CompanyInteractionFactory.create_batch(
             len(contacts),
-            contact=factory.Iterator(contacts)
+            contact=factory.Iterator(contacts),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'contact': contacts[5].id
+            'contact': contacts[5].id,
         }
         response = self.api_client.post(url, request_data)
 
@@ -436,13 +436,13 @@ class TestInteractionEntitySearchView(APITestMixin):
         contacts = ContactFactory.create_batch(10)
         CompanyInteractionFactory.create_batch(
             len(contacts),
-            contact=factory.Iterator(contacts)
+            contact=factory.Iterator(contacts),
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'contact_name': contacts[5].name
+            'contact_name': contacts[5].name,
         }
         response = self.api_client.post(url, request_data)
 
@@ -459,7 +459,7 @@ class TestInteractionEntitySearchView(APITestMixin):
 
     @pytest.mark.parametrize(
         'created_on_exists',
-        (True, False)
+        (True, False),
     )
     def test_filter_by_created_on_exists(self, setup_es, created_on_exists):
         """Tests filtering interaction by created_on exists."""
@@ -482,22 +482,24 @@ class TestInteractionEntitySearchView(APITestMixin):
         response_data = response.json()
         results = response_data['results']
         assert response_data['count'] == 3
-        assert all((not result['created_on'] is None) == created_on_exists
-                   for result in results)
+        assert all(
+            (not result['created_on'] is None) == created_on_exists
+            for result in results
+        )
 
     def test_filter_by_dit_adviser_id(self, setup_es):
         """Tests filtering interaction by dit adviser id."""
         advisers = AdviserFactory.create_batch(10)
         CompanyInteractionFactory.create_batch(
             len(advisers),
-            dit_adviser=factory.Iterator(advisers)
+            dit_adviser=factory.Iterator(advisers),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'dit_adviser': advisers[5].id
+            'dit_adviser': advisers[5].id,
         }
         response = self.api_client.post(url, request_data)
 
@@ -517,14 +519,14 @@ class TestInteractionEntitySearchView(APITestMixin):
         advisers = AdviserFactory.create_batch(10)
         CompanyInteractionFactory.create_batch(
             len(advisers),
-            dit_adviser=factory.Iterator(advisers)
+            dit_adviser=factory.Iterator(advisers),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'dit_adviser_name': advisers[5].name
+            'dit_adviser_name': advisers[5].name,
         }
         response = self.api_client.post(url, request_data)
 
@@ -549,7 +551,7 @@ class TestInteractionEntitySearchView(APITestMixin):
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'dit_team': dit_team_id
+            'dit_team': dit_team_id,
         }
         response = self.api_client.post(url, request_data)
 
@@ -567,18 +569,18 @@ class TestInteractionEntitySearchView(APITestMixin):
         communication_channels = list(CommunicationChannel.objects.order_by('?')[:2])
         CompanyInteractionFactory.create_batch(
             5,
-            communication_channel=communication_channels[0]
+            communication_channel=communication_channels[0],
         )
         CompanyInteractionFactory.create_batch(
             5,
-            communication_channel=communication_channels[1]
+            communication_channel=communication_channels[1],
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         request_data = {
             'original_query': '',
-            'communication_channel': communication_channels[1].pk
+            'communication_channel': communication_channels[1].pk,
         }
         response = self.api_client.post(url, request_data)
 
@@ -596,18 +598,18 @@ class TestInteractionEntitySearchView(APITestMixin):
         """Tests filtering interaction by service."""
         CompanyInteractionFactory.create_batch(
             5,
-            service_id=constants.Service.trade_enquiry.value.id
+            service_id=constants.Service.trade_enquiry.value.id,
         )
         service_id = constants.Service.account_management.value.id
         CompanyInteractionFactory.create_batch(
             5,
-            service_id=service_id
+            service_id=service_id,
         )
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         request_data = {
-            'service': service_id
+            'service': service_id,
         }
         response = self.api_client.post(url, request_data)
 
@@ -626,31 +628,31 @@ class TestInteractionEntitySearchView(APITestMixin):
         (
             (
                 {
-                    'date_after': '2017-12-01'
+                    'date_after': '2017-12-01',
                 },
                 {
                     'talking about cats',
                     'Event at HQ',
-                }
+                },
             ),
             (
                 {
                     'date_after': '2017-12-01',
-                    'date_before': '2018-01-02'
+                    'date_before': '2018-01-02',
                 },
                 {
                     'Event at HQ',
-                }
+                },
             ),
             (
                 {
-                    'date_before': '2017-01-01'
+                    'date_before': '2017-01-01',
                 },
                 {
                     'Email about exhibition',
-                }
+                },
             ),
-        )
+        ),
     )
     def test_filter_by_date(self, interactions, data, results):
         """Tests filtering interaction by date."""
@@ -679,29 +681,29 @@ class TestInteractionEntitySearchView(APITestMixin):
 
         companies = CompanyFactory.create_batch(
             num_sectors,
-            sector_id=factory.Iterator(sectors_ids)
+            sector_id=factory.Iterator(sectors_ids),
         )
         company_interactions = CompanyInteractionFactory.create_batch(
             3,
-            company=factory.Iterator(companies)
+            company=factory.Iterator(companies),
         )
 
         other_companies = CompanyFactory.create_batch(
             3,
             sector=factory.LazyFunction(lambda: random_obj_for_queryset(
-                Sector.objects.exclude(pk__in=sectors_ids)
-            ))
+                Sector.objects.exclude(pk__in=sectors_ids),
+            )),
         )
         CompanyInteractionFactory.create_batch(
             3,
-            company=factory.Iterator(other_companies)
+            company=factory.Iterator(other_companies),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         body = {
-            'sector_descends': hierarchical_sectors[sector_level].pk
+            'sector_descends': hierarchical_sectors[sector_level].pk,
         }
         response = self.api_client.post(url, body)
         assert response.status_code == status.HTTP_200_OK
@@ -729,29 +731,29 @@ class TestInteractionEntitySearchView(APITestMixin):
 
         projects = ActiveInvestmentProjectFactory.create_batch(
             num_sectors,
-            sector_id=factory.Iterator(sectors_ids)
+            sector_id=factory.Iterator(sectors_ids),
         )
         investment_project_interactions = InvestmentProjectInteractionFactory.create_batch(
             3,
-            investment_project=factory.Iterator(projects)
+            investment_project=factory.Iterator(projects),
         )
 
         other_projects = ActiveInvestmentProjectFactory.create_batch(
             3,
             sector=factory.LazyFunction(lambda: random_obj_for_queryset(
-                Sector.objects.exclude(pk__in=sectors_ids)
-            ))
+                Sector.objects.exclude(pk__in=sectors_ids),
+            )),
         )
         InvestmentProjectInteractionFactory.create_batch(
             3,
-            investment_project=factory.Iterator(other_projects)
+            investment_project=factory.Iterator(other_projects),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:interaction')
         body = {
-            'sector_descends': hierarchical_sectors[sector_level].pk
+            'sector_descends': hierarchical_sectors[sector_level].pk,
         }
         response = self.api_client.post(url, body)
         assert response.status_code == status.HTTP_200_OK
@@ -770,11 +772,12 @@ class TestInteractionExportView(APITestMixin):
     """Tests the interaction export view."""
 
     @pytest.mark.parametrize(
-        'permissions', (
+        'permissions',
+        (
             (),
             (InteractionPermission.view_all,),
             (InteractionPermission.export,),
-        )
+        ),
     )
     def test_user_without_permission_cannot_export(self, setup_es, permissions):
         """Test that a user without the correct permissions cannot export data."""
@@ -788,7 +791,7 @@ class TestInteractionExportView(APITestMixin):
     def test_policy_feedback_excluded_for_non_policy_feedback_user(
         self,
         setup_es,
-        non_policy_feedback_user
+        non_policy_feedback_user,
     ):
         """
         Test that a user without policy feedback interaction permissions cannot export
@@ -812,7 +815,7 @@ class TestInteractionExportView(APITestMixin):
             (None, '-date'),
             ('date', 'date'),
             ('company.name', 'company__name'),
-        )
+        ),
     )
     def test_interaction_export(
         self,
@@ -843,7 +846,7 @@ class TestInteractionExportView(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})
         assert parse_header(response.get('Content-Disposition')) == (
-            'attachment', {'filename': 'Data Hub - Interactions - 2018-01-01-11-12-13.csv'}
+            'attachment', {'filename': 'Data Hub - Interactions - 2018-01-01-11-12-13.csv'},
         )
 
         sorted_interactions = Interaction.objects.order_by(orm_ordering, 'pk')
@@ -902,10 +905,13 @@ class TestInteractionGlobalSearchView(APITestMixin):
         url = reverse('api-v3:search:basic')
 
         api_client = self.create_api_client(user=non_policy_feedback_user)
-        response = api_client.get(url, {
-            'term': '',
-            'entity': 'interaction',
-        })
+        response = api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': 'interaction',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -914,7 +920,7 @@ class TestInteractionGlobalSearchView(APITestMixin):
         assert Counter([item['id'] for item in response_data['results']]) == expected_ids
         assert response_data['aggregations'] == [{
             'count': 5,
-            'entity': 'interaction'
+            'entity': 'interaction',
         }]
 
     def test_policy_feedback_user_can_access_policy_feedback(
@@ -927,10 +933,13 @@ class TestInteractionGlobalSearchView(APITestMixin):
         url = reverse('api-v3:search:basic')
 
         api_client = self.create_api_client(user=policy_feedback_user)
-        response = api_client.get(url, {
-            'term': '',
-            'entity': 'interaction',
-        })
+        response = api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': 'interaction',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -940,5 +949,5 @@ class TestInteractionGlobalSearchView(APITestMixin):
         assert Counter([item['id'] for item in response_data['results']]) == expected_ids
         assert response_data['aggregations'] == [{
             'count': 8,
-            'entity': 'interaction'
+            'entity': 'interaction',
         }]

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -49,7 +49,7 @@ class SearchInteractionParams:
     COMPOSITE_FILTERS = {
         'contact_name': [
             'contact.name',
-            'contact.name_trigram'
+            'contact.name_trigram',
         ],
         'company_name': [
             'company.name',
@@ -59,7 +59,7 @@ class SearchInteractionParams:
         ],
         'dit_adviser_name': [
             'dit_adviser.name',
-            'dit_adviser.name_trigram'
+            'dit_adviser.name_trigram',
         ],
         'sector_descends': [
             'company_sector.id',

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -3,7 +3,7 @@ from datahub.investment.models import (
     InvestmentProjectPermission,
 )
 from datahub.investment.permissions import (
-    get_association_filters, InvestmentProjectAssociationChecker
+    get_association_filters, InvestmentProjectAssociationChecker,
 )
 from .models import InvestmentProject
 from .views import SearchInvestmentExportAPIView, SearchInvestmentProjectAPIView
@@ -24,7 +24,7 @@ class InvestmentSearchApp(SearchApp):
     export_view = SearchInvestmentExportAPIView
     view_permissions = (
         f'investment.{InvestmentProjectPermission.view_all}',
-        f'investment.{InvestmentProjectPermission.view_associated}'
+        f'investment.{InvestmentProjectPermission.view_associated}',
     )
     export_permission = f'investment.{InvestmentProjectPermission.export}'
     queryset = DBInvestmentProject.objects.select_related(

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -67,14 +67,14 @@ class InvestmentProject(BaseESModel):
     client_cannot_provide_total_investment = Boolean()
     client_contacts = fields.nested_contact_or_adviser_field('client_contacts')
     client_relationship_manager = fields.nested_contact_or_adviser_field(
-        'client_relationship_manager', include_dit_team=True
+        'client_relationship_manager', include_dit_team=True,
     )
     client_requirements = fields.TextWithKeyword()
     comments = fields.EnglishText()
     country_lost_to = _country_lost_to_mapping()
     created_on = Date()
     created_by = fields.nested_contact_or_adviser_field(
-        'created_by', include_dit_team=True
+        'created_by', include_dit_team=True,
     )
     date_abandoned = Date()
     date_lost = Date()
@@ -94,10 +94,10 @@ class InvestmentProject(BaseESModel):
     level_of_involvement = fields.nested_id_name_field()
     likelihood_of_landing = Long()
     project_assurance_adviser = fields.nested_contact_or_adviser_field(
-        'project_assurance_adviser', include_dit_team=True
+        'project_assurance_adviser', include_dit_team=True,
     )
     project_manager = fields.nested_contact_or_adviser_field(
-        'project_manager', include_dit_team=True
+        'project_manager', include_dit_team=True,
     )
     name = fields.SortableText(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = fields.SortableCaseInsensitiveKeywordText()
@@ -179,7 +179,7 @@ class InvestmentProject(BaseESModel):
 
     COMPUTED_MAPPINGS = {
         'investor_company_country': dict_utils.computed_nested_id_name_dict(
-            'investor_company.registered_address_country'
+            'investor_company.registered_address_country',
         ),
     }
 

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -71,5 +71,5 @@ class SearchInvestmentProjectSerializer(SearchSerializer):
         'site_decided',
         'stage.name',
         'total_investment',
-        'uk_company.name'
+        'uk_company.name',
     )

--- a/datahub/search/investment/signals.py
+++ b/datahub/search/investment/signals.py
@@ -5,7 +5,7 @@ from django.db.models.signals import post_delete, post_save
 from datahub.company.models import Advisor
 from datahub.investment.models import (
     InvestmentProject as DBInvestmentProject,
-    InvestmentProjectTeamMember
+    InvestmentProjectTeamMember,
 )
 from .models import InvestmentProject as ESInvestmentProject
 from ..signals import SignalReceiver
@@ -42,7 +42,7 @@ def investment_project_sync_es_adviser_change(sender, instance, **kwargs):
             | Q(client_relationship_manager_id=instance.pk)
             | Q(project_manager_id=instance.pk)
             | Q(project_assurance_adviser_id=instance.pk)
-            | Q(team_members__adviser_id=instance.pk)
+            | Q(team_members__adviser_id=instance.pk),
         )
 
         for project in queryset:

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -9,7 +9,7 @@ from ..models import InvestmentProject as ESInvestmentProject
 def test_get_basic_search_query():
     """Tests basic search query."""
     query = get_basic_search_query(
-        'test', entities=(ESInvestmentProject,), offset=5, limit=5
+        'test', entities=(ESInvestmentProject,), offset=5, limit=5,
     )
 
     assert query.to_dict() == {
@@ -20,14 +20,16 @@ def test_get_basic_search_query():
                         'match_phrase': {
                             'name_keyword': {
                                 'query': 'test',
-                                'boost': 2
-                            }
-                        }
-                    }, {
+                                'boost': 2,
+                            },
+                        },
+                    },
+                    {
                         'match_phrase': {
-                            'id': 'test'
-                        }
-                    }, {
+                            'id': 'test',
+                        },
+                    },
+                    {
                         'multi_match': {
                             'query': 'test',
                             'fields': [
@@ -69,38 +71,38 @@ def test_get_basic_search_query():
                                 'trading_name_trigram',
                                 'uk_company.name',
                                 'uk_company.name_trigram',
-                                'uk_region.name_trigram'
+                                'uk_region.name_trigram',
                             ],
                             'type': 'cross_fields',
-                            'operator': 'and'
-                        }
-                    }
-                ]
-            }
+                            'operator': 'and',
+                        },
+                    },
+                ],
+            },
         },
         'post_filter': {
             'bool': {
                 'should': [
                     {
                         'term': {
-                            '_type': 'investment_project'
-                        }
-                    }
-                ]
-            }
+                            '_type': 'investment_project',
+                        },
+                    },
+                ],
+            },
         },
         'aggs': {
             'count_by_type': {
                 'terms': {
-                    'field': '_type'
-                }
-            }
+                    'field': '_type',
+                },
+            },
         },
         'from': 5,
         'size': 5,
         'sort': [
             '_score',
-            'id'
+            'id',
         ],
     }
 
@@ -122,7 +124,7 @@ def test_limited_get_search_by_entity_query():
     query = limit_search_query(
         query,
         offset=5,
-        limit=5
+        limit=5,
     )
 
     assert query.to_dict() == {
@@ -131,23 +133,26 @@ def test_limited_get_search_by_entity_query():
                 'must': [
                     {
                         'term': {
-                            '_type': 'investment_project'
-                        }
-                    }, {
+                            '_type': 'investment_project',
+                        },
+                    },
+                    {
                         'bool': {
                             'should': [
                                 {
                                     'match_phrase': {
                                         'name_keyword': {
                                             'query': 'test',
-                                            'boost': 2
-                                        }
-                                    }
-                                }, {
+                                            'boost': 2,
+                                        },
+                                    },
+                                },
+                                {
                                     'match_phrase': {
-                                        'id': 'test'
-                                    }
-                                }, {
+                                        'id': 'test',
+                                    },
+                                },
+                                {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
@@ -160,14 +165,14 @@ def test_limited_get_search_by_entity_query():
                                             'project_code_trigram',
                                         ),
                                         'type': 'cross_fields',
-                                        'operator': 'and'
-                                    }
-                                }
-                            ]
-                        }
-                    }
-                ]
-            }
+                                        'operator': 'and',
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                ],
+            },
         },
         'post_filter': {
             'bool': {
@@ -179,40 +184,42 @@ def test_limited_get_search_by_entity_query():
                                     'match': {
                                         'address_town': {
                                             'query': 'Woodside',
-                                            'operator': 'and'
-                                        }
-                                    }
-                                }
+                                            'operator': 'and',
+                                        },
+                                    },
+                                },
                             ],
-                            'minimum_should_match': 1
-                        }
-                    }, {
+                            'minimum_should_match': 1,
+                        },
+                    },
+                    {
                         'bool': {
                             'should': [
                                 {
                                     'match_phrase': {
                                         'trading_address_country.id':
-                                            '80756b9a-5d95-e211-a939-e4115bead28a'
-                                    }
-                                }
+                                            '80756b9a-5d95-e211-a939-e4115bead28a',
+                                    },
+                                },
                             ],
-                            'minimum_should_match': 1
-                        }
-                    }, {
+                            'minimum_should_match': 1,
+                        },
+                    },
+                    {
                         'range': {
                             'estimated_land_date': {
                                 'gte': '2017-06-13T09:44:31.062870',
-                                'lte': '2017-06-13T09:44:31.062870'
-                            }
-                        }
-                    }
-                ]
-            }
+                                'lte': '2017-06-13T09:44:31.062870',
+                            },
+                        },
+                    },
+                ],
+            },
         },
         'from': 5,
         'size': 5,
         'sort': [
             '_score',
-            'id'
-        ]
+            'id',
+        ],
     }

--- a/datahub/search/investment/test/test_signals.py
+++ b/datahub/search/investment/test/test_signals.py
@@ -2,7 +2,7 @@ import pytest
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.investment.test.factories import (
-    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory
+    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
 )
 from datahub.metadata.test.factories import TeamFactory
 from datahub.search.query_builder import (
@@ -17,14 +17,14 @@ def test_investment_project_auto_sync_to_es(setup_es):
     """Tests if investment project gets synced to Elasticsearch."""
     test_name = 'very_hard_to_find_project'
     InvestmentProjectFactory(
-        name=test_name
+        name=test_name,
     )
     setup_es.indices.refresh()
 
     result = get_search_by_entity_query(
         term='',
         filter_data={'name': test_name},
-        entity=InvestmentProject
+        entity=InvestmentProject,
     ).execute()
 
     assert result.hits.total == 1
@@ -41,7 +41,7 @@ def test_investment_project_auto_updates_to_es(setup_es):
     result = get_search_by_entity_query(
         term='',
         filter_data={'name': new_test_name},
-        entity=InvestmentProject
+        entity=InvestmentProject,
     ).execute()
 
     assert result.hits.total == 1
@@ -107,12 +107,15 @@ def test_investment_project_team_member_deleted_sync_to_es(setup_es, team_member
     assert len(result['team_members']) == 0
 
 
-@pytest.mark.parametrize('field', (
-    'created_by',
-    'client_relationship_manager',
-    'project_manager',
-    'project_assurance_adviser',
-))
+@pytest.mark.parametrize(
+    'field',
+    (
+        'created_by',
+        'client_relationship_manager',
+        'project_manager',
+        'project_assurance_adviser',
+    ),
+)
 def test_investment_project_syncs_when_adviser_changes(setup_es, field):
     """
     Tests that when an adviser is updated, investment projects related to that adviser are
@@ -129,7 +132,7 @@ def test_investment_project_syncs_when_adviser_changes(setup_es, field):
     result = get_search_by_entity_query(
         term='',
         filter_data={'id': project.pk},
-        entity=InvestmentProject
+        entity=InvestmentProject,
     ).execute()
 
     assert result.hits.total == 1
@@ -152,7 +155,7 @@ def test_investment_project_syncs_when_team_member_adviser_changes(setup_es, tea
     result = get_search_by_entity_query(
         term='',
         filter_data={'id': team_member.investment_project.pk},
-        entity=InvestmentProject
+        entity=InvestmentProject,
     ).execute()
 
     assert result.hits.total == 1

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -49,7 +49,7 @@ def setup_data(setup_es):
             estimated_land_date=datetime.date(2011, 6, 13),
             actual_land_date=datetime.date(2010, 8, 13),
             investor_company=CompanyFactory(
-                registered_address_country_id=constants.Country.united_states.value.id
+                registered_address_country_id=constants.Country.united_states.value.id,
             ),
             status=InvestmentProject.STATUSES.ongoing,
             uk_region_locations=[
@@ -63,7 +63,7 @@ def setup_data(setup_es):
             estimated_land_date=datetime.date(2057, 6, 13),
             actual_land_date=datetime.date(2047, 8, 13),
             investor_company=CompanyFactory(
-                registered_address_country_id=constants.Country.japan.value.id
+                registered_address_country_id=constants.Country.japan.value.id,
             ),
             project_manager=AdviserFactory(),
             project_assurance_adviser=AdviserFactory(),
@@ -79,7 +79,7 @@ def setup_data(setup_es):
             estimated_land_date=datetime.date(2027, 9, 13),
             actual_land_date=datetime.date(2022, 11, 13),
             investor_company=CompanyFactory(
-                registered_address_country_id=constants.Country.united_kingdom.value.id
+                registered_address_country_id=constants.Country.united_kingdom.value.id,
             ),
             project_manager=AdviserFactory(),
             project_assurance_adviser=AdviserFactory(),
@@ -88,7 +88,7 @@ def setup_data(setup_es):
             uk_region_locations=[
                 constants.UKRegion.north_west.value.id,
             ],
-        )
+        ),
     ]
     setup_es.indices.refresh()
 
@@ -106,7 +106,7 @@ def created_on_data(setup_es):
     for date in dates:
         with freeze_time(date):
             investment_projects.append(
-                InvestmentProjectFactory()
+                InvestmentProjectFactory(),
             )
 
     setup_es.indices.refresh()
@@ -121,9 +121,12 @@ class TestSearch(APITestMixin):
         """Tests detailed investment project search."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, {
-            'original_query': 'abc defg',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': 'abc defg',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -162,16 +165,21 @@ class TestSearch(APITestMixin):
 
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, {
-            'adviser': adviser.pk,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'adviser': adviser.pk,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['count'] == 6
         results = response_data['results']
-        expected_ids = {str(project_1.pk), str(project_2.pk), str(project_3.pk),
-                        str(project_4.pk), str(project_5.pk), str(project_6.pk)}
+        expected_ids = {
+            str(project_1.pk), str(project_2.pk), str(project_3.pk),
+            str(project_4.pk), str(project_5.pk), str(project_6.pk),
+        }
         assert {result['id'] for result in results} == expected_ids
 
     @pytest.mark.parametrize(
@@ -179,13 +187,13 @@ class TestSearch(APITestMixin):
         (
             (
                 {
-                    'estimated_land_date_before': '2017-06-13'
+                    'estimated_land_date_before': '2017-06-13',
                 },
                 1,
             ),
             (
                 {
-                    'estimated_land_date_after': '2017-06-13'
+                    'estimated_land_date_after': '2017-06-13',
                 },
                 2,
             ),
@@ -203,13 +211,13 @@ class TestSearch(APITestMixin):
                 },
                 0,
             ),
-        )
+        ),
     )
     def test_search_investment_project_estimated_land_date_json(
         self,
         setup_data,
         query,
-        num_results
+        num_results,
     ):
         """Tests detailed investment project search."""
         url = reverse('api-v3:search:investment_project')
@@ -235,7 +243,7 @@ class TestSearch(APITestMixin):
         (
             (
                 {
-                    'actual_land_date_before': '2010-12-13'
+                    'actual_land_date_before': '2010-12-13',
                 },
                 [
                     'abc defg',
@@ -243,7 +251,7 @@ class TestSearch(APITestMixin):
             ),
             (
                 {
-                    'actual_land_date_before': '2022-11-13'
+                    'actual_land_date_before': '2022-11-13',
                 },
                 [
                     'abc defg',
@@ -252,7 +260,7 @@ class TestSearch(APITestMixin):
             ),
             (
                 {
-                    'actual_land_date_after': '2010-12-13'
+                    'actual_land_date_after': '2010-12-13',
                 },
                 [
                     'delayed project',
@@ -261,7 +269,7 @@ class TestSearch(APITestMixin):
             ),
             (
                 {
-                    'actual_land_date_after': '2022-11-13'
+                    'actual_land_date_after': '2022-11-13',
                 },
                 [
                     'delayed project',
@@ -284,7 +292,7 @@ class TestSearch(APITestMixin):
                 },
                 [],
             ),
-        )
+        ),
     )
     def test_search_investment_project_actual_land_date_json(
         self,
@@ -303,28 +311,29 @@ class TestSearch(APITestMixin):
         assert Counter(result['name'] for result in results) == Counter(expected_results)
 
     @pytest.mark.parametrize(
-        'query,num_results', (
+        'query,num_results',
+        (
             (
                 {
-                    'created_on_before': '2016-09-13T09:44:31.062870Z'
+                    'created_on_before': '2016-09-13T09:44:31.062870Z',
                 },
                 2,
             ),
             (
                 {
-                    'created_on_before': '2016-09-12T00:00:00.000000Z'
+                    'created_on_before': '2016-09-12T00:00:00.000000Z',
                 },
                 2,
             ),
             (
                 {
-                    'created_on_after': '2017-06-13T09:44:31.062870Z'
+                    'created_on_after': '2017-06-13T09:44:31.062870Z',
                 },
                 3,
             ),
             (
                 {
-                    'created_on_after': '2016-09-12T00:00:00.000000Z'
+                    'created_on_after': '2016-09-12T00:00:00.000000Z',
                 },
                 4,
             ),
@@ -342,7 +351,7 @@ class TestSearch(APITestMixin):
                 },
                 0,
             ),
-        )
+        ),
     )
     def test_search_investment_project_created_on_json(self, created_on_data, query, num_results):
         """Tests detailed investment project search."""
@@ -368,9 +377,12 @@ class TestSearch(APITestMixin):
         """Tests detailed investment project search."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, {
-            'estimated_land_date_before': 'this is definitely not a valid date',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'estimated_land_date_before': 'this is definitely not a valid date',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -378,9 +390,12 @@ class TestSearch(APITestMixin):
         """Tests investment project search status filter."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, {
-            'status': ['delayed', 'won'],
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'status': ['delayed', 'won'],
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -392,9 +407,12 @@ class TestSearch(APITestMixin):
         """Tests investor company country filter."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, {
-            'investor_company_country': constants.Country.japan.value.id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'investor_company_country': constants.Country.japan.value.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -405,9 +423,12 @@ class TestSearch(APITestMixin):
         """Tests uk_region_location filter."""
         url = reverse('api-v3:search:investment_project')
 
-        response = self.api_client.post(url, {
-            'uk_region_location': constants.UKRegion.east_midlands.value.id,
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'uk_region_location': constants.UKRegion.east_midlands.value.id,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -425,20 +446,20 @@ class TestSearch(APITestMixin):
 
         projects = InvestmentProjectFactory.create_batch(
             num_sectors,
-            sector_id=factory.Iterator(sectors_ids)
+            sector_id=factory.Iterator(sectors_ids),
         )
         InvestmentProjectFactory.create_batch(
             3,
             sector=factory.LazyFunction(lambda: random_obj_for_queryset(
-                Sector.objects.exclude(pk__in=sectors_ids)
-            ))
+                Sector.objects.exclude(pk__in=sectors_ids),
+            )),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:investment_project')
         body = {
-            'sector_descends': hierarchical_sectors[sector_level].pk
+            'sector_descends': hierarchical_sectors[sector_level].pk,
         }
         response = self.api_client.post(url, body)
         assert response.status_code == status.HTTP_200_OK
@@ -472,7 +493,7 @@ class TestSearch(APITestMixin):
         url = reverse('api-v3:search:investment_project')
         investment_project1 = InvestmentProjectFactory(
             investment_type_id=constants.InvestmentType.fdi.value.id,
-            stage_id=constants.InvestmentProjectStage.active.value.id
+            stage_id=constants.InvestmentProjectStage.active.value.id,
         )
         investment_project2 = InvestmentProjectFactory(
             investment_type_id=constants.InvestmentType.fdi.value.id,
@@ -480,7 +501,7 @@ class TestSearch(APITestMixin):
         )
 
         InvestmentProjectFactory(
-            stage_id=constants.InvestmentProjectStage.won.value.id
+            stage_id=constants.InvestmentProjectStage.won.value.id,
         )
         InvestmentProjectFactory(
             investment_type_id=constants.InvestmentType.fdi.value.id,
@@ -489,17 +510,20 @@ class TestSearch(APITestMixin):
 
         setup_es.indices.refresh()
 
-        response = self.api_client.post(url, {
-            'investment_type': constants.InvestmentType.fdi.value.id,
-            'investor_company': [
-                investment_project1.investor_company.pk,
-                investment_project2.investor_company.pk,
-            ],
-            'stage': [
-                constants.InvestmentProjectStage.won.value.id,
-                constants.InvestmentProjectStage.active.value.id,
-            ],
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'investment_type': constants.InvestmentType.fdi.value.id,
+                'investor_company': [
+                    investment_project1.investor_company.pk,
+                    investment_project2.investor_company.pk,
+                ],
+                'stage': [
+                    constants.InvestmentProjectStage.won.value.id,
+                    constants.InvestmentProjectStage.active.value.id,
+                ],
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -508,7 +532,7 @@ class TestSearch(APITestMixin):
         # checks if we only have investment projects with stages we filtered
         assert {
             constants.InvestmentProjectStage.active.value.id,
-            constants.InvestmentProjectStage.won.value.id
+            constants.InvestmentProjectStage.won.value.id,
         } == {
             investment_project['stage']['id']
             for investment_project in response.data['results']
@@ -517,7 +541,7 @@ class TestSearch(APITestMixin):
         # checks if we only have investment projects with investor companies we filtered
         assert {
             str(investment_project1.investor_company.pk),
-            str(investment_project2.investor_company.pk)
+            str(investment_project2.investor_company.pk),
         } == {
             investment_project['investor_company']['id']
             for investment_project in response.data['results']
@@ -525,7 +549,7 @@ class TestSearch(APITestMixin):
 
         # checks if we only have investment projects with fdi investment type
         assert {
-            constants.InvestmentType.fdi.value.id
+            constants.InvestmentType.fdi.value.id,
         } == {
             investment_project['investment_type']['id']
             for investment_project in response.data['results']
@@ -537,7 +561,7 @@ class TestSearch(APITestMixin):
 
         InvestmentProjectFactory(
             name='Pear 1',
-            stage_id=constants.InvestmentProjectStage.active.value.id
+            stage_id=constants.InvestmentProjectStage.active.value.id,
         )
         InvestmentProjectFactory(
             name='Pear 2',
@@ -545,31 +569,36 @@ class TestSearch(APITestMixin):
         )
         InvestmentProjectFactory(
             name='Pear 3',
-            stage_id=constants.InvestmentProjectStage.prospect.value.id
+            stage_id=constants.InvestmentProjectStage.prospect.value.id,
         )
         InvestmentProjectFactory(
             name='Pear 4',
-            stage_id=constants.InvestmentProjectStage.won.value.id
+            stage_id=constants.InvestmentProjectStage.won.value.id,
         )
 
         setup_es.indices.refresh()
 
-        response = self.api_client.post(url, {
-            'original_query': 'Pear',
-            'stage': [
-                constants.InvestmentProjectStage.prospect.value.id,
-                constants.InvestmentProjectStage.active.value.id,
-            ],
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': 'Pear',
+                'stage': [
+                    constants.InvestmentProjectStage.prospect.value.id,
+                    constants.InvestmentProjectStage.active.value.id,
+                ],
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 3
         assert len(response.data['results']) == 3
         assert 'aggregations' in response.data
 
-        stages = [{'key': constants.InvestmentProjectStage.prospect.value.id, 'doc_count': 2},
-                  {'key': constants.InvestmentProjectStage.active.value.id, 'doc_count': 1},
-                  {'key': constants.InvestmentProjectStage.won.value.id, 'doc_count': 1}]
+        stages = [
+            {'key': constants.InvestmentProjectStage.prospect.value.id, 'doc_count': 2},
+            {'key': constants.InvestmentProjectStage.active.value.id, 'doc_count': 1},
+            {'key': constants.InvestmentProjectStage.won.value.id, 'doc_count': 1},
+        ]
         assert all(stage in response.data['aggregations']['stage'] for stage in stages)
 
 
@@ -584,10 +613,13 @@ class TestSearchPermissions(APITestMixin):
         response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @pytest.mark.parametrize('permissions', (
-        (InvestmentProjectPermission.view_all,),
-        (InvestmentProjectPermission.view_associated, InvestmentProjectPermission.view_all),
-    ))
+    @pytest.mark.parametrize(
+        'permissions',
+        (
+            (InvestmentProjectPermission.view_all,),
+            (InvestmentProjectPermission.view_associated, InvestmentProjectPermission.view_all),
+        ),
+    )
     def test_non_restricted_user_can_see_all_projects(self, setup_es, permissions):
         """Test that normal users can see all projects."""
         team = TeamFactory()
@@ -597,7 +629,7 @@ class TestSearchPermissions(APITestMixin):
 
         request_user = create_test_user(
             permission_codenames=permissions,
-            dit_team=team
+            dit_team=team,
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -628,7 +660,7 @@ class TestSearchPermissions(APITestMixin):
 
         adviser_other = AdviserFactory(dit_team_id=None)
         request_user = create_test_user(
-            permission_codenames=['view_associated_investmentproject']
+            permission_codenames=['view_associated_investmentproject'],
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -653,7 +685,7 @@ class TestSearchPermissions(APITestMixin):
         adviser_same_team = AdviserFactory(dit_team_id=team.id)
         request_user = create_test_user(
             permission_codenames=['view_associated_investmentproject'],
-            dit_team=team
+            dit_team=team,
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -676,8 +708,10 @@ class TestSearchPermissions(APITestMixin):
         assert response_data['count'] == 5
 
         results = response_data['results']
-        expected_ids = {str(project_1.id), str(project_2.id), str(project_3.id),
-                        str(project_4.id), str(project_5.id)}
+        expected_ids = {
+            str(project_1.id), str(project_2.id), str(project_3.id),
+            str(project_4.id), str(project_5.id),
+        }
 
         assert {result['id'] for result in results} == expected_ids
 
@@ -691,11 +725,12 @@ class TestInvestmentProjectExportView(APITestMixin):
     """Tests the investment project export view."""
 
     @pytest.mark.parametrize(
-        'permissions', (
+        'permissions',
+        (
             (),
             (InvestmentProjectPermission.view_all,),
             (InvestmentProjectPermission.export,),
-        )
+        ),
     )
     def test_user_without_permission_cannot_export(self, setup_es, permissions):
         """Test that a user without the correct permissions cannot export data."""
@@ -758,7 +793,7 @@ class TestInvestmentProjectExportView(APITestMixin):
         (
             ('created_on:desc', '-created_on'),
             ('investor_company.name', 'investor_company__name'),
-        )
+        ),
     )
     def test_export(self, setup_es, request_sortby, orm_ordering):
         """Test export of investment project search results."""
@@ -781,7 +816,7 @@ class TestInvestmentProjectExportView(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Disposition')) == (
-            'attachment', {'filename': 'Data Hub - Investment projects - 2018-01-01-11-12-13.csv'}
+            'attachment', {'filename': 'Data Hub - Investment projects - 2018-01-01-11-12-13.csv'},
         )
 
         sorted_projects = InvestmentProject.objects.order_by(orm_ordering, 'pk')
@@ -865,10 +900,13 @@ class TestBasicSearch(APITestMixin):
         term = 'abc defg'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'investment_project'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'investment_project',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -880,10 +918,13 @@ class TestBasicSearch(APITestMixin):
         investment_project = setup_data[0]
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': investment_project.project_code,
-            'entity': 'investment_project'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': investment_project.project_code,
+                'entity': 'investment_project',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -893,10 +934,13 @@ class TestBasicSearch(APITestMixin):
 class TestBasicSearchPermissions(APITestMixin):
     """Tests basic search view permissions."""
 
-    @pytest.mark.parametrize('permissions', (
-        (InvestmentProjectPermission.view_all,),
-        (InvestmentProjectPermission.view_associated, InvestmentProjectPermission.view_all),
-    ))
+    @pytest.mark.parametrize(
+        'permissions',
+        (
+            (InvestmentProjectPermission.view_all,),
+            (InvestmentProjectPermission.view_associated, InvestmentProjectPermission.view_all),
+        ),
+    )
     def test_global_non_restricted_user_can_see_all_projects(self, setup_es, permissions):
         """Test that normal users can see all projects."""
         team = TeamFactory()
@@ -906,7 +950,7 @@ class TestBasicSearchPermissions(APITestMixin):
 
         request_user = create_test_user(
             permission_codenames=permissions,
-            dit_team=team
+            dit_team=team,
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -919,10 +963,13 @@ class TestBasicSearchPermissions(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = api_client.get(url, data={
-            'term': '',
-            'entity': 'investment_project'
-        })
+        response = api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': 'investment_project',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -941,7 +988,7 @@ class TestBasicSearchPermissions(APITestMixin):
         adviser_same_team = AdviserFactory(dit_team_id=team.id)
         request_user = create_test_user(
             permission_codenames=['view_associated_investmentproject'],
-            dit_team=team
+            dit_team=team,
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -958,18 +1005,23 @@ class TestBasicSearchPermissions(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = api_client.get(url, data={
-            'term': '',
-            'entity': 'investment_project'
-        })
+        response = api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': 'investment_project',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['count'] == 5
 
         results = response_data['results']
-        expected_ids = {str(project_1.id), str(project_2.id), str(project_3.id),
-                        str(project_4.id), str(project_5.id)}
+        expected_ids = {
+            str(project_1.id), str(project_2.id), str(project_3.id),
+            str(project_4.id), str(project_5.id),
+        }
 
         assert {result['id'] for result in results} == expected_ids
 
@@ -980,7 +1032,7 @@ class TestBasicSearchPermissions(APITestMixin):
         """
         adviser_other = AdviserFactory(dit_team_id=None)
         request_user = create_test_user(
-            permission_codenames=['view_associated_investmentproject']
+            permission_codenames=['view_associated_investmentproject'],
         )
         api_client = self.create_api_client(user=request_user)
 
@@ -990,10 +1042,13 @@ class TestBasicSearchPermissions(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = api_client.get(url, data={
-            'term': '',
-            'entity': 'investment_project'
-        })
+        response = api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': 'investment_project',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -64,7 +64,7 @@ class SearchInvestmentProjectParams:
         ],
         'sector_descends': [
             'sector.id',
-            'sector.ancestors.id'
+            'sector.ancestors.id',
         ],
     }
 
@@ -104,7 +104,7 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectParams, SearchExportA
             'actual_uk_regions__name',
         ),
         investor_company_global_account_manager=get_full_name_expression(
-            'investor_company__one_list_account_owner'
+            'investor_company__one_list_account_owner',
         ),
         client_relationship_manager_name=get_full_name_expression('client_relationship_manager'),
         project_manager_name=get_full_name_expression('project_manager'),

--- a/datahub/search/management/commands/migrate_es.py
+++ b/datahub/search/management/commands/migrate_es.py
@@ -41,7 +41,7 @@ See docs/Elasticsearch migrations.md for further details."""
 
         if not are_apps_initialised(apps):
             raise CommandError(
-                f'Index and mapping not initialised, please run `init_es` first.'
+                f'Index and mapping not initialised, please run `init_es` first.',
             )
 
         with advisory_lock('leeloo_migrate_es'):

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -43,10 +43,10 @@ class Command(BaseCommand):
 
         if not are_apps_initialised(apps):
             raise CommandError(
-                f'Index and mapping not initialised, please run `init_es` first.'
+                f'Index and mapping not initialised, please run `init_es` first.',
             )
 
         sync_es(
             batch_size=options['batch_size'],
-            search_apps=apps
+            search_apps=apps,
         )

--- a/datahub/search/migrate.py
+++ b/datahub/search/migrate.py
@@ -43,8 +43,10 @@ def _perform_migration(search_app):
     current_read_indices, current_write_index = es_model.get_read_and_write_indices()
 
     if current_write_index not in current_read_indices:
-        raise DataHubException('Cannot migrate Elasticsearch index with a read alias referencing '
-                               'a different index to the write alias')
+        raise DataHubException(
+            'Cannot migrate Elasticsearch index with a read alias referencing '
+            'a different index to the write alias',
+        )
 
     logger.info(f'Updating aliases for the {app_name} search app')
 
@@ -61,5 +63,5 @@ def _perform_migration(search_app):
 def _schedule_resync(search_app):
     logger.info(f'Scheduling resync and clean-up for the {search_app.name} search app')
     complete_model_migration.apply_async(
-        args=(search_app.name, search_app.es_model.get_target_mapping_hash())
+        args=(search_app.name, search_app.es_model.get_target_mapping_hash()),
     )

--- a/datahub/search/migrate_utils.py
+++ b/datahub/search/migrate_utils.py
@@ -21,7 +21,7 @@ def resync_after_migrate(search_app):
     if not search_app.es_model.was_migration_started():
         logger.warning(
             f'No pending migration detected for the {search_app.name} search app, aborting '
-            f'resync...'
+            f'resync...',
         )
         return
 

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -57,7 +57,7 @@ class BaseESModel(DocType):
     def get_read_and_write_indices(cls):
         """Gets the indices currently referenced by the read and write aliases."""
         read_indices, write_indices = get_indices_for_aliases(
-            cls.get_read_alias(), cls.get_write_alias()
+            cls.get_read_alias(), cls.get_write_alias(),
         )
         return read_indices, _get_write_index(write_indices)
 
@@ -78,8 +78,10 @@ class BaseESModel(DocType):
         current_write_index = cls.get_write_index()
         prefix = cls.get_index_prefix()
         if not current_write_index.startswith(prefix):
-            logger.warning(f'Unexpected index prefix for search model {cls._doc_type.name} and '
-                           f'index {current_write_index}. It may be a legacy index.')
+            logger.warning(
+                f'Unexpected index prefix for search model {cls._doc_type.name} and '
+                f'index {current_write_index}. It may be a legacy index.',
+            )
             return ''
         return current_write_index[len(prefix):]
 
@@ -123,8 +125,10 @@ class BaseESModel(DocType):
 
         # Should not normally happen
         if not alias_exists(cls.get_read_alias()):
-            logger.warning(f'Missing read alias {cls.get_read_alias()} detected, recreating '
-                           f'the alias...')
+            logger.warning(
+                f'Missing read alias {cls.get_read_alias()} detected, recreating '
+                f'the alias...',
+            )
             associate_index_with_alias(cls.get_read_alias(), cls.get_write_index())
 
     @classmethod

--- a/datahub/search/omis/signals.py
+++ b/datahub/search/omis/signals.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_delete, post_save
 from datahub.omis.order.models import (
     Order as DBOrder,
     OrderAssignee as DBOrderAssignee,
-    OrderSubscriber as DBOrderSubscriber
+    OrderSubscriber as DBOrderSubscriber,
 )
 from .models import Order as ESOrder
 from ..signals import SignalReceiver
@@ -14,7 +14,7 @@ from ..sync_async import sync_object_async
 def order_sync_es(sender, instance, **kwargs):
     """Sync an order to the Elasticsearch."""
     transaction.on_commit(
-        lambda: sync_object_async(ESOrder, DBOrder, str(instance.pk))
+        lambda: sync_object_async(ESOrder, DBOrder, str(instance.pk)),
     )
 
 

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -4,7 +4,7 @@ from elasticsearch_dsl import Mapping
 from datahub.omis.order.test.factories import (
     OrderCancelledFactory, OrderCompleteFactory,
     OrderFactory, OrderPaidFactory,
-    OrderWithAcceptedQuoteFactory
+    OrderWithAcceptedQuoteFactory,
 )
 from .. import OrderSearchApp
 from ..models import Order as ESOrder
@@ -28,104 +28,104 @@ def test_mapping(setup_es):
                             'include_in_parent': True,
                             'properties': {
                                 'id': {
-                                    'type': 'keyword'
+                                    'type': 'keyword',
                                 },
                                 'name': {
                                     'analyzer': 'lowercase_keyword_analyzer',
                                     'fielddata': True,
-                                    'type': 'text'
-                                }
+                                    'type': 'text',
+                                },
                             },
-                            'type': 'nested'
+                            'type': 'nested',
                         },
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'last_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name': {
                             'copy_to': ['assignees.name_trigram'],
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'billing_address_1': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'billing_address_2': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'billing_address_country': {
                     'include_in_parent': True,
                     'properties': {
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'billing_address_county': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'billing_address_postcode': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'billing_address_town': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'billing_contact_name': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'billing_company_name': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'billing_email': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'billing_phone': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'cancellation_reason': {
                     'include_in_parent': True,
                     'properties': {
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'cancelled_by': {
                     'include_in_parent': True,
@@ -133,60 +133,60 @@ def test_mapping(setup_es):
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'last_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name': {
                             'copy_to': ['cancelled_by.name_trigram'],
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'cancelled_on': {
-                    'type': 'date'
+                    'type': 'date',
                 },
                 'company': {
                     'include_in_parent': True,
                     'properties': {
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'name': {
                             'copy_to': ['company.name_trigram'],
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'trading_name': {
                             'copy_to': ['company.trading_name_trigram'],
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'trading_name_trigram': {
                             'analyzer': 'trigram_analyzer',
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'completed_by': {
                     'include_in_parent': True,
@@ -194,31 +194,31 @@ def test_mapping(setup_es):
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'last_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name': {
                             'copy_to': ['completed_by.name_trigram'],
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'completed_on': {
-                    'type': 'date'
+                    'type': 'date',
                 },
                 'contact': {
                     'include_in_parent': True,
@@ -226,39 +226,39 @@ def test_mapping(setup_es):
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'last_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name': {
                             'copy_to': ['contact.name_trigram'],
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'contact_email': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'contact_phone': {
-                    'type': 'keyword'
+                    'type': 'keyword',
                 },
                 'contacts_not_to_approach': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'created_by': {
                     'include_in_parent': True,
@@ -266,163 +266,163 @@ def test_mapping(setup_es):
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'last_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name': {
                             'copy_to': ['created_by.name_trigram'],
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'dit_team': {
                             'include_in_parent': True,
                             'properties': {
                                 'id': {
-                                    'type': 'keyword'
+                                    'type': 'keyword',
                                 },
                                 'name': {
                                     'analyzer': 'lowercase_keyword_analyzer',
                                     'fielddata': True,
-                                    'type': 'text'
-                                }
+                                    'type': 'text',
+                                },
                             },
-                            'type': 'nested'
-                        }
+                            'type': 'nested',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'created_on': {
-                    'type': 'date'
+                    'type': 'date',
                 },
                 'delivery_date': {
-                    'type': 'date'
+                    'type': 'date',
                 },
                 'description': {
                     'analyzer': 'english_analyzer',
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'discount_value': {
                     'index': False,
-                    'type': 'integer'
+                    'type': 'integer',
                 },
                 'existing_agents': {
                     'index': False,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'further_info': {
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'id': {
-                    'type': 'keyword'
+                    'type': 'keyword',
                 },
                 'modified_on': {
-                    'type': 'date'
+                    'type': 'date',
                 },
                 'net_cost': {
                     'index': False,
-                    'type': 'integer'
+                    'type': 'integer',
                 },
                 'paid_on': {
-                    'type': 'date'
+                    'type': 'date',
                 },
                 'payment_due_date': {
-                    'type': 'date'
+                    'type': 'date',
                 },
                 'po_number': {
                     'index': False,
-                    'type': 'keyword'
+                    'type': 'keyword',
                 },
                 'primary_market': {
                     'include_in_parent': True,
                     'properties': {
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'reference': {
                     'copy_to': ['reference_trigram'],
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'reference_trigram': {
                     'analyzer': 'trigram_analyzer',
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'sector': {
                     'include_in_parent': True,
                     'properties': {
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'ancestors': {
                             'include_in_parent': True,
                             'properties': {
                                 'id': {
-                                    'type': 'keyword'
-                                }
+                                    'type': 'keyword',
+                                },
                             },
-                            'type': 'nested'
-                        }
+                            'type': 'nested',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'uk_region': {
                     'include_in_parent': True,
                     'properties': {
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'service_types': {
                     'include_in_parent': True,
                     'properties': {
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'status': {
                     'analyzer': 'lowercase_keyword_analyzer',
                     'fielddata': True,
-                    'type': 'text'
+                    'type': 'text',
                 },
                 'subscribers': {
                     'include_in_parent': True,
@@ -431,74 +431,74 @@ def test_mapping(setup_es):
                             'include_in_parent': True,
                             'properties': {
                                 'id': {
-                                    'type': 'keyword'
+                                    'type': 'keyword',
                                 },
                                 'name': {
                                     'analyzer': 'lowercase_keyword_analyzer',
                                     'fielddata': True,
-                                    'type': 'text'
-                                }
+                                    'type': 'text',
+                                },
                             },
-                            'type': 'nested'
+                            'type': 'nested',
                         },
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'id': {
-                            'type': 'keyword'
+                            'type': 'keyword',
                         },
                         'last_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name': {
                             'copy_to': ['subscribers.name_trigram'],
                             'analyzer': 'lowercase_keyword_analyzer',
                             'fielddata': True,
-                            'type': 'text'
+                            'type': 'text',
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
-                            'type': 'text'
-                        }
+                            'type': 'text',
+                        },
                     },
-                    'type': 'nested'
+                    'type': 'nested',
                 },
                 'subtotal_cost': {
                     'copy_to': ['subtotal_cost_string'],
-                    'type': 'integer'
+                    'type': 'integer',
                 },
                 'subtotal_cost_string': {
-                    'type': 'keyword'
+                    'type': 'keyword',
                 },
                 'total_cost': {
                     'copy_to': ['total_cost_string'],
-                    'type': 'integer'
+                    'type': 'integer',
                 },
                 'total_cost_string': {
-                    'type': 'keyword'
+                    'type': 'keyword',
                 },
                 'vat_cost': {
                     'index': False,
-                    'type': 'integer'
+                    'type': 'integer',
                 },
                 'vat_number': {
                     'index': False,
-                    'type': 'keyword'
+                    'type': 'keyword',
                 },
                 'vat_status': {
                     'index': False,
-                    'type': 'keyword'
+                    'type': 'keyword',
                 },
                 'vat_verified': {
                     'index': False,
-                    'type': 'boolean'
-                }
-            }
-        }
+                    'type': 'boolean',
+                },
+            },
+        },
     }
 
 
@@ -510,7 +510,7 @@ def test_mapping(setup_es):
         OrderCancelledFactory,
         OrderCompleteFactory,
         OrderPaidFactory,
-    )
+    ),
 )
 def test_indexed_doc(Factory, setup_es):
     """Test the ES data of an indexed order."""
@@ -525,7 +525,7 @@ def test_indexed_doc(Factory, setup_es):
     indexed_order = setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
 
     assert indexed_order == {
@@ -543,8 +543,8 @@ def test_indexed_doc(Factory, setup_es):
                 'name': order.created_by.name,
                 'dit_team': {
                     'id': str(order.created_by.dit_team.id),
-                    'name': order.created_by.dit_team.name
-                }
+                    'name': order.created_by.dit_team.name,
+                },
             },
             'company': {
                 'id': str(order.company.pk),
@@ -555,27 +555,27 @@ def test_indexed_doc(Factory, setup_es):
                 'id': str(order.contact.pk),
                 'first_name': order.contact.first_name,
                 'last_name': order.contact.last_name,
-                'name': order.contact.name
+                'name': order.contact.name,
             },
             'primary_market': {
                 'id': str(order.primary_market.pk),
-                'name': order.primary_market.name
+                'name': order.primary_market.name,
             },
             'sector': {
                 'id': str(order.sector.pk),
                 'name': order.sector.name,
                 'ancestors': [{
                     'id': str(ancestor.pk),
-                } for ancestor in order.sector.get_ancestors()]
+                } for ancestor in order.sector.get_ancestors()],
             },
             'uk_region': {
                 'id': str(order.uk_region.pk),
-                'name': order.uk_region.name
+                'name': order.uk_region.name,
             },
             'service_types': [
                 {
                     'id': str(service_type.pk),
-                    'name': service_type.name
+                    'name': service_type.name,
                 }
                 for service_type in order.service_types.all()
             ],
@@ -608,7 +608,7 @@ def test_indexed_doc(Factory, setup_es):
                     'dit_team': {
                         'id': str(assignee.adviser.dit_team.id),
                         'name': assignee.adviser.dit_team.name,
-                    }
+                    },
                 }
                 for assignee in order.assignees.all()
             ],
@@ -633,26 +633,26 @@ def test_indexed_doc(Factory, setup_es):
             'billing_address_postcode': order.billing_address_postcode,
             'billing_address_country': {
                 'id': str(order.billing_address_country.pk),
-                'name': order.billing_address_country.name
+                'name': order.billing_address_country.name,
             },
             'paid_on': order.paid_on.isoformat() if order.paid_on else None,
             'completed_by': {
                 'id': str(order.completed_by.pk),
                 'first_name': order.completed_by.first_name,
                 'last_name': order.completed_by.last_name,
-                'name': order.completed_by.name
+                'name': order.completed_by.name,
             } if order.completed_by else None,
             'completed_on': order.completed_on.isoformat() if order.completed_on else None,
             'cancelled_by': {
                 'id': str(order.cancelled_by.pk),
                 'first_name': order.cancelled_by.first_name,
                 'last_name': order.cancelled_by.last_name,
-                'name': order.cancelled_by.name
+                'name': order.cancelled_by.name,
             } if order.cancelled_by else None,
             'cancelled_on': order.cancelled_on.isoformat() if order.cancelled_on else None,
             'cancellation_reason': {
                 'id': str(order.cancellation_reason.pk),
-                'name': order.cancellation_reason.name
+                'name': order.cancellation_reason.name,
             } if order.cancellation_reason else None,
-        }
+        },
     }

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -3,7 +3,7 @@ import pytest
 from datahub.omis.order.test.factories import (
     OrderAssigneeFactory, OrderCancelledFactory, OrderCompleteFactory,
     OrderFactory, OrderPaidFactory, OrderSubscriberFactory,
-    OrderWithAcceptedQuoteFactory
+    OrderWithAcceptedQuoteFactory,
 )
 from ..models import Order as ESOrder
 
@@ -17,8 +17,8 @@ pytestmark = pytest.mark.django_db
         OrderCompleteFactory,
         OrderFactory,
         OrderPaidFactory,
-        OrderWithAcceptedQuoteFactory
-    )
+        OrderWithAcceptedQuoteFactory,
+    ),
 )
 def test_order_to_dict(Factory):
     """Test converting an order to dict."""
@@ -41,27 +41,27 @@ def test_order_to_dict(Factory):
             'id': str(order.contact.pk),
             'first_name': order.contact.first_name,
             'last_name': order.contact.last_name,
-            'name': order.contact.name
+            'name': order.contact.name,
         },
         'primary_market': {
             'id': str(order.primary_market.pk),
-            'name': order.primary_market.name
+            'name': order.primary_market.name,
         },
         'sector': {
             'id': str(order.sector.pk),
             'name': order.sector.name,
             'ancestors': [{
                 'id': str(ancestor.pk),
-            } for ancestor in order.sector.get_ancestors()]
+            } for ancestor in order.sector.get_ancestors()],
         },
         'uk_region': {
             'id': str(order.uk_region.pk),
-            'name': order.uk_region.name
+            'name': order.uk_region.name,
         },
         'service_types': [
             {
                 'id': str(service_type.pk),
-                'name': service_type.name
+                'name': service_type.name,
             }
             for service_type in order.service_types.all()
         ],
@@ -73,8 +73,8 @@ def test_order_to_dict(Factory):
             'name': order.created_by.name,
             'dit_team': {
                 'id': str(order.created_by.dit_team.id),
-                'name': order.created_by.dit_team.name
-            }
+                'name': order.created_by.dit_team.name,
+            },
         },
         'modified_on': order.modified_on,
         'reference': order.reference,
@@ -95,7 +95,7 @@ def test_order_to_dict(Factory):
                 'dit_team': {
                     'id': str(subscriber.adviser.dit_team.pk),
                     'name': str(subscriber.adviser.dit_team.name),
-                }
+                },
             }
             for subscriber in order.subscribers.all()
         ],
@@ -108,7 +108,7 @@ def test_order_to_dict(Factory):
                 'dit_team': {
                     'id': str(assignee.adviser.dit_team.pk),
                     'name': str(assignee.adviser.dit_team.name),
-                }
+                },
             }
             for assignee in order.assignees.all()
         ],
@@ -133,26 +133,26 @@ def test_order_to_dict(Factory):
         'billing_address_postcode': order.billing_address_postcode,
         'billing_address_country': {
             'id': str(order.billing_address_country.pk),
-            'name': order.billing_address_country.name
+            'name': order.billing_address_country.name,
         },
         'paid_on': order.paid_on,
         'completed_by': {
             'id': str(order.completed_by.pk),
             'first_name': order.completed_by.first_name,
             'last_name': order.completed_by.last_name,
-            'name': order.completed_by.name
+            'name': order.completed_by.name,
         } if order.completed_by else None,
         'completed_on': order.completed_on,
         'cancelled_by': {
             'id': str(order.cancelled_by.pk),
             'first_name': order.cancelled_by.first_name,
             'last_name': order.cancelled_by.last_name,
-            'name': order.cancelled_by.name
+            'name': order.cancelled_by.name,
         } if order.cancelled_by else None,
         'cancelled_on': order.cancelled_on,
         'cancellation_reason': {
             'id': str(order.cancellation_reason.pk),
-            'name': order.cancellation_reason.name
+            'name': order.cancellation_reason.name,
         } if order.cancellation_reason else None,
     }
 

--- a/datahub/search/omis/test/test_signals.py
+++ b/datahub/search/omis/test/test_signals.py
@@ -2,7 +2,7 @@ import pytest
 
 from datahub.omis.order.test.factories import (
     OrderAssigneeFactory, OrderFactory,
-    OrderSubscriberFactory, OrderWithOpenQuoteFactory
+    OrderSubscriberFactory, OrderWithOpenQuoteFactory,
 )
 from .. import OrderSearchApp
 
@@ -17,7 +17,7 @@ def test_creating_order_syncs_to_es(setup_es):
     assert setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
 
 
@@ -32,7 +32,7 @@ def test_updating_order_updates_es(setup_es):
     result = setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
     assert result['_source']['description'] == new_description
 
@@ -48,7 +48,7 @@ def test_accepting_quote_updates_es(setup_es):
     result = setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
     assert not result['_source']['payment_due_date']
 
@@ -58,7 +58,7 @@ def test_accepting_quote_updates_es(setup_es):
     result = setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
     assert result['_source']['payment_due_date'] == order.invoice.payment_due_date.isoformat()
 
@@ -75,7 +75,7 @@ def test_adding_subscribers_syncs_order_to_es(setup_es):
     result = setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
 
     indexed = {str(subscriber['id']) for subscriber in result['_source']['subscribers']}
@@ -97,7 +97,7 @@ def test_removing_subscribers_syncs_order_to_es(setup_es):
     result = setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
 
     indexed = {str(subscriber['id']) for subscriber in result['_source']['subscribers']}
@@ -118,7 +118,7 @@ def test_adding_assignees_syncs_order_to_es(setup_es):
     result = setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
 
     indexed = {str(assignee['id']) for assignee in result['_source']['assignees']}
@@ -140,7 +140,7 @@ def test_removing_assignees_syncs_order_to_es(setup_es):
     result = setup_es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
-        id=order.pk
+        id=order.pk,
     )
 
     indexed = {str(assignee['id']) for assignee in result['_source']['assignees']}

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -63,16 +63,16 @@ def setup_data(setup_es):
             contact=contact,
             discount_value=0,
             delivery_date=dateutil_parse('2018-01-01').date(),
-            vat_verified=False
+            vat_verified=False,
         )
         OrderSubscriberFactory(
             order=order,
-            adviser=AdviserFactory(dit_team_id=constants.Team.healthcare_uk.value.id)
+            adviser=AdviserFactory(dit_team_id=constants.Team.healthcare_uk.value.id),
         )
         OrderAssigneeFactory(
             order=order,
             adviser=AdviserFactory(dit_team_id=constants.Team.tees_valley_lep.value.id),
-            estimated_time=60
+            estimated_time=60,
         )
 
     with freeze_time('2017-02-01 13:00:00'):
@@ -88,16 +88,16 @@ def setup_data(setup_es):
             contact=contact,
             discount_value=0,
             delivery_date=dateutil_parse('2018-02-01').date(),
-            vat_verified=False
+            vat_verified=False,
         )
         OrderSubscriberFactory(
             order=order,
-            adviser=AdviserFactory(dit_team_id=constants.Team.td_events_healthcare.value.id)
+            adviser=AdviserFactory(dit_team_id=constants.Team.td_events_healthcare.value.id),
         )
         OrderAssigneeFactory(
             order=order,
             adviser=AdviserFactory(dit_team_id=constants.Team.food_from_britain.value.id),
-            estimated_time=120
+            estimated_time=120,
         )
 
         setup_es.indices.refresh()
@@ -119,148 +119,148 @@ class TestSearchOrder(APITestMixin):
         (
             (  # no filter => return all records
                 {},
-                ['efgh', 'abcd']
+                ['efgh', 'abcd'],
             ),
             (  # pagination
                 {'limit': 1, 'offset': 1},
-                ['abcd']
+                ['abcd'],
             ),
             (  # filter by primary market
                 {'primary_market': constants.Country.france.value.id},
-                ['efgh']
+                ['efgh'],
             ),
             (  # filter by uk region
                 {'uk_region': constants.UKRegion.east_midlands.value.id},
-                ['efgh']
+                ['efgh'],
             ),
             (  # filter by a range of date for created_on
                 {
                     'created_on_before': '2017-02-02',
-                    'created_on_after': '2017-02-01'
+                    'created_on_after': '2017-02-01',
                 },
-                ['efgh']
+                ['efgh'],
             ),
             (  # filter by created_on_before only
                 {'created_on_before': '2017-01-15'},
-                ['abcd']
+                ['abcd'],
             ),
             (  # filter by created_on_after only
                 {'created_on_after': '2017-01-15'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # filter by status
                 {'status': 'quote_awaiting_acceptance'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # invalid status => no results
                 {'status': 'invalid'},
-                []
+                [],
             ),
             (  # search by reference
                 {'original_query': 'efgh'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by reference partial
                 {'original_query': 'efg'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by contact name exact
                 {'original_query': 'Jenny Cakeman'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by contact name partial
                 {'original_query': 'Jenny Cakem'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by company name exact
                 {'original_query': 'Venus Ltd'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by company name partial
                 {'original_query': 'Venus'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by subtotal_cost
                 {'original_query': '2000'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by total_cost
                 {'original_query': '2400'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by reference
                 {'reference': 'efgh'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by reference partial
                 {'reference': 'efg'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by subtotal_cost
                 {'subtotal_cost': 2000},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by total_cost
                 {'total_cost': 2400},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by contact name exact
                 {'contact_name': 'Jenny Cakeman'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by contact name partial
                 {'contact_name': 'Jenny Cakem'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by company name exact
                 {'company_name': 'Venus Ltd'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by company name partial
                 {'company_name': 'Venus'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by trading name exact
                 {'company_name': 'Earth outsourcing'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by trading name partial
                 {'company_name': 'Earth'},
-                ['efgh']
+                ['efgh'],
             ),
             (  # sort by created_on ASC
                 {'sortby': 'created_on:asc'},
-                ['abcd', 'efgh']
+                ['abcd', 'efgh'],
             ),
             (  # sort by created_on DESC
                 {'sortby': 'created_on:desc'},
-                ['efgh', 'abcd']
+                ['efgh', 'abcd'],
             ),
             (  # sort by modified_on ASC
                 {'sortby': 'modified_on:asc'},
-                ['abcd', 'efgh']
+                ['abcd', 'efgh'],
             ),
             (  # sort by modified_on DESC
                 {'sortby': 'modified_on:desc'},
-                ['efgh', 'abcd']
+                ['efgh', 'abcd'],
             ),
             (  # sort by delivery_date ASC
                 {'sortby': 'delivery_date:asc'},
-                ['abcd', 'efgh']
+                ['abcd', 'efgh'],
             ),
             (  # sort by delivery_date DESC
                 {'sortby': 'delivery_date:desc'},
-                ['efgh', 'abcd']
+                ['efgh', 'abcd'],
             ),
             (  # sort by payment_due_date ASC
                 {'sortby': 'payment_due_date:asc'},
-                ['abcd', 'efgh']
+                ['abcd', 'efgh'],
             ),
             (  # sort by payment_due_date DESC
                 {'sortby': 'payment_due_date:desc'},
-                ['efgh', 'abcd']
+                ['efgh', 'abcd'],
             ),
-        )
+        ),
     )
     def test_search(self, setup_data, data, results):
         """Test search results."""
@@ -279,8 +279,9 @@ class TestSearchOrder(APITestMixin):
         url = reverse('api-v3:search:order')
 
         response = self.api_client.post(
-            url, {
-                'company': Company.objects.get(name='Venus Ltd').pk
+            url,
+            data={
+                'company': Company.objects.get(name='Venus Ltd').pk,
             },
         )
 
@@ -292,9 +293,12 @@ class TestSearchOrder(APITestMixin):
         """Test that if the dates are not in a valid format, the API return a validation error."""
         url = reverse('api-v3:search:order')
 
-        response = self.api_client.post(url, {
-            'created_on_before': 'invalid',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'created_on_before': 'invalid',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'created_on_before': ['Date is in incorrect format.']}
@@ -306,9 +310,12 @@ class TestSearchOrder(APITestMixin):
         """
         url = reverse('api-v3:search:order')
 
-        response = self.api_client.post(url, {
-            'primary_market': 'invalid',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'primary_market': 'invalid',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == {'primary_market': ['"invalid" is not a valid UUID.']}
@@ -324,20 +331,20 @@ class TestSearchOrder(APITestMixin):
 
         orders = OrderFactory.create_batch(
             num_sectors,
-            sector_id=factory.Iterator(sectors_ids)
+            sector_id=factory.Iterator(sectors_ids),
         )
         OrderFactory.create_batch(
             3,
             sector=factory.LazyFunction(lambda: random_obj_for_queryset(
-                Sector.objects.exclude(pk__in=sectors_ids)
-            ))
+                Sector.objects.exclude(pk__in=sectors_ids),
+            )),
         )
 
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:order')
         body = {
-            'sector_descends': hierarchical_sectors[sector_level].pk
+            'sector_descends': hierarchical_sectors[sector_level].pk,
         }
         response = self.api_client.post(url, body)
         assert response.status_code == status.HTTP_200_OK
@@ -355,9 +362,12 @@ class TestSearchOrder(APITestMixin):
 
         url = reverse('api-v3:search:order')
 
-        response = self.api_client.post(url, {
-            'assigned_to_adviser': assignee.adviser.pk
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'assigned_to_adviser': assignee.adviser.pk,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == 1
@@ -369,9 +379,12 @@ class TestSearchOrder(APITestMixin):
 
         url = reverse('api-v3:search:order')
 
-        response = self.api_client.post(url, {
-            'assigned_to_team': assignee.adviser.dit_team.pk
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'assigned_to_team': assignee.adviser.dit_team.pk,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == 1
@@ -386,7 +399,7 @@ class TestOrderExportView(APITestMixin):
             (),
             (f'order.{OrderPermission.view}',),
             (f'order.{OrderPermission.export}',),
-        )
+        ),
     )
     def test_user_without_permission_cannot_export(self, setup_es, permissions):
         """Test that a user without the correct permissions cannot export data."""
@@ -406,7 +419,7 @@ class TestOrderExportView(APITestMixin):
             ('modified_on:desc', '-modified_on'),
             ('delivery_date', 'delivery_date'),
             ('delivery_date:desc', '-delivery_date'),
-        )
+        ),
     )
     def test_export(
         self,
@@ -460,7 +473,7 @@ class TestOrderExportView(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})
         assert parse_header(response.get('Content-Disposition')) == (
-            'attachment', {'filename': 'Data Hub - Orders - 2018-01-01-11-12-13.csv'}
+            'attachment', {'filename': 'Data Hub - Orders - 2018-01-01-11-12-13.csv'},
         )
 
         sorted_orders = Order.objects.order_by(orm_ordering, 'pk')
@@ -477,7 +490,7 @@ class TestOrderExportView(APITestMixin):
                 'Order reference': order.reference,
                 'Net price': Decimal(order.subtotal_cost) / 100,
                 'Net refund': Decimal(
-                    sum(refund.net_amount for refund in refunds)
+                    sum(refund.net_amount for refund in refunds),
                 ) / 100 if refunds else None,
                 'Status': order.get_status_display(),
                 'Link': order.get_datahub_frontend_url(),
@@ -518,51 +531,54 @@ class TestGlobalSearch(APITestMixin):
         (
             (  # no filter => return all records
                 '',
-                ['abcd', 'efgh']
+                ['abcd', 'efgh'],
             ),
             (  # search by reference
                 'efgh',
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by reference partial
                 'efg',
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by contact name exact
                 'Jenny Cakeman',
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by contact name partial
                 'Jenny Cakem',
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by company name exact
                 'Venus Ltd',
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by company name partial
                 'Venus',
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by subtotal_cost
                 '2000',
-                ['efgh']
+                ['efgh'],
             ),
             (  # search by total_cost
                 '2400',
-                ['efgh']
+                ['efgh'],
             ),
-        )
+        ),
     )
     def test_search(self, setup_data, term, results):
         """Test search results."""
         url = reverse('api-v3:search:basic')
 
-        response = self.api_client.get(url, {
-            'term': term,
-            'sortby': 'created_on:asc',
-            'entity': 'order'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'sortby': 'created_on:asc',
+                'entity': 'order',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.json()['results']) == len(results)

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -52,7 +52,7 @@ class SearchOrderParams:
     COMPOSITE_FILTERS = {
         'contact_name': [
             'contact.name',
-            'contact.name_trigram'
+            'contact.name_trigram',
         ],
         'company_name': [
             'company.name',
@@ -84,7 +84,7 @@ class SearchOrderExportAPIView(SearchOrderParams, SearchExportAPIView):
         net_refund_in_pounds=Subquery(
             Refund.objects.filter(
                 order=OuterRef('pk'),
-                status=RefundStatus.approved
+                status=RefundStatus.approved,
             ).order_by(
             ).values(
                 'order',
@@ -92,11 +92,11 @@ class SearchOrderExportAPIView(SearchOrderParams, SearchExportAPIView):
                 total_refund=Cast(
                     Sum('net_amount'),
                     DecimalField(max_digits=19, decimal_places=2),
-                ) / 100
+                ) / 100,
             ).values(
                 'total_refund',
             ),
-            output_field=DecimalField(max_digits=19, decimal_places=2)
+            output_field=DecimalField(max_digits=19, decimal_places=2),
         ),
         status_name=get_choices_as_case_expression(DBOrder, 'status'),
         link=get_front_end_url_expression('order', 'pk'),

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -52,7 +52,7 @@ class SearchSerializer(LimitOffsetSerializer):
 
     SORT_DIRECTIONS = (
         'asc',
-        'desc'
+        'desc',
     )
 
     DEFAULT_ORDERING = None
@@ -79,8 +79,10 @@ class SearchSerializer(LimitOffsetSerializer):
             errors.append(f"'sortby' field is not one of {self.SORT_BY_FIELDS}.")
 
         if sep and order not in self.SORT_DIRECTIONS:
-            errors.append(f"Invalid sort direction '{order}', must be one of "
-                          f'{self.SORT_DIRECTIONS}')
+            errors.append(
+                f"Invalid sort direction '{order}', must be one of "
+                f'{self.SORT_DIRECTIONS}',
+            )
 
         if errors:
             raise serializers.ValidationError(errors)

--- a/datahub/search/signals.py
+++ b/datahub/search/signals.py
@@ -29,16 +29,18 @@ class SignalReceiver:
 
     @property
     def _dispatch_uid(self):
-        return (f'{id(self.signal):x}'
-                f'__{self._receiver_func.__module__}.{self._receiver_func.__name__}'
-                f'__{self.sender.__name__}')
+        return (
+            f'{id(self.signal):x}'
+            f'__{self._receiver_func.__module__}.{self._receiver_func.__name__}'
+            f'__{self.sender.__name__}'
+        )
 
     def connect(self):
         """Connects the signal receiver."""
         self.signal.connect(
             self._receiver_func,
             sender=self.sender,
-            dispatch_uid=self._dispatch_uid
+            dispatch_uid=self._dispatch_uid,
         )
         self.is_connected = True
 
@@ -47,7 +49,7 @@ class SignalReceiver:
         self.signal.disconnect(
             self._receiver_func,
             sender=self.sender,
-            dispatch_uid=self._dispatch_uid
+            dispatch_uid=self._dispatch_uid,
         )
         self.is_connected = False
 

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -58,7 +58,7 @@ Rescheduling the {search_app_name} search app migration to attempt to resolve th
         if not lock_held:
             logger.warning(
                 f'Another complete_model_migration task is in progress for the {search_app_name} '
-                f'search app. Aborting...'
+                f'search app. Aborting...',
             )
             return
 

--- a/datahub/search/test/commands/test_sync_es.py
+++ b/datahub/search/test/commands/test_sync_es.py
@@ -10,7 +10,7 @@ from ...apps import get_search_apps
 
 @mock.patch(
     'datahub.search.apps.index_exists',
-    mock.Mock(return_value=False)
+    mock.Mock(return_value=False),
 )
 def test_fails_if_index_doesnt_exist():
     """Tests that if the index doesn't exist, sync_es fails."""
@@ -22,7 +22,7 @@ def test_fails_if_index_doesnt_exist():
 @mock.patch('datahub.search.management.commands.sync_es.get_search_apps_by_name')
 @mock.patch(
     'datahub.search.apps.index_exists',
-    mock.Mock(return_value=True)
+    mock.Mock(return_value=True),
 )
 @pytest.mark.django_db
 def test_sync_es(get_search_apps_by_name_mock, sync_es_mock):
@@ -37,12 +37,12 @@ def test_sync_es(get_search_apps_by_name_mock, sync_es_mock):
 
 @pytest.mark.parametrize(
     'search_model',
-    (app.name for app in get_search_apps())
+    (app.name for app in get_search_apps()),
 )
 @mock.patch('datahub.search.management.commands.sync_es.sync_app')
 @mock.patch(
     'datahub.search.apps.index_exists',
-    mock.Mock(return_value=True)
+    mock.Mock(return_value=True),
 )
 def test_sync_one_model(sync_app_mock, search_model):
     """
@@ -56,7 +56,7 @@ def test_sync_one_model(sync_app_mock, search_model):
 @mock.patch('datahub.search.management.commands.sync_es.sync_app')
 @mock.patch(
     'datahub.search.apps.index_exists',
-    mock.Mock(return_value=True)
+    mock.Mock(return_value=True),
 )
 def test_sync_all_models(sync_app_mock):
     """
@@ -70,7 +70,7 @@ def test_sync_all_models(sync_app_mock):
 @mock.patch('datahub.search.management.commands.sync_es.sync_app')
 @mock.patch(
     'datahub.search.apps.index_exists',
-    mock.Mock(return_value=True)
+    mock.Mock(return_value=True),
 )
 def test_sync_invalid_model(sync_app_mock):
     """

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -15,7 +15,7 @@ def test_sync_app_with_default_batch_size(monkeypatch):
     monkeypatch.setattr('datahub.search.bulk_sync.bulk', bulk_mock)
 
     search_app = create_mock_search_app(
-        queryset=MockQuerySet([Mock(id=1), Mock(id=2)])
+        queryset=MockQuerySet([Mock(id=1), Mock(id=2)]),
     )
     sync_app(search_app)
 
@@ -28,7 +28,7 @@ def test_sync_app_with_overridden_batch_size(monkeypatch):
     monkeypatch.setattr('datahub.search.bulk_sync.bulk', bulk_mock)
 
     search_app = create_mock_search_app(
-        queryset=MockQuerySet([Mock(id=1), Mock(id=2)])
+        queryset=MockQuerySet([Mock(id=1), Mock(id=2)]),
     )
     sync_app(search_app, batch_size=1)
 
@@ -44,7 +44,7 @@ def test_sync_app_logic(monkeypatch):
         target_mapping_hash='mapping-hash',
         read_indices=('index1', 'index2'),
         write_index='index1',
-        queryset=MockQuerySet([Mock(id=1), Mock(id=2)])
+        queryset=MockQuerySet([Mock(id=1), Mock(id=2)]),
     )
     sync_app(search_app, batch_size=1000)
     assert bulk_mock.call_args_list[0][1]['actions'] == [

--- a/datahub/search/test/test_deletion.py
+++ b/datahub/search/test/test_deletion.py
@@ -13,7 +13,7 @@ from ..deletion import (
     BULK_DELETION_TIMEOUT_SECS,
     Collector,
     delete_documents,
-    update_es_after_deletions
+    update_es_after_deletions,
 )
 from ..sync_async import sync_object_async
 
@@ -44,7 +44,7 @@ def test_delete_documents(es_bulk, mock_es_client):
         'chunk_size': BULK_CHUNK_SIZE,
         'request_timeout': BULK_DELETION_TIMEOUT_SECS,
         'max_chunk_bytes': settings.ES_BULK_MAX_CHUNK_BYTES,
-        'raise_on_error': False
+        'raise_on_error': False,
     }
 
 
@@ -56,7 +56,7 @@ def test_delete_documents_with_errors(es_bulk, mock_es_client):
         [
             {'delete': {'status': 404}},
             {'delete': {'status': 500}},
-        ]
+        ],
     )
 
     index = 'test-index'
@@ -122,7 +122,7 @@ def test_collector(monkeypatch, setup_es):
         assert receiver.connect.called
 
     assert collector.deletions == {
-        SimpleModel: [es_doc]
+        SimpleModel: [es_doc],
     }
 
     read_alias = search_app.es_model.get_read_alias()

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -53,7 +53,7 @@ def test_company_dict():
         id=123,
         name='Name',
         alias='Trading',
-        spec_set=('id', 'name', 'alias')
+        spec_set=('id', 'name', 'alias'),
     )
 
     res = dict_utils.company_dict(obj)
@@ -102,8 +102,8 @@ def test_contact_or_adviser_dict_include_dit_team():
         'name': obj.name,
         'dit_team': {
             'id': '321',
-            'name': 'team name'
-        }
+            'name': 'team name',
+        },
     }
 
 
@@ -123,7 +123,7 @@ def test_contact_or_adviser_dict_none_dit_team():
         'first_name': obj.first_name,
         'last_name': obj.last_name,
         'name': obj.name,
-        'dit_team': {}
+        'dit_team': {},
     }
 
 

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -17,7 +17,7 @@ def test_bulk(es_bulk, mock_es_client):
         mock_es_client.return_value,
         actions=actions,
         chunk_size=chunk_size,
-        max_chunk_bytes=settings.ES_BULK_MAX_CHUNK_BYTES
+        max_chunk_bytes=settings.ES_BULK_MAX_CHUNK_BYTES,
     )
 
 
@@ -46,15 +46,18 @@ def test_configure_connection(connections, settings):
 
     connections.configure.assert_called_with(default={
         'hosts': [settings.ES_URL],
-        'verify_certs': settings.ES_VERIFY_CERTS
+        'verify_certs': settings.ES_VERIFY_CERTS,
     })
 
 
 def test_creates_index(monkeypatch, mock_es_client):
     """Test creates_index()."""
-    monkeypatch.setattr('django.conf.settings.ES_INDEX_SETTINGS', {
-        'testsetting1': 'testval1'
-    })
+    monkeypatch.setattr(
+        'django.conf.settings.ES_INDEX_SETTINGS',
+        {
+            'testsetting1': 'testval1',
+        },
+    )
     mock_mapping = mock.Mock(
         _collect_analysis=mock.Mock(return_value={}),
         to_dict=mock.Mock(return_value={'mapping': 'test-mapping'}),
@@ -73,13 +76,13 @@ def test_creates_index(monkeypatch, mock_es_client):
                         'lowercase_keyword_analyzer': {
                             'tokenizer': 'keyword',
                             'filter': ['lowercase'],
-                            'type': 'custom'
+                            'type': 'custom',
                         },
                         'trigram_analyzer': {
                             'tokenizer': 'trigram',
                             'char_filter': ['special_chars'],
                             'filter': ['lowercase'],
-                            'type': 'custom'
+                            'type': 'custom',
                         },
                         'english_analyzer': {
                             'tokenizer': 'standard',
@@ -87,51 +90,52 @@ def test_creates_index(monkeypatch, mock_es_client):
                                 'english_possessive_stemmer',
                                 'lowercase',
                                 'english_stop',
-                                'english_stemmer'
+                                'english_stemmer',
                             ],
-                            'type': 'custom'
+                            'type': 'custom',
                         },
                         'lowercase_analyzer': {
                             'tokenizer': 'standard',
                             'filter': ['lowercase'],
-                            'type': 'custom'
-                        }
+                            'type': 'custom',
+                        },
                     },
                     'tokenizer': {
                         'trigram': {
                             'min_gram': 3,
                             'max_gram': 3,
                             'token_chars': ('letter', 'digit'),
-                            'type': 'nGram'
-                        }
+                            'type': 'nGram',
+                        },
                     },
                     'char_filter': {
                         'special_chars': {
                             'mappings': ('-=>',),
-                            'type': 'mapping'}
+                            'type': 'mapping',
+                        },
                     },
                     'filter': {
                         'english_possessive_stemmer': {
                             'language': 'possessive_english',
-                            'type': 'stemmer'
+                            'type': 'stemmer',
                         },
                         'english_stop': {
-                            'stopwords': '_english_', 'type': 'stop'
+                            'stopwords': '_english_', 'type': 'stop',
                         },
                         'english_stemmer': {
-                            'language': 'english', 'type': 'stemmer'
-                        }
-                    }
-                }
+                            'language': 'english', 'type': 'stemmer',
+                        },
+                    },
+                },
             },
             'aliases': {
                 'alias1': {},
-                'alias2': {}
+                'alias2': {},
             },
             'mappings': {
-                'mapping': 'test-mapping'
-            }
-        }
+                'mapping': 'test-mapping',
+            },
+        },
     )
 
 
@@ -161,7 +165,7 @@ def test_delete_index(mock_es_client):
             [{'index2'}],
         ),
         (
-            ('alias1', 'alias2',),
+            ('alias1', 'alias2'),
             {
                 'index1': {'aliases': {'alias1': {}}},
                 'index2': {'aliases': {'alias2': {}}},
@@ -187,8 +191,8 @@ def test_get_aliases_for_index(mock_es_client):
             'aliases': {
                 'alias1': {},
                 'alias2': {},
-            }
-        }
+            },
+        },
     }
     assert elasticsearch.get_aliases_for_index(index) == {'alias1', 'alias2'}
     client.indices.get_alias.assert_called_with(index=index)
@@ -220,9 +224,9 @@ def test_alias_exists(mock_es_client, expected):
                         'remove': {
                             'alias': 'test-alias',
                             'indices': ['index1', 'index2'],
-                        }
-                    }]
-                }
+                        },
+                    }],
+                },
             ),
             (
                 (
@@ -234,9 +238,9 @@ def test_alias_exists(mock_es_client, expected):
                         'add': {
                             'alias': 'test-alias',
                             'indices': ['index1', 'index2'],
-                        }
-                    }]
-                }
+                        },
+                    }],
+                },
             ),
             (
                 (
@@ -251,19 +255,19 @@ def test_alias_exists(mock_es_client, expected):
                             'add': {
                                 'alias': 'test-alias',
                                 'indices': ['index1', 'index2'],
-                            }
+                            },
                         },
                         {
                             'remove': {
                                 'alias': 'test-alias-2',
                                 'indices': ['index3', 'index4'],
-                            }
+                            },
                         },
-                    ]
-                }
+                    ],
+                },
             ),
         )
-    )
+    ),
 )
 def test_update_alias(mock_es_client, add_actions, remove_actions, expected_body):
     """Test get_aliases_for_index()."""

--- a/datahub/search/test/test_migrate.py
+++ b/datahub/search/test/test_migrate.py
@@ -45,27 +45,27 @@ def test_migrate_app_with_app_needing_migration(monkeypatch, mock_es_client):
                 {
                     'add': {
                         'alias': 'test-read-alias',
-                        'indices': [new_index]
-                    }
+                        'indices': [new_index],
+                    },
                 },
                 {
                     'add': {
                         'alias': 'test-write-alias',
-                        'indices': [new_index]
-                    }
+                        'indices': [new_index],
+                    },
                 },
                 {
                     'remove': {
                         'alias': 'test-write-alias',
-                        'indices': [old_index]
-                    }
+                        'indices': [old_index],
+                    },
                 },
-            ]
-        }
+            ],
+        },
     )
 
     migrate_model_task_mock.apply_async.assert_called_once_with(
-        args=(mock_app.name, target_hash)
+        args=(mock_app.name, target_hash),
     )
 
 
@@ -120,7 +120,7 @@ def test_migrate_app_with_app_in_inconsistent_state(monkeypatch, mock_es_client)
     mock_client.indices.update_aliases.assert_not_called()
 
     migrate_model_task_mock.apply_async.assert_called_once_with(
-        args=(mock_app.name, target_hash)
+        args=(mock_app.name, target_hash),
     )
 
 

--- a/datahub/search/test/test_migrate_utils.py
+++ b/datahub/search/test/test_migrate_utils.py
@@ -36,7 +36,7 @@ class TestResyncAfterMigrate:
         mock_app = create_mock_search_app(
             read_indices=read_indices,
             write_index=write_index,
-            queryset=MockQuerySet([Mock(id=1), Mock(id=2)])
+            queryset=MockQuerySet([Mock(id=1), Mock(id=2)]),
         )
 
         resync_after_migrate(mock_app)
@@ -81,11 +81,11 @@ class TestResyncAfterMigrate:
                     {
                         'remove': {
                             'alias': 'test-read-alias',
-                            'indices': ANY
-                        }
+                            'indices': ANY,
+                        },
                     },
-                ]
-            }
+                ],
+            },
         )
 
         actions = mock_client.indices.update_aliases.call_args_list[0][1]['body']['actions']
@@ -115,7 +115,7 @@ class TestResyncAfterMigrate:
         mock_app = create_mock_search_app(
             read_indices=read_indices,
             write_index=write_index,
-            queryset=MockQuerySet([Mock(id=1), Mock(id=2)])
+            queryset=MockQuerySet([Mock(id=1), Mock(id=2)]),
         )
 
         with pytest.raises(DataHubException):
@@ -155,11 +155,11 @@ class TestResyncAfterMigrate:
                     {
                         'remove': {
                             'alias': 'test-read-alias',
-                            'indices': ['index2']
-                        }
+                            'indices': ['index2'],
+                        },
                     },
-                ]
-            }
+                ],
+            },
         )
 
         mock_client.indices.delete.assert_not_called()

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -22,28 +22,28 @@ from datahub.search.query_builder import (
                 'match': {
                     'field_name': {
                         'query': 'field value',
-                        'operator': 'and'
-                    }
-                }
-            }
+                        'operator': 'and',
+                    },
+                },
+            },
         ),
         (
             'field_name.id',
             'field value',
             {
                 'match_phrase': {
-                    'field_name.id': 'field value'
-                }
-            }
+                    'field_name.id': 'field value',
+                },
+            },
         ),
         (
             'field_name.name_keyword',
             'field value',
             {
                 'match_phrase': {
-                    'field_name.name_keyword': 'field value'
-                }
-            }
+                    'field_name.name_keyword': 'field value',
+                },
+            },
         ),
         (
             'field_name.prop',
@@ -52,10 +52,10 @@ from datahub.search.query_builder import (
                 'match': {
                     'field_name.prop': {
                         'query': 'field value',
-                        'operator': 'and'
-                    }
-                }
-            }
+                        'operator': 'and',
+                    },
+                },
+            },
         ),
         (
             'field_name_exists',
@@ -65,12 +65,12 @@ from datahub.search.query_builder import (
                     'must': [
                         {
                             'exists': {
-                                'field': 'field_name'
-                            }
-                        }
-                    ]
-                }
-            }
+                                'field': 'field_name',
+                            },
+                        },
+                    ],
+                },
+            },
         ),
         (
             'field_name_exists',
@@ -80,12 +80,12 @@ from datahub.search.query_builder import (
                     'must_not': [
                         {
                             'exists': {
-                                'field': 'field_name'
-                            }
-                        }
-                    ]
-                }
-            }
+                                'field': 'field_name',
+                            },
+                        },
+                    ],
+                },
+            },
         ),
         (
             'field_name',
@@ -95,12 +95,12 @@ from datahub.search.query_builder import (
                     'must_not': [
                         {
                             'exists': {
-                                'field': 'field_name'
-                            }
-                        }
-                    ]
-                }
-            }
+                                'field': 'field_name',
+                            },
+                        },
+                    ],
+                },
+            },
         ),
         (
             'field_name_exists',
@@ -110,12 +110,12 @@ from datahub.search.query_builder import (
                     'must_not': [
                         {
                             'exists': {
-                                'field': 'field_name'
-                            }
-                        }
-                    ]
-                }
-            }
+                                'field': 'field_name',
+                            },
+                        },
+                    ],
+                },
+            },
         ),
         (
             'field_name',
@@ -128,23 +128,23 @@ from datahub.search.query_builder import (
                             'match': {
                                 'field_name': {
                                     'query': 'field value 1',
-                                    'operator': 'and'
-                                }
-                            }
+                                    'operator': 'and',
+                                },
+                            },
                         },
                         {
                             'match': {
                                 'field_name': {
                                     'query': 'field value 2',
-                                    'operator': 'and'
-                                }
-                            }
-                        }
-                    ]
-                }
-            }
+                                    'operator': 'and',
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
         ),
-    )
+    ),
 )
 def test_build_field_query(field, value, expected):
     """Test for the _build_field_query function."""
@@ -163,32 +163,34 @@ def test_build_field_query(field, value, expected):
                             'match_phrase': {
                                 'name_keyword': {
                                     'query': 'hello',
-                                    'boost': 2
-                                }
-                            }
-                        }, {
+                                    'boost': 2,
+                                },
+                            },
+                        },
+                        {
                             'match_phrase': {
-                                'id': 'hello'
-                            }
-                        }, {
+                                'id': 'hello',
+                            },
+                        },
+                        {
                             'multi_match': {
                                 'query': 'hello',
                                 'fields': ('country.id', 'sector'),
                                 'type': 'cross_fields',
-                                'operator': 'and'
-                            }
-                        }
-                    ]
-                }
-            }
+                                'operator': 'and',
+                            },
+                        },
+                    ],
+                },
+            },
         ),
         (
             '',
             {
-                'match_all': {}
-            }
-        )
-    )
+                'match_all': {},
+            },
+        ),
+    ),
 )
 def test_build_term_query(term, expected):
     """Tests search term query."""
@@ -201,12 +203,12 @@ def test_build_term_query(term, expected):
         (8950, 1000, 1000),
         (9950, 1000, 50),
         (10000, 1000, 0),
-    )
+    ),
 )
 def test_offset_near_max_results(offset, limit, expected_size):
     """Tests limit clipping when near max_results."""
     query = get_basic_search_query(
-        'test', entities=(mock.Mock(),), offset=offset, limit=limit
+        'test', entities=(mock.Mock(),), offset=offset, limit=limit,
     )
 
     query_dict = query.to_dict()
@@ -226,13 +228,13 @@ def test_date_range_fields():
     filters, ranges = _split_date_range_fields(fields)
 
     assert filters == {
-        'adviser.id': 1234
+        'adviser.id': 1234,
     }
     assert ranges == {
         'estimated_land_date': {
             'gte': now,
-            'lte': now
-        }
+            'lte': now,
+        },
     }
 
 
@@ -244,12 +246,12 @@ def test_date_range_fields():
         (
             [],
             {
-                'match_none': {}
-            }
+                'match_none': {},
+            },
         ),
         (
             None,
-            None
+            None,
         ),
         (
             [
@@ -258,10 +260,10 @@ def test_date_range_fields():
             {
                 'bool': {
                     'should': [
-                        {'term': {'field_name': 'field value'}}
-                    ]
-                }
-            }
+                        {'term': {'field_name': 'field value'}},
+                    ],
+                },
+            },
         ),
         (
             [
@@ -272,12 +274,12 @@ def test_date_range_fields():
                 'bool': {
                     'should': [
                         {'term': {'field_name1': 'field value 1'}},
-                        {'term': {'field_name2': 'field value 2'}}
-                    ]
-                }
-            }
-        )
-    )
+                        {'term': {'field_name2': 'field value 2'}},
+                    ],
+                },
+            },
+        ),
+    ),
 )
 def test_build_entity_permission_query_no_conditions(filters, expected):
     """Test for the _build_entity_permission_query function."""

--- a/datahub/search/test/test_utils.py
+++ b/datahub/search/test/test_utils.py
@@ -5,13 +5,16 @@ from datahub.search.utils import get_model_copy_to_target_field_names
 
 def test_get_model_copy_to_field_names(monkeypatch):
     """Test that get_model_copy_to_field_names handles() handles various copy_to forms."""
-    monkeypatch.setattr('datahub.search.utils.get_model_fields', Mock(
-        return_value={
-            'field1': Mock(spec_set=()),
-            'field2': Mock(spec_set=('copy_to',), copy_to='copy_to_str'),
-            'field3': Mock(spec_set=('copy_to',), copy_to=['copy_to_list1', 'copy_to_list2']),
-        }
-    ))
+    monkeypatch.setattr(
+        'datahub.search.utils.get_model_fields',
+        Mock(
+            return_value={
+                'field1': Mock(spec_set=()),
+                'field2': Mock(spec_set=('copy_to',), copy_to='copy_to_str'),
+                'field3': Mock(spec_set=('copy_to',), copy_to=['copy_to_list1', 'copy_to_list2']),
+            },
+        ),
+    )
     assert get_model_copy_to_target_field_names(Mock()) == {
         'copy_to_str',
         'copy_to_list1',

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -32,12 +32,12 @@ def setup_data():
     ContactFactory(
         first_name='abc',
         last_name='defg',
-        company=CompanyFactory(name='name0')
+        company=CompanyFactory(name='name0'),
     )
     ContactFactory(
         first_name='first',
         last_name='last',
-        company=CompanyFactory(name='name1')
+        company=CompanyFactory(name='name1'),
     )
     InvestmentProjectFactory(
         name='abc defg',
@@ -48,7 +48,7 @@ def setup_data():
         investor_company=CompanyFactory(name='name3'),
         client_relationship_manager=AdviserFactory(first_name='name 2', last_name='surname 2'),
         referral_source_adviser=AdviserFactory(first_name='name 3', last_name='surname 3'),
-        client_contacts=[]
+        client_contacts=[],
     )
     InvestmentProjectFactory(
         description='investmentproject2',
@@ -58,7 +58,7 @@ def setup_data():
         investor_company=CompanyFactory(name='name4'),
         client_relationship_manager=AdviserFactory(first_name='name 6', last_name='surname 6'),
         referral_source_adviser=AdviserFactory(first_name='name 7', last_name='surname 7'),
-        client_contacts=[]
+        client_contacts=[],
     )
 
     country_uk = constants.Country.united_kingdom.value.id
@@ -67,14 +67,14 @@ def setup_data():
         name='abc defg ltd',
         trading_address_1='1 Fake Lane',
         trading_address_town='Downtown',
-        trading_address_country_id=country_uk
+        trading_address_country_id=country_uk,
     )
     CompanyFactory(
         name='abc defg us ltd',
         trading_address_1='1 Fake Lane',
         trading_address_town='Downtown',
         trading_address_country_id=country_us,
-        registered_address_country_id=country_us
+        registered_address_country_id=country_us,
     )
 
 
@@ -151,22 +151,28 @@ class TestSearch(APITestMixin):
         term = 'abc defg'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company',
-            'offset': 1,
-            'limit': 1,
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+                'offset': 1,
+                'limit': 1,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
         assert len(response.data['results']) == 1
 
-    @pytest.mark.parametrize('sortby', (
-        {},
-        {'sortby': 'name:asc'},
-        {'sortby': 'created_on:asc'},
-    ))
+    @pytest.mark.parametrize(
+        'sortby',
+        (
+            {},
+            {'sortby': 'name:asc'},
+            {'sortby': 'created_on:asc'},
+        ),
+    )
     def test_basic_search_consistent_paging(self, setup_es, sortby):
         """Tests if content placement is consistent between pages."""
         ids = sorted((uuid4() for _ in range(9)))
@@ -186,13 +192,16 @@ class TestSearch(APITestMixin):
 
         for page in range((len(ids) + page_size - 1) // page_size):
             url = reverse('api-v3:search:basic')
-            response = self.api_client.get(url, {
-                'term': name,
-                'entity': 'company',
-                'offset': page * page_size,
-                'limit': page_size,
-                **sortby
-            })
+            response = self.api_client.get(
+                url,
+                data={
+                    'term': name,
+                    'entity': 'company',
+                    'offset': page * page_size,
+                    'limit': page_size,
+                    **sortby,
+                },
+            )
 
             assert response.status_code == status.HTTP_200_OK
 
@@ -205,10 +214,13 @@ class TestSearch(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': 'test',
-            'entity': 'sloths',
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': 'test',
+                'entity': 'sloths',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -224,10 +236,13 @@ class TestSearch(APITestMixin):
         term = 'The Advisory'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 3
@@ -251,10 +266,13 @@ class TestSearch(APITestMixin):
         term = 'Veryuniquenam'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 4
@@ -264,7 +282,7 @@ class TestSearch(APITestMixin):
             'Veryuniquename1',
             'Veryuniquename2',
             'Veryuniquename3',
-            'Veryuniquename4'
+            'Veryuniquename4',
         } == {company['name'] for company in response.data['results']}
 
     def test_search_hyphen_match(self, setup_es, setup_data):
@@ -279,10 +297,13 @@ class TestSearch(APITestMixin):
         term = 't-shirt'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
@@ -305,10 +326,13 @@ class TestSearch(APITestMixin):
         term = '0fb4379c-341c-4dc4-b325-bf8d47b26baa'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
@@ -326,18 +350,23 @@ class TestSearch(APITestMixin):
         term = 'Water'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'sortby': 'name:desc',
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'sortby': 'name:desc',
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 4
-        assert ['Water 4',
-                'water 3',
-                'water 2',
-                'Water 1'] == [company['name'] for company in response.data['results']]
+        assert [
+            'Water 4',
+            'water 3',
+            'water 2',
+            'Water 1',
+        ] == [company['name'] for company in response.data['results']]
 
     def test_search_sort_asc(self, setup_es, setup_data):
         """Tests sorting in ascending order."""
@@ -351,17 +380,22 @@ class TestSearch(APITestMixin):
         term = 'Fire'
 
         url = reverse('api-v3:search:company')
-        response = self.api_client.post(url, {
-            'original_query': term,
-            'sortby': 'name:asc'
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': term,
+                'sortby': 'name:asc',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 4
-        assert ['Fire 1',
-                'fire 2',
-                'fire 3',
-                'Fire 4'] == [company['name'] for company in response.data['results']]
+        assert [
+            'Fire 1',
+            'fire 2',
+            'fire 3',
+            'Fire 4',
+        ] == [company['name'] for company in response.data['results']]
 
     def test_search_sort_nested_desc(self, setup_es, setup_data):
         """Tests sorting by nested field."""
@@ -387,18 +421,24 @@ class TestSearch(APITestMixin):
         term = 'Potato'
 
         url = reverse('api-v3:search:investment_project')
-        response = self.api_client.post(url, {
-            'original_query': term,
-            'sortby': 'stage.name:desc',
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': term,
+                'sortby': 'stage.name:desc',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 4
-        assert ['Won',
-                'Won',
-                'Prospect',
-                'Active'] == [investment_project['stage']['name']
-                              for investment_project in response.data['results']]
+        assert [
+            'Won',
+            'Won',
+            'Prospect',
+            'Active',
+        ] == [
+            investment_project['stage']['name'] for investment_project in response.data['results']
+        ]
 
     def test_search_sort_invalid(self, setup_es, setup_data):
         """Tests attempt to sort by non existent field."""
@@ -412,10 +452,13 @@ class TestSearch(APITestMixin):
         term = 'Fire'
 
         url = reverse('api-v3:search:company')
-        response = self.api_client.post(url, {
-            'original_query': term,
-            'sortby': 'some_field_that_doesnt_exist:asc'
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': term,
+                'sortby': 'some_field_that_doesnt_exist:asc',
+            },
+        )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
@@ -429,16 +472,23 @@ class TestSearch(APITestMixin):
         term = 'Earth'
 
         url = reverse('api-v3:search:investment_project')
-        response = self.api_client.post(url, {
-            'original_query': term,
-            'sortby': 'total_investment:asc'
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': term,
+                'sortby': 'total_investment:asc',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
-        assert [('Earth 2', None),
-                ('Earth 1', 1000)] == [(investment['name'], investment['total_investment'],)
-                                       for investment in response.data['results']]
+        assert [
+            ('Earth 2', None),
+            ('Earth 1', 1000),
+        ] == [
+            (investment['name'], investment['total_investment'])
+            for investment in response.data['results']
+        ]
 
     def test_search_sort_desc_with_null_values(self, setup_es, setup_data):
         """Tests placement of null values in sorted results when order is descending."""
@@ -450,16 +500,23 @@ class TestSearch(APITestMixin):
         term = 'Ether'
 
         url = reverse('api-v3:search:investment_project')
-        response = self.api_client.post(url, {
-            'original_query': term,
-            'sortby': 'total_investment:desc'
-        })
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': term,
+                'sortby': 'total_investment:desc',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2
-        assert [('Ether 1', 1000),
-                ('Ether 2', None)] == [(investment['name'], investment['total_investment'],)
-                                       for investment in response.data['results']]
+        assert [
+            ('Ether 1', 1000),
+            ('Ether 2', None),
+        ] == [
+            (investment['name'], investment['total_investment'])
+            for investment in response.data['results']
+        ]
 
     def test_basic_search_aggregations(self, setup_es, setup_data):
         """Tests basic aggregate query."""
@@ -472,37 +529,48 @@ class TestSearch(APITestMixin):
         term = 'very_unique_company'
 
         url = reverse('api-v3:search:basic')
-        response = self.api_client.get(url, {
-            'term': term,
-            'entity': 'company'
-        })
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 1
         assert response.data['results'][0]['name'] == 'very_unique_company'
 
-        aggregations = [{'count': 1, 'entity': 'company'},
-                        {'count': 1, 'entity': 'contact'},
-                        {'count': 1, 'entity': 'investment_project'}]
+        aggregations = [
+            {'count': 1, 'entity': 'company'},
+            {'count': 1, 'entity': 'contact'},
+            {'count': 1, 'entity': 'investment_project'},
+        ]
         assert all(aggregation in response.data['aggregations'] for aggregation in aggregations)
 
-    @pytest.mark.parametrize('permission,permission_entity', (
-        ('view_company', 'company'),
-        ('view_contact', 'contact'),
-        ('view_event', 'event'),
-        ('view_all_interaction', 'interaction'),
-        ('view_all_investmentproject', 'investment_project'),
-        ('view_associated_investmentproject', 'investment_project'),
-        ('view_order', 'order'),
-    ))
-    @pytest.mark.parametrize('entity', (
-        'company',
-        'contact',
-        'event',
-        'interaction',
-        'investment_project',
-        'order',
-    ))
+    @pytest.mark.parametrize(
+        'permission,permission_entity',
+        (
+            ('view_company', 'company'),
+            ('view_contact', 'contact'),
+            ('view_event', 'event'),
+            ('view_all_interaction', 'interaction'),
+            ('view_all_investmentproject', 'investment_project'),
+            ('view_associated_investmentproject', 'investment_project'),
+            ('view_order', 'order'),
+        ),
+    )
+    @pytest.mark.parametrize(
+        'entity',
+        (
+            'company',
+            'contact',
+            'event',
+            'interaction',
+            'investment_project',
+            'order',
+        ),
+    )
     def test_basic_search_permissions(self, setup_es, permission, permission_entity, entity):
         """Tests model permissions enforcement in basic search."""
         user = create_test_user(permission_codenames=[permission], dit_team=TeamFactory())
@@ -518,10 +586,13 @@ class TestSearch(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = api_client.get(url, {
-            'term': '',
-            'entity': entity,
-        })
+        response = api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': entity,
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -545,10 +616,13 @@ class TestSearch(APITestMixin):
         setup_es.indices.refresh()
 
         url = reverse('api-v3:search:basic')
-        response = api_client.get(url, {
-            'term': '',
-            'entity': 'company',
-        })
+        response = api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': 'company',
+            },
+        )
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
@@ -575,9 +649,12 @@ class TestSearchExportAPIView(APITestMixin):
 
         frozen_time = datetime.datetime(2018, 1, 2, 12, 30, 50, tzinfo=utc)
         with freeze_time(frozen_time):
-            response = api_client.post(url, {
-                'name': 'test',
-            })
+            response = api_client.post(
+                url,
+                data={
+                    'name': 'test',
+                },
+            )
 
         assert response.status_code == status.HTTP_200_OK
         assert UserEvent.objects.count() == 1

--- a/datahub/search/urls.py
+++ b/datahub/search/urls.py
@@ -14,12 +14,12 @@ for search_app in get_search_apps():
         urlpatterns.append(path(
             f'search/{search_app.name}',
             search_app.view.as_view(search_app=search_app),
-            name=search_app.name
+            name=search_app.name,
         ))
 
     if search_app.export_view:
         urlpatterns.append(path(
             f'search/{search_app.name}/export',
             search_app.export_view.as_view(search_app=search_app),
-            name=f'{search_app.name}-export'
+            name=f'{search_app.name}-export',
         ))

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -71,7 +71,7 @@ class SearchBasicAPIView(APIView):
         entity = request.query_params.get('entity', self.DEFAULT_ENTITY)
         if entity not in (self.entity_by_name):
             raise ValidationError(
-                f'Entity is not one of {", ".join(self.entity_by_name)}'
+                f'Entity is not one of {", ".join(self.entity_by_name)}',
             )
 
         sortby = request.query_params.get('sortby')
@@ -90,7 +90,7 @@ class SearchBasicAPIView(APIView):
             ordering=sortby,
             ignored_entities=self.IGNORED_ENTITIES,
             offset=offset,
-            limit=limit
+            limit=limit,
         )
 
         results = _execute_search_query(query)
@@ -194,7 +194,7 @@ class SearchAPIView(APIView):
         data = request.data.copy()
 
         # to support legacy paging parameters that can be in query_string
-        for legacy_query_param in ('limit', 'offset',):
+        for legacy_query_param in ('limit', 'offset'):
             if legacy_query_param in request.query_params \
                     and legacy_query_param not in request.data:
                 data[legacy_query_param] = request.query_params[legacy_query_param]
@@ -280,7 +280,7 @@ class SearchExportAPIView(SearchAPIView):
             validated_data,
         ).source(
             # Stops _source from being returned in the responses
-            fields=False
+            fields=False,
         ).params(
             # Keeps the sort order that the user specified
             preserve_order=True,
@@ -301,11 +301,11 @@ class SearchExportAPIView(SearchAPIView):
         ordering = self._translate_search_sortby_to_django_ordering(sort_by)
 
         return self.queryset.filter(
-            pk__in=ids
+            pk__in=ids,
         ).order_by(
-            *ordering
+            *ordering,
         ).values(
-            *self.field_titles.keys()
+            *self.field_titles.keys(),
         ).iterator()
 
     def _translate_search_sortby_to_django_ordering(self, sort_by):
@@ -331,10 +331,13 @@ def _execute_search_query(query):
 
     if response.took >= settings.ES_SEARCH_REQUEST_WARNING_THRESHOLD * 1000:
         logger.warning(f'Elasticsearch query took a long time ({response.took/1000:.2f} seconds)')
-        client.captureMessage('Elasticsearch query took a long time', extra={
-            'query': query.to_dict(),
-            'took': response.took,
-            'timed_out': response.timed_out
-        })
+        client.captureMessage(
+            'Elasticsearch query took a long time',
+            extra={
+                'query': query.to_dict(),
+                'took': response.took,
+                'timed_out': response.timed_out,
+            },
+        )
 
     return response


### PR DESCRIPTION
### Description of change

This adds trailing commas to the search app where they were missing. This includes some related code reformatting and the removal of some incorrect trailing commas.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
