### PR TITLE
Convert all imports to absolute in investment apps

### DIFF
--- a/datahub/investment/evidence/admin.py
+++ b/datahub/investment/evidence/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
+from datahub.investment.evidence.models import EvidenceTag
 from datahub.metadata.admin import DisableableMetadataAdmin
-from .models import EvidenceTag
 
 
 @admin.register(EvidenceTag)

--- a/datahub/investment/evidence/metadata.py
+++ b/datahub/investment/evidence/metadata.py
@@ -1,5 +1,5 @@
+from datahub.investment.evidence.models import EvidenceTag
 from datahub.metadata.registry import registry
-from .models import EvidenceTag
 
 
 registry.register(

--- a/datahub/investment/evidence/test/factories.py
+++ b/datahub/investment/evidence/test/factories.py
@@ -2,7 +2,7 @@ import uuid
 
 import factory
 
-from ..models import EvidenceTag
+from datahub.investment.evidence.models import EvidenceTag
 
 
 class EvidenceTagFactory(factory.django.DjangoModelFactory):

--- a/datahub/investment/evidence/test/test_views.py
+++ b/datahub/investment/evidence/test/test_views.py
@@ -11,11 +11,11 @@ from rest_framework.reverse import reverse
 from datahub.company.test.factories import TeamFactory
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
 from datahub.documents.models import Document, UPLOAD_STATUSES
+from datahub.investment.evidence.models import EvidenceDocument, EvidenceDocumentPermission
+from datahub.investment.evidence.test.factories import EvidenceTagFactory
+from datahub.investment.evidence.test.utils import create_evidence_document
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.user_event_log.models import USER_EVENT_TYPES, UserEvent
-from .factories import EvidenceTagFactory
-from .utils import create_evidence_document
-from ..models import EvidenceDocument, EvidenceDocumentPermission
 
 pytestmark = pytest.mark.django_db
 

--- a/datahub/investment/evidence/test/utils.py
+++ b/datahub/investment/evidence/test/utils.py
@@ -1,6 +1,6 @@
+from datahub.investment.evidence.models import EvidenceDocument
+from datahub.investment.evidence.test.factories import EvidenceTagFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
-from .factories import EvidenceTagFactory
-from ..models import EvidenceDocument
 
 
 def create_evidence_document(user=None, associated=False, investment_project=None):

--- a/datahub/investment/proposition/models.py
+++ b/datahub/investment/proposition/models.py
@@ -13,7 +13,8 @@ from datahub.core.utils import StrEnum
 from datahub.documents.models import AbstractEntityDocumentModel, UPLOAD_STATUSES
 from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.investment.proposition.constants import (
-    FEATURE_FLAG_PROPOSITION_DOCUMENT, PropositionStatus,
+    FEATURE_FLAG_PROPOSITION_DOCUMENT,
+    PropositionStatus,
 )
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH

--- a/datahub/investment/proposition/test/test_views.py
+++ b/datahub/investment/proposition/test/test_views.py
@@ -14,15 +14,19 @@ from datahub.core.test_utils import APITestMixin, create_test_user, format_date_
 from datahub.documents.models import Document, UPLOAD_STATUSES
 from datahub.feature_flag.test.factories import FeatureFlagFactory
 from datahub.investment.proposition.constants import (
-    FEATURE_FLAG_PROPOSITION_DOCUMENT, PropositionStatus,
+    FEATURE_FLAG_PROPOSITION_DOCUMENT,
+    PropositionStatus,
 )
 from datahub.investment.proposition.models import (
-    Proposition, PropositionDocument, PropositionDocumentPermission, PropositionPermission,
+    Proposition,
+    PropositionDocument,
+    PropositionDocumentPermission,
+    PropositionPermission,
 )
+from datahub.investment.proposition.test.factories import PropositionFactory
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.metadata.test.factories import TeamFactory
 from datahub.user_event_log.models import USER_EVENT_TYPES, UserEvent
-from .factories import PropositionFactory
 
 NON_RESTRICTED_VIEW_PERMISSIONS = (
     (

--- a/datahub/investment/report/tasks.py
+++ b/datahub/investment/report/tasks.py
@@ -5,7 +5,7 @@ from django.utils.timezone import now
 
 from datahub.documents.utils import get_bucket_name, get_s3_client_for_bucket
 from datahub.investment.report.models import SPIReport
-from .spi import write_report
+from datahub.investment.report.spi import write_report
 
 
 def _get_report_key():

--- a/datahub/investment/report/test/test_spi.py
+++ b/datahub/investment/report/test/test_spi.py
@@ -10,7 +10,8 @@ from datahub.investment.proposition.models import PropositionDocument
 from datahub.investment.proposition.test.factories import PropositionFactory
 from datahub.investment.report.spi import SPIReport
 from datahub.investment.test.factories import (
-    InvestmentProjectFactory, VerifyWinInvestmentProjectFactory,
+    InvestmentProjectFactory,
+    VerifyWinInvestmentProjectFactory,
 )
 from datahub.metadata.models import Team
 

--- a/datahub/investment/report/test/test_tasks.py
+++ b/datahub/investment/report/test/test_tasks.py
@@ -1,6 +1,6 @@
 from freezegun import freeze_time
 
-from ..tasks import _get_report_key
+from datahub.investment.report.tasks import _get_report_key
 
 
 @freeze_time('2018-03-01 01:02:03')

--- a/datahub/investment/test/factories.py
+++ b/datahub/investment/test/factories.py
@@ -8,13 +8,20 @@ from django.utils.timezone import now
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.core.constants import (
-    InvestmentBusinessActivity, InvestmentProjectStage, InvestmentStrategicDriver,
-    InvestmentType, ReferralSourceActivity, SalaryRange, Sector,
+    InvestmentBusinessActivity,
+    InvestmentProjectStage,
+    InvestmentStrategicDriver,
+    InvestmentType,
+    ReferralSourceActivity,
+    SalaryRange,
+    Sector,
 )
 from datahub.core.test.factories import to_many_field
 from datahub.core.test_utils import random_obj_for_model
 from datahub.investment.constants import (
-    InvestorType, Involvement, SpecificProgramme,
+    InvestorType,
+    Involvement,
+    SpecificProgramme,
 )
 from datahub.investment.models import InvestmentDeliveryPartner, InvestmentProject
 from datahub.metadata.models import UKRegion

--- a/datahub/investment/test/test_models.py
+++ b/datahub/investment/test/test_models.py
@@ -11,7 +11,8 @@ from freezegun import freeze_time
 from datahub.company.test.factories import AdviserFactory
 from datahub.core import constants
 from datahub.investment.test.factories import (
-    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
+    InvestmentProjectFactory,
+    InvestmentProjectTeamMemberFactory,
 )
 
 pytestmark = pytest.mark.django_db

--- a/datahub/investment/test/test_serializers.py
+++ b/datahub/investment/test/test_serializers.py
@@ -2,9 +2,13 @@ import pytest
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.investment.serializers import (
-    IProjectTeamMemberListSerializer, IProjectTeamMemberSerializer,
+    IProjectTeamMemberListSerializer,
+    IProjectTeamMemberSerializer,
 )
-from .factories import InvestmentProjectFactory, InvestmentProjectTeamMemberFactory
+from datahub.investment.test.factories import (
+    InvestmentProjectFactory,
+    InvestmentProjectTeamMemberFactory,
+)
 
 
 pytestmark = pytest.mark.django_db

--- a/datahub/investment/test/test_validate.py
+++ b/datahub/investment/test/test_validate.py
@@ -5,7 +5,10 @@ from datahub.core import constants
 from datahub.core.test_utils import random_obj_for_model
 from datahub.investment.models import InvestmentDeliveryPartner
 from datahub.investment.serializers import (
-    CORE_FIELDS, REQUIREMENTS_FIELDS, TEAM_FIELDS, VALUE_FIELDS,
+    CORE_FIELDS,
+    REQUIREMENTS_FIELDS,
+    TEAM_FIELDS,
+    VALUE_FIELDS,
 )
 from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.investment.validate import validate

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -19,17 +19,25 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory, Conta
 from datahub.core import constants
 from datahub.core.reversion import EXCLUDED_BASE_MODEL_FIELDS
 from datahub.core.test_utils import (
-    APITestMixin, create_test_user, format_date_or_datetime, random_obj_for_model,
+    APITestMixin,
+    create_test_user,
+    format_date_or_datetime,
+    random_obj_for_model,
 )
 from datahub.investment import views
 from datahub.investment.models import (
-    InvestmentDeliveryPartner, InvestmentProject,
-    InvestmentProjectPermission, InvestmentProjectTeamMember,
+    InvestmentDeliveryPartner,
+    InvestmentProject,
+    InvestmentProjectPermission,
+    InvestmentProjectTeamMember,
 )
 from datahub.investment.test.factories import (
-    ActiveInvestmentProjectFactory, AssignPMInvestmentProjectFactory,
-    InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
-    VerifyWinInvestmentProjectFactory, WonInvestmentProjectFactory,
+    ActiveInvestmentProjectFactory,
+    AssignPMInvestmentProjectFactory,
+    InvestmentProjectFactory,
+    InvestmentProjectTeamMemberFactory,
+    VerifyWinInvestmentProjectFactory,
+    WonInvestmentProjectFactory,
 )
 from datahub.metadata.models import UKRegion
 from datahub.metadata.test.factories import TeamFactory

--- a/datahub/investment/urls.py
+++ b/datahub/investment/urls.py
@@ -5,8 +5,10 @@ from django.urls import include, path
 from datahub.investment.evidence.urls import urlpatterns as evidence_urlpatterns
 from datahub.investment.proposition.urls import urlpatterns as proposition_urlpatterns
 from datahub.investment.views import (
-    IProjectAuditViewSet, IProjectModifiedSinceViewSet,
-    IProjectTeamMembersViewSet, IProjectViewSet,
+    IProjectAuditViewSet,
+    IProjectModifiedSinceViewSet,
+    IProjectTeamMembersViewSet,
+    IProjectViewSet,
 )
 
 project_collection = IProjectViewSet.as_view({

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -15,8 +15,10 @@ from datahub.core.mixins import ArchivableViewSetMixin
 from datahub.core.viewsets import CoreViewSet
 from datahub.investment.models import InvestmentProject, InvestmentProjectTeamMember
 from datahub.investment.permissions import (
-    InvestmentProjectModelPermissions, InvestmentProjectTeamMemberModelPermissions,
-    IsAssociatedToInvestmentProjectFilter, IsAssociatedToInvestmentProjectPermission,
+    InvestmentProjectModelPermissions,
+    InvestmentProjectTeamMemberModelPermissions,
+    IsAssociatedToInvestmentProjectFilter,
+    IsAssociatedToInvestmentProjectPermission,
     IsAssociatedToInvestmentProjectTeamMemberPermission,
 )
 from datahub.investment.serializers import IProjectSerializer, IProjectTeamMemberSerializer


### PR DESCRIPTION
### Description of change

This converts all imports to absolute in all investment apps.
I've also re-formatted some imports to have just one per line.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
