### PR TITLE
Add remainder of trailing commas and add flake8-commas

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -105,7 +105,7 @@ def local_memory_cache(monkeypatch):
     monkeypatch.setitem(
         settings.CACHES,
         'default',
-        {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'}
+        {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'},
     )
     monkeypatch.setattr('django.core.cache.caches', CacheHandler())
 
@@ -115,7 +115,7 @@ def synchronous_thread_pool(monkeypatch):
     """Run everything submitted to thread pools executor in sync."""
     monkeypatch.setattr(
         'datahub.core.thread_pool._submit_to_thread_pool',
-        _synchronous_submit_to_thread_pool
+        _synchronous_submit_to_thread_pool,
     )
 
 
@@ -156,7 +156,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize(
             'search_app',
             apps,
-            ids=[app.__class__.__name__ for app in apps]
+            ids=[app.__class__.__name__ for app in apps],
         )
 
 
@@ -222,7 +222,7 @@ def setup_es(_setup_es_indexes, synchronous_on_commit, synchronous_thread_pool):
     indices = [search_app.es_model.get_target_index_name() for search_app in get_search_apps()]
     _setup_es_indexes.delete_by_query(
         indices,
-        body={'query': {'match_all': {}}}
+        body={'query': {'match_all': {}}},
     )
     _setup_es_indexes.indices.refresh()
 

--- a/datahub/leads/models.py
+++ b/datahub/leads/models.py
@@ -25,29 +25,56 @@ class BusinessLead(ArchivableModel, BaseModel):
     first_name = models.CharField(max_length=MAX_LENGTH, null=True, blank=True)
     last_name = models.CharField(max_length=MAX_LENGTH, null=True, blank=True)
     job_title = models.CharField(max_length=MAX_LENGTH, null=True, blank=True)
-    company_name = models.CharField(max_length=MAX_LENGTH, null=True,
-                                    blank=True)
-    trading_name = models.CharField(max_length=MAX_LENGTH, null=True,
-                                    blank=True)
-    company = models.ForeignKey(
-        'company.Company', null=True, blank=True, on_delete=models.SET_NULL,
-        related_name='business_leads'
+    company_name = models.CharField(
+        max_length=MAX_LENGTH,
+        null=True,
+        blank=True,
     )
-    telephone_number = models.CharField(max_length=MAX_LENGTH, null=True,
-                                        blank=True)
+    trading_name = models.CharField(
+        max_length=MAX_LENGTH,
+        null=True,
+        blank=True,
+    )
+    company = models.ForeignKey(
+        'company.Company',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name='business_leads',
+    )
+    telephone_number = models.CharField(
+        max_length=MAX_LENGTH,
+        null=True,
+        blank=True,
+    )
     email = models.EmailField(null=True, blank=True)
     address_1 = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     address_2 = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
-    address_town = models.CharField(max_length=MAX_LENGTH, blank=True,
-                                    null=True)
-    address_county = models.CharField(max_length=MAX_LENGTH, blank=True,
-                                      null=True)
-    address_country = models.ForeignKey(metadata_models.Country, null=True,
-                                        blank=True, on_delete=models.SET_NULL)
-    address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True,
-                                        null=True)
-    telephone_alternative = models.CharField(max_length=MAX_LENGTH,
-                                             blank=True, null=True)
+    address_town = models.CharField(
+        max_length=MAX_LENGTH,
+        blank=True,
+        null=True,
+    )
+    address_county = models.CharField(
+        max_length=MAX_LENGTH,
+        blank=True,
+        null=True,
+    )
+    address_country = models.ForeignKey(
+        metadata_models.Country,
+        null=True,
+        blank=True, on_delete=models.SET_NULL,
+    )
+    address_postcode = models.CharField(
+        max_length=MAX_LENGTH,
+        blank=True,
+        null=True,
+    )
+    telephone_alternative = models.CharField(
+        max_length=MAX_LENGTH,
+        blank=True,
+        null=True,
+    )
     email_alternative = models.EmailField(null=True, blank=True)
 
     # Marketing preferences

--- a/datahub/leads/serializers.py
+++ b/datahub/leads/serializers.py
@@ -15,10 +15,10 @@ class BusinessLeadSerializer(serializers.ModelSerializer):
     """Business lead serialiser."""
 
     company = NestedRelatedField(
-        Company, required=False, allow_null=True
+        Company, required=False, allow_null=True,
     )
     address_country = NestedRelatedField(
-        meta_models.Country, required=False, allow_null=True
+        meta_models.Country, required=False, allow_null=True,
     )
     archived = serializers.BooleanField(read_only=True)
     archived_on = serializers.DateTimeField(read_only=True)
@@ -100,5 +100,5 @@ class BusinessLeadSerializer(serializers.ModelSerializer):
             'archived': {'read_only': True},
             'archived_on': {'read_only': True},
             'archived_reason': {'read_only': True},
-            'archived_by': {'read_only': True}
+            'archived_by': {'read_only': True},
         }

--- a/datahub/leads/test/factories.py
+++ b/datahub/leads/test/factories.py
@@ -5,7 +5,7 @@ import uuid
 import factory
 
 from datahub.company.test.factories import (
-    AdviserFactory, CompanyFactory
+    AdviserFactory, CompanyFactory,
 )
 
 

--- a/datahub/leads/test/test_serializers.py
+++ b/datahub/leads/test/test_serializers.py
@@ -16,14 +16,14 @@ def test_no_contact_details_update():
     lead = BusinessLeadFactory()
     data = {
         'email': None,
-        'telephone_number': None
+        'telephone_number': None,
     }
     serializer = BusinessLeadSerializer(lead, data)
 
     assert not serializer.is_valid()
     assert serializer.errors == {
         'email': ['Email address or phone number required'],
-        'telephone_number': ['Email address or phone number required']
+        'telephone_number': ['Email address or phone number required'],
     }
 
 
@@ -42,7 +42,7 @@ def test_no_name_update():
     assert serializer.errors == {
         'first_name': ['Company name or first name and last name required'],
         'last_name': ['Company name or first name and last name required'],
-        'company_name': ['Company name or first name and last name required']
+        'company_name': ['Company name or first name and last name required'],
     }
 
 
@@ -57,5 +57,5 @@ def test_no_name_contact_create():
         'telephone_number': ['Email address or phone number required'],
         'first_name': ['Company name or first name and last name required'],
         'last_name': ['Company name or first name and last name required'],
-        'company_name': ['Company name or first name and last name required']
+        'company_name': ['Company name or first name and last name required'],
     }

