### PR TITLE
Fix investment estimated land date validation

### DIFF
--- a/changelog/investment/investment-collection-estimated-land-date.bugfix
+++ b/changelog/investment/investment-collection-estimated-land-date.bugfix
@@ -1,0 +1,1 @@
+Estimated land date now validated when other required fields are missing.

--- a/datahub/investment/test/test_serializers.py
+++ b/datahub/investment/test/test_serializers.py
@@ -2,6 +2,7 @@ import pytest
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.investment.serializers import (
+    IProjectSerializer,
     IProjectTeamMemberListSerializer,
     IProjectTeamMemberSerializer,
 )
@@ -14,116 +15,140 @@ from datahub.investment.test.factories import (
 pytestmark = pytest.mark.django_db
 
 
-def test_team_member_list_update_remove_all():
-    """Tests removing all team members."""
-    project = InvestmentProjectFactory()
+class TestIProjectTeamMemberListSerializer:
+    """Tests for IProjectTeamMemberListSerializer."""
 
-    team_members = InvestmentProjectTeamMemberFactory.create_batch(
-        2, investment_project=project,
-    )
+    def test_team_member_list_update_remove_all(self):
+        """Tests removing all team members."""
+        project = InvestmentProjectFactory()
 
-    child_serializer = IProjectTeamMemberSerializer()
-    serializer = IProjectTeamMemberListSerializer(child=child_serializer)
+        team_members = InvestmentProjectTeamMemberFactory.create_batch(
+            2, investment_project=project,
+        )
 
-    assert serializer.update(team_members, []) == []
-    assert project.team_members.count() == 0
+        child_serializer = IProjectTeamMemberSerializer()
+        serializer = IProjectTeamMemberListSerializer(child=child_serializer)
+
+        assert serializer.update(team_members, []) == []
+        assert project.team_members.count() == 0
+
+    def test_team_member_list_update_mixed_changes(self):
+        """Tests making mixed changes to team members."""
+        project = InvestmentProjectFactory()
+
+        team_members = InvestmentProjectTeamMemberFactory.create_batch(
+            2, investment_project=project, role='old role',
+        )
+        adviser = AdviserFactory()
+
+        new_team_member_data = [
+            {
+                'investment_project': project,
+                'adviser': team_members[1].adviser,
+                'role': 'new role',
+            },
+            {
+                'investment_project': project,
+                'adviser': adviser,
+                'role': 'new team member',
+            },
+        ]
+
+        child_serializer = IProjectTeamMemberSerializer()
+        serializer = IProjectTeamMemberListSerializer(child=child_serializer)
+
+        updated_team_members = serializer.update(team_members, new_team_member_data)
+
+        assert len(updated_team_members) == 2
+        assert updated_team_members[0].adviser == new_team_member_data[0]['adviser']
+        assert updated_team_members[0].role == new_team_member_data[0]['role']
+        assert updated_team_members[1].adviser == new_team_member_data[1]['adviser']
+        assert updated_team_members[1].role == new_team_member_data[1]['role']
+        assert project.team_members.count() == 2
+
+    def test_team_member_list_update_change_only(self):
+        """Tests updating existing team members."""
+        project = InvestmentProjectFactory()
+
+        team_members = InvestmentProjectTeamMemberFactory.create_batch(
+            2, investment_project=project, role='old role',
+        )
+
+        new_team_member_data = [
+            {
+                'investment_project': project,
+                'adviser': team_members[0].adviser,
+                'role': 'new role',
+            },
+            {
+                'investment_project': project,
+                'adviser': team_members[1].adviser,
+                'role': 'new role',
+            },
+        ]
+
+        child_serializer = IProjectTeamMemberSerializer()
+        serializer = IProjectTeamMemberListSerializer(child=child_serializer)
+
+        updated_team_members = serializer.update(team_members, new_team_member_data)
+
+        assert len(updated_team_members) == 2
+        assert updated_team_members[0].adviser == new_team_member_data[0]['adviser']
+        assert updated_team_members[0].role == new_team_member_data[0]['role']
+        assert updated_team_members[1].adviser == new_team_member_data[1]['adviser']
+        assert updated_team_members[1].role == new_team_member_data[1]['role']
+        assert project.team_members.count() == 2
+
+    def test_team_member_list_update_add_only(self):
+        """Tests updating adding team members when none previously existed."""
+        project = InvestmentProjectFactory()
+
+        new_team_member_data = [
+            {
+                'investment_project': project,
+                'adviser': AdviserFactory(),
+                'role': 'new role',
+            },
+            {
+                'investment_project': project,
+                'adviser': AdviserFactory(),
+                'role': 'new team member',
+            },
+        ]
+
+        child_serializer = IProjectTeamMemberSerializer()
+        serializer = IProjectTeamMemberListSerializer(child=child_serializer)
+
+        updated_team_members = serializer.update([], new_team_member_data)
+
+        assert updated_team_members[0].adviser == new_team_member_data[0]['adviser']
+        assert updated_team_members[0].role == new_team_member_data[0]['role']
+        assert updated_team_members[1].adviser == new_team_member_data[1]['adviser']
+        assert updated_team_members[1].role == new_team_member_data[1]['role']
+        assert project.team_members.count() == 2
 
 
-def test_team_member_list_update_mixed_changes():
-    """Tests making mixed changes to team members."""
-    project = InvestmentProjectFactory()
+class TestIProjectSerializer:
+    """Tests for IProjectSerializer."""
 
-    team_members = InvestmentProjectTeamMemberFactory.create_batch(
-        2, investment_project=project, role='old role',
-    )
-    adviser = AdviserFactory()
+    def test_estimated_land_date_is_required_for_new_project(self):
+        """Tests estimated land date is required for new projects."""
+        project_data = {'estimated_land_date': None}
+        serializer = IProjectSerializer(data=project_data)
+        assert not serializer.is_valid()
+        assert serializer.errors['estimated_land_date'] == ['This field is required.']
 
-    new_team_member_data = [
-        {
-            'investment_project': project,
-            'adviser': team_members[1].adviser,
-            'role': 'new role',
-        },
-        {
-            'investment_project': project,
-            'adviser': adviser,
-            'role': 'new team member',
-        },
-    ]
+    def test_estimated_land_date_cannot_be_erased_if_not_allowed_to_be_blank(self):
+        """Tests updating estimated land date cannot be set to a blank if not allowed."""
+        project = InvestmentProjectFactory()
+        project_data = {'estimated_land_date': None}
+        serializer = IProjectSerializer(project, data=project_data, partial=True)
+        assert not serializer.is_valid()
+        assert serializer.errors['estimated_land_date'] == ['This field is required.']
 
-    child_serializer = IProjectTeamMemberSerializer()
-    serializer = IProjectTeamMemberListSerializer(child=child_serializer)
-
-    updated_team_members = serializer.update(team_members, new_team_member_data)
-
-    assert len(updated_team_members) == 2
-    assert updated_team_members[0].adviser == new_team_member_data[0]['adviser']
-    assert updated_team_members[0].role == new_team_member_data[0]['role']
-    assert updated_team_members[1].adviser == new_team_member_data[1]['adviser']
-    assert updated_team_members[1].role == new_team_member_data[1]['role']
-
-    assert project.team_members.count() == 2
-
-
-def test_team_member_list_update_change_only():
-    """Tests updating existing team members."""
-    project = InvestmentProjectFactory()
-
-    team_members = InvestmentProjectTeamMemberFactory.create_batch(
-        2, investment_project=project, role='old role',
-    )
-
-    new_team_member_data = [
-        {
-            'investment_project': project,
-            'adviser': team_members[0].adviser,
-            'role': 'new role',
-        },
-        {
-            'investment_project': project,
-            'adviser': team_members[1].adviser,
-            'role': 'new role',
-        },
-    ]
-
-    child_serializer = IProjectTeamMemberSerializer()
-    serializer = IProjectTeamMemberListSerializer(child=child_serializer)
-
-    updated_team_members = serializer.update(team_members, new_team_member_data)
-
-    assert len(updated_team_members) == 2
-    assert updated_team_members[0].adviser == new_team_member_data[0]['adviser']
-    assert updated_team_members[0].role == new_team_member_data[0]['role']
-    assert updated_team_members[1].adviser == new_team_member_data[1]['adviser']
-    assert updated_team_members[1].role == new_team_member_data[1]['role']
-
-    assert project.team_members.count() == 2
-
-
-def test_team_member_list_update_add_only():
-    """Tests updating adding team members when none previously existed."""
-    project = InvestmentProjectFactory()
-
-    new_team_member_data = [
-        {
-            'investment_project': project,
-            'adviser': AdviserFactory(),
-            'role': 'new role',
-        },
-        {
-            'investment_project': project,
-            'adviser': AdviserFactory(),
-            'role': 'new team member',
-        },
-    ]
-
-    child_serializer = IProjectTeamMemberSerializer()
-    serializer = IProjectTeamMemberListSerializer(child=child_serializer)
-
-    updated_team_members = serializer.update([], new_team_member_data)
-
-    assert updated_team_members[0].adviser == new_team_member_data[0]['adviser']
-    assert updated_team_members[0].role == new_team_member_data[0]['role']
-    assert updated_team_members[1].adviser == new_team_member_data[1]['adviser']
-    assert updated_team_members[1].role == new_team_member_data[1]['role']
-    assert project.team_members.count() == 2
+    def test_estimated_land_date_can_be_erased_if_allowed_to_be_blank(self):
+        """Tests updating estimated land date to a blank when allowed."""
+        project = InvestmentProjectFactory(allow_blank_estimated_land_date=True)
+        project_data = {'estimated_land_date': None}
+        serializer = IProjectSerializer(project, data=project_data, partial=True)
+        assert serializer.is_valid()

--- a/datahub/investment/test/test_validate.py
+++ b/datahub/investment/test/test_validate.py
@@ -48,25 +48,6 @@ def test_validate_fdi_type():
     assert 'fdi_type' in errors
 
 
-@pytest.mark.parametrize(
-    'allow_blank_estimated_land_date,is_error',
-    (
-        (True, False),
-        (False, True),
-    ),
-)
-def test_validate_estimated_land_date(allow_blank_estimated_land_date, is_error):
-    """Tests estimated_land_date conditional validation."""
-    investment_type_id = constants.InvestmentType.fdi.value.id
-    project = InvestmentProjectFactory(
-        investment_type_id=investment_type_id,
-        allow_blank_estimated_land_date=allow_blank_estimated_land_date,
-        estimated_land_date=None,
-    )
-    errors = validate(instance=project, fields=CORE_FIELDS)
-    assert ('estimated_land_date' in errors) == is_error
-
-
 def test_validate_business_activity_other_instance():
     """Tests other_business_activity conditional validation for a model instance."""
     project = InvestmentProjectFactory(

--- a/datahub/investment/validate.py
+++ b/datahub/investment/validate.py
@@ -59,8 +59,6 @@ def _get_to_many_id(instance):
 
 # Conditional validation rules. Mapping from field names to validation rules.
 CONDITIONAL_VALIDATION_MAPPING = {
-    'estimated_land_date':
-        CondValRule('allow_blank_estimated_land_date', False, Stage.prospect.value),
     'referral_source_activity_event':
         CondValRule('referral_source_activity', Activity.event.value.id, Stage.prospect.value),
     'other_business_activity':


### PR DESCRIPTION
### Description of change
When creating a new investment project estimated land date is required. This change means that the check is carried out even when other required fields are missing. Previously this was only done when all other required fields had been populated.

### How to test
- On master
- Navigate to a Company -> Investment -> Add new investment project
- Select a type of investment and a source of foreign equity investment
- Press continue
- Don't enter any project data and hit save, estimated land date won't be highlighted as required.
- On this branch
- Repeat Hit save, estimated land date will now be highlighted
- Find an existing Investment that does not have an estimated land date, make sure that it can be saved without an estimated land date

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
