### PR TITLE
Remove unused view permission regex

### DIFF
--- a/datahub/user/serializers.py
+++ b/datahub/user/serializers.py
@@ -1,12 +1,7 @@
-import re
-
 from rest_framework import serializers
 
 from datahub.company.models.adviser import Advisor
 from datahub.metadata.serializers import TeamSerializer
-
-
-VIEW_PERMISSION_REGEX = re.compile(r'^([^.]*\.)view(_.*)$')
 
 
 class WhoAmISerializer(serializers.ModelSerializer):


### PR DESCRIPTION
### Description of change

Removes a regex for matching view permissions that is unused following https://github.com/uktrade/data-hub-leeloo/pull/1156.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