--- a/datahub/leads/test/test_views.py
+++ b/datahub/leads/test/test_views.py
@@ -41,9 +41,12 @@ class TestBusinessLeadViews(APITestMixin):
     def test_get_success(self):
         """Tests that getting a single lead."""
         lead = BusinessLeadFactory(created_by=self.user)
-        url = reverse('api-v3:business-leads:lead-item', kwargs={
-            'pk': lead.pk
-        })
+        url = reverse(
+            'api-v3:business-leads:lead-item',
+            kwargs={
+                'pk': lead.pk,
+            },
+        )
         response = self.api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -59,13 +62,13 @@ class TestBusinessLeadViews(APITestMixin):
                 'first_name': self.user.first_name,
                 'id': str(self.user.pk),
                 'last_name': self.user.last_name,
-                'name': self.user.name
+                'name': self.user.name,
             },
             'modified_by': {
                 'first_name': lead.modified_by.first_name,
                 'id': str(lead.modified_by.pk),
                 'last_name': lead.modified_by.last_name,
-                'name': lead.modified_by.name
+                'name': lead.modified_by.name,
             },
             'archived': False,
             'archived_by': None,
@@ -73,7 +76,7 @@ class TestBusinessLeadViews(APITestMixin):
             'archived_reason': None,
             'company': {
                 'id': str(lead.company.pk),
-                'name': lead.company.name
+                'name': lead.company.name,
             },
             'company_name': lead.company_name,
             'contactable_by_dit': False,
@@ -91,7 +94,7 @@ class TestBusinessLeadViews(APITestMixin):
             'notes': None,
             'telephone_alternative': None,
             'telephone_number': '+44 123456789',
-            'trading_name': None
+            'trading_name': None,
         }
 
     def test_create_lead_success(self):
@@ -100,7 +103,7 @@ class TestBusinessLeadViews(APITestMixin):
         request_data = {
             'first_name': 'First name',
             'last_name': 'Last name',
-            'telephone_number': '+44 7000 123456'
+            'telephone_number': '+44 7000 123456',
         }
         response = self.api_client.post(url, data=request_data)
 
