### PR TITLE
Update to Python 3.6.7

### DIFF
--- a/changelog/python-3.6.7.internal
+++ b/changelog/python-3.6.7.internal
@@ -1,0 +1,1 @@
+Python was updated from version 3.6.6 to 3.6.7 in deployed environments.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,3 +1,3 @@
 ---
 applications:
-- buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.21
+- buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.23

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.6
+python-3.6.7


### PR DESCRIPTION
### Description of change

Updates Python from version 3.6.6 to 3.6.7 in deployed environments. Includes a build pack update to version 1.6.23.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
