### PR TITLE
Convert imports to absolute in all omis apps

### DIFF
--- a/datahub/omis/invoice/managers.py
+++ b/datahub/omis/invoice/managers.py
@@ -1,8 +1,8 @@
 from django.db import models
 
 from datahub.omis.core.utils import generate_datetime_based_reference
-from . import constants
-from .utils import calculate_payment_due_date
+from datahub.omis.invoice import constants
+from datahub.omis.invoice.utils import calculate_payment_due_date
 
 
 class InvoiceManager(models.Manager):

--- a/datahub/omis/invoice/models.py
+++ b/datahub/omis/invoice/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from datahub.core.models import BaseModel
 from datahub.metadata.models import Country
-from .managers import InvoiceManager
+from datahub.omis.invoice.managers import InvoiceManager
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 

--- a/datahub/omis/invoice/serializers.py
+++ b/datahub/omis/invoice/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from datahub.core.serializers import NestedRelatedField
 from datahub.metadata.models import Country
-from .models import Invoice
+from datahub.omis.invoice.models import Invoice
 
 
 class InvoiceSerializer(serializers.ModelSerializer):

--- a/datahub/omis/invoice/test/test_managers.py
+++ b/datahub/omis/invoice/test/test_managers.py
@@ -3,9 +3,9 @@ from unittest import mock
 import pytest
 from dateutil.parser import parse as dateutil_parse
 
+from datahub.omis.invoice import constants
+from datahub.omis.invoice.models import Invoice
 from datahub.omis.order.test.factories import OrderFactory
-from .. import constants
-from ..models import Invoice
 
 
 # mark the whole module for db use

--- a/datahub/omis/invoice/test/test_utils.py
+++ b/datahub/omis/invoice/test/test_utils.py
@@ -5,9 +5,9 @@ from dateutil.parser import parse as dateutil_parse
 from freezegun import freeze_time
 
 from datahub.omis.core.utils import generate_datetime_based_reference
+from datahub.omis.invoice.models import Invoice
+from datahub.omis.invoice.utils import calculate_payment_due_date
 from datahub.omis.order.test.factories import OrderWithAcceptedQuoteFactory
-from ..models import Invoice
-from ..utils import calculate_payment_due_date
 
 
 @pytest.mark.django_db

--- a/datahub/omis/invoice/test/views/test_public_invoice_details.py
+++ b/datahub/omis/invoice/test/views/test_public_invoice_details.py
@@ -7,8 +7,10 @@ from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import (
-    OrderCompleteFactory, OrderFactory,
-    OrderPaidFactory, OrderWithAcceptedQuoteFactory,
+    OrderCompleteFactory,
+    OrderFactory,
+    OrderPaidFactory,
+    OrderWithAcceptedQuoteFactory,
 )
 
 

--- a/datahub/omis/invoice/urls.py
+++ b/datahub/omis/invoice/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, re_path
 
-from .views import InvoiceViewSet, PublicInvoiceViewSet
+from datahub.omis.invoice.views import InvoiceViewSet, PublicInvoiceViewSet
 
 
 # internal frontend API

--- a/datahub/omis/invoice/utils.py
+++ b/datahub/omis/invoice/utils.py
@@ -1,6 +1,9 @@
 from datetime import timedelta
 
-from .constants import PAYMENT_DUE_DAYS_BEFORE_DELIVERY, PAYMENT_DUE_DAYS_FROM_NOW
+from datahub.omis.invoice.constants import (
+    PAYMENT_DUE_DAYS_BEFORE_DELIVERY,
+    PAYMENT_DUE_DAYS_FROM_NOW,
+)
 
 
 def calculate_payment_due_date(order):

--- a/datahub/omis/invoice/views.py
+++ b/datahub/omis/invoice/views.py
@@ -2,11 +2,11 @@ from django.http import Http404
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 
 from datahub.oauth.scopes import Scope
+from datahub.omis.invoice.models import Invoice
+from datahub.omis.invoice.serializers import InvoiceSerializer
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.models import Order
 from datahub.omis.order.views import BaseNestedOrderViewSet
-from .models import Invoice
-from .serializers import InvoiceSerializer
 
 
 class BaseInvoiceViewSet(BaseNestedOrderViewSet):

--- a/datahub/omis/market/admin.py
+++ b/datahub/omis/market/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Market
+from datahub.omis.market.models import Market
 
 
 @admin.register(Market)

--- a/datahub/omis/market/metadata.py
+++ b/datahub/omis/market/metadata.py
@@ -1,7 +1,7 @@
 from datahub.metadata.fixtures import Fixture
 from datahub.metadata.registry import registry
-from . import models
-from .serializers import MarketSerializer
+from datahub.omis.market import models
+from datahub.omis.market.serializers import MarketSerializer
 
 
 class MarketFixtures(Fixture):

--- a/datahub/omis/market/test/test_serializers.py
+++ b/datahub/omis/market/test/test_serializers.py
@@ -1,7 +1,7 @@
 import pytest
 
-from ..models import Market
-from ..serializers import MarketSerializer
+from datahub.omis.market.models import Market
+from datahub.omis.market.serializers import MarketSerializer
 
 
 pytestmark = pytest.mark.django_db

--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -8,8 +8,8 @@ from notifications_python_client.notifications import NotificationsAPIClient
 
 from datahub.core.thread_pool import submit_to_thread_pool
 from datahub.omis.market.models import Market
+from datahub.omis.notification.constants import Template
 from datahub.omis.region.models import UKRegionalSettings