@@ -109,7 +112,8 @@ class TestBusinessLeadViews(APITestMixin):
         assert response_data['first_name'] == request_data['first_name']
         assert response_data['last_name'] == request_data['last_name']
         assert (response_data['telephone_number'] == request_data[
-            'telephone_number'])
+            'telephone_number'
+        ])
         assert response_data['created_by']['id'] == str(self.user.pk)
 
     def test_create_lead_failure(self):
@@ -121,65 +125,77 @@ class TestBusinessLeadViews(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'first_name': ['Company name or first name and last name '
-                           'required'],
+            'first_name': [
+                'Company name or first name and last name required',
+            ],
             'last_name': ['Company name or first name and last name required'],
-            'company_name': ['Company name or first name and last name '
-                             'required'],
+            'company_name': [
+                'Company name or first name and last name required',
+            ],
             'email': ['Email address or phone number required'],
-            'telephone_number': ['Email address or phone number required']
+            'telephone_number': ['Email address or phone number required'],
         }
 
     def test_patch_success(self):
         """Tests updating a business lead."""
         lead = BusinessLeadFactory(created_by=self.user)
-        url = reverse('api-v3:business-leads:lead-item', kwargs={
-            'pk': lead.pk
-        })
+        url = reverse(
+            'api-v3:business-leads:lead-item',
+            kwargs={
+                'pk': lead.pk,
+            },
+        )
         request_data = {
             'first_name': 'New first name',
-            'email_alternative': 'altemail@blah.com'
+            'email_alternative': 'altemail@blah.com',
         }
         response = self.api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         assert response_data['first_name'] == request_data['first_name']
-        assert (response_data['email_alternative'] == request_data[
-            'email_alternative'])
+        assert response_data['email_alternative'] == request_data['email_alternative']
 
     def test_patch_failure(self):
         """Tests updating a business lead."""
         lead = BusinessLeadFactory(created_by=self.user)
-        url = reverse('api-v3:business-leads:lead-item', kwargs={
-            'pk': lead.pk
-        })
+        url = reverse(
+            'api-v3:business-leads:lead-item',
+            kwargs={
+                'pk': lead.pk,
+            },
+        )
         request_data = {
             'first_name': None,
             'company_name': None,
-            'company': None
+            'company': None,
         }
         response = self.api_client.patch(url, data=request_data)
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         response_data = response.json()
         assert response_data == {
-            'first_name': ['Company name or first name and last name '
-                           'required'],
+            'first_name': [
+                'Company name or first name and last name required',
+            ],
             'last_name': ['Company name or first name and last name required'],
-            'company_name': ['Company name or first name and last name '
-                             'required']
+            'company_name': [
+                'Company name or first name and last name required',
+            ],
         }
 
     @freeze_time(FROZEN_TIME)
     def test_archive_success(self):
         """Tests archiving a business lead."""
         lead = BusinessLeadFactory(created_by=self.user)
-        url = reverse('api-v3:business-leads:archive-lead-item', kwargs={
-            'pk': lead.pk
-        })
+        url = reverse(
+            'api-v3:business-leads:archive-lead-item',
+            kwargs={
+                'pk': lead.pk,
+            },
+        )
         request_data = {
-            'reason': 'archive test'
+            'reason': 'archive test',
         }
         response = self.api_client.post(url, data=request_data)
 
@@ -194,11 +210,14 @@ class TestBusinessLeadViews(APITestMixin):
         """Tests unarchiving a business lead."""
         lead = BusinessLeadFactory(
             created_by=self.user, archived=True, archived_by=self.user,
-            archived_reason='unarchive test', archived_on=datetime(2016, 1, 1, tzinfo=utc)
+            archived_reason='unarchive test', archived_on=datetime(2016, 1, 1, tzinfo=utc),
         )
-        url = reverse('api-v3:business-leads:unarchive-lead-item', kwargs={
-            'pk': lead.pk
-        })
+        url = reverse(
+            'api-v3:business-leads:unarchive-lead-item',
+            kwargs={
+                'pk': lead.pk,
+            },
+        )
         response = self.api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK

