### PR TITLE
Add company selection part of duplicate company merging tool

### DIFF
--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -3,6 +3,7 @@ from django.contrib import admin
 from django.db import models
 from reversion.admin import VersionAdmin
 
+from datahub.company.admin.company_merge_list import CompanyMergeViews
 from datahub.company.models import Company, CompanyCoreTeamMember
 from datahub.core.admin import BaseModelAdminMixin
 
@@ -133,3 +134,46 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
     inlines = (
         CompanyCoreTeamMemberInline,
     )
+
+    def __init__(self, *args, **kwargs):
+        """Initialises the instance."""
+        self.merge_views = CompanyMergeViews(self)
+        super().__init__(*args, **kwargs)
+
+    def get_urls(self):
+        """Gets the URLs for this model."""
+        return [
+            *self.merge_views.get_urls(),
+            *super().get_urls(),
+        ]
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        """
+        Change view with additional data added to the context.
+
+        Based on this example in the Django docs:
+        https://docs.djangoproject.com/en/2.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.changelist_view
+        """
+        extra_context = {
+            **({} if extra_context is None else extra_context),
+            **self.merge_views.changelist_context(request),
+        }
+        return super().change_view(
+            request,
+            object_id,
+            form_url=form_url,
+            extra_context=extra_context,
+        )
+
+    def changelist_view(self, request, extra_context=None):
+        """
+        Change list view with additional data added to the context.
+
+        Based on this example in the Django docs:
+        https://docs.djangoproject.com/en/2.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.changelist_view
+        """
+        extra_context = {
+            **({} if extra_context is None else extra_context),
+            **self.merge_views.changelist_context(request),
+        }
+        return super().changelist_view(request, extra_context=extra_context)