-from .constants import Template
 
 
 logger = getLogger(__name__)

--- a/datahub/omis/notification/signal_receivers.py
+++ b/datahub/omis/notification/signal_receivers.py
@@ -7,8 +7,12 @@ from django.dispatch import receiver
 from datahub.omis.notification.client import notify
 from datahub.omis.order.models import Order, OrderAssignee, OrderSubscriber
 from datahub.omis.order.signals import (
-    order_cancelled, order_completed, order_paid,
-    quote_accepted, quote_cancelled, quote_generated,
+    order_cancelled,
+    order_completed,
+    order_paid,
+    quote_accepted,
+    quote_cancelled,
+    quote_generated,
 )
 
 

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -8,13 +8,18 @@ from django.conf import settings
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import UKRegion
 from datahub.omis.market.models import Market
+from datahub.omis.notification.client import notify, send_email
+from datahub.omis.notification.constants import Template
 from datahub.omis.order.test.factories import (
-    OrderAssigneeCompleteFactory, OrderAssigneeFactory, OrderCompleteFactory,
-    OrderFactory, OrderPaidFactory, OrderSubscriberFactory, OrderWithOpenQuoteFactory,
+    OrderAssigneeCompleteFactory,
+    OrderAssigneeFactory,
+    OrderCompleteFactory,
+    OrderFactory,
+    OrderPaidFactory,
+    OrderSubscriberFactory,
+    OrderWithOpenQuoteFactory,
 )
 from datahub.omis.region.models import UKRegionalSettings
-from ..client import notify, send_email
-from ..constants import Template
 
 pytestmark = pytest.mark.django_db
 

--- a/datahub/omis/notification/test/test_signal_receivers.py
+++ b/datahub/omis/notification/test/test_signal_receivers.py
@@ -2,14 +2,18 @@ import pytest
 from dateutil.parser import parse as dateutil_parse
 
 from datahub.company.test.factories import AdviserFactory
+from datahub.omis.notification.client import notify
+from datahub.omis.notification.constants import Template
 from datahub.omis.order.models import CancellationReason
 from datahub.omis.order.test.factories import (
-    OrderAssigneeCompleteFactory, OrderAssigneeFactory, OrderFactory,
-    OrderPaidFactory, OrderSubscriberFactory,
-    OrderWithAcceptedQuoteFactory, OrderWithOpenQuoteFactory,
+    OrderAssigneeCompleteFactory,
+    OrderAssigneeFactory,
+    OrderFactory,
+    OrderPaidFactory,
+    OrderSubscriberFactory,
+    OrderWithAcceptedQuoteFactory,
+    OrderWithOpenQuoteFactory,
 )
-from ..client import notify
-from ..constants import Template
 
 pytestmark = pytest.mark.django_db
 

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -5,12 +5,14 @@ from django.conf import settings
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import UKRegion
 from datahub.omis.market.models import Market
+from datahub.omis.notification.client import Notify
 from datahub.omis.order.test.factories import (
-    OrderCompleteFactory, OrderFactory,
-    OrderPaidFactory, OrderWithOpenQuoteFactory,
+    OrderCompleteFactory,
+    OrderFactory,
+    OrderPaidFactory,
+    OrderWithOpenQuoteFactory,
 )
 from datahub.omis.region.models import UKRegionalSettings
-from ..client import Notify
 
 
 pytestmark = pytest.mark.django_db

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -22,8 +22,8 @@ from django.views.decorators.csrf import csrf_protect
 
 from datahub.core.admin import BaseModelAdminMixin, get_change_url, ViewAndChangeOnlyAdmin
 from datahub.core.exceptions import APIConflictException
-from . import validators
-from .models import CancellationReason, Order
+from datahub.omis.order import validators
+from datahub.omis.order.models import CancellationReason, Order
 
 csrf_protect_m = method_decorator(csrf_protect)
 

--- a/datahub/omis/order/managers.py
+++ b/datahub/omis/order/managers.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from .constants import OrderStatus
+from datahub.omis.order.constants import OrderStatus
 
 
 class OrderQuerySet(models.QuerySet):

--- a/datahub/omis/order/metadata.py
+++ b/datahub/omis/order/metadata.py
@@ -1,7 +1,7 @@
 from datahub.core.serializers import ConstantModelSerializer
 from datahub.metadata.fixtures import Fixture
 from datahub.metadata.registry import registry
-from . import models
+from datahub.omis.order import models
 
 
 class ServiceTypeFixtures(Fixture):

--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -12,23 +12,29 @@ from mptt.fields import TreeForeignKey
 
 from datahub.company.models import Advisor, Company, Contact
 from datahub.core.models import (
-    BaseConstantModel, BaseModel, BaseOrderedConstantModel,
+    BaseConstantModel,
+    BaseModel,
+    BaseOrderedConstantModel,
 )
 from datahub.core.utils import StrEnum
 from datahub.metadata.models import Country, Sector, Team, UKRegion
 from datahub.omis.core.utils import generate_reference
 from datahub.omis.invoice.models import Invoice
+from datahub.omis.order import validators
+from datahub.omis.order.constants import DEFAULT_HOURLY_RATE, OrderStatus, VATStatus
+from datahub.omis.order.managers import OrderQuerySet
+from datahub.omis.order.signals import (
+    order_cancelled,
+    order_completed,
+    order_paid,
+    quote_accepted,
+    quote_cancelled,
+    quote_generated,
+)
+from datahub.omis.order.utils import populate_billing_data
 from datahub.omis.payment.models import Payment
 from datahub.omis.payment.validators import ReconcilablePaymentsValidator
 from datahub.omis.quote.models import Quote