--- a/datahub/leads/urls.py
+++ b/datahub/leads/urls.py
@@ -6,25 +6,25 @@ from datahub.leads.views import BusinessLeadViewSet
 
 lead_collection = BusinessLeadViewSet.as_view({
     'get': 'list',
-    'post': 'create'
+    'post': 'create',
 })
 
 lead_item = BusinessLeadViewSet.as_view({
     'get': 'retrieve',
-    'patch': 'partial_update'
+    'patch': 'partial_update',
 })
 
 archive_lead_item = BusinessLeadViewSet.as_view({
-    'post': 'archive'
+    'post': 'archive',
 })
 
 unarchive_lead_item = BusinessLeadViewSet.as_view({
-    'post': 'unarchive'
+    'post': 'unarchive',
 })
 
 urlpatterns = [
     path('business-leads', lead_collection, name='lead-collection'),
     path('business-leads/<uuid:pk>', lead_item, name='lead-item'),
     path('business-leads/<uuid:pk>/archive', archive_lead_item, name='archive-lead-item'),
-    path('business-leads/<uuid:pk>/unarchive', unarchive_lead_item, name='unarchive-lead-item')
+    path('business-leads/<uuid:pk>/unarchive', unarchive_lead_item, name='unarchive-lead-item'),
 ]

--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -43,8 +43,8 @@ class DisableableMetadataAdmin(admin.ModelAdmin):
     Intended to be used across apps.
     """
 
-    fields = ('id', 'name', 'disabled_on',)
-    list_display = ('name', 'disabled_on',)
+    fields = ('id', 'name', 'disabled_on')
+    list_display = ('name', 'disabled_on')
     readonly_fields = ('id',)
     search_fields = ('name', 'pk')
     list_filter = (DisabledOnFilter,)
@@ -57,7 +57,7 @@ class ReadOnlyMetadataAdmin(ViewOnlyAdmin):
     Intended to be used across apps.
     """
 
-    list_display = ('name', 'disabled_on',)
+    list_display = ('name', 'disabled_on')
     search_fields = ('name', 'pk')
     list_filter = (DisabledOnFilter,)
 
@@ -69,8 +69,8 @@ class OrderedMetadataAdmin(admin.ModelAdmin):
     Intended to be used across apps.
     """
 
-    fields = ('id', 'name', 'order', 'disabled_on',)
-    list_display = ('name', 'order', 'disabled_on',)
+    fields = ('id', 'name', 'order', 'disabled_on')
+    list_display = ('name', 'order', 'disabled_on')
     readonly_fields = ('id',)
     search_fields = ('name', 'pk')
     list_filter = (DisabledOnFilter,)
@@ -91,7 +91,7 @@ admin.site.register(MODELS_TO_REGISTER_READ_ONLY, ReadOnlyMetadataAdmin)
 admin.site.register(MODELS_TO_REGISTER_WITH_ORDER, OrderedMetadataAdmin)
 admin.site.register(
     MODELS_TO_REGISTER_EDITABLE_ORDER_ONLY,
-    EditableOrderOnlyOrderedMetadataAdmin
+    EditableOrderOnlyOrderedMetadataAdmin,
 )
 
 
@@ -99,8 +99,8 @@ admin.site.register(
 class CountryAdmin(admin.ModelAdmin):
     """Admin for countries."""
 
-    fields = ('pk', 'name', 'overseas_region', 'disabled_on',)
-    list_display = ('name', 'overseas_region', 'disabled_on',)
+    fields = ('pk', 'name', 'overseas_region', 'disabled_on')
+    list_display = ('name', 'overseas_region', 'disabled_on')
     readonly_fields = ('pk',)
     search_fields = ('name', 'pk')
     list_filter = (DisabledOnFilter, 'overseas_region')
@@ -118,8 +118,8 @@ class ServiceAdmin(DisableableMetadataAdmin):
 class TeamAdmin(admin.ModelAdmin):
     """Team Admin."""
 
-    fields = ('id', 'name', 'country', 'uk_region', 'role', 'tags', 'disabled_on',)
-    list_display = ('name', 'role', 'get_tags_display', 'disabled_on',)
+    fields = ('id', 'name', 'country', 'uk_region', 'role', 'tags', 'disabled_on')
+    list_display = ('name', 'role', 'get_tags_display', 'disabled_on')
     list_select_related = ('role',)
     readonly_fields = ('id',)
     search_fields = ('name', 'pk')
@@ -130,8 +130,8 @@ class TeamAdmin(admin.ModelAdmin):
 class TeamRoleAdmin(admin.ModelAdmin):
     """Team Admin."""
 
-    fields = ('id', 'name', 'groups', 'disabled_on',)
-    list_display = ('name', 'disabled_on',)
+    fields = ('id', 'name', 'groups', 'disabled_on')
+    list_display = ('name', 'disabled_on')
     readonly_fields = ('id',)
     search_fields = ('name', 'pk')
     filter_horizontal = ('groups',)
@@ -142,8 +142,8 @@ class TeamRoleAdmin(admin.ModelAdmin):
 class SectorAdmin(MPTTModelAdmin):
     """Sector admin."""
 
-    fields = ('id', 'segment', 'parent', 'disabled_on',)
-    list_display = ('segment', 'disabled_on',)
+    fields = ('id', 'segment', 'parent', 'disabled_on')
+    list_display = ('segment', 'disabled_on')
     readonly_fields = ('id',)
     search_fields = ('segment', 'pk')
     list_filter = (DisabledOnFilter,)

--- a/datahub/metadata/filters.py
+++ b/datahub/metadata/filters.py
@@ -16,7 +16,7 @@ class ServiceFilterSet(FilterSet):
         Multiple values are separated by a comma.
         """
         filter_args = {
-            f'{field_name}__overlap': value.split(',')
+            f'{field_name}__overlap': value.split(','),
         }
         return queryset.filter(**filter_args)
 

