### PR TITLE
Add links to the front end on change pages in the admin site

### DIFF
--- a/changelog/data-hub-links-in-admin.feature
+++ b/changelog/data-hub-links-in-admin.feature
@@ -1,0 +1,1 @@
+When viewing a record in the admin site, a link to the page for the record in the main application is now displayed (when applicable).

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -324,8 +324,9 @@ DATAHUB_FRONTEND_BASE_URL = env('DATAHUB_FRONTEND_BASE_URL', default='http://loc
 DATAHUB_FRONTEND_URL_PREFIXES = {
     'company': f'{DATAHUB_FRONTEND_BASE_URL}/companies',
     'contact': f'{DATAHUB_FRONTEND_BASE_URL}/contacts',
+    'event': f'{DATAHUB_FRONTEND_BASE_URL}/events',
     'interaction': f'{DATAHUB_FRONTEND_BASE_URL}/interactions',
-    'investment-project': f'{DATAHUB_FRONTEND_BASE_URL}/investment-projects',
+    'investmentproject': f'{DATAHUB_FRONTEND_BASE_URL}/investment-projects',
     'order': f'{DATAHUB_FRONTEND_BASE_URL}/omis',
 }
 

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -9,7 +9,7 @@ from mptt.fields import TreeForeignKey
 from datahub.company.ch_constants import COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPING
 from datahub.core import constants, reversion
 from datahub.core.models import ArchivableModel, BaseConstantModel, BaseModel
-from datahub.core.utils import StrEnum
+from datahub.core.utils import get_front_end_url, StrEnum
 from datahub.metadata import models as metadata_models
 from datahub.metadata.models import BusinessType
 
@@ -144,6 +144,10 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
         max_length=MAX_LENGTH, blank=True,
         help_text='Legacy field. File browser path to the archived documents for this company.',
     )
+
+    def get_absolute_url(self):
+        """URL to the object in the Data Hub internal front end."""
+        return get_front_end_url(self)
 
     class Meta:
         verbose_name_plural = 'companies'

--- a/datahub/company/models/contact.py
+++ b/datahub/company/models/contact.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from datahub.core import reversion
 from datahub.core.models import ArchivableModel, BaseModel
-from datahub.core.utils import StrEnum
+from datahub.core.utils import get_front_end_url, StrEnum
 from datahub.metadata import models as metadata_models
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -71,6 +71,10 @@ class Contact(ArchivableModel, BaseModel):
 
     # Marketing preferences
     accepts_dit_email_marketing = models.BooleanField(default=False)
+
+    def get_absolute_url(self):
+        """URL to the object in the Data Hub internal front end."""
+        return get_front_end_url(self)
 
     class Meta:
         permissions = (

--- a/datahub/company/test/test_models.py
+++ b/datahub/company/test/test_models.py
@@ -1,7 +1,8 @@
 import pytest
+from django.conf import settings
 
 from datahub.company.models import Company
-from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db
@@ -21,3 +22,19 @@ def test_company_can_have_one_list_owner_assigned():
     company_refetch = Company.objects.get(pk=str(company.pk))
 
     assert company_refetch.one_list_account_owner_id == adviser.pk
+
+
+def test_company_get_absolute_url():
+    """Test that Company.get_absolute_url() returns the correct URL."""
+    company = CompanyFactory.build()
+    assert company.get_absolute_url() == (
+        f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.pk}'
+    )
+
+
+def test_contact_get_absolute_url():
+    """Test that Contact.get_absolute_url() returns the correct URL."""
+    contact = ContactFactory.build()
+    assert contact.get_absolute_url() == (
+        f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{contact.pk}'
+    )

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -3,6 +3,7 @@ from itertools import islice
 from logging import getLogger
 
 import requests
+from django.conf import settings
 
 logger = getLogger(__name__)
 
@@ -93,3 +94,9 @@ def load_constants_to_database(constants, model):
 
             model_obj.name = constant.value.name
             model_obj.save()
+
+
+def get_front_end_url(obj):
+    """Gets the URL for the object in the Data Hub internal front end."""
+    url_prefix = settings.DATAHUB_FRONTEND_URL_PREFIXES[obj._meta.model_name]
+    return f'{url_prefix}/{obj.pk}'

--- a/datahub/event/models.py
+++ b/datahub/event/models.py
@@ -5,6 +5,7 @@ from django.db import models
 
 from datahub.core import reversion
 from datahub.core.models import BaseConstantModel, BaseModel, DisableableModel
+from datahub.core.utils import get_front_end_url
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -48,6 +49,10 @@ class Event(BaseModel, DisableableModel):
         max_length=MAX_LENGTH, blank=True,
         help_text='Legacy field. File browser path to the archived documents for this event.',
     )
