### PR TITLE
Convert all imports to absolute in metadata app

### DIFF
--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from mptt.admin import MPTTModelAdmin
 
 from datahub.core.admin import DisabledOnFilter, ViewAndChangeOnlyAdmin, ViewOnlyAdmin
-from . import models
+from datahub.metadata import models
 
 
 MODELS_TO_REGISTER_DISABLEABLE = (

--- a/datahub/metadata/metadata.py
+++ b/datahub/metadata/metadata.py
@@ -1,7 +1,7 @@
-from . import models
-from .filters import ServiceFilterSet
-from .registry import registry
-from .serializers import SectorSerializer, ServiceSerializer, TeamSerializer
+from datahub.metadata import models
+from datahub.metadata.filters import ServiceFilterSet
+from datahub.metadata.registry import registry
+from datahub.metadata.serializers import SectorSerializer, ServiceSerializer, TeamSerializer
 
 registry.register(metadata_id='business-type', model=models.BusinessType)
 registry.register(metadata_id='country', model=models.Country)

--- a/datahub/metadata/serializers.py
+++ b/datahub/metadata/serializers.py
@@ -3,7 +3,7 @@ from functools import partial
 from rest_framework import serializers
 
 from datahub.core.serializers import ConstantModelSerializer, NestedRelatedField
-from .models import Country, Service, TeamRole, UKRegion
+from datahub.metadata.models import Country, Service, TeamRole, UKRegion
 
 
 TeamWithGeographyField = partial(

--- a/datahub/metadata/test/test_registry.py
+++ b/datahub/metadata/test/test_registry.py
@@ -3,8 +3,8 @@ from django.core.exceptions import ImproperlyConfigured
 from rest_framework import serializers
 
 from datahub.core.serializers import ConstantModelSerializer
-from ..models import Sector, UKRegion
-from ..registry import MetadataRegistry
+from datahub.metadata.models import Sector, UKRegion
+from datahub.metadata.registry import MetadataRegistry
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db

--- a/datahub/metadata/test/test_views.py
+++ b/datahub/metadata/test/test_views.py
@@ -8,10 +8,10 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import format_date_or_datetime
-from .factories import ServiceFactory
-from .. import urls
-from ..models import Sector, Service
-from ..registry import registry
+from datahub.metadata import urls
+from datahub.metadata.models import Sector, Service
+from datahub.metadata.registry import registry
+from datahub.metadata.test.factories import ServiceFactory
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db

--- a/datahub/metadata/urls.py
+++ b/datahub/metadata/urls.py
@@ -1,5 +1,5 @@
 from django.urls import path
 
-from . import views
+from datahub.metadata import views
 
 urlpatterns = [path(*args, **kwargs) for args, kwargs in views.urls_args]

--- a/datahub/metadata/views.py
+++ b/datahub/metadata/views.py
@@ -2,7 +2,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.mixins import ListModelMixin
 from rest_framework.viewsets import GenericViewSet
 
-from .registry import registry
+from datahub.metadata.registry import registry
 
 
 def _create_metadata_view(mapping):


### PR DESCRIPTION
### Description of change

This converts all imports to absolute in the metadata app.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