--- a/datahub/metadata/metadata.py
+++ b/datahub/metadata/metadata.py
@@ -23,15 +23,15 @@ registry.register(
     filterset_class=ServiceFilterSet,
     metadata_id='service',
     model=models.Service,
-    serializer=ServiceSerializer
+    serializer=ServiceSerializer,
 )
 registry.register(metadata_id='team-role', model=models.TeamRole)
 registry.register(
     metadata_id='team',
     model=models.Team,
     queryset=models.Team.objects.select_related('role', 'uk_region', 'country'),
-    serializer=TeamSerializer
-),
+    serializer=TeamSerializer,
+)
 registry.register(metadata_id='title', model=models.Title)
 registry.register(metadata_id='turnover', model=models.TurnoverRange)
 registry.register(metadata_id='uk-region', model=models.UKRegion)
@@ -44,11 +44,11 @@ registry.register(metadata_id='referral-source-website', model=models.ReferralSo
 registry.register(metadata_id='referral-source-marketing', model=models.ReferralSourceMarketing)
 registry.register(
     metadata_id='investment-business-activity',
-    model=models.InvestmentBusinessActivity
+    model=models.InvestmentBusinessActivity,
 )
 registry.register(
     metadata_id='investment-strategic-driver',
-    model=models.InvestmentStrategicDriver
+    model=models.InvestmentStrategicDriver,
 )
 registry.register(metadata_id='salary-range', model=models.SalaryRange)
 registry.register(metadata_id='investment-project-stage', model=models.InvestmentProjectStage)

--- a/datahub/metadata/models.py
+++ b/datahub/metadata/models.py
@@ -28,14 +28,14 @@ class Sector(MPTTModel, DisableableModel):
     segment = models.CharField(max_length=settings.CHAR_FIELD_MAX_LENGTH)
     parent = TreeForeignKey(
         'self', null=True, blank=True, related_name='children', db_index=True,
-        on_delete=models.PROTECT
+        on_delete=models.PROTECT,
     )
 
     def __str__(self):
         """Human-readable representation."""
         return join_truthy_strings(
             self.segment,
-            '(disabled)' if self.disabled_on else None
+            '(disabled)' if self.disabled_on else None,
         )
 
     @cached_property

--- a/datahub/metadata/query_utils.py
+++ b/datahub/metadata/query_utils.py
@@ -35,7 +35,7 @@ def get_sector_name_subquery(relation_name=None):
     outer_ref_prefix = f'{relation_name}__' if relation_name is not None else ''
 
     subquery = Sector._base_manager.annotate(
-        name=_SectorStringAgg(F('segment'), Value(Sector.PATH_SEPARATOR))
+        name=_SectorStringAgg(F('segment'), Value(Sector.PATH_SEPARATOR)),
     ).filter(
         lft__lte=OuterRef(f'{outer_ref_prefix}lft'),
         rght__gte=OuterRef(f'{outer_ref_prefix}rght'),

--- a/datahub/metadata/registry.py
+++ b/datahub/metadata/registry.py
@@ -39,8 +39,15 @@ class MetadataRegistry:
         """Keeps a local copy of the metadata registered."""
         self.metadata = {}
 
-    def register(self, metadata_id, model, queryset=None, serializer=ConstantModelSerializer,
-                 filterset_fields=None, filterset_class=None):
+    def register(
+        self,
+        metadata_id,
+        model,
+        queryset=None,
+        serializer=ConstantModelSerializer,
+        filterset_fields=None,
+        filterset_class=None,
+    ):
         """Registers a new metadata."""
         if metadata_id in self.metadata:
             raise ImproperlyConfigured(f'Metadata {metadata_id} already registered.')

--- a/datahub/metadata/serializers.py
+++ b/datahub/metadata/serializers.py
@@ -13,7 +13,7 @@ TeamWithGeographyField = partial(
         'name',
         ('uk_region', NestedRelatedField(UKRegion, read_only=True)),
         ('country', NestedRelatedField(Country, read_only=True)),
-    )
+    ),
 )
 
 

