### PR TITLE
Add other company selection part of duplicate company merging tool

### DIFF
--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -1,10 +1,20 @@
 from django import forms
 from django.contrib import admin
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.contrib.admin.utils import unquote
+from django.core.exceptions import PermissionDenied, ValidationError
 from django.db import models
+from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+from django.utils.translation import gettext_lazy
 from reversion.admin import VersionAdmin
 
 from datahub.company.models import Company, CompanyCoreTeamMember
-from datahub.core.admin import BaseModelAdminMixin
+from datahub.core.admin import BaseModelAdminMixin, RawIdWidget
+from datahub.feature_flag.utils import feature_flagged_view, is_feature_flag_active
+
+MERGE_COMPANY_TOOL_FEATURE_FLAG = 'admin-merge-company-tool'
 
 
 class CompanyCoreTeamMemberInline(admin.TabularInline):
@@ -19,6 +29,31 @@ class CompanyCoreTeamMemberInline(admin.TabularInline):
     raw_id_fields = (
         'adviser',
     )
+
+
+class SelectOtherCompanyForm(forms.Form):
+    """Form used for selecting a second company when merging duplicate companies."""
+
+    BOTH_COMPANIES_ARE_THE_SAME_MSG = gettext_lazy(
+        'The two companies to merge cannot be the same. Please select a different company.',
+    )
+
+    other_company = forms.ModelChoiceField(
+        Company.objects.all(),
+        widget=RawIdWidget(Company),
+    )
+
+    def __init__(self, first_company_id, *args, **kwargs):
+        """Initialises the form, saving the ID of the company already selected."""
+        super().__init__(*args, **kwargs)
+        self._first_company_id = first_company_id
+
+    def clean_other_company(self):
+        """Checks that a different company than the one navigated from has been selected."""
+        other_company = self.cleaned_data['other_company']
+        if str(other_company.pk) == str(self._first_company_id):
+            raise ValidationError(self.BOTH_COMPANIES_ARE_THE_SAME_MSG)
+        return other_company
 
 
 @admin.register(Company)
@@ -133,3 +168,71 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
     inlines = (
         CompanyCoreTeamMemberInline,
     )
+
+    def get_urls(self):
+        """Gets the URLs for this model."""
+        model_meta = self.model._meta
+
+        return [
+            path(
+                '<path:object_id>/merge-select-other-company/',
+                self.admin_site.admin_view(self.merge_select_other_company),
+                name=f'{model_meta.app_label}_'
+                     f'{model_meta.model_name}_merge-select-other-company',
+            ),
+            *super().get_urls(),
+        ]
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        """
+        Change view with additional data added to the context.
+
+        Based on this example in the Django docs:
+        https://docs.djangoproject.com/en/2.1/ref/contrib/admin/#django.contrib.admin.ModelAdmin.changelist_view
+        """
+        merge_company_tool_feature_flag = is_feature_flag_active(MERGE_COMPANY_TOOL_FEATURE_FLAG)
+        extra_context = {
+            **({} if extra_context is None else extra_context),
+            'merge_company_tool_feature_flag': merge_company_tool_feature_flag,
+        }
+
+        return super().change_view(
+            request,
+            object_id,
+            form_url=form_url,
+            extra_context=extra_context,
+        )
+
+    @feature_flagged_view(MERGE_COMPANY_TOOL_FEATURE_FLAG)
+    def merge_select_other_company(self, request, object_id):
+        """
+        First view as part of the merge duplicate companies process.
+
+        Used to select the second company of the two to merge.
+
+        As this does not modify state, the form is submitted using GET rather than POST.
+        """
+        if not self.has_change_permission(request):
+            raise PermissionDenied
+
+        template_name = 'admin/company/company/merge_select_other_company.html'
+        title = gettext_lazy('Merge with another company')
+
+        obj = self.get_object(request, unquote(object_id))
+        form = SelectOtherCompanyForm(object_id, request.GET or None)
+
+        if request.GET and form.is_valid():
+            # The next page is still to be implemented, redirect to the change list for now
+            changelist_route_name = admin_urlname(self.model._meta, 'changelist')
+            changelist_url = reverse(changelist_route_name)
+            return HttpResponseRedirect(changelist_url)
+
+        context = {
+            **self.admin_site.each_context(request),
+            'opts': self.model._meta,
+            'title': title,
+            'form': form,
+            'media': self.media,
+            'object': obj,
+        }
+        return TemplateResponse(request, template_name, context)

