### PR TITLE
Convert imports to absolute in config/settings and ping

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,5 +1,5 @@
 # This will make sure the app is always imported when
 # Django starts so that shared_task will use this app.
-from .celery import app as celery_app
+from config.celery import app as celery_app
 
 __all__ = ['celery_app']

--- a/config/settings/dev.py
+++ b/config/settings/dev.py
@@ -1,4 +1,4 @@
-from .common_sentry import *
+from config.settings.common_sentry import *
 
 # DRF
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += ['rest_framework.authentication.SessionAuthentication']

--- a/config/settings/heroku.py
+++ b/config/settings/heroku.py
@@ -1,6 +1,6 @@
 import socket
 
-from .production import *
+from config.settings.production import *
 
 MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 INSTALLED_APPS += ('debug_toolbar',)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -4,7 +4,7 @@ import environ
 environ.Env.read_env()  # reads the .env file
 env = environ.Env()
 
-from .common import *
+from config.settings.common import *
 
 # DRF
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += ['rest_framework.authentication.SessionAuthentication']

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -1,3 +1,3 @@
-from .common_sentry import *
+from config.settings.common_sentry import *
 
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/config/settings/staging.py
+++ b/config/settings/staging.py
@@ -1,4 +1,4 @@
-from .common_sentry import *
+from config.settings.common_sentry import *
 
 # DRF
 REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] += ['rest_framework.authentication.SessionAuthentication']

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -3,7 +3,7 @@ import environ
 environ.Env.read_env()  # reads the .env file
 env = environ.Env()
 
-from .common import *
+from config.settings.common import *
 
 # We need to prevent Django from initialising datahub.search for tests.
 # Removing SearchConfig stops django from calling .ready() which initialises

--- a/datahub/ping/views.py
+++ b/datahub/ping/views.py
@@ -1,7 +1,7 @@
 from django.http import HttpResponse
 from rest_framework import status
 
-from .services import services_to_check
+from datahub.ping.services import services_to_check
 
 PINGDOM_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
 <pingdom_http_custom_check>


### PR DESCRIPTION
### Description of change

This converts all imports to absolute in `config/settings` and the `ping` app.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