--- a/datahub/metadata/test/factories.py
+++ b/datahub/metadata/test/factories.py
@@ -13,7 +13,7 @@ class ServiceFactory(factory.django.DjangoModelFactory):
     id = factory.LazyFunction(uuid.uuid4)
     name = factory.Sequence(lambda n: f'name {n}')
     contexts = factory.LazyFunction(
-        lambda: sample(tuple(Service.CONTEXTS), randrange(0, len(Service.CONTEXTS)))
+        lambda: sample(tuple(Service.CONTEXTS), randrange(0, len(Service.CONTEXTS))),
     )
 
     class Meta:

--- a/datahub/metadata/test/test_query_utils.py
+++ b/datahub/metadata/test/test_query_utils.py
@@ -11,9 +11,9 @@ def test_annotated_sector_name_root_node():
     """Test the sector name annotation for a sector at root level."""
     sector = SectorFactory(parent=None)
     annotated_sector = Sector.objects.annotate(
-        name_annotation=get_sector_name_subquery()
+        name_annotation=get_sector_name_subquery(),
     ).get(
-        pk=sector.pk
+        pk=sector.pk,
     )
 
     assert annotated_sector.name_annotation == sector.name
@@ -24,9 +24,9 @@ def test_annotated_sector_name_level_one():
     parent = SectorFactory()
     sector = SectorFactory(parent=parent)
     annotated_sector = Sector.objects.annotate(
-        name_annotation=get_sector_name_subquery()
+        name_annotation=get_sector_name_subquery(),
     ).get(
-        pk=sector.pk
+        pk=sector.pk,
     )
 
     assert annotated_sector.name_annotation == sector.name
@@ -38,9 +38,9 @@ def test_annotated_sector_name_level_two():
     parent = SectorFactory(parent=grandparent)
     sector = SectorFactory(parent=parent)
     annotated_sector = Sector.objects.annotate(
-        name_annotation=get_sector_name_subquery()
+        name_annotation=get_sector_name_subquery(),
     ).get(
-        pk=sector.pk
+        pk=sector.pk,
     )
 
     assert annotated_sector.name_annotation == sector.name
@@ -52,9 +52,9 @@ def test_annotated_sector_name_via_relation():
     parent = SectorFactory(parent=grandparent)
     sector = SectorFactory(parent=parent)
     annotated_sector = Sector.objects.annotate(
-        parent_name_annotation=get_sector_name_subquery('parent')
+        parent_name_annotation=get_sector_name_subquery('parent'),
     ).get(
-        pk=sector.pk
+        pk=sector.pk,
     )
 
     assert annotated_sector.parent_name_annotation == parent.name

--- a/datahub/metadata/test/test_views.py
+++ b/datahub/metadata/test/test_views.py
@@ -30,7 +30,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize(
             'metadata_view_name',
             view_names,
-            ids=[f'{view_name} metadata view' for view_name in view_names]
+            ids=[f'{view_name} metadata view' for view_name in view_names],
         )
 
     if 'ordered_mapping' in metafunc.fixturenames:
@@ -43,7 +43,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize(
             'ordered_mapping',
             view_data,
-            ids=[f'{view_data_item[0]} ordered metadata view' for view_data_item in view_data]
+            ids=[f'{view_data_item[0]} ordered metadata view' for view_data_item in view_data],
         )
 
 
@@ -110,12 +110,12 @@ def test_team_view(api_client):
         'name': 'Aberdeen City Council',
         'role': {
             'name': 'ATO',
-            'id': '846cb21e-6095-e211-a939-e4115bead28a'
+            'id': '846cb21e-6095-e211-a939-e4115bead28a',
         },
         'uk_region': None,
         'country': {
             'name': 'United Kingdom',
-            'id': '80756b9a-5d95-e211-a939-e4115bead28a'
+            'id': '80756b9a-5d95-e211-a939-e4115bead28a',
         },
         'disabled_on': None,
     }
