### PR TITLE
Remove injection of read_* permissions from /whoami/ endpoint

### DIFF
--- a/changelog/remove-read-permission-injection.api
+++ b/changelog/remove-read-permission-injection.api
@@ -1,0 +1,1 @@
+- ``GET /whoami/`` no longer returns the ``read_*`` permissions that were being returned for backwards compatibility following the introduction of ``view_*`` permissions.

--- a/changelog/remove-read-permission-injection.removal
+++ b/changelog/remove-read-permission-injection.removal
@@ -1,0 +1,1 @@
+- ``GET /whoami/`` no longer returns the ``read_*`` permissions that were being returned for backwards compatibility following the introduction of ``view_*`` permissions.

--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -39,11 +39,4 @@ class WhoAmISerializer(serializers.ModelSerializer):
         replicated as permissions with codenames that start with read_. (Once the front end has
         been updated to use the new view_ permissions, this replication can be removed.)
         """
-        permissions = obj.get_all_permissions()
-        view_permissions_subs = (
-            VIEW_PERMISSION_REGEX.subn(r'\1read\2', permission) for permission in permissions
-        )
-        read_permissions = {
-            permission for permission, sub_count in view_permissions_subs if sub_count > 0
-        }
-        return permissions | read_permissions
+        return obj.get_all_permissions()

--- a/datahub/user/test/test_views.py
+++ b/datahub/user/test/test_views.py
@@ -49,8 +49,6 @@ class TestUserView(APITestMixin):
 
         expected_permissions = [
             'admin.add_cats',
-            'admin.read_ipsum',
-            'admin.read_lorem',
             'admin.view_ipsum',
             'admin.view_lorem',
         ]


### PR DESCRIPTION
### Description of change

These were replaced by view_* permissions (which the front end is now using).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