+
+    def get_absolute_url(self):
+        """URL to the object in the Data Hub internal front end."""
+        return get_front_end_url(self)
 
     def __str__(self):
         """Human-readable representation"""

--- a/datahub/event/test/test_models.py
+++ b/datahub/event/test/test_models.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+
+from datahub.event.test.factories import EventFactory
+
+
+def test_event_get_absolute_url():
+    """Test that Event.get_absolute_url() returns the correct URL."""
+    event = EventFactory.build()
+    assert event.get_absolute_url() == (
+        f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["event"]}/{event.pk}'
+    )

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -6,7 +6,7 @@ from model_utils import Choices
 
 from datahub.core import reversion
 from datahub.core.models import BaseConstantModel, BaseModel, BaseOrderedConstantModel
-from datahub.core.utils import StrEnum
+from datahub.core.utils import get_front_end_url, StrEnum
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -195,6 +195,10 @@ class Interaction(BaseModel):
         if self.kind == self.KINDS.service_delivery:
             return bool(self.event)
         return None
+
+    def get_absolute_url(self):
+        """URL to the object in the Data Hub internal front end."""
+        return get_front_end_url(self)
 
     def __str__(self):
         """Human-readable representation."""

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -22,7 +22,10 @@ class InteractionFactoryBase(factory.django.DjangoModelFactory):
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     company = factory.SubFactory(CompanyFactory)
-    contact = factory.LazyAttribute(lambda i: ContactFactory(company=i.company))
+    contact = factory.SubFactory(
+        ContactFactory,
+        company=factory.SelfAttribute('..company'),
+    )
     subject = factory.Faker('sentence', nb_words=8)
     date = factory.Faker('past_datetime', start_date='-5y', tzinfo=utc)
     notes = factory.Faker('paragraph', nb_sentences=10)

