### PR TITLE
Flake8-ignore only config/settings

### DIFF
--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -1,6 +1,6 @@
 """API URL config."""
 
-from django.urls import path, include
+from django.urls import include, path
 from rest_framework import routers
 
 from datahub.activity_stream import urls as activity_stream_urls
@@ -26,7 +26,13 @@ v1_urls = router_v1.urls
 # API V3
 
 v3_urls = [
-    path('', include((activity_stream_urls.activity_stream_urls, 'activity-stream'), namespace='activity-stream')),
+    path(
+        '',
+        include(
+            (activity_stream_urls.activity_stream_urls, 'activity-stream'),
+            namespace='activity-stream',
+        ),
+    ),
     path('', include((company_urls.contact_urls, 'contact'), namespace='contact')),
     path('', include((company_urls.company_urls, 'company'), namespace='company')),
     path('', include((company_urls.ch_company_urls, 'ch-company'), namespace='ch-company')),
@@ -39,6 +45,9 @@ v3_urls = [
     path('omis/', include((omis_urls.internal_frontend_urls, 'omis'), namespace='omis')),
     path(
         'omis/public/',
-        include((omis_urls.public_urls, 'omis-public'), namespace='omis-public')
+        include(
+            (omis_urls.public_urls, 'omis-public'),
+            namespace='omis-public',
+        ),
     ),
 ]

--- a/config/celery.py
+++ b/config/celery.py
@@ -24,7 +24,7 @@ app.autodiscover_tasks()
 # config sentry
 client = Client(
     dsn=os.environ.get('DJANGO_SENTRY_DSN'),
-    environment=os.environ.get('SENTRY_ENVIRONMENT')
+    environment=os.environ.get('SENTRY_ENVIRONMENT'),
 )
 
 # register a custom filter to filter out duplicate logs

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -5,18 +5,22 @@ from psycogreen.gevent import patch_psycopg
 accesslog = os.environ.get('GUNICORN_ACCESSLOG', '-')
 access_log_format = os.environ.get(
     'GUNICORN_ACCESS_LOG_FORMAT',
-    '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" '
-    '%({X-Forwarded-For}i)s'
+    '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({X-Forwarded-For}i)s',
 )
 worker_class = os.environ.get('GUNICORN_WORKER_CLASS', 'gevent')
 worker_connections = os.environ.get('GUNICORN_WORKER_CONNECTIONS', '10')
 
 _enable_async_psycopg2 = (
-        os.environ.get('GUNICORN_ENABLE_ASYNC_PSYCOPG2', '').lower() in ('true', '1')
+    os.environ.get('GUNICORN_ENABLE_ASYNC_PSYCOPG2', '').lower() in ('true', '1')
 )
 
 
 def post_fork(server, worker):
+    """
+    Called just after a worker has been forked.
+
+    Enables async processing in Psycopg2 if GUNICORN_ENABLE_ASYNC_PSYCOPG2 is set.
+    """
     if worker_class == 'gevent' and _enable_async_psycopg2:
         patch_psycopg()
-        worker.log.info("Enabled async Psycopg2")
+        worker.log.info('Enabled async Psycopg2')

--- a/config/urls.py
+++ b/config/urls.py
@@ -3,10 +3,9 @@ from django.contrib import admin
 from django.urls import include, path
 from oauth2_provider.views import TokenView
 
+from config import api_urls
 from datahub.ping.views import ping
 from datahub.user.views import who_am_i
-
-from . import api_urls
 
 
 unversioned_urls = [
@@ -17,7 +16,13 @@ unversioned_urls = [
     path('metadata/', include('datahub.metadata.urls')),
     path('token/', TokenView.as_view(), name='token'),
     path('whoami/', who_am_i, name='who_am_i'),
-    path('dashboard/', include(('datahub.search.dashboard.urls', 'dashboard'), namespace='dashboard'))
+    path(
+        'dashboard/',
+        include(
+            ('datahub.search.dashboard.urls', 'dashboard'),
+            namespace='dashboard',
+        ),
+    ),
 ]
 
 urlpatterns = [

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -8,6 +8,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.production")
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.production')
 
 application = get_wsgi_application()

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 # See https://docs.codeclimate.com/v1.0/docs/pep8
 [pep8]
 # W503: line break occurred before a binary operator (not recommended in PEP 8)
-exclude = */migrations/*,__pycache__,manage.py,config/*,
+exclude = */migrations/*,__pycache__,manage.py,config/settings/*,
 ignore = W503
 max-line-length = 99
 
@@ -18,9 +18,9 @@ max-line-length = 99
 # D400: First line should end with a period
 # D401: First line should be in imperative mood
 # W503: line break occurred before a binary operator (not recommended in PEP 8)
-exclude = */migrations/*,__pycache__,manage.py,config/*,env/*
+exclude = */migrations/*,__pycache__,manage.py,config/settings/*,env/*
 ignore = D100,D104,D106,D200,D203,D205,D400,D401,W503
 max-line-length = 99
 max-complexity = 10
-application-import-names = datahub,loading_scripts
+application-import-names = config,datahub,loading_scripts
 import_order_style = smarkets


### PR DESCRIPTION
### Description of change

Before flake8 was ignoring the whole `config` folder whilst now only `config/settings` is ignored and this commit fixes the flake8 issues with the files no longer ignored.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