--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -156,7 +156,7 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
         """
         extra_context = {
             **({} if extra_context is None else extra_context),
-            **self.merge_views.changelist_context(request),
+            **self.merge_views.change_context(request),
         }
         return super().change_view(
             request,

--- a/datahub/company/admin/company_merge_list.py
+++ b/datahub/company/admin/company_merge_list.py
@@ -1,0 +1,206 @@
+from logging import getLogger
+
+from django.contrib import messages as django_messages
+from django.contrib.admin import ModelAdmin
+from django.contrib.admin.templatetags.admin_urls import add_preserved_filters, admin_urlname
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils.decorators import method_decorator
+from django.utils.html import format_html
+from django.utils.translation import gettext_lazy
+from django.views.decorators.csrf import csrf_protect
+
+from datahub.feature_flag.utils import feature_flagged_view, is_feature_flag_active
+
+MERGE_LIST_SESSION_KEY = 'admin-company-company-merge-list'
+MERGE_LIST_FEATURE_FLAG = 'admin-merge-company-tool'
+
+logger = getLogger(__name__)
+
+
+class CompanyMergeViews:
+    """Views related to the merge-duplicate-companies functionality."""
+
+    MERGE_LIST_FIELDS = (
+        'id',
+        'name',
+        'created_on',
+        'created_by',
+        'modified_on',
+        'modified_by',
+    )
+    ADDED_TO_MERGE_LIST_MSG = gettext_lazy(
+        '1 item added to the merge list. <a href="{url}">View merge list</a>.',
+    )
+    ALREADY_ON_MERGE_LIST_MSG = gettext_lazy(
+        'This item was already on the merge list. <a href="{url}">View merge list</a>.',
+    )
+    REMOVED_FROM_MERGE_LIST_MSG = gettext_lazy('1 item removed from the merge list.')
+
+    def __init__(self, model_admin: ModelAdmin):
+        """Initialises the instance, storing a reference to the relevant ModelAdmin."""
+        self.model_admin = model_admin
+
+    def get_urls(self):
+        """Gets the URLs for the merge views."""
+        model_meta = self.model_admin.model._meta
+        admin_site = self.model_admin.admin_site
+        return [
+            path(
+                'merge-list/',
+                admin_site.admin_view(self.merge_list),
+                name=f'{model_meta.app_label}_{model_meta.model_name}'
+                     f'_merge-list',
+            ),
+            path(
+                '<path:object_id>/add-to-merge-list/',
+                admin_site.admin_view(self.add_to_merge_list),
+                name=f'{model_meta.app_label}_{model_meta.model_name}'
+                     f'_add-to-merge-list',
+            ),
+            path(
+                '<path:object_id>/remove-from-merge-list/',
+                admin_site.admin_view(self.remove_from_merge_list),
+                name=f'{model_meta.app_label}_{model_meta.model_name}'
+                     f'_remove-from-merge-list',
+            ),
+        ]
+
+    @feature_flagged_view(MERGE_LIST_FEATURE_FLAG)
+    def merge_list(self, request):
+        """View listing companies that have been added to the merge list."""
+        if not self.model_admin.has_change_permission(request):
+            raise PermissionDenied
+
+        template_name = 'admin/company/company/merge_list.html'
+        title = 'Company merge list'
+
+        model = self.model_admin.model
+        admin_site = self.model_admin.admin_site
+
+        company_pks = _get_pks_from_merge_list_store(request)
+        merge_items_gen = (model.objects.filter(pk=pk).first() for pk in company_pks)
+        merge_items = {
+            str(obj.pk): [getattr(obj, field) for field in self.MERGE_LIST_FIELDS]
+            for obj in merge_items_gen if obj
+        }
+
+        columns = {
+            field: model._meta.get_field(field).verbose_name for field in self.MERGE_LIST_FIELDS
+        }
+
+        context = {
+            **admin_site.each_context(request),
+            'opts': model._meta,
+            'title': title,
+            'columns': columns,
+            'merge_items': merge_items,
+        }
+        return TemplateResponse(request, template_name, context)
+
+    @method_decorator(csrf_protect)
+    @feature_flagged_view(MERGE_LIST_FEATURE_FLAG)
+    def add_to_merge_list(self, request, object_id):
+        """View handling additions to the merge list."""
+        if not self.model_admin.has_change_permission(request):
+            raise PermissionDenied
+
+        model_meta = self.model_admin.model._meta
+        was_added = _add_pk_to_merge_list_store(request, object_id)
+
+        route_name = admin_urlname(model_meta, 'merge-list')
+        merge_list_url = reverse(route_name, current_app=self.model_admin.admin_site.name)
+
+        msg_template = (
+            self.ADDED_TO_MERGE_LIST_MSG if was_added else self.ALREADY_ON_MERGE_LIST_MSG
+        )
+        msg = format_html(msg_template, url=merge_list_url)
+        self.model_admin.message_user(request, msg, django_messages.SUCCESS)
+
+        return _changelist_preserved_filters_redirect(request, self.model_admin)
+
+    @method_decorator(csrf_protect)
+    @feature_flagged_view(MERGE_LIST_FEATURE_FLAG)
+    def remove_from_merge_list(self, request, object_id):
+        """View handling removals from the merge list."""
+        if not self.model_admin.has_change_permission(request):
+            raise PermissionDenied
+
+        _remove_pk_from_merge_list_store(request, object_id)
+
+        model_meta = self.model_admin.model._meta
+        route_name = admin_urlname(model_meta, 'merge-list')
+        merge_list_url = reverse(route_name, current_app=self.model_admin.admin_site.name)
+
+        self.model_admin.message_user(
+            request,
+            self.REMOVED_FROM_MERGE_LIST_MSG,
+            django_messages.SUCCESS,
+        )
+
+        return HttpResponseRedirect(merge_list_url)
+
+    @staticmethod
+    def changelist_context(request):
+        """Returns additional context data for the change list view."""
+        merge_list = _get_pks_from_merge_list_store(request)
+        return {
+            'merge_list_count': len(merge_list),
+            'merge_list_feature_flag': is_feature_flag_active(MERGE_LIST_FEATURE_FLAG),
+        }
+
+    @staticmethod
+    def change_context(request):
+        """Returns additional context data for the change view."""
+        return {
+            'merge_list_feature_flag': is_feature_flag_active(MERGE_LIST_FEATURE_FLAG),
+        }
+
+
+def _get_pks_from_merge_list_store(request):
+    try:
+        return list(request.session.get(MERGE_LIST_SESSION_KEY, []))
+    except TypeError:
+        logger.warning('Corrupt merge list detected in session')
+        return []
+
+
+def _add_pk_to_merge_list_store(request, pk):
+    merge_list = _get_pks_from_merge_list_store(request)
+    pk_str = str(pk)
+    if pk_str not in merge_list:
+        merge_list.append(pk_str)
+        request.session[MERGE_LIST_SESSION_KEY] = merge_list
+        return True
+    return False
+
+
+def _remove_pk_from_merge_list_store(request, pk):
+    merge_list = _get_pks_from_merge_list_store(request)
+    pk_str = str(pk)
+    try:
+        merge_list.remove(pk_str)
+    except ValueError:
+        return False
+
+    request.session[MERGE_LIST_SESSION_KEY] = merge_list
+    return True
+
+
+def _changelist_preserved_filters_redirect(request, model_admin):
+    model_meta = model_admin.model._meta
+    route_name = admin_urlname(model_meta, 'changelist')
+    changelist_url = reverse(route_name, current_app=model_admin.admin_site.name)
+
+    preserved_filters = model_admin.get_preserved_filters(request)
+    filtered_changelist_url = add_preserved_filters(
+        {
+            'preserved_filters': preserved_filters,
+            'opts': model_meta,
+        },
+        changelist_url,
+    )
+
+    return HttpResponseRedirect(filtered_changelist_url)

--- a/datahub/company/static/company/admin/css/merge-button.css
+++ b/datahub/company/static/company/admin/css/merge-button.css
@@ -1,0 +1,23 @@
+.object-tool-button {
+  background: #999;
+  border:none;
+  border-radius: 15px;
+  color: #fff;
+  cursor: pointer;
+  display: block;
+  float: left;
+  font-size: 11px;
+  font-weight: 400;
+  letter-spacing: 0.5px;
+  line-height: inherit;
+  padding: 3px 12px;
+  text-transform: uppercase;
+}
+
+.object-tool-button:focus, .object-tool-button:hover {
+    background-color: #417690;
+}
+
+.object-tool-button:focus {
+    text-decoration: none;
+}

--- a/datahub/company/static/company/admin/css/merge-list.css
+++ b/datahub/company/static/company/admin/css/merge-list.css
@@ -1,0 +1,3 @@
+.company-merge-list {
+  width: 100%;
+}

--- a/datahub/company/templates/admin/company/company/change_form.html
+++ b/datahub/company/templates/admin/company/company/change_form.html
@@ -1,0 +1,7 @@
+{% extends "admin/change_form.html" %}
+{% load static %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static 'company/admin/css/merge-button.css' %}">
+{% endblock %}

--- a/datahub/company/templates/admin/company/company/change_form_object_tools.html
+++ b/datahub/company/templates/admin/company/company/change_form_object_tools.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_form_object_tools.html" %}
+{% load admin_urls %}
+
+{% block object-tools-items %}
+{% if merge_list_feature_flag %}
+  <li>
+    {% url opts|admin_urlname:'add-to-merge-list' original.pk|admin_urlquote as add_to_merge_list_url %}
+    <form action="{% add_preserved_filters add_to_merge_list_url %}" method="post">
+      {% csrf_token %}
+      <button type="submit" class="object-tool-button">Add to merge list</button>
+    </form>
+  </li>
+  {{block.super}}
+{% endif %}
+{% endblock %}

--- a/datahub/company/templates/admin/company/company/change_list_object_tools.html
+++ b/datahub/company/templates/admin/company/company/change_list_object_tools.html
@@ -1,4 +1,5 @@
 {% extends "admin/change_list_object_tools.html" %}
+{% load admin_urls %}
 
 {% block object-tools-items %}
   <li>
@@ -6,5 +7,12 @@
       Export One List
     </a>
   </li>
+  {% if merge_list_feature_flag and has_change_permission and merge_list_count > 0 %}
+    <li>
+      <a href="{% url opts|admin_urlname:'merge-list' %}">
+        View merge list ({{ merge_list_count }})
+      </a>
+    </li>
+  {% endif %}
   {{block.super}}
 {% endblock %}

--- a/datahub/company/templates/admin/company/company/merge_list.html
+++ b/datahub/company/templates/admin/company/company/merge_list.html
@@ -1,0 +1,69 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'company/admin/css/merge-list.css' %}">
+<link rel="stylesheet" type="text/css" href="{% static 'company/admin/css/merge-button.css' %}">
+{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media }}
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+{% if not merge_items %}
+  <p>No companies have been added to the merge list.</p>
+{% else %}
+  <div class="results">
+    <table class="company-merge-list">
+    <thead>
+      <tr>
+      {% for column in columns.values %}
+      <th scope="col">
+         <div class="text">{{ column|capfirst }}</div>
+         <div class="clear"></div>
+      </th>
+      {% endfor %}
+      <th scope="col">
+         <div class="text">Actions</div>
+         <div class="clear"></div>
+      </th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for pk, item in merge_items.items %}
+      <tr class="{% cycle 'row1' 'row2' %}">
+        {% for value in item %}
+        {% if forloop.counter0 == 0 %}
+        <td><a href="{% url opts|admin_urlname:'change' pk|admin_urlquote %}">{{ value }}</a></td>
+        {% else %}
+          <td>{{ value }}</td>
+        {% endif %}
+        {% endfor %}
+        <td>
+          <form action="{% url opts|admin_urlname:'remove-from-merge-list' pk|admin_urlquote %}" method="post">
+            {% csrf_token %}
+            <button class="object-tool-button">Remove from list</button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+    </table>
+  </div>
+{% endif %}
+
+{% endblock %}

--- a/datahub/company/test/admin/test_company_merge_list.py
+++ b/datahub/company/test/admin/test_company_merge_list.py
@@ -1,0 +1,294 @@
+from uuid import uuid4
+
+import pytest
+from django.contrib import messages as django_messages
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.test import Client
+from django.urls import reverse
+from rest_framework import status
+
+from datahub.company.admin.company_merge_list import (
+    MERGE_LIST_FEATURE_FLAG,
+    MERGE_LIST_SESSION_KEY,
+)
+from datahub.company.models import Company, CompanyPermission
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def merge_list_feature_flag():
+    """Creates the merge list feature flag."""
+    yield FeatureFlagFactory(code=MERGE_LIST_FEATURE_FLAG)
+
+
+class TestAddToMergeList(AdminTestMixin):
+    """Tests for the add to merge list button on the change form page."""
+
+    def test_add_company_to_merge_list_button_is_shown(self):
+        """Test that the button to add a company to the merge list is shown."""
+        company = CompanyFactory()
+
+        change_route_name = admin_urlname(Company._meta, 'change')
+        change_url = reverse(change_route_name, args=(company.id,))
+
+        response = self.client.get(change_url)
+
+        add_to_list_route_name = admin_urlname(Company._meta, 'add-to-merge-list')
+        add_to_list_url = reverse(add_to_list_route_name, args=(company.id,))
+
+        assert add_to_list_url in response.rendered_content
+
+    def test_can_add_company_to_merge_list(self):
+        """Test that a company can be added to the merge list."""
+        company = CompanyFactory()
+
+        add_to_list_route_name = admin_urlname(Company._meta, 'add-to-merge-list')
+        add_to_list_url = reverse(add_to_list_route_name, args=(company.id,))
+
+        response = self.client.post(add_to_list_url, follow=True)
+        session = self.client.session
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+
+        changelist_route_name = admin_urlname(Company._meta, 'changelist')
+        changelist_url = reverse(changelist_route_name)
+
+        assert response.redirect_chain[0][0] == changelist_url
+        assert session[MERGE_LIST_SESSION_KEY] == [str(company.pk)]
+
+        merge_list_route_name = admin_urlname(Company._meta, 'merge-list')
+        merge_list_url = reverse(merge_list_route_name)
+
+        messages = list(response.context['messages'])
+        assert len(messages) == 1
+        assert messages[0].level == django_messages.SUCCESS
+        assert messages[0].message == (
+            f'1 item added to the merge list. <a href="{merge_list_url}">View merge list</a>.'
+        )
+
+
+class TestViewMergeList(AdminTestMixin):
+    """Tests for the merge list page."""
+
+    def test_added_companies_are_listed(self):
+        """Test that companies in the merge list are listed."""
+        companies = CompanyFactory.create_batch(3)
+        session = self.client.session
+        session[MERGE_LIST_SESSION_KEY] = [str(company.pk) for company in companies]
+        session.save()
+
+        merge_list_route_name = admin_urlname(Company._meta, 'merge-list')
+        merge_list_url = reverse(merge_list_route_name)
+
+        response = self.client.get(merge_list_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert all(str(company.pk) in response.rendered_content for company in companies)
+
+    def test_invalid_companies_are_ignored(self):
+        """Test that companies in the merge list are listed."""
+        company = CompanyFactory()
+        non_existent_uuid = uuid4()
+
+        session = self.client.session
+        session[MERGE_LIST_SESSION_KEY] = [str(non_existent_uuid), str(company.pk)]
+        session.save()
+
+        merge_list_route_name = admin_urlname(Company._meta, 'merge-list')
+        merge_list_url = reverse(merge_list_route_name)
+
+        response = self.client.get(merge_list_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert str(company.pk) in response.rendered_content
+        assert str(non_existent_uuid) not in response.rendered_content
+
+    def test_message_displayed_if_no_companies_added(self):
+        """Test that a message is displayed if no companies are in the merge list."""
+        merge_list_route_name = admin_urlname(Company._meta, 'merge-list')
+        merge_list_url = reverse(merge_list_route_name)
+
+        response = self.client.get(merge_list_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert 'No companies have been added to the merge list.' in response.rendered_content
+
+    def test_can_remove_a_company(self):
+        """Test that a company can be removed from the merge list."""
+        companies = CompanyFactory.create_batch(3)
+        session = self.client.session
+        session[MERGE_LIST_SESSION_KEY] = [str(company.pk) for company in companies]
+        session.save()
+
+        remove_route_name = admin_urlname(Company._meta, 'remove-from-merge-list')
+        remove_url = reverse(remove_route_name, args=(companies[0].pk,))
+
+        response = self.client.post(remove_url, follow=True)
+        session = self.client.session
+
+        assert response.status_code == status.HTTP_200_OK
+
+        assert len(response.redirect_chain) == 1
+
+        merge_list_route_name = admin_urlname(Company._meta, 'merge-list')
+        merge_list_url = reverse(merge_list_route_name)
+
+        assert response.redirect_chain[0][0] == merge_list_url
+        assert session[MERGE_LIST_SESSION_KEY] == [str(company.pk) for company in companies[1:]]
+
+
+class TestViewMergeListLink(AdminTestMixin):
+    """Tests for the view merge list link on the change list page."""
+
+    def test_link_is_not_displayed_if_no_items_in_merge_list(self):
+        """
+        Test that the 'View merge list' link is not displayed if there are no items in the list.
+        """
+        changelist_route_name = admin_urlname(Company._meta, 'changelist')
+        changelist_url = reverse(changelist_route_name)
+
+        response = self.client.get(changelist_url)
+
+        merge_list_route_name = admin_urlname(Company._meta, 'merge-list')
+        merge_list_url = reverse(merge_list_route_name)
+
+        assert merge_list_url not in response.rendered_content
+
+    def test_link_is_displayed_if_items_in_merge_list(self):
+        """Test that the 'View merge list' link is displayed if there are items in the list."""
+        company = CompanyFactory()
+        session = self.client.session
+        session[MERGE_LIST_SESSION_KEY] = [str(company.pk)]
+        session.save()
+
+        changelist_route_name = admin_urlname(Company._meta, 'changelist')
+        changelist_url = reverse(changelist_route_name)
+
+        response = self.client.get(changelist_url)
+
+        merge_list_route_name = admin_urlname(Company._meta, 'merge-list')
+        merge_list_url = reverse(merge_list_route_name)
+
+        assert merge_list_url in response.rendered_content
+
+
+class TestMergeListPermissions(AdminTestMixin):
+    """Test permission handling in the merge list views."""
+
+    @pytest.mark.parametrize(
+        'route_name,needs_arg,method',
+        (
+            (
+                admin_urlname(Company._meta, 'merge-list'),
+                False,
+                'get',
+            ),
+            (
+                admin_urlname(Company._meta, 'add-to-merge-list'),
+                True,
+                'post',
+            ),
+            (
+                admin_urlname(Company._meta, 'remove-from-merge-list'),
+                True,
+                'post',
+            ),
+        ),
+    )
+    def test_redirects_to_login_page_if_not_logged_in(self, route_name, needs_arg, method):
+        """Test that the view redirects to the login page if the user isn't authenticated."""
+        args = (CompanyFactory().pk,) if needs_arg else ()
+        url = reverse(route_name, args=args)
+
+        client = Client()
+        request_func = getattr(client, method)
+        response = request_func(url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+
+    @pytest.mark.parametrize(
+        'route_name,needs_arg,method',
+        (
+            (
+                admin_urlname(Company._meta, 'merge-list'),
+                False,
+                'get',
+            ),
+            (
+                admin_urlname(Company._meta, 'add-to-merge-list'),
+                True,
+                'post',
+            ),
+            (
+                admin_urlname(Company._meta, 'remove-from-merge-list'),
+                True,
+                'post',
+            ),
+        ),
+    )
+    def test_redirects_to_login_page_if_not_staff(self, route_name, needs_arg, method):
+        """Test that the view redirects to the login page if the user isn't a member of staff."""
+        args = (CompanyFactory().pk,) if needs_arg else ()
+        url = reverse(route_name, args=args)
+
+        user = create_test_user(is_staff=False, password=self.PASSWORD)
+        client = self.create_client(user=user)
+        request_func = getattr(client, method)
+
+        response = request_func(url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+
+    @pytest.mark.parametrize(
+        'route_name,needs_arg,method',
+        (
+            (
+                admin_urlname(Company._meta, 'merge-list'),
+                False,
+                'get',
+            ),
+            (
+                admin_urlname(Company._meta, 'add-to-merge-list'),
+                True,
+                'post',
+            ),
+            (
+                admin_urlname(Company._meta, 'remove-from-merge-list'),
+                True,
+                'post',
+            ),
+        ),
+    )
+    def test_permission_denied_if_staff_and_without_change_permission(
+            self,
+            route_name,
+            needs_arg,
+            method,
+    ):
+        """
+        Test that the view returns a 403 response if the staff user does not have the
+        change company permission.
+        """
+        args = (CompanyFactory().pk,) if needs_arg else ()
+        url = reverse(route_name, args=args)
+
+        user = create_test_user(
+            permission_codenames=(CompanyPermission.view_company,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+        client = self.create_client(user=user)
+        request_func = getattr(client, method)
+
+        response = request_func(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -92,7 +92,9 @@ class AdminTestMixin:
     @property
     def client(self):
         """Returns an authenticated admin client."""
-        return self.create_client()
+        if not hasattr(self, '_client'):
+            self._client = self.create_client()
+        return self._client
 
     def create_client(self, user=None):
         """Creates a client with admin access."""
@@ -144,7 +146,9 @@ class APITestMixin:
     @property
     def api_client(self):
         """An API client with data-hub:internal-front-end scope."""
-        return self.create_api_client()
+        if not hasattr(self, '_client'):
+            self._api_client = self.create_api_client()
+        return self._api_client
 
     def create_api_client(self, scope=Scope.internal_front_end, *additional_scopes,
                           grant_type=Application.GRANT_PASSWORD, user=None):

--- a/datahub/feature_flag/utils.py
+++ b/datahub/feature_flag/utils.py
@@ -1,3 +1,7 @@
+from functools import wraps
+
+from django.http import Http404
+
 from datahub.feature_flag.models import FeatureFlag
 
 
@@ -8,3 +12,23 @@ def is_feature_flag_active(code):
     If feature flag doesn't exist, it returns False.
     """
     return FeatureFlag.objects.filter(code=code, is_active=True).exists()
+
+
+def feature_flagged_view(code):
+    """
+    Decorator to put a view behind a feature flag.
+
+    This returns a 404 is a specified feature flag is not active. Otherwise, the view is called
+    normally.
+    """
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapped_view(*args, **kwargs):
+            if not is_feature_flag_active(code):
+                raise Http404
+
+            return view_func(*args, **kwargs)
+
+        return wrapped_view
+
+    return decorator


### PR DESCRIPTION
### Description of change

This is the first part of a feature being added to the admin site to deal with duplicate companies.

This part allows the selection of companies that are duplicates and viewing the companies that have been selected. The selection of companies is done via the company change page so that the existing company search on the change list can be reused for this purpose.

As the feature is incomplete, it is currently behind a feature flag. The terminology used at the moment refers to merging companies, though this may change.

The logic for the views has been placed in a new class named CompanyMergeViews, to help keep things organised, and also to make it easier to reuse in case we decide to use a similar pattern elsewhere.

Subsequent parts will include the selection of which company should be kept as the active record, and the transfer of contacts and interactions from one company to another.

The actual tool will be limited to two companies, though the logic for that will follow in another PR.

Since it's an incomplete feature in the admin site, I haven't added a news fragment in this PR.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
