### PR TITLE
Update to Elasticsearch 6.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,25 +77,24 @@ job_defaults: &job_defaults
             command: |
               wget -O codecov.sh https://codecov.io/bash
               bash ./codecov.sh -t ${COV_TOKEN}
-
 jobs:
 
-  build_es_55:
+  build_es_63:
     <<: *job_defaults
 
-  build_es_63:
+  build_es_64:
     <<: *job_defaults
 
 workflows:
   version: 2
 
-  Elasticsearch 5.5:
-    jobs:
-      - build_es_55:
-          publish_coverage: true
-          es_image: elasticsearch:5.5
-
   Elasticsearch 6.3:
     jobs:
       - build_es_63:
+          publish_coverage: true
           es_image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+
+  Elasticsearch 6.4:
+    jobs:
+      - build_es_64:
+          es_image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Dependencies:
 -   Python 3.6.x
 -   PostgreSQL 9.6
 -   redis 3.2
+-   Elasticsearch 6.3
 
 1.  Clone the repository:
 
@@ -106,7 +107,7 @@ Dependencies:
 8. Make sure you have Elasticsearch running locally. If you don't, you can run one in Docker:
 
     ```shell
-    docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" elasticsearch:5.5
+    docker run -p 9200:9200 -e "http.host=0.0.0.0" -e "transport.host=127.0.0.1" docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     ```
 
 9. Make sure you have redis running locally and that the REDIS_BASE_URL in your `.env` is up-to-date.

--- a/changelog/elasticsearch-6.3.internal
+++ b/changelog/elasticsearch-6.3.internal
@@ -1,0 +1,1 @@
+The Elasticsearch Python client libraries were updated to 6.x versions, as was the Docker image used during development.

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -4,6 +4,9 @@ from datahub.search import dict_utils, fields
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'companieshousecompany'
+
+
 class CompaniesHouseCompany(BaseESModel):
     """Elasticsearch representation of CompaniesHouseCompany model."""
 