--- a/datahub/company/templates/admin/company/company/change_form_object_tools.html
+++ b/datahub/company/templates/admin/company/company/change_form_object_tools.html
@@ -1,0 +1,13 @@
+{% extends "admin/change_form_object_tools.html" %}
+{% load admin_urls %}
+
+{% block object-tools-items %}
+  {% if merge_company_tool_feature_flag and has_change_permission %}
+  <li>
+    <a href="{% url opts|admin_urlname:'merge-select-other-company' original.pk|admin_urlquote %}">
+      Merge with another company
+    </a>
+  </li>
+  {% endif %}
+{{block.super}}
+{% endblock %}

--- a/datahub/company/templates/admin/company/company/merge_select_other_company.html
+++ b/datahub/company/templates/admin/company/company/merge_select_other_company.html
@@ -1,0 +1,45 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+{% endblock %}
+
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a>
+&rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+  <p>If this company has a duplicate record in the system, you can use this tool to merge the two records. It&rsquo;s not intended to be used to merge companies for other reasons (e.g. following a merger or acquisition).</p>
+  <p>Which company should {{ object }} be merged with?</p>
+
+  <form action="" method="get">
+    {% for field in form %}
+      <div class="fieldWrapper">
+        {{ field.errors }}
+        {{ field.label_tag }} {{ field }}
+        {% if field.help_text %}
+        <p class="help">{{ field.help_text|safe }}</p>
+        {% endif %}
+      </div>
+    {% endfor %}
+
+    <div>
+      <input type="submit" value="{% trans 'Next' %}">
+    </div>
+  </form>
+{% endblock %}

--- a/datahub/company/test/admin/test_company.py
+++ b/datahub/company/test/admin/test_company.py
@@ -3,21 +3,29 @@ from unittest import mock
 
 import pytest
 from django.contrib.admin.sites import site
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 
-from datahub.company.admin.company import CompanyAdmin
+from datahub.company.admin.company import CompanyAdmin, MERGE_COMPANY_TOOL_FEATURE_FLAG
 from datahub.company.admin_reports import OneListReport
-from datahub.company.models import Company
+from datahub.company.models import Company, CompanyPermission
 from datahub.company.test.factories import (
     AdviserFactory,
     CompanyCoreTeamMemberFactory,
     CompanyFactory,
 )
-from datahub.core.test_utils import AdminTestMixin
-
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+from datahub.feature_flag.test.factories import FeatureFlagFactory
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture()
+def merge_list_feature_flag():
+    """Creates the merge tool feature flag."""
+    yield FeatureFlagFactory(code=MERGE_COMPANY_TOOL_FEATURE_FLAG)
 
 
 class TestChangeCompanyAdmin(AdminTestMixin):
@@ -105,6 +113,122 @@ class TestChangeCompanyAdmin(AdminTestMixin):
         assert company.core_team_members.count() == team_size - 1
 
 