--- a/datahub/interaction/test/test_models.py
+++ b/datahub/interaction/test/test_models.py
@@ -1,0 +1,13 @@
+import pytest
+from django.conf import settings
+
+from datahub.interaction.test.factories import CompanyInteractionFactory
+
+
+@pytest.mark.django_db
+def test_interaction_get_absolute_url():
+    """Test that Interaction.get_absolute_url() returns the correct URL."""
+    interaction = CompanyInteractionFactory.build()
+    assert interaction.get_absolute_url() == (
+        f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["interaction"]}/{interaction.pk}'
+    )

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -176,13 +176,8 @@ class TestListInteractions(APITestMixin):
             {
                 'created_on': datetime(2015, 1, 1),
                 'company__name': 'Black Group',
-                'contact': factory.LazyAttribute(
-                    lambda i: ContactFactory(
-                        company=i.company,
-                        first_name='Holly',
-                        last_name='Taylor',
-                    ),
-                ),
+                'contact__first_name': 'Holly',
+                'contact__last_name': 'Taylor',
                 'dit_adviser__first_name': 'Elaine',
                 'dit_adviser__last_name': 'Johnston',
                 'subject': 'lorem',
@@ -190,13 +185,8 @@ class TestListInteractions(APITestMixin):
             {
                 'created_on': datetime(2005, 4, 1),
                 'company__name': 'Hicks Ltd',
-                'contact': factory.LazyAttribute(
-                    lambda i: ContactFactory(
-                        company=i.company,
-                        first_name='Conor',
-                        last_name='Webb',
-                    ),
-                ),
+                'contact__first_name': 'Conor',
+                'contact__last_name': 'Webb',
                 'dit_adviser__first_name': 'Connor',
                 'dit_adviser__last_name': 'Webb',
                 'subject': 'ipsum',
@@ -204,13 +194,8 @@ class TestListInteractions(APITestMixin):
             {
                 'created_on': datetime(2019, 1, 1),
                 'company__name': 'Sheppard LLC',
-                'contact': factory.LazyAttribute(
-                    lambda i: ContactFactory(
-                        company=i.company,
-                        first_name='Suzanne',
-                        last_name='Palmer',
-                    ),
-                ),
+                'contact__first_name': 'Suzanne',
+                'contact__last_name': 'Palmer',
                 'dit_adviser__first_name': 'Hayley',
                 'dit_adviser__last_name': 'Hunt',
                 'subject': 'dolor',

--- a/datahub/investment/models.py
+++ b/datahub/investment/models.py
@@ -18,7 +18,7 @@ from datahub.core.models import (
     BaseConstantModel,
     BaseModel,
 )
-from datahub.core.utils import StrEnum
+from datahub.core.utils import get_front_end_url, StrEnum
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -399,6 +399,10 @@ class InvestmentProject(
         super().__init__(*args, **kwargs)
         self.__stage_id = self.stage_id
         self.__project_manager_id = self.project_manager_id
+
+    def get_absolute_url(self):
+        """URL to the object in the Data Hub internal front end."""
+        return get_front_end_url(self)
 
     def save(self, *args, **kwargs):
         """Updates the stage log after saving."""

--- a/datahub/investment/test/test_models.py
+++ b/datahub/investment/test/test_models.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from uuid import UUID
 
 import pytest
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.timezone import utc
 from freezegun import freeze_time
@@ -41,6 +42,14 @@ def test_no_project_code():
     project = InvestmentProjectFactory(cdms_project_code='P-79661656')
     project.cdms_project_code = None
     assert project.project_code is None
+
+
+def test_interaction_get_absolute_url():
+    """Test that InvestmentProject.get_absolute_url() returns the correct URL."""
+    project = InvestmentProjectFactory.build()
+    assert project.get_absolute_url() == (
+        f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["investmentproject"]}/{project.pk}'
+    )
 
 
 def test_client_relationship_manager_team_none():

--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -16,7 +16,7 @@ from datahub.core.models import (
     BaseModel,
     BaseOrderedConstantModel,
 )
-from datahub.core.utils import StrEnum
+from datahub.core.utils import get_front_end_url, StrEnum
 from datahub.metadata.models import Country, Sector, Team, UKRegion
 from datahub.omis.core.utils import generate_reference
 from datahub.omis.invoice.models import Invoice
@@ -303,6 +303,10 @@ class Order(BaseModel):
     def __str__(self):
         """Human-readable representation"""
         return self.reference
+
+    def get_absolute_url(self):
+        """URL to the object in the Data Hub internal front end."""
+        return get_front_end_url(self)
 
     def get_current_contact_email(self):
         """

--- a/datahub/omis/order/test/factories.py
+++ b/datahub/omis/order/test/factories.py
@@ -24,7 +24,10 @@ class OrderFactory(factory.django.DjangoModelFactory):
     created_by = factory.SubFactory(AdviserFactory)
     modified_by = factory.SubFactory(AdviserFactory)
     company = factory.SubFactory(CompanyFactory)
-    contact = factory.LazyAttribute(lambda o: ContactFactory(company=o.company))
+    contact = factory.SubFactory(
+        ContactFactory,
+        company=factory.SelfAttribute('..company'),
+    )
     primary_market_id = Country.france.value.id
     sector_id = Sector.aerospace_assembly_aircraft.value.id
     uk_region_id = UKRegion.england.value.id

--- a/datahub/omis/order/test/test_models.py
+++ b/datahub/omis/order/test/test_models.py
@@ -5,6 +5,7 @@ from unittest import mock
 import factory
 import pytest
 from dateutil.parser import parse as dateutil_parse
+from django.conf import settings
 from django.utils.crypto import get_random_string
 from django.utils.timezone import now
 from freezegun import freeze_time
@@ -755,3 +756,11 @@ class TestOrderAssignee:
         with pytest.raises(ValueError):
             assignee.adviser = AdviserFactory()
             assignee.save()
+
+
+def test_order_get_absolute_url():
+    """Test that Order.get_absolute_url() returns the correct URL."""
+    order = OrderFactory.build()
+    assert order.get_absolute_url() == (
+        f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["order"]}/{order.pk}'
+    )

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -837,7 +837,7 @@ class TestInvestmentProjectExportView(APITestMixin):
                 'Status': project.get_status_display(),
                 'Stage': get_attr_or_none(project, 'stage.name'),
                 'Link':
-                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["investment-project"]}'
+                    f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["investmentproject"]}'
                     f'/{project.pk}',
                 'Actual land date': project.actual_land_date,
                 'Estimated land date': project.estimated_land_date,

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -81,7 +81,7 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectParams, SearchExportA
     queryset = DBInvestmentProject.objects.annotate(
         computed_project_code=get_project_code_expression(),
         status_name=get_choices_as_case_expression(DBInvestmentProject, 'status'),
-        link=get_front_end_url_expression('investment-project', 'pk'),
+        link=get_front_end_url_expression('investmentproject', 'pk'),
         date_of_latest_interaction=get_aggregate_subquery(
             DBInvestmentProject,
             Max('interactions__date'),


### PR DESCRIPTION
### Description of change

This adds links in the change form in the admin site to the the relevant page for the record in the front end (where such links are available). This is just to make it easier to navigate to that page when viewing the record in the admin site.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