@@ -129,12 +129,12 @@ def test_team_view(api_client):
         'name': 'Business Information Centre Bhopal India',
         'role': {
             'name': 'Post',
-            'id': '62329c18-6095-e211-a939-e4115bead28a'
+            'id': '62329c18-6095-e211-a939-e4115bead28a',
         },
         'uk_region': None,
         'country': {
             'name': 'India',
-            'id': '6f6a9ab2-5d95-e211-a939-e4115bead28a'
+            'id': '6f6a9ab2-5d95-e211-a939-e4115bead28a',
         },
         'disabled_on': '2013-03-31T16:21:07Z',
     }
@@ -184,7 +184,7 @@ class TestServiceView:
 
         ServiceFactory.create_batch(
             len(test_data_contexts),
-            contexts=factory.Iterator(test_data_contexts)
+            contexts=factory.Iterator(test_data_contexts),
         )
 
         url = reverse(viewname='service')

--- a/datahub/metadata/views.py
+++ b/datahub/metadata/views.py
@@ -26,7 +26,7 @@ def _create_metadata_view(mapping):
     )
 
     return view_set.as_view({
-        'get': 'list'
+        'get': 'list',
     })
 
 

--- a/datahub/oauth/models.py
+++ b/datahub/oauth/models.py
@@ -10,7 +10,7 @@ class OAuthApplicationScope(models.Model):
     application = models.OneToOneField(oauth2_settings.APPLICATION_MODEL, on_delete=models.CASCADE)
     scopes = ArrayField(
         models.CharField(max_length=settings.CHAR_FIELD_MAX_LENGTH),
-        help_text='Allowed scopes for this application. (Comma separated in Django admin.)'
+        help_text='Allowed scopes for this application. (Comma separated in Django admin.)',
     )
 
     def __str__(self):

