### PR TITLE
Update Flake8 to version 3.6.0

### DIFF
--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -347,19 +347,16 @@ class TestGetCompany(APITestMixin):
         assert response.data['id'] == str(company.pk)
         assert response.data['companies_house_data'] is None
         assert response.data['name'] == company.name
-        assert (response.data['registered_address_1'] ==
-                company.registered_address_1)
+        assert response.data['registered_address_1'] == company.registered_address_1
         assert response.data['registered_address_2'] is None
-        assert (response.data['registered_address_town'] ==
-                company.registered_address_town)
+        assert response.data['registered_address_town'] == company.registered_address_town
         assert response.data['registered_address_country'] == {
             'name': company.registered_address_country.name,
             'id': str(company.registered_address_country.pk),
         }
         assert response.data['registered_address_county'] is None
         assert response.data['registered_address_postcode'] is None
-        assert (response.data['headquarter_type']['id'] ==
-                HeadquarterType.ukhq.value.id)
+        assert response.data['headquarter_type']['id'] == HeadquarterType.ukhq.value.id
         assert response.data['classification'] == {
             'id': str(company.classification.pk),
             'name': company.classification.name,

--- a/datahub/core/validators/rules_based.py
+++ b/datahub/core/validators/rules_based.py
@@ -26,7 +26,7 @@ class AbstractRule(ABC):
 class BaseRule(AbstractRule):
     """Base class for rules."""
 
-    def __init__(self, field: str=None):
+    def __init__(self, field: str = None):
         """Sets the field name."""
         self._field = field
 
@@ -90,7 +90,7 @@ class InRule(OperatorRule):
 class ConditionalRule:
     """A rule that is only checked when a condition is met."""
 
-    def __init__(self, rule: AbstractRule, when: AbstractRule=None):
+    def __init__(self, rule: AbstractRule, when: AbstractRule = None):
         """
         Initialises the rule.
 
@@ -176,7 +176,7 @@ class ValidationRule(AbstractValidationRule):
         self,
         error_key: str,
         *rules: AbstractRule,
-        when: AbstractRule=None,
+        when: AbstractRule = None,
     ):
         """
         Initialises a validation rule.

--- a/datahub/dbmaintenance/management/base.py
+++ b/datahub/dbmaintenance/management/base.py
@@ -77,7 +77,7 @@ class CSVBaseCommand(BaseCommand):
         """
         try:
             self._process_row(row, **options)
-        except Exception as e:
+        except Exception:
             logger.exception(f'Row {row} - Failed')
             return False
         else:

--- a/datahub/dbmaintenance/management/commands/update_investment_project_company.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_company.py
@@ -39,10 +39,12 @@ class Command(CSVBaseCommand):
         :param uk_company_decided: Boolean
         :return: True if investment project needs to be updated
         """
-        return (investment_project.investor_company_id != investor_company_id or
-                investment_project.intermediate_company_id != intermediate_company_id or
-                investment_project.uk_company_id != uk_company_id or
-                investment_project.uk_company_decided != uk_company_decided)
+        return (
+            investment_project.investor_company_id != investor_company_id
+            or investment_project.intermediate_company_id != intermediate_company_id
+            or investment_project.uk_company_id != uk_company_id
+            or investment_project.uk_company_decided != uk_company_decided
+        )
 
     def get_uk_company_decided(self, uk_company_decided):
         """

--- a/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_marketing.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_marketing.py
@@ -19,8 +19,8 @@ class Command(CSVBaseCommand):
                 None otherwise
         """
         if (
-            not referral_source_activity_id or
-            referral_source_activity_id.lower().strip() == 'null'
+            not referral_source_activity_id
+            or referral_source_activity_id.lower().strip() == 'null'
         ):
             return None
         return ReferralSourceActivity.objects.get(id=referral_source_activity_id)
@@ -34,8 +34,8 @@ class Command(CSVBaseCommand):
                 None otherwise
         """
         if (
-            not referral_source_activity_marketing_id or
-            referral_source_activity_marketing_id.lower().strip() == 'null'
+            not referral_source_activity_marketing_id
+            or referral_source_activity_marketing_id.lower().strip() == 'null'
         ):
             return None
         return ReferralSourceMarketing.objects.get(id=referral_source_activity_marketing_id)
@@ -56,10 +56,10 @@ class Command(CSVBaseCommand):
         :return: True if investment project needs to be updated
         """
         return (
-            investment_project.referral_source_activity_id !=
-            referral_source_activity.id or
-            investment_project.referral_source_activity_marketing_id !=
-            referral_source_activity_marketing.id
+            investment_project.referral_source_activity_id
+            != referral_source_activity.id
+            or investment_project.referral_source_activity_marketing_id
+            != referral_source_activity_marketing.id
         )
 
     def _process_row(self, row, simulate=False, **options):

--- a/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_website.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_referral_source_activity_website.py
@@ -19,8 +19,8 @@ class Command(CSVBaseCommand):
                 None otherwise
         """
         if (
-            not referral_source_activity_id or
-            referral_source_activity_id.lower().strip() == 'null'
+            not referral_source_activity_id
+            or referral_source_activity_id.lower().strip() == 'null'
         ):
             return None
         return ReferralSourceActivity.objects.get(id=referral_source_activity_id)
@@ -34,8 +34,8 @@ class Command(CSVBaseCommand):
                 None otherwise
         """
         if (
-            not referral_source_activity_website_id or
-            referral_source_activity_website_id.lower().strip() == 'null'
+            not referral_source_activity_website_id
+            or referral_source_activity_website_id.lower().strip() == 'null'
         ):
             return None
         return ReferralSourceWebsite.objects.get(id=referral_source_activity_website_id)
@@ -56,10 +56,10 @@ class Command(CSVBaseCommand):
         :return: True if investment project needs to be updated
         """
         return (
-            investment_project.referral_source_activity_id !=
-            referral_source_activity.id or
-            investment_project.referral_source_activity_website_id !=
-            referral_source_activity_website.id
+            investment_project.referral_source_activity_id
+            != referral_source_activity.id
+            or investment_project.referral_source_activity_website_id
+            != referral_source_activity_website.id
         )
 
     def _process_row(self, row, simulate=False, **options):

--- a/datahub/dbmaintenance/management/commands/update_one_list_fields.py
+++ b/datahub/dbmaintenance/management/commands/update_one_list_fields.py
@@ -84,7 +84,7 @@ class Command(CSVBaseCommand):
                 new_one_list_account_owner_id=None,
                 simulate=simulate,
             )
-        except Exception as e:
+        except Exception:
             logger.exception(f'Resetting company {company} - Failed')
             return False
         else:

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_marketing.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_referral_source_activity_marketing.py
@@ -161,8 +161,8 @@ def test_simulate(s3_stubber):
             investment_projects[i].referral_source_activity == referral_source_activities[i]
         )
         assert (
-            investment_projects[i].referral_source_activity_marketing ==
-            referral_source_marketings[i]
+            investment_projects[i].referral_source_activity_marketing
+            == referral_source_marketings[i]
         )
 
 

--- a/datahub/investment/serializers.py
+++ b/datahub/investment/serializers.py
@@ -360,8 +360,10 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
 
         if str(new_stage.id) == InvestmentProjectStage.won.value.id:
             data['status'] = InvestmentProject.STATUSES.won
-        elif (old_stage and str(old_stage.id) == InvestmentProjectStage.won.value.id and
-                new_status == InvestmentProject.STATUSES.won):
+        elif (
+            old_stage and str(old_stage.id) == InvestmentProjectStage.won.value.id
+            and new_status == InvestmentProject.STATUSES.won
+        ):
             data['status'] = InvestmentProject.STATUSES.ongoing
 
     class Meta:

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -418,8 +418,10 @@ class TestCreateView(APITestMixin):
         assert response_data['description'] == request_data['description']
         assert response_data['anonymous_description'] == request_data['anonymous_description']
         assert response_data['estimated_land_date'] == request_data['estimated_land_date']
-        assert (response_data['quotable_as_public_case_study'] ==
-                request_data['quotable_as_public_case_study'])
+        assert (
+            response_data['quotable_as_public_case_study']
+            == request_data['quotable_as_public_case_study']
+        )
         assert response_data['likelihood_of_landing'] == request_data['likelihood_of_landing']
         assert response_data['priority'] == request_data['priority']
         assert re.match(r'^DHP-\d+$', response_data['project_code'])

--- a/requirements.in
+++ b/requirements.in
@@ -57,7 +57,7 @@ piprot==0.9.10
 towncrier==18.6.0
 
 # Code static analysis
-flake8==3.5.0
+flake8==3.6.0
 flake8-blind-except==0.1.1
 flake8-commas==2.0.0
 flake8-debugger==3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ aws-requests-auth==0.4.2
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4         # via celery
 boto3==1.9.27
-botocore==1.12.27         # via boto3, s3transfer
+botocore==1.12.30         # via boto3, s3transfer
 celery==4.2.1
 certifi==2018.10.15       # via requests
 chardet==3.0.4
@@ -51,7 +51,7 @@ flake8-polyfill==1.0.2    # via flake8-docstrings, pep8-naming
 flake8-print==3.1.0
 flake8-quotes==1.0.0
 flake8-string-format==0.2.3
-flake8==3.5.0
+flake8==3.6.0
 freezegun==0.3.11
 future==0.16.0            # via future, notifications-python-client
 gevent==1.3.7
@@ -86,9 +86,9 @@ psycogreen==1.0
 psycopg2==2.7.5
 ptyprocess==0.6.0         # via pexpect
 py==1.7.0                 # via pytest
-pycodestyle==2.3.1        # via flake8, flake8-debugger, flake8-import-order, flake8-print, pycodestyle
+pycodestyle==2.4.0        # via flake8, flake8-debugger, flake8-import-order, flake8-print
 pydocstyle==2.1.1
-pyflakes==1.6.0           # via flake8
+pyflakes==2.0.0           # via flake8
 pygments==2.2.0           # via ipython, pygments
 pyjwt==1.6.4              # via notifications-python-client
 pytest-cov==2.6.0
@@ -98,11 +98,11 @@ pytest-sugar==0.9.1
 pytest-xdist==1.23.2
 pytest==3.9.1
 python-dateutil==2.7.3
-pytz==2018.5              # via celery, django
+pytz==2018.6              # via celery, django
 pyyaml==3.13
 raven==6.9.0
 redis==2.10.6             # via django-redis
-requests-futures==0.9.7   # via piprot
+requests-futures==0.9.8   # via piprot
 requests-mock==1.5.2
 requests==2.20.0
 requests_toolbelt==0.8.0
@@ -116,7 +116,7 @@ text-unidecode==1.2       # via faker
 toml==0.10.0              # via towncrier
 towncrier==18.6.0
 traitlets==4.3.2          # via ipython, traitlets
-urllib3==1.23             # via botocore, elasticsearch, requests
+urllib3==1.24             # via botocore, elasticsearch, requests
 vine==1.1.4               # via amqp
 wcwidth==0.1.7            # via prompt-toolkit, wcwidth
 werkzeug==0.14.1


### PR DESCRIPTION
### Description of change

Change log: https://flake8.readthedocs.io/en/latest/release-notes/3.6.0.html

This includes fixing related linting errors occurring with the new version.

[Note that pycodestyle has added a rule (W504) to enforce line breaks before binary operators.](https://github.com/PyCQA/pycodestyle/issues/498) This was our preferred style (and recommended in PEP 8) so it is enabled (by virtue of it not being in the ignore list).

There is already a news fragment for dependency updates, but this is only used for development purposes anyway.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
