### PR TITLE
Add data_source_label to the company timeline API

### DIFF
--- a/changelog/company/company_timeline_data_source_label.api
+++ b/changelog/company/company_timeline_data_source_label.api
@@ -1,0 +1,1 @@
+``GET /v3/company/<uuid:pk>/timeline`` endpoint now includes ``data_source_label`` field in the response. This field contains human-readable data source description.

--- a/changelog/company/company_timeline_data_source_label.feature
+++ b/changelog/company/company_timeline_data_source_label.feature
@@ -1,0 +1,1 @@
+Company timeline now includes ``data_source_label`` field that contains human-readable data source description.

--- a/datahub/company/test/timeline/test_client.py
+++ b/datahub/company/test/timeline/test_client.py
@@ -17,13 +17,15 @@ FAKE_RESPONSES = {
             'events': [
                 {
                     'data_source': 'companies_house.companies',
+                    'data_source_label': 'Companies House (Companies)',
                     'datetime': 'Mon, 31 Dec 2018 00:00:00 GMT',
                     'description': 'Accounts next due date',
                 },
                 {
-                    'data_source': 'companies_house.companies',
+                    'data_source': 'dit.export_wins',
+                    'data_source_label': 'DIT (Export Wins)',
                     'datetime': 'Mon, 31 Dec 2017 00:00:00 GMT',
-                    'description': 'Accounts filed',
+                    'description': 'Export Win',
                 },
             ],
         },
@@ -105,12 +107,14 @@ class TestDataScienceCompanyAPIClient:
         assert client.get_timeline_events_by_company_number(company_number) == [
             {
                 'data_source': 'companies_house.companies',
+                'data_source_label': 'Companies House (Companies)',
                 'datetime': datetime(2018, 12, 31, tzinfo=utc),
                 'description': 'Accounts next due date',
             },
             {
-                'data_source': 'companies_house.companies',
+                'data_source': 'dit.export_wins',
+                'data_source_label': 'DIT (Export Wins)',
                 'datetime': datetime(2017, 12, 31, tzinfo=utc),
-                'description': 'Accounts filed',
+                'description': 'Export Win',
             },
         ]

--- a/datahub/company/test/timeline/test_views.py
+++ b/datahub/company/test/timeline/test_views.py
@@ -24,13 +24,15 @@ class TestCompanyTimelineViews(APITestMixin):
             'events': [
                 {
                     'data_source': 'companies_house.companies',
+                    'data_source_label': 'Companies House (Companies)',
                     'datetime': 'Mon, 31 Dec 2018 00:00:00 GMT',
                     'description': 'Accounts next due date',
                 },
                 {
-                    'data_source': 'companies_house.companies',
+                    'data_source': 'dit.export_wins',
+                    'data_source_label': 'DIT (Export Wins)',
                     'datetime': 'Mon, 31 Dec 2017 00:00:00 GMT',
-                    'description': 'Accounts filed',
+                    'description': 'Export Win',
                 },
             ],
         }
@@ -55,13 +57,15 @@ class TestCompanyTimelineViews(APITestMixin):
             'results': [
                 {
                     'data_source': 'companies_house.companies',
+                    'data_source_label': 'Companies House (Companies)',
                     'datetime': '2018-12-31T00:00:00Z',
                     'description': 'Accounts next due date',
                 },
                 {
-                    'data_source': 'companies_house.companies',
+                    'data_source': 'dit.export_wins',
+                    'data_source_label': 'DIT (Export Wins)',
                     'datetime': '2017-12-31T00:00:00Z',
-                    'description': 'Accounts filed',
+                    'description': 'Export Win',
                 },
             ],
         }
@@ -169,13 +173,15 @@ class TestCompanyTimelineViews(APITestMixin):
             'events': [
                 {
                     'data_source_wrong': 'companies_house.companies',
+                    'data_source_label_wrong': 'Companies House (Companies)',
                     'datetime_wrong': 'Mon, 31 Dec 2018 00:00:00 GMT',
                     'description_wrong': 'Accounts next due date',
                 },
                 {
-                    'data_source_wrong': 'companies_house.companies',
+                    'data_source_wrong': 'dit.export_wins',
+                    'data_source_label_wrong': 'DIT (Export Wins)',
                     'datetime_wrong': 'Mon, 31 Dec 2017 00:00:00 GMT',
-                    'description_wrong': 'Accounts filed',
+                    'description_wrong': 'Export Win',
                 },
             ],
         }

--- a/datahub/company/timeline/serializers.py
+++ b/datahub/company/timeline/serializers.py
@@ -7,5 +7,6 @@ class TimelineEventSerializer(serializers.Serializer):
     """Company timeline event serialiser."""
 
     data_source = serializers.CharField()
+    data_source_label = serializers.CharField()
     datetime = RelaxedDateTimeField()
     description = serializers.CharField()


### PR DESCRIPTION
### Description of change

This adds support for `data_source_label` to the company timeline API.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
