### PR TITLE
Add streamlined investment flow via a feature flag

### DIFF
--- a/changelog/investment/streamlined_investment_flow_feature.feature
+++ b/changelog/investment/streamlined_investment_flow_feature.feature
@@ -1,0 +1,2 @@
+First part of the streamlined investment flow. Feature flag `streamlined-investment-flow` introduced
+to control when the project manager information is required and to allow the assign pm stage to be deprecated.

--- a/datahub/investment/constants.py
+++ b/datahub/investment/constants.py
@@ -3,6 +3,9 @@ from enum import Enum
 from datahub.core.constants import Constant
 
 
+FEATURE_FLAG_STREAMLINED_FLOW = 'streamlined-investment-flow'
+
+
 class SpecificProgramme(Enum):
     """Specific Investment Programme constants."""
 


### PR DESCRIPTION
### Description of change
This is the main part of the streamlined investment flow. Released under a feature flag to eliminate any disruption to the investment views to also allow sync with the front end and to control exactly when the feature is activated. The change moves when the project manager data is required and will eventually result in the Assign PM stage being deprecated.

Still to do in separate PRs:
 - Migration/Command to update any Projects currently in the Assign PM stage back to Prospect
 - Migration/Command to update the exclude_from_investment_flow flag for 'Assign PM'
- A FE release that filters any project stage with the exclude flag set.
- Stage removed as a search option.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