@@ -48,4 +51,7 @@ class CompaniesHouseCompany(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = 'companieshousecompany'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -7,6 +7,9 @@ from datahub.search import fields
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'company'
+
+
 class Company(BaseESModel):
     """Elasticsearch representation of Company model."""
 
@@ -116,4 +119,7 @@ class Company(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = 'company'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -6,6 +6,9 @@ from datahub.search.contact import dict_utils as contact_dict_utils
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'contact'
+
+
 class Contact(BaseESModel):
     """Elasticsearch representation of Contact model."""
 
@@ -89,4 +92,7 @@ class Contact(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = 'contact'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -135,7 +135,7 @@ def create_index(index_name, mapping, alias_names=()):
     Note: If you need to perform multiple alias operations atomically, you should use
     start_alias_transaction() instead of specifying aliases when creating an index.
     """
-    index = Index(index_name)
+    index = Index(index_name, mapping.doc_type)
     for analyzer in ANALYZERS:
         index.analyzer(analyzer)
 

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -4,6 +4,9 @@ from datahub.search import dict_utils, fields
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'event'
+
+
 class Event(BaseESModel):
     """Elasticsearch representation of Event model."""
 
@@ -64,4 +67,7 @@ class Event(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = 'event'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -6,6 +6,9 @@ from datahub.search import dict_utils, fields
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'interaction'
+
+
 class Interaction(BaseESModel):
     """Elasticsearch representation of Interaction model."""
 
@@ -72,4 +75,7 @@ class Interaction(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = 'interaction'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -5,6 +5,9 @@ from datahub.search import fields
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'investment_project'
+
+
 def _referral_source_adviser_mapping():
     """
     Mapping for referral_source_adviser.
@@ -196,4 +199,7 @@ class InvestmentProject(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = 'investment_project'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -2,7 +2,7 @@ from hashlib import blake2b
 from logging import getLogger
 
 from django.conf import settings
-from elasticsearch_dsl import DocType, MetaField
+from elasticsearch_dsl import Document, MetaField
 
 from datahub.core.exceptions import DataHubException
 from datahub.search.elasticsearch import (
@@ -17,7 +17,7 @@ from datahub.search.utils import get_model_non_mapped_field_names, serialise_map
 logger = getLogger(__name__)
 
 
-class BaseESModel(DocType):
+class BaseESModel(Document):
     """Helps convert Django models to dictionaries."""
 
     MAPPINGS = {}

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -5,6 +5,9 @@ from datahub.search import fields
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'order'
+
+
 class Order(BaseESModel):
     """Elasticsearch representation of Order model."""
 
@@ -98,4 +101,7 @@ class Order(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = 'order'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/test/search_support/relatedmodel/models.py
+++ b/datahub/search/test/search_support/relatedmodel/models.py
@@ -5,6 +5,9 @@ from datahub.search import fields
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'relatedmodel'
+
+
 class ESRelatedModel(BaseESModel):
     """Elasticsearch representation of SimpleModel model."""
 
@@ -20,4 +23,7 @@ class ESRelatedModel(BaseESModel):
     class Meta:
         """Model configuration."""
 
-        doc_type = 'relatedmodel'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/test/search_support/simplemodel/models.py
+++ b/datahub/search/test/search_support/simplemodel/models.py
@@ -4,6 +4,9 @@ from datahub.search import fields
 from datahub.search.models import BaseESModel
 
 
+DOC_TYPE = 'simplemodel'
+
+
 class ESSimpleModel(BaseESModel):
     """Elasticsearch representation of SimpleModel model."""
 
@@ -24,4 +27,7 @@ class ESSimpleModel(BaseESModel):
     class Meta:
         """Default document meta data."""
 
-        doc_type = 'simplemodel'
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/test/test_serializers.py
+++ b/datahub/search/test/test_serializers.py
@@ -2,7 +2,6 @@ import pytest
 from rest_framework import serializers
 
 from datahub.search.serializers import SingleOrListField
-from datahub.search.test.utils import model_has_field_path
 
 
 class TestSingleOrListField:
@@ -41,11 +40,12 @@ class TestSerializerAttributes:
     def test_sort_by_fields(self, search_app):
         """Validate that the values of SORT_BY_FIELDS are valid field paths."""
         view = search_app.view
+        mapping = search_app.es_model._doc_type.mapping
 
         invalid_fields = {
             field
             for field in view.serializer_class.SORT_BY_FIELDS
-            if not model_has_field_path(search_app.es_model, field)
+            if not mapping.resolve_field(field)
         }
 
         assert not invalid_fields

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -19,7 +19,6 @@ from datahub.omis.order.test.factories import OrderFactory
 from datahub.search.sync_async import sync_object_async
 from datahub.search.test.search_support.models import SimpleModel
 from datahub.search.test.search_support.simplemodel.models import ESSimpleModel
-from datahub.search.test.utils import model_has_field_path
 from datahub.user_event_log.constants import USER_EVENT_TYPES
 from datahub.user_event_log.models import UserEvent
 
@@ -96,10 +95,11 @@ class TestValidateViewAttributes:
     def test_validate_remap_fields_exist(self, search_app):
         """Validate that the values of REMAP_FIELDS are valid field paths."""
         view = search_app.view
+        mapping = search_app.es_model._doc_type.mapping
 
         invalid_fields = {
             field for field in view.REMAP_FIELDS.values()
-            if not model_has_field_path(search_app.es_model, field)
+            if not mapping.resolve_field(field)
         }
 
         assert not invalid_fields
@@ -113,12 +113,13 @@ class TestValidateViewAttributes:
     def test_validate_composite_filter_fields(self, search_app):
         """Validate that the values of COMPOSITE_FILTERS are valid field paths."""
         view = search_app.view
+        mapping = search_app.es_model._doc_type.mapping
 
         invalid_fields = {
             field
             for field_list in view.COMPOSITE_FILTERS.values()
             for field in field_list
-            if not model_has_field_path(search_app.es_model, field)
+            if not mapping.resolve_field(field)
             and field not in search_app.es_model.PREVIOUS_MAPPING_FIELDS
         }
 
@@ -131,6 +132,7 @@ class TestValidateExportViewAttributes:
     def test_validate_sort_by_remappings(self, search_app):
         """Validate that the values of sort_by_remappings are valid field paths."""
         view = search_app.export_view
+        mapping = search_app.es_model._doc_type.mapping
 
         if not view:
             return
@@ -138,7 +140,7 @@ class TestValidateExportViewAttributes:
         invalid_fields = {
             field
             for field in view.sort_by_remappings
-            if not model_has_field_path(search_app.es_model, field)
+            if not mapping.resolve_field(field)
             and field not in search_app.es_model.PREVIOUS_MAPPING_FIELDS
         }
 

--- a/datahub/search/test/utils.py
+++ b/datahub/search/test/utils.py
@@ -1,26 +1,5 @@
 from unittest.mock import Mock
 
-from elasticsearch_dsl import AttrDict
-
-from datahub.search.utils import get_model_fields
-
-
-def model_has_field_path(es_model, path):
-    """Checks whether a field path (e.g. company.id) exists in a model."""
-    path_components = path.split('.')
-    fields = get_model_fields(es_model)
-
-    for sub_field_name in path_components:
-        if sub_field_name not in fields:
-            return False
-
-        sub_field = fields.get(sub_field_name)
-        fields = getattr(sub_field, 'properties', AttrDict({})).to_dict()
-        if not fields:
-            fields = getattr(sub_field, 'fields', {})
-
-    return True
-
 
 def create_mock_search_app(
         current_mapping_hash='mapping-hash',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - POSTGRES_DB=datahub
 
   es:
-    image: elasticsearch:5.5
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     restart: always
     ports:
       - "9200:9200"

--- a/requirements.in
+++ b/requirements.in
@@ -32,8 +32,8 @@ notifications-python-client==5.2.0
 django-redis==4.9.0
 
 # ES
-elasticsearch==5.5.3
-elasticsearch-dsl==5.4.0
+elasticsearch==6.3.1
+elasticsearch-dsl==6.2.1
 aws-requests-auth==0.4.2
 
 # Celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,8 @@ django==2.1.2
 djangorestframework==3.8.2
 docopt==0.6.2             # via docopt, notifications-python-client
 docutils==0.14            # via botocore, docutils
-elasticsearch-dsl==5.4.0
-elasticsearch==5.5.3
+elasticsearch-dsl==6.2.1
+elasticsearch==6.3.1
 execnet==1.5.0            # via pytest-xdist
 factory-boy==2.11.1
 faker==0.9.2              # via factory-boy
@@ -59,6 +59,7 @@ greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
 idna==2.7                 # via requests
 incremental==17.5.0       # via towncrier
+ipaddress==1.0.22         # via elasticsearch-dsl
 ipdb==0.11
 ipython-genutils==0.2.0   # via ipython-genutils, traitlets
 ipython==7.0.1


### PR DESCRIPTION
### Description of change

This includes updating the elasticsearch and elasticsearch-dsl libraries, and updating the docker image used for development.

There is some further clean-up that could be done around mapping type names ([should now be _doc for all models](https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html)) and object fields and nested documents ([using the new InnerDoc class](https://elasticsearch-dsl.readthedocs.io/en/latest/persistence.html?highlight=innerdoc)). However, those have been left as a future exercise as they are more involved changes.

See the change logs for the client libraries for more details on what's changed there:

- https://elasticsearch-dsl.readthedocs.io/en/latest/Changelog.html
- https://elasticsearch-py.readthedocs.io/en/latest/Changelog.html

The update to elasticsearch-dsl does not affect the current mapping hashes.

I've marked this as blocked as we need to update all of our environments to ES 6.3 first.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