-from . import validators
-from .constants import DEFAULT_HOURLY_RATE, OrderStatus, VATStatus
-from .managers import OrderQuerySet
-from .signals import (
-    order_cancelled, order_completed, order_paid,
-    quote_accepted, quote_cancelled, quote_generated,
-)
-from .utils import populate_billing_data
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 

--- a/datahub/omis/order/pricing.py
+++ b/datahub/omis/order/pricing.py
@@ -3,8 +3,8 @@ from collections import namedtuple
 from django.db.models import Sum
 from rest_framework.exceptions import ValidationError
 
-from .constants import VATStatus
-from .validators import VATValidator
+from datahub.omis.order.constants import VATStatus
+from datahub.omis.order.validators import VATValidator
 
 
 OrderPricing = namedtuple(

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -16,9 +16,15 @@ from datahub.core.validators import (
 )
 from datahub.metadata.models import Country, Sector, Team, UKRegion
 from datahub.omis.market.models import Market
-from .constants import OrderStatus, VATStatus
-from .models import CancellationReason, Order, OrderAssignee, OrderSubscriber, ServiceType
-from .validators import (
+from datahub.omis.order.constants import OrderStatus, VATStatus
+from datahub.omis.order.models import (
+    CancellationReason,
+    Order,
+    OrderAssignee,
+    OrderSubscriber,
+    ServiceType,
+)
+from datahub.omis.order.validators import (
     ContactWorksAtCompanyValidator,
     OrderEditableFieldsValidator,
     OrderInStatusRule,

--- a/datahub/omis/order/signal_receivers.py
+++ b/datahub/omis/order/signal_receivers.py
@@ -2,7 +2,7 @@ from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 
 from datahub.omis.order.models import Order, OrderAssignee
-from .pricing import update_order_pricing
+from datahub.omis.order.pricing import update_order_pricing
 
 
 @receiver(pre_save, sender=Order)

--- a/datahub/omis/order/test/factories.py
+++ b/datahub/omis/order/test/factories.py
@@ -8,11 +8,13 @@ from datahub.company.test.factories import AdviserFactory, CompanyFactory, Conta
 from datahub.core.constants import Country, Sector, UKRegion
 from datahub.core.test.factories import to_many_field
 from datahub.omis.invoice.models import Invoice
+from datahub.omis.order.constants import OrderStatus, VATStatus
+from datahub.omis.order.models import CancellationReason, ServiceType
 from datahub.omis.quote.test.factories import (
-    AcceptedQuoteFactory, CancelledQuoteFactory, QuoteFactory,
+    AcceptedQuoteFactory,
+    CancelledQuoteFactory,
+    QuoteFactory,
 )
-from ..constants import OrderStatus, VATStatus
-from ..models import CancellationReason, ServiceType
 
 
 class OrderFactory(factory.django.DjangoModelFactory):

--- a/datahub/omis/order/test/test_admin.py
+++ b/datahub/omis/order/test/test_admin.py
@@ -6,13 +6,16 @@ from django.test.client import Client
 from django.urls import reverse
 
 from datahub.core.test_utils import AdminTestMixin, create_test_user
-from .factories import (
-    OrderCancelledFactory, OrderCompleteFactory,
-    OrderFactory, OrderPaidFactory,
-    OrderWithAcceptedQuoteFactory, OrderWithOpenQuoteFactory,
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.models import CancellationReason, Order, OrderPermission
+from datahub.omis.order.test.factories import (
+    OrderCancelledFactory,
+    OrderCompleteFactory,
+    OrderFactory,
+    OrderPaidFactory,
+    OrderWithAcceptedQuoteFactory,
+    OrderWithOpenQuoteFactory,
 )
-from ..constants import OrderStatus
-from ..models import CancellationReason, Order, OrderPermission
 
 
 class TestCancelOrderAdmin(AdminTestMixin):

--- a/datahub/omis/order/test/test_managers.py
+++ b/datahub/omis/order/test/test_managers.py
@@ -1,9 +1,9 @@
 import pytest
 
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.models import Order
+from datahub.omis.order.test.factories import OrderFactory
 from datahub.omis.quote.test.factories import CancelledQuoteFactory
-from .factories import OrderFactory
-from ..constants import OrderStatus
-from ..models import Order
 
 
 pytestmark = pytest.mark.django_db

--- a/datahub/omis/order/test/test_models.py
+++ b/datahub/omis/order/test/test_models.py
@@ -15,9 +15,9 @@ from datahub.core import constants
 from datahub.core.exceptions import APIConflictException
 from datahub.metadata.test.factories import TeamFactory
 from datahub.omis.invoice.models import Invoice
-from datahub.omis.payment.models import Payment
-from datahub.omis.quote.models import Quote
-from .factories import (
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.models import CancellationReason
+from datahub.omis.order.test.factories import (
     OrderAssigneeCompleteFactory,
     OrderAssigneeFactory,
     OrderFactory,
@@ -25,8 +25,8 @@ from .factories import (
     OrderWithAcceptedQuoteFactory,
     OrderWithOpenQuoteFactory,
 )
-from ..constants import OrderStatus
-from ..models import CancellationReason
+from datahub.omis.payment.models import Payment
+from datahub.omis.quote.models import Quote
 
 pytestmark = pytest.mark.django_db
 

--- a/datahub/omis/order/test/test_pricing.py
+++ b/datahub/omis/order/test/test_pricing.py
@@ -4,15 +4,18 @@ from unittest import mock
 import pytest
 from rest_framework.exceptions import ValidationError
 
-from .factories import HourlyRateFactory, OrderAssigneeFactory, OrderFactory
-from ..constants import VATStatus
-from ..models import Order
-from ..pricing import (
-    _calculate_pricing, calculate_order_pricing,
-    can_pricing_be_calculated, get_pricing_from_order,
-    OrderPricing, should_vat_be_applied,
+from datahub.omis.order.constants import VATStatus
+from datahub.omis.order.models import Order
+from datahub.omis.order.pricing import (
+    _calculate_pricing,
+    calculate_order_pricing,
+    can_pricing_be_calculated,
+    get_pricing_from_order,
+    OrderPricing,
+    should_vat_be_applied,
     update_order_pricing, ZERO_PRICING,
 )
+from datahub.omis.order.test.factories import HourlyRateFactory, OrderAssigneeFactory, OrderFactory
 
 
 class TestGetPricingFromOrder:

--- a/datahub/omis/order/test/test_signal_receivers.py
+++ b/datahub/omis/order/test/test_signal_receivers.py
@@ -1,8 +1,8 @@
 import pytest
 
-from .factories import OrderAssigneeFactory, OrderFactory
-from ..constants import VATStatus
-from ..pricing import get_pricing_from_order
+from datahub.omis.order.constants import VATStatus
+from datahub.omis.order.pricing import get_pricing_from_order
+from datahub.omis.order.test.factories import OrderAssigneeFactory, OrderFactory
 
 
 pytestmark = pytest.mark.django_db

--- a/datahub/omis/order/test/test_utils.py
+++ b/datahub/omis/order/test/test_utils.py
@@ -2,11 +2,13 @@ import factory
 import pytest
 
 from datahub.company.test.factories import (
-    CompaniesHouseCompanyFactory, CompanyFactory, ContactFactory,
+    CompaniesHouseCompanyFactory,
+    CompanyFactory,
+    ContactFactory,
 )
 from datahub.core import constants
-from .factories import OrderFactory
-from ..utils import populate_billing_data
+from datahub.omis.order.test.factories import OrderFactory
+from datahub.omis.order.utils import populate_billing_data
 
 pytestmark = pytest.mark.django_db
 

--- a/datahub/omis/order/test/test_validators.py
+++ b/datahub/omis/order/test/test_validators.py
@@ -5,14 +5,14 @@ from django.db.models import Sum
 from rest_framework.exceptions import ValidationError
 
 from datahub.core.exceptions import APIConflictException
-from .factories import (
+from datahub.omis.order.constants import OrderStatus, VATStatus
+from datahub.omis.order.models import Order
+from datahub.omis.order.test.factories import (
     OrderFactory,
     OrderWithCancelledQuoteFactory,
     OrderWithOpenQuoteFactory,
 )
-from ..constants import OrderStatus, VATStatus
-from ..models import Order
-from ..validators import (
+from datahub.omis.order.validators import (
     AssigneesFilledInValidator,
     CancellableOrderValidator,
     CompletableOrderValidator,

--- a/datahub/omis/order/test/views/test_order_assignees.py
+++ b/datahub/omis/order/test/views/test_order_assignees.py
@@ -4,10 +4,10 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import APITestMixin
-from ..factories import OrderAssigneeFactory, OrderFactory, OrderPaidFactory
-from ...constants import OrderStatus
-from ...models import OrderAssignee
-from ...views import AssigneeView
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.models import OrderAssignee
+from datahub.omis.order.test.factories import OrderAssigneeFactory, OrderFactory, OrderPaidFactory
+from datahub.omis.order.views import AssigneeView
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db

--- a/datahub/omis/order/test/views/test_order_details.py
+++ b/datahub/omis/order/test/views/test_order_details.py
@@ -11,14 +11,18 @@ from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core.constants import Country, Sector, UKRegion
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.omis.market.models import Market
-from ..factories import (
-    OrderAssigneeCompleteFactory, OrderAssigneeFactory,
-    OrderCancelledFactory, OrderCompleteFactory, OrderFactory,
-    OrderPaidFactory, OrderWithAcceptedQuoteFactory,
+from datahub.omis.order.constants import OrderStatus, VATStatus
+from datahub.omis.order.models import CancellationReason, ServiceType
+from datahub.omis.order.test.factories import (
+    OrderAssigneeCompleteFactory,
+    OrderAssigneeFactory,
+    OrderCancelledFactory,
+    OrderCompleteFactory,
+    OrderFactory,
+    OrderPaidFactory,
+    OrderWithAcceptedQuoteFactory,
     OrderWithOpenQuoteFactory,
 )
-from ...constants import OrderStatus, VATStatus
-from ...models import CancellationReason, ServiceType
 
 
 # mark the whole module for db use

--- a/datahub/omis/order/test/views/test_public_order_details.py
+++ b/datahub/omis/order/test/views/test_public_order_details.py
@@ -5,9 +5,9 @@ from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.oauth.scopes import Scope
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.test.factories import OrderFactory, OrderWithCancelledQuoteFactory
 from datahub.omis.quote.test.factories import QuoteFactory
-from ..factories import OrderFactory, OrderWithCancelledQuoteFactory
-from ...constants import OrderStatus
 
 
 # mark the whole module for db use

--- a/datahub/omis/order/test/views/test_subscriber_list.py
+++ b/datahub/omis/order/test/views/test_subscriber_list.py
@@ -4,8 +4,8 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import APITestMixin
-from ..factories import OrderFactory, OrderSubscriberFactory
-from ...constants import OrderStatus
+from datahub.omis.order.constants import OrderStatus
+from datahub.omis.order.test.factories import OrderFactory, OrderSubscriberFactory
 
 
 # mark the whole module for db use

--- a/datahub/omis/order/urls.py
+++ b/datahub/omis/order/urls.py
@@ -2,7 +2,12 @@
 
 from django.urls import path, re_path
 
-from .views import AssigneeView, OrderViewSet, PublicOrderViewSet, SubscriberListView
+from datahub.omis.order.views import (
+    AssigneeView,
+    OrderViewSet,
+    PublicOrderViewSet,
+    SubscriberListView,
+)
 
 # internal frontend API
 internal_frontend_urls = [

--- a/datahub/omis/order/validators.py
+++ b/datahub/omis/order/validators.py
@@ -7,7 +7,7 @@ from rest_framework.settings import api_settings
 from datahub.core.exceptions import APIConflictException
 from datahub.core.validate_utils import DataCombiner
 from datahub.core.validators import AbstractRule, BaseRule
-from .constants import OrderStatus, VATStatus
+from datahub.omis.order.constants import OrderStatus, VATStatus
 
 
 class ContactWorksAtCompanyValidator:

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -6,8 +6,8 @@ from rest_framework.views import APIView
 
 from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
-from .models import Order
-from .serializers import (
+from datahub.omis.order.models import Order
+from datahub.omis.order.serializers import (
     CancelOrderSerializer,
     CompleteOrderSerializer,
     OrderAssigneeSerializer,

--- a/datahub/omis/payment/admin.py
+++ b/datahub/omis/payment/admin.py
@@ -7,8 +7,8 @@ from django.utils.translation import ugettext_lazy as _
 
 from datahub.core.admin import BaseModelAdminMixin
 from datahub.omis.order.constants import OrderStatus
-from .constants import RefundStatus
-from .models import Refund
+from datahub.omis.payment.constants import RefundStatus
+from datahub.omis.payment.models import Refund
 
 
 class RefundForm(forms.ModelForm):

--- a/datahub/omis/payment/managers.py
+++ b/datahub/omis/payment/managers.py
@@ -6,8 +6,8 @@ from django.db import models
 from datahub.omis.core.utils import generate_datetime_based_reference
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.validators import OrderInStatusValidator
-from .constants import PaymentGatewaySessionStatus
-from .govukpay import PayClient
+from datahub.omis.payment.constants import PaymentGatewaySessionStatus
+from datahub.omis.payment.govukpay import PayClient
 
 
 class BasePaymentGatewaySessionManager(models.Manager):

--- a/datahub/omis/payment/models.py
+++ b/datahub/omis/payment/models.py
@@ -5,10 +5,10 @@ from django.db import models, transaction
 
 from datahub.core.models import BaseModel
 from datahub.omis.core.utils import generate_datetime_based_reference
-from .constants import PaymentGatewaySessionStatus, PaymentMethod, RefundStatus
-from .govukpay import PayClient
-from .managers import PaymentGatewaySessionManager, PaymentManager
-from .utils import trasform_govuk_payment_to_omis_payment_data
+from datahub.omis.payment.constants import PaymentGatewaySessionStatus, PaymentMethod, RefundStatus
+from datahub.omis.payment.govukpay import PayClient
+from datahub.omis.payment.managers import PaymentGatewaySessionManager, PaymentManager
+from datahub.omis.payment.utils import trasform_govuk_payment_to_omis_payment_data
 
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH

--- a/datahub/omis/payment/serializers.py
+++ b/datahub/omis/payment/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
-from .constants import PaymentMethod
-from .models import Payment, PaymentGatewaySession
+from datahub.omis.payment.constants import PaymentMethod
+from datahub.omis.payment.models import Payment, PaymentGatewaySession
 
 
 class PaymentListSerializer(serializers.ListSerializer):

--- a/datahub/omis/payment/tasks.py
+++ b/datahub/omis/payment/tasks.py
@@ -4,7 +4,7 @@ from celery.task import task
 from django.db import transaction
 from django.utils.timezone import now
 
-from .models import PaymentGatewaySession
+from datahub.omis.payment.models import PaymentGatewaySession
 
 
 @task(ignore_result=True)

--- a/datahub/omis/payment/test/factories.py
+++ b/datahub/omis/payment/test/factories.py
@@ -6,8 +6,8 @@ from django.utils.timezone import utc
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.omis.order.test.factories import OrderPaidFactory, OrderWithAcceptedQuoteFactory
-from .. import constants
-from ..models import RefundStatus
+from datahub.omis.payment import constants
+from datahub.omis.payment.models import RefundStatus
 
 
 class PaymentFactory(factory.django.DjangoModelFactory):

--- a/datahub/omis/payment/test/test_admin.py
+++ b/datahub/omis/payment/test/test_admin.py
@@ -7,9 +7,13 @@ from rest_framework import status
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import AdminTestMixin
 from datahub.omis.order.test.factories import OrderPaidFactory, OrderWithOpenQuoteFactory
-from .factories import ApprovedRefundFactory, RejectedRefundFactory, RequestedRefundFactory
-from ..constants import PaymentMethod, RefundStatus
-from ..models import Refund
+from datahub.omis.payment.constants import PaymentMethod, RefundStatus
+from datahub.omis.payment.models import Refund
+from datahub.omis.payment.test.factories import (
+    ApprovedRefundFactory,
+    RejectedRefundFactory,
+    RequestedRefundFactory,
+)
 
 
 class TestRefundAdmin(AdminTestMixin):

--- a/datahub/omis/payment/test/test_govukpay.py
+++ b/datahub/omis/payment/test/test_govukpay.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ..govukpay import govuk_url, GOVUKPayAPIException, PayClient
+from datahub.omis.payment.govukpay import govuk_url, GOVUKPayAPIException, PayClient
 
 
 def test_govuk_url(settings):

--- a/datahub/omis/payment/test/test_managers.py
+++ b/datahub/omis/payment/test/test_managers.py
@@ -9,12 +9,14 @@ from datahub.company.test.factories import AdviserFactory
 from datahub.core.exceptions import APIConflictException
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import (
-    OrderFactory, OrderPaidFactory, OrderWithAcceptedQuoteFactory,
+    OrderFactory,
+    OrderPaidFactory,
+    OrderWithAcceptedQuoteFactory,
 )
-from .factories import PaymentGatewaySessionFactory
-from ..constants import PaymentGatewaySessionStatus, PaymentMethod
-from ..govukpay import govuk_url, GOVUKPayAPIException
-from ..models import Payment, PaymentGatewaySession
+from datahub.omis.payment.constants import PaymentGatewaySessionStatus, PaymentMethod
+from datahub.omis.payment.govukpay import govuk_url, GOVUKPayAPIException
+from datahub.omis.payment.models import Payment, PaymentGatewaySession
+from datahub.omis.payment.test.factories import PaymentGatewaySessionFactory
 
 
 # mark the whole module for db use

--- a/datahub/omis/payment/test/test_models.py
+++ b/datahub/omis/payment/test/test_models.py
@@ -5,10 +5,10 @@ from dateutil.parser import parse as dateutil_parse
 
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import OrderWithAcceptedQuoteFactory
-from .factories import PaymentGatewaySessionFactory
-from ..constants import PaymentGatewaySessionStatus, PaymentMethod
-from ..govukpay import govuk_url, GOVUKPayAPIException
-from ..models import Payment, PaymentGatewaySession
+from datahub.omis.payment.constants import PaymentGatewaySessionStatus, PaymentMethod
+from datahub.omis.payment.govukpay import govuk_url, GOVUKPayAPIException
+from datahub.omis.payment.models import Payment, PaymentGatewaySession
+from datahub.omis.payment.test.factories import PaymentGatewaySessionFactory
 
 
 class TestPaymentGatewaySessionIsFinished:

--- a/datahub/omis/payment/test/test_tasks.py
+++ b/datahub/omis/payment/test/test_tasks.py
@@ -4,10 +4,10 @@ import factory
 import pytest
 from freezegun import freeze_time
 
-from .factories import PaymentGatewaySessionFactory
-from ..constants import PaymentGatewaySessionStatus
-from ..govukpay import govuk_url
-from ..tasks import refresh_pending_payment_gateway_sessions
+from datahub.omis.payment.constants import PaymentGatewaySessionStatus
+from datahub.omis.payment.govukpay import govuk_url
+from datahub.omis.payment.tasks import refresh_pending_payment_gateway_sessions
+from datahub.omis.payment.test.factories import PaymentGatewaySessionFactory
 
 
 # mark the whole module for db use

--- a/datahub/omis/payment/test/test_utils.py
+++ b/datahub/omis/payment/test/test_utils.py
@@ -1,7 +1,7 @@
 from dateutil.parser import parse as dateutil_parse
 
-from ..constants import PaymentMethod
-from ..utils import trasform_govuk_payment_to_omis_payment_data
+from datahub.omis.payment.constants import PaymentMethod
+from datahub.omis.payment.utils import trasform_govuk_payment_to_omis_payment_data
 
 
 class TestGetOmisPaymentDataFromGovukPayment:

--- a/datahub/omis/payment/test/test_validators.py
+++ b/datahub/omis/payment/test/test_validators.py
@@ -4,7 +4,7 @@ import pytest
 from dateutil.parser import parse as dateutil_parse
 from rest_framework.exceptions import ValidationError
 
-from ..validators import ReconcilablePaymentsValidator
+from datahub.omis.payment.validators import ReconcilablePaymentsValidator
 
 
 class TestReconcilablePaymentsValidator:

--- a/datahub/omis/payment/test/views/test_payments.py
+++ b/datahub/omis/payment/test/views/test_payments.py
@@ -10,10 +10,12 @@ from rest_framework.reverse import reverse
 from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import (
-    OrderFactory, OrderPaidFactory, OrderWithAcceptedQuoteFactory,
+    OrderFactory,
+    OrderPaidFactory,
+    OrderWithAcceptedQuoteFactory,
 )
-from ..factories import PaymentFactory
-from ...constants import PaymentMethod
+from datahub.omis.payment.constants import PaymentMethod
+from datahub.omis.payment.test.factories import PaymentFactory
 
 
 class TestGetPayments(APITestMixin):

--- a/datahub/omis/payment/test/views/test_public_payment_gateway_sessions.py
+++ b/datahub/omis/payment/test/views/test_public_payment_gateway_sessions.py
@@ -10,10 +10,10 @@ from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import OrderFactory, OrderWithAcceptedQuoteFactory
-from ..factories import PaymentGatewaySessionFactory
-from ...constants import PaymentGatewaySessionStatus
-from ...govukpay import govuk_url
-from ...models import Payment, PaymentGatewaySession
+from datahub.omis.payment.constants import PaymentGatewaySessionStatus
+from datahub.omis.payment.govukpay import govuk_url
+from datahub.omis.payment.models import Payment, PaymentGatewaySession
+from datahub.omis.payment.test.factories import PaymentGatewaySessionFactory
 
 
 class TestPublicCreatePaymentGatewaySession(APITestMixin):

--- a/datahub/omis/payment/test/views/test_public_payments.py
+++ b/datahub/omis/payment/test/views/test_public_payments.py
@@ -7,7 +7,7 @@ from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import OrderFactory, OrderPaidFactory
-from ..factories import PaymentFactory
+from datahub.omis.payment.test.factories import PaymentFactory
 
 
 class TestPublicGetPayments(APITestMixin):

--- a/datahub/omis/payment/urls.py
+++ b/datahub/omis/payment/urls.py
@@ -1,6 +1,10 @@
 from django.urls import path, re_path
 
-from .views import PaymentViewSet, PublicPaymentGatewaySessionViewSet, PublicPaymentViewSet
+from datahub.omis.payment.views import (
+    PaymentViewSet,
+    PublicPaymentGatewaySessionViewSet,
+    PublicPaymentViewSet,
+)
 
 
 # internal frontend API

--- a/datahub/omis/payment/utils.py
+++ b/datahub/omis/payment/utils.py
@@ -1,6 +1,6 @@
 from dateutil.parser import parse as dateutil_parse
 
-from .constants import PaymentMethod
+from datahub.omis.payment.constants import PaymentMethod
 
 
 def trasform_govuk_payment_to_omis_payment_data(govuk_payment):

--- a/datahub/omis/payment/views.py
+++ b/datahub/omis/payment/views.py
@@ -8,8 +8,8 @@ from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.models import Order
 from datahub.omis.order.views import BaseNestedOrderViewSet
-from .models import Payment, PaymentGatewaySession
-from .serializers import PaymentGatewaySessionSerializer, PaymentSerializer
+from datahub.omis.payment.models import Payment, PaymentGatewaySession
+from datahub.omis.payment.serializers import PaymentGatewaySessionSerializer, PaymentSerializer
 
 
 class BasePaymentViewSet(BaseNestedOrderViewSet):

--- a/datahub/omis/quote/admin.py
+++ b/datahub/omis/quote/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import TermsAndConditions
+from datahub.omis.quote.models import TermsAndConditions
 
 
 @admin.register(TermsAndConditions)

--- a/datahub/omis/quote/managers.py
+++ b/datahub/omis/quote/managers.py
@@ -1,6 +1,6 @@
 from django.db import models
 
-from .utils import (
+from datahub.omis.quote.utils import (
     calculate_quote_expiry_date,
     generate_quote_content,
     generate_quote_reference,

--- a/datahub/omis/quote/models.py
+++ b/datahub/omis/quote/models.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.utils.timezone import now
 
 from datahub.core.models import BaseModel
-from .managers import QuoteManager
+from datahub.omis.quote.managers import QuoteManager
 
 
 class TermsAndConditions(models.Model):

--- a/datahub/omis/quote/serializers.py
+++ b/datahub/omis/quote/serializers.py
@@ -3,7 +3,7 @@ from rest_framework import serializers
 from datahub.company.models import Contact
 from datahub.company.serializers import NestedAdviserField
 from datahub.core.serializers import NestedRelatedField
-from .models import Quote
+from datahub.omis.quote.models import Quote
 
 
 class QuoteSerializer(serializers.ModelSerializer):

--- a/datahub/omis/quote/test/factories.py
+++ b/datahub/omis/quote/test/factories.py
@@ -4,7 +4,7 @@ import factory
 from django.utils.timezone import now
 
 from datahub.company.test.factories import AdviserFactory, ContactFactory
-from ..models import TermsAndConditions
+from datahub.omis.quote.models import TermsAndConditions
 
 
 class QuoteFactory(factory.django.DjangoModelFactory):

--- a/datahub/omis/quote/test/test_admin.py
+++ b/datahub/omis/quote/test/test_admin.py
@@ -2,7 +2,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from datahub.core.test_utils import AdminTestMixin
-from ..models import TermsAndConditions
+from datahub.omis.quote.models import TermsAndConditions
 
 
 class TestTermsAndConditionsAdmin(AdminTestMixin):

--- a/datahub/omis/quote/test/test_managers.py
+++ b/datahub/omis/quote/test/test_managers.py
@@ -4,7 +4,7 @@ import pytest
 from dateutil.parser import parse as dateutil_parse
 
 from datahub.company.test.factories import AdviserFactory
-from ..models import Quote, TermsAndConditions
+from datahub.omis.quote.models import Quote, TermsAndConditions
 
 
 # mark the whole module for db use

--- a/datahub/omis/quote/test/test_models.py
+++ b/datahub/omis/quote/test/test_models.py
@@ -3,9 +3,12 @@ from django.utils.timezone import now
 from freezegun import freeze_time
 
 from datahub.company.test.factories import AdviserFactory, ContactFactory
-from datahub.omis.quote.test.factories import AcceptedQuoteFactory, CancelledQuoteFactory
-from .factories import QuoteFactory
-from ..models import Quote
+from datahub.omis.quote.models import Quote
+from datahub.omis.quote.test.factories import (
+    AcceptedQuoteFactory,
+    CancelledQuoteFactory,
+    QuoteFactory,
+)
 
 
 # mark the whole module for db use

--- a/datahub/omis/quote/test/test_utils.py
+++ b/datahub/omis/quote/test/test_utils.py
@@ -8,15 +8,19 @@ from freezegun import freeze_time
 from rest_framework.exceptions import ValidationError
 
 from datahub.company.test.factories import (
-    AdviserFactory, CompaniesHouseCompanyFactory,
-    CompanyFactory, ContactFactory,
+    AdviserFactory,
+    CompaniesHouseCompanyFactory,
+    CompanyFactory,
+    ContactFactory,
 )
 from datahub.core.constants import Country
 from datahub.omis.order.constants import VATStatus
 from datahub.omis.order.test.factories import (
-    HourlyRateFactory, OrderAssigneeFactory, OrderFactory,
+    HourlyRateFactory,
+    OrderAssigneeFactory,
+    OrderFactory,
 )
-from ..utils import (
+from datahub.omis.quote.utils import (
     calculate_quote_expiry_date,
     escape_markdown,
     generate_quote_content,

--- a/datahub/omis/quote/test/views/test_public_quote_details.py
+++ b/datahub/omis/quote/test/views/test_public_quote_details.py
@@ -9,8 +9,8 @@ from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.test.factories import OrderFactory, OrderWithOpenQuoteFactory
-from ..factories import QuoteFactory
-from ...models import TermsAndConditions
+from datahub.omis.quote.models import TermsAndConditions
+from datahub.omis.quote.test.factories import QuoteFactory
 
 
 class TestPublicGetQuote(APITestMixin):

--- a/datahub/omis/quote/test/views/test_quote_details.py
+++ b/datahub/omis/quote/test/views/test_quote_details.py
@@ -11,10 +11,12 @@ from datahub.core.test_utils import APITestMixin, format_date_or_datetime
 from datahub.omis.order.constants import OrderStatus
 from datahub.omis.order.models import Order
 from datahub.omis.order.test.factories import (
-    OrderFactory, OrderWithCancelledQuoteFactory, OrderWithOpenQuoteFactory,
+    OrderFactory,
+    OrderWithCancelledQuoteFactory,
+    OrderWithOpenQuoteFactory,
 )
-from ..factories import QuoteFactory
-from ...models import Quote, TermsAndConditions
+from datahub.omis.quote.models import Quote, TermsAndConditions
+from datahub.omis.quote.test.factories import QuoteFactory
 
 
 # mark the whole module for db use

--- a/datahub/omis/quote/urls.py
+++ b/datahub/omis/quote/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, re_path
 
-from .views import PublicQuoteViewSet, QuoteViewSet
+from datahub.omis.quote.views import PublicQuoteViewSet, QuoteViewSet
 
 
 # internal frontend API

--- a/datahub/omis/quote/utils.py
+++ b/datahub/omis/quote/utils.py
@@ -11,7 +11,10 @@ from rest_framework.exceptions import ValidationError
 
 from datahub.omis.core.utils import generate_reference
 from datahub.omis.order.pricing import get_pricing_from_order
-from .constants import QUOTE_EXPIRY_DAYS_BEFORE_DELIVERY, QUOTE_EXPIRY_DAYS_FROM_NOW
+from datahub.omis.quote.constants import (
+    QUOTE_EXPIRY_DAYS_BEFORE_DELIVERY,
+    QUOTE_EXPIRY_DAYS_FROM_NOW,
+)
 
 
 QUOTE_TEMPLATE = PurePath(__file__).parent / 'templates/content.md'
@@ -45,7 +48,7 @@ def generate_quote_reference(order):
             <order.reference>/Q-<(2) lettes>/<(1) number> e.g. GEA962/16/Q-AB1
     :raises RuntimeError: if no reference can be generated.
     """
-    from .models import Quote
+    from datahub.omis.quote.models import Quote
 
     def gen():
         return '{letters}{numbers}'.format(
@@ -124,6 +127,6 @@ def get_latest_terms_and_conditions():
     """
     :returns: the latest TermsAndConditions object if it exists, None otherwise.
     """
-    from .models import TermsAndConditions
+    from datahub.omis.quote.models import TermsAndConditions
 
     return TermsAndConditions.objects.order_by('-created_on').first()

--- a/datahub/omis/quote/views.py
+++ b/datahub/omis/quote/views.py
@@ -6,8 +6,8 @@ from rest_framework.response import Response
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.models import Order
 from datahub.omis.order.views import BaseNestedOrderViewSet
-from .models import Quote
-from .serializers import PublicQuoteSerializer, QuoteSerializer
+from datahub.omis.quote.models import Quote
+from datahub.omis.quote.serializers import PublicQuoteSerializer, QuoteSerializer
 
 
 class BaseQuoteViewSet(BaseNestedOrderViewSet):

--- a/datahub/omis/region/admin.py
+++ b/datahub/omis/region/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import UKRegionalSettings
+from datahub.omis.region.models import UKRegionalSettings
 
 
 @admin.register(UKRegionalSettings)

--- a/datahub/omis/urls.py
+++ b/datahub/omis/urls.py
@@ -1,9 +1,9 @@
 from django.urls import include, path
 
-from .invoice import urls as invoice_urls
-from .order import urls as order_urls
-from .payment import urls as payment_urls
-from .quote import urls as quote_urls
+from datahub.omis.invoice import urls as invoice_urls
+from datahub.omis.order import urls as order_urls
+from datahub.omis.payment import urls as payment_urls
+from datahub.omis.quote import urls as quote_urls
 
 internal_frontend_urls = [
     path('', include((order_urls.internal_frontend_urls, 'order'), namespace='order')),


### PR DESCRIPTION
### Description of change

This converts imports to absolute in all OMIS apps and it re-formats some to have one import per line.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