--- a/datahub/oauth/scopes.py
+++ b/datahub/oauth/scopes.py
@@ -57,5 +57,5 @@ class ApplicationScopesBackend(BaseScopes):
         Currently returns all available scopes for the app.
         """
         return self.get_available_scopes(
-            application=application, request=request, *args, **kwargs
+            application=application, request=request, *args, **kwargs,
         )

--- a/datahub/oauth/test/test_backend.py
+++ b/datahub/oauth/test/test_backend.py
@@ -38,7 +38,7 @@ class TestContentTypeAwareOAuthLibCore(APITestMixin):
             'Bearer token',
             '',
             'Cool cats',
-        )
+        ),
     )
     @patch.object(RestrictedAccessViewSet, 'create')
     def test_request_is_not_parsed_if_oauth2_token_is_invalid_and_content_type_is_application_json(
@@ -60,7 +60,7 @@ class TestContentTypeAwareOAuthLibCore(APITestMixin):
             Authorization=token,
         )
         my_view = RestrictedAccessViewSet.as_view(
-            actions={'post': 'create'}
+            actions={'post': 'create'},
         )
         response = my_view(request)
 
@@ -73,7 +73,7 @@ class TestContentTypeAwareOAuthLibCore(APITestMixin):
             ('application/x-www-form-urlencoded; charset=utf-8', True),
             ('application/x-www-form-urlencoded;', True),
             ('application/cats-on-mars', False),
-        )
+        ),
     )
     @patch.object(RestrictedAccessViewSet, 'create')
     def test_request_is_parsed_if_oauth2_token_is_in_the_form(
@@ -96,7 +96,7 @@ class TestContentTypeAwareOAuthLibCore(APITestMixin):
             content_type=content_type,
         )
         my_view = RestrictedAccessViewSet.as_view(
-            actions={'post': 'create'}
+            actions={'post': 'create'},
         )
         response = my_view(request)
         if expected_authorized:

--- a/datahub/oauth/test/test_scopes.py
+++ b/datahub/oauth/test/test_scopes.py
@@ -29,7 +29,7 @@ class TestOAuthScopeBackend:
         app = app_and_scope.application
         client = APIClient()
         client.credentials(
-            HTTP_AUTHORIZATION=_create_auth_header(app.client_id, app.client_secret)
+            HTTP_AUTHORIZATION=_create_auth_header(app.client_id, app.client_secret),
         )
         data = {'grant_type': 'client_credentials'}
         url = reverse('token')
@@ -50,7 +50,7 @@ class TestOAuthScopeBackend:
         app = app_and_scope.application
         client = APIClient()
         client.credentials(
-            HTTP_AUTHORIZATION=_create_auth_header(app.client_id, app.client_secret)
+            HTTP_AUTHORIZATION=_create_auth_header(app.client_id, app.client_secret),
         )
         data = {
             'grant_type': 'client_credentials',
@@ -70,12 +70,12 @@ class TestOAuthScopeBackend:
         Test creating an access token when specifying a scope that the app hasn't been assigned.
         """
         app_and_scope = OAuthApplicationScopeFactory(scopes=[
-            TestScope.test_scope_1
+            TestScope.test_scope_1,
         ])
         app = app_and_scope.application
         client = APIClient()
         client.credentials(
-            HTTP_AUTHORIZATION=_create_auth_header(app.client_id, app.client_secret)
+            HTTP_AUTHORIZATION=_create_auth_header(app.client_id, app.client_secret),
         )
         data = {
             'grant_type': 'client_credentials',
@@ -89,7 +89,7 @@ class TestOAuthScopeBackend:
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
         assert response.json() == {
-            'error': 'invalid_scope'
+            'error': 'invalid_scope',
         }
 
 
@@ -104,10 +104,13 @@ def test_urls():  # noqa: D403
 class TestOAuthViewScope(APITestMixin):
     """Tests app-specific OAuth scopes in views."""
 
-    @pytest.mark.parametrize('grant_type', (
-        Application.GRANT_PASSWORD,
-        Application.GRANT_CLIENT_CREDENTIALS,
-    ))
+    @pytest.mark.parametrize(
+        'grant_type',
+        (
+            Application.GRANT_PASSWORD,
+            Application.GRANT_CLIENT_CREDENTIALS,
+        ),
+    )
     def test_scope_allowed(self, test_urls, grant_type):
         """Tests a test view with the required scope."""
         client = self.create_api_client(TestScope.test_scope_1, grant_type=grant_type)
@@ -115,10 +118,13 @@ class TestOAuthViewScope(APITestMixin):
         response = client.get(url)
         assert response.status_code == status.HTTP_200_OK
 
-    @pytest.mark.parametrize('grant_type', (
-        Application.GRANT_PASSWORD,
-        Application.GRANT_CLIENT_CREDENTIALS,
-    ))
+    @pytest.mark.parametrize(
+        'grant_type',
+        (
+            Application.GRANT_PASSWORD,
+            Application.GRANT_CLIENT_CREDENTIALS,
+        ),
+    )
     def test_scope_not_allowed(self, test_urls, grant_type):
         """Tests a test view without the required scope."""
         client = self.create_api_client(TestScope.test_scope_2, grant_type=grant_type)
@@ -126,10 +132,13 @@ class TestOAuthViewScope(APITestMixin):
         response = client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    @pytest.mark.parametrize('grant_type', (
-        Application.GRANT_PASSWORD,
-        Application.GRANT_CLIENT_CREDENTIALS,
-    ))
+    @pytest.mark.parametrize(
+        'grant_type',
+        (
+            Application.GRANT_PASSWORD,
+            Application.GRANT_CLIENT_CREDENTIALS,
+        ),
+    )
     def test_expired_token(self, test_urls, grant_type):
         """Tests a test view with an expired token and the required scope."""
         application = self.get_application(grant_type=grant_type)

--- a/requirements.in
+++ b/requirements.in
@@ -58,6 +58,7 @@ towncrier==18.6.0
 # Code static analysis
 flake8==3.5.0
 flake8-blind-except==0.1.1
+flake8-commas==2.0.0
 flake8-debugger==3.1.0
 flake8-import-order==0.18
 flake8-docstrings==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ aws-requests-auth==0.4.2
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4         # via celery
 boto3==1.9.12
-botocore==1.12.12         # via boto3, s3transfer
+botocore==1.12.14         # via boto3, s3transfer
 celery==4.2.1
 certifi==2018.8.24        # via requests
 chardet==3.0.4
@@ -44,6 +44,7 @@ factory-boy==2.11.1
 faker==0.9.1              # via factory-boy
 first==2.0.1              # via first, pip-tools
 flake8-blind-except==0.1.1
+flake8-commas==2.0.0
 flake8-debugger==3.1.0
 flake8-docstrings==1.3.0
 flake8-import-order==0.18


### PR DESCRIPTION
### Description of change

This adds the remainder of missing trailing commas and adds flake8-commas to enforce the code style for trailing commas.

I haven't added a news fragment as it's not really a functional change but could add one if desired.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