+@pytest.mark.usefixtures('merge_list_feature_flag')
+class TestMergeWithAnotherCompanyLink(AdminTestMixin):
+    """Tests the 'merge with another company' link on the change form."""
+
+    def test_link_exists(self):
+        """Test that the link exists for a user with the change company permission."""
+        company = CompanyFactory()
+
+        change_route_name = admin_urlname(Company._meta, 'change')
+        change_url = reverse(change_route_name, args=(company.pk,))
+
+        response = self.client.get(change_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        select_other_route_name = admin_urlname(Company._meta, 'merge-select-other-company')
+        select_other_url = reverse(select_other_route_name, args=(company.pk,))
+
+        assert select_other_url in response.rendered_content
+
+    def test_link_does_not_exist_with_only_view_permission(self):
+        """Test that the link does not exist for a user with only the view company permission."""
+        company = CompanyFactory()
+
+        change_route_name = admin_urlname(Company._meta, 'change')
+        change_url = reverse(change_route_name, args=(company.pk,))
+
+        user = create_test_user(
+            permission_codenames=(CompanyPermission.view_company,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+        client = self.create_client(user=user)
+        response = client.get(change_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        select_other_route_name = admin_urlname(Company._meta, 'merge-select-other-company')
+        select_other_url = reverse(select_other_route_name, args=(company.pk,))
+
+        assert select_other_url not in response.rendered_content
+
+
+@pytest.mark.usefixtures('merge_list_feature_flag')
+class TestMergeWithAnotherCompanyView(AdminTestMixin):
+    """Tests the 'merge with another company' form."""
+
+    SAME_COMPANY = object()
+
+    def test_proceeds_if_valid_company_provided(self):
+        """Test the view redirects if a valid company is provided."""
+        main_company = CompanyFactory()
+        other_company = CompanyFactory()
+
+        select_other_route_name = admin_urlname(Company._meta, 'merge-select-other-company')
+        select_other_url = reverse(select_other_route_name, args=(main_company.pk,))
+
+        response = self.client.get(
+            select_other_url,
+            follow=True,
+            data={
+                'other_company': str(other_company.pk),
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+
+        changelist_route_name = admin_urlname(Company._meta, 'changelist')
+        changelist_url = reverse(changelist_route_name)
+
+        assert response.redirect_chain[0][0] == changelist_url
+
+    @pytest.mark.parametrize(
+        'other_company,expected_error',
+        (
+            (
+                SAME_COMPANY,
+                'The two companies to merge cannot be the same. Please select a different '
+                'company.',
+            ),
+            (
+                '1234',
+                "'1234' is not a valid UUID.",
+            ),
+            (
+                '',
+                'This field is required.',
+            ),
+        ),
+    )
+    def test_error_if_same_company_provided(self, other_company, expected_error):
+        """
+        Test that an error is displayed if the same company is provided as the second
+        company.
+        """
+        company = CompanyFactory()
+
+        select_other_route_name = admin_urlname(Company._meta, 'merge-select-other-company')
+        select_other_url = reverse(select_other_route_name, args=(company.pk,))
+
+        value = str(company.pk) if other_company is self.SAME_COMPANY else other_company
+
+        response = self.client.get(
+            select_other_url,
+            data={
+                'other_company': value,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        form = response.context['form']
+
+        assert 'other_company' in form.errors
+        assert form.errors['other_company'] == [expected_error]
+
+
 class TestOneListLink(AdminTestMixin):
     """
     Tests for the one list export.
@@ -123,3 +247,91 @@ class TestOneListLink(AdminTestMixin):
             kwargs={'report_id': OneListReport.id},
         )
         assert one_list_url in response.rendered_content
+
+
+@pytest.mark.usefixtures('merge_list_feature_flag')
+class TestCompanyAdminPermissions(AdminTestMixin):
+    """Test permission handling in various views."""
+
+    @pytest.mark.parametrize(
+        'route_name,needs_arg,method',
+        (
+            (
+                admin_urlname(Company._meta, 'merge-select-other-company'),
+                True,
+                'get',
+            ),
+        ),
+    )
+    def test_redirects_to_login_page_if_not_logged_in(self, route_name, needs_arg, method):
+        """Test that the view redirects to the login page if the user isn't authenticated."""
+        args = (CompanyFactory().pk,) if needs_arg else ()
+        url = reverse(route_name, args=args)
+
+        client = Client()
+        request_func = getattr(client, method)
+        response = request_func(url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+
+    @pytest.mark.parametrize(
+        'route_name,needs_arg,method',
+        (
+            (
+                admin_urlname(Company._meta, 'merge-select-other-company'),
+                True,
+                'get',
+            ),
+        ),
+    )
+    def test_redirects_to_login_page_if_not_staff(self, route_name, needs_arg, method):
+        """Test that the view redirects to the login page if the user isn't a member of staff."""
+        args = (CompanyFactory().pk,) if needs_arg else ()
+        url = reverse(route_name, args=args)
+
+        user = create_test_user(is_staff=False, password=self.PASSWORD)
+        client = self.create_client(user=user)
+        request_func = getattr(client, method)
+
+        response = request_func(url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+
+    @pytest.mark.parametrize(
+        'route_name,needs_arg,method',
+        (
+            (
+                admin_urlname(Company._meta, 'merge-select-other-company'),
+                True,
+                'get',
+            ),
+        ),
+    )
+    def test_permission_denied_if_staff_and_without_change_permission(
+            self,
+            route_name,
+            needs_arg,
+            method,
+    ):
+        """
+        Test that the view returns a 403 response if the staff user does not have the
+        change company permission.
+        """
+        args = (CompanyFactory().pk,) if needs_arg else ()
+        url = reverse(route_name, args=args)
+
+        user = create_test_user(
+            permission_codenames=(CompanyPermission.view_company,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+        client = self.create_client(user=user)
+        request_func = getattr(client, method)
+
+        response = request_func(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -92,7 +92,9 @@ class AdminTestMixin:
     @property
     def client(self):
         """Returns an authenticated admin client."""
-        return self.create_client()
+        if not hasattr(self, '_client'):
+            self._client = self.create_client()
+        return self._client
 
     def create_client(self, user=None):
         """Creates a client with admin access."""
@@ -144,7 +146,9 @@ class APITestMixin:
     @property
     def api_client(self):
         """An API client with data-hub:internal-front-end scope."""
-        return self.create_api_client()
+        if not hasattr(self, '_client'):
+            self._api_client = self.create_api_client()
+        return self._api_client
 
     def create_api_client(self, scope=Scope.internal_front_end, *additional_scopes,
                           grant_type=Application.GRANT_PASSWORD, user=None):

--- a/datahub/feature_flag/utils.py
+++ b/datahub/feature_flag/utils.py
@@ -1,3 +1,7 @@
+from functools import wraps
+
+from django.http import Http404
+
 from datahub.feature_flag.models import FeatureFlag
 
 
@@ -8,3 +12,23 @@ def is_feature_flag_active(code):
     If feature flag doesn't exist, it returns False.
     """
     return FeatureFlag.objects.filter(code=code, is_active=True).exists()
+
+
+def feature_flagged_view(code):
+    """
+    Decorator to put a view behind a feature flag.
+
+    This returns a 404 is a specified feature flag is not active. Otherwise, the view is called
+    normally.
+    """
+    def decorator(view_func):
+        @wraps(view_func)
+        def wrapped_view(*args, **kwargs):
+            if not is_feature_flag_active(code):
+                raise Http404
+
+            return view_func(*args, **kwargs)
+
+        return wrapped_view
+
+    return decorator


### PR DESCRIPTION
### Description of change

This is a simplified version of https://github.com/uktrade/data-hub-leeloo/pull/1172, using a new form widget similar to `ForeignKeyRawIdWidget` (but not tied to a specific model field).

The new flow is to search for a company, click on it and then click on the Merge with another company button. The second company is then specified on that form.

The advantage is that the workflow is much simpler. There is a slight disadvantage in that there's less information visible about the other company (though we could add additional columns to the company change list).

As before, the overall tool is incomplete so it's behind a feature flag. There will probably be some additional logic added to these bits later on as well (e.g. stop archived companies from being merged).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
