### PR TITLE
Stop WhiteNoise warning about STATIC_ROOT not existing during tests

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -50,6 +50,10 @@ CACHES = {
 
 CELERY_TASK_ALWAYS_EAGER = True
 
+# Stop WhiteNoise emitting warnings when running tests without running collectstatic first
+WHITENOISE_AUTOREFRESH = True
+WHITENOISE_USE_FINDERS = True
+
 ACTIVITY_STREAM_IP_WHITELIST = '1.2.3.4'
 ACTIVITY_STREAM_ACCESS_KEY_ID = 'some-id'
 ACTIVITY_STREAM_SECRET_ACCESS_KEY = 'some-secret'


### PR DESCRIPTION
### Description of change

This is related to https://github.com/evansd/whitenoise/issues/191, but that fix doesn't work as settings.DEBUG gets set to False when running tests.

This simply sets the two settings that are normally set from settings.DEBUG to True, which then triggers the fix in WhiteNoise. I don't expect any real effect on the tests as there wouldn't normally be requests for static files in them.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
