### PR TITLE
Convert imports to absolute in cleanup and company apps

### DIFF
--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -8,13 +8,13 @@ from django.core import management
 from django.core.management.base import CommandError
 from reversion.models import Revision, Version
 
+from datahub.cleanup.management.commands import delete_orphaned_versions
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.investment.test.factories import (
     InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
 )
-from ...management.commands import delete_orphaned_versions
 
 
 MAPPINGS = {

--- a/datahub/company/models/__init__.py
+++ b/datahub/company/models/__init__.py
@@ -1,12 +1,12 @@
-from .adviser import Advisor
-from .company import (
+from datahub.company.models.adviser import Advisor
+from datahub.company.models.company import (
     CompaniesHouseCompany,
     Company,
     CompanyCoreTeamMember,
     CompanyPermission,
     ExportExperienceCategory,
 )
-from .contact import Contact, ContactPermission
+from datahub.company.models.contact import Contact, ContactPermission
 
 __all__ = (
     'Advisor',

--- a/datahub/company/test/test_advisor_views.py
+++ b/datahub/company/test/test_advisor_views.py
@@ -1,9 +1,9 @@
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import APITestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
-from .factories import AdviserFactory
 
 
 class TestAdviser(APITestMixin):

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -9,6 +9,14 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from reversion.models import Version
 
+from datahub.company.constants import BusinessTypeConstant
+from datahub.company.models import CompaniesHouseCompany, Company
+from datahub.company.test.factories import (
+    AdviserFactory,
+    CompaniesHouseCompanyFactory,
+    CompanyCoreTeamMemberFactory,
+    CompanyFactory,
+)
 from datahub.core.constants import Country, HeadquarterType, Sector, UKRegion
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
 from datahub.core.test_utils import (
@@ -16,14 +24,6 @@ from datahub.core.test_utils import (
 )
 from datahub.metadata.models import CompanyClassification
 from datahub.metadata.test.factories import TeamFactory
-from .factories import (
-    AdviserFactory,
-    CompaniesHouseCompanyFactory,
-    CompanyCoreTeamMemberFactory,
-    CompanyFactory,
-)
-from ..constants import BusinessTypeConstant
-from ..models import CompaniesHouseCompany, Company
 
 
 class TestListCompanies(APITestMixin):

--- a/datahub/company/test/test_contact_views.py
+++ b/datahub/company/test/test_contact_views.py
@@ -9,11 +9,11 @@ from rest_framework.reverse import reverse
 from reversion.models import Version
 
 from datahub.company.models import Contact
+from datahub.company.test.factories import ArchivedContactFactory, CompanyFactory, ContactFactory
 from datahub.core import constants
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
 from datahub.metadata.test.factories import TeamFactory
-from .factories import ArchivedContactFactory, CompanyFactory, ContactFactory
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -6,25 +6,25 @@ from rest_framework import mixins, viewsets
 from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 
-from datahub.core.audit import AuditViewSet
-from datahub.core.mixins import ArchivableViewSetMixin
-from datahub.core.viewsets import CoreViewSet
-from datahub.investment.queryset import get_slim_investment_project_queryset
-from datahub.oauth.scopes import Scope
-from .models import (
+from datahub.company.models import (
     Advisor,
     CompaniesHouseCompany,
     Company,
     Contact,
 )
-from .queryset import get_contact_queryset
-from .serializers import (
+from datahub.company.queryset import get_contact_queryset
+from datahub.company.serializers import (
     AdviserSerializer,
     CompaniesHouseCompanySerializer,
     CompanyCoreTeamMemberSerializer,
     CompanySerializer,
     ContactSerializer,
 )
+from datahub.core.audit import AuditViewSet
+from datahub.core.mixins import ArchivableViewSetMixin
+from datahub.core.viewsets import CoreViewSet
+from datahub.investment.queryset import get_slim_investment_project_queryset
+from datahub.oauth.scopes import Scope
 
 
 class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):


### PR DESCRIPTION
### Description of change

This converts imports to absolute in cleanup and company apps.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
