### PR TITLE
Implement merging part of company merging tool

### DIFF
--- a/datahub/company/admin/merge/step_3.py
+++ b/datahub/company/admin/merge/step_3.py
@@ -74,7 +74,7 @@ def confirm_merge(model_admin, request):
 
 
 def _perform_merge(request, merger, model_admin):
-    if not merger.is_merge_allowed():
+    if not merger.is_valid():
         failure_msg = MERGE_FAILURE_MSG.format(
             source_company=merger.source_company,
             target_company=merger.target_company,

--- a/datahub/company/admin/merge/step_3.py
+++ b/datahub/company/admin/merge/step_3.py
@@ -1,3 +1,5 @@
+import django.contrib.messages as django_messages
+import reversion
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.core.exceptions import PermissionDenied, SuspiciousOperation
 from django.http import HttpResponseRedirect
@@ -9,7 +11,20 @@ from django.views.decorators.csrf import csrf_protect
 
 from datahub.company.admin.merge.constants import MERGE_COMPANY_TOOL_FEATURE_FLAG
 from datahub.company.merge import DuplicateCompanyMerger
+from datahub.company.models import Contact
+from datahub.core.templatetags.datahub_extras import verbose_name_for_count
 from datahub.feature_flag.utils import feature_flagged_view
+from datahub.interaction.models import Interaction
+
+
+REVERSION_REVISION_COMMENT = 'Company marked as a duplicate and related records transferred.'
+MERGE_SUCCESS_MSG = gettext_lazy(
+    'Merge complete – {num_interactions_moved} {interaction_verbose_name}'
+    ' and {num_contacts_moved} {contact_verbose_name} moved.',
+)
+MERGE_FAILURE_MSG = gettext_lazy(
+    'Merging failed – merging {source_company} into {target_company} is not allowed.',
+)
 
 
 @feature_flagged_view(MERGE_COMPANY_TOOL_FEATURE_FLAG)
@@ -33,9 +48,9 @@ def confirm_merge(model_admin, request):
         raise SuspiciousOperation()
 
     is_post = request.method == 'POST'
+    merger = DuplicateCompanyMerger(source_company, target_company)
 
-    if is_post:
-        # The merging logic is still to be implemented, redirect to the change list for now
+    if is_post and _perform_merge(request, merger, model_admin):
         changelist_route_name = admin_urlname(model_admin.model._meta, 'changelist')
         changelist_url = reverse(changelist_route_name)
         return HttpResponseRedirect(changelist_url)
@@ -43,7 +58,6 @@ def confirm_merge(model_admin, request):
     template_name = 'admin/company/company/merge/step_3_confirm_selection.html'
     title = gettext_lazy('Confirm merge')
 
-    merger = DuplicateCompanyMerger(source_company, target_company)
     move_entries, should_archive_source = merger.get_planned_changes()
 
     context = {
@@ -57,3 +71,34 @@ def confirm_merge(model_admin, request):
         'title': title,
     }
     return TemplateResponse(request, template_name, context)
+
+
+def _perform_merge(request, merger, model_admin):
+    if not merger.is_merge_allowed():
+        failure_msg = MERGE_FAILURE_MSG.format(
+            source_company=merger.source_company,
+            target_company=merger.target_company,
+        )
+        model_admin.message_user(request, failure_msg, django_messages.ERROR)
+        return False
+
+    reversion.set_comment(REVERSION_REVISION_COMMENT)
+
+    merge_result = merger.perform_merge(request.user)
+    success_msg = _build_success_msg(merge_result)
+    model_admin.message_user(request, success_msg, django_messages.SUCCESS)
+    return True
+
+
+def _build_success_msg(merge_result):
+    interaction_verbose_name = verbose_name_for_count(
+        merge_result.num_interactions_moved,
+        Interaction._meta,
+    )
+    contact_verbose_name = verbose_name_for_count(merge_result.num_contacts_moved, Contact._meta)
+    return MERGE_SUCCESS_MSG.format(
+        num_interactions_moved=merge_result.num_interactions_moved,
+        num_contacts_moved=merge_result.num_contacts_moved,
+        interaction_verbose_name=interaction_verbose_name,
+        contact_verbose_name=contact_verbose_name,
+    )

--- a/datahub/company/templates/admin/company/company/merge/step_2_primary_selection.html
+++ b/datahub/company/templates/admin/company/company/merge/step_2_primary_selection.html
@@ -33,8 +33,8 @@
     <div class="fieldWrapper">
       {{ form.selected_company.errors }}
       <ul id="id_selected_company">
-        {% include 'admin/company/company/merge/step_2_primary_selection_radio.html' with company=company_1 other_company=company_2 index='1' opts=opts only %}
-        {% include 'admin/company/company/merge/step_2_primary_selection_radio.html' with company=company_2 other_company=company_1 index='2' opts=opts only %}
+        {% include 'admin/company/company/merge/step_2_primary_selection_radio.html' with option=option_1 index='1' opts=opts only %}
+        {% include 'admin/company/company/merge/step_2_primary_selection_radio.html' with option=option_2 index='2' opts=opts only %}
       </ul>
     </div>
 

--- a/datahub/company/templates/admin/company/company/merge/step_2_primary_selection_radio.html
+++ b/datahub/company/templates/admin/company/company/merge/step_2_primary_selection_radio.html
@@ -1,33 +1,33 @@
 {% load i18n datahub_extras %}
 <li>
   <input name="selected_company" value="{{ index }}" required="" id="id_selected_company_radio_{{ index }}" type="radio"
-    {% if not company.is_valid_merge_target or not other_company.is_valid_merge_source %}disabled{% endif %}
+    {% if not option.is_valid %}disabled{% endif %}
   >
   <label for="id_selected_company_radio_{{ index }}">
-    {% if not company.is_valid_merge_target %}
+    {% if not option.is_target_valid %}
       <span class="error">{% trans 'This company can&rsquo;t be selected as it&rsquo;s been archived.' %}</span>
       <br>
     {% endif %}
 
-    {% if not other_company.is_valid_merge_source %}
+    {% if not option.is_source_valid %}
       <span class="error">{% trans 'This company can&rsquo;t be selected as there are related records that can&rsquo;t be moved from the other company.' %}</span>
       <br>
     {% endif %}
 
-    <strong>{{ company.name }}</strong>
+    <strong>{{ option.target.name }}</strong>
     <br>
-    {{ company.pk }}
+    {{ option.target.pk }}
     <br>
-    {% blocktrans with created_on=company.created_on %}Created on {{ created_on }}{% endblocktrans %}
+    {% blocktrans with created_on=option.target.created_on %}Created on {{ created_on }}{% endblocktrans %}
     <br>
-    {% with company.contacts.count as contact_count %}
+    {% with option.target.contacts.count as contact_count %}
     {{ contact_count }} contact{{ contact_count|pluralize }}
     {% endwith %}
     <br>
-    {% with company.interactions.count as interaction_count %}
+    {% with option.target.interactions.count as interaction_count %}
     {{ interaction_count }} interaction{{ interaction_count|pluralize }}
     {% endwith %}
     <br>
-    <a href="{{ company|admin_change_url }}">{% trans 'View complete record' %}</a>
+    <a href="{{ option.target|admin_change_url }}">{% trans 'View complete record' %}</a>
   </label>
 </li>

--- a/datahub/company/test/admin/merge/test_step_3.py
+++ b/datahub/company/test/admin/merge/test_step_3.py
@@ -1,12 +1,29 @@
+import re
+from datetime import datetime
+from itertools import chain
+
 import pytest
+from django.contrib import messages as django_messages
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.urls import reverse
+from django.utils.timezone import utc
+from freezegun import freeze_time
 from rest_framework import status
+from reversion.models import Version
 
+from datahub.company.admin.merge.step_3 import REVERSION_REVISION_COMMENT
 from datahub.company.models import Company
-from datahub.company.test.factories import CompanyFactory
+from datahub.company.test.factories import (
+    ArchivedCompanyFactory,
+    CompanyFactory,
+    ContactFactory,
+    SubsidiaryFactory,
+)
 from datahub.core.test_utils import AdminTestMixin
 from datahub.core.utils import reverse_with_query_string
+from datahub.interaction.test.factories import CompanyInteractionFactory
+from datahub.investment.test.factories import InvestmentProjectFactory
+from datahub.omis.order.test.factories import OrderFactory
 
 
 @pytest.mark.usefixtures('merge_list_feature_flag')
@@ -78,31 +95,182 @@ class TestConfirmMergeViewGet(AdminTestMixin):
 class TestConfirmMergeViewPost(AdminTestMixin):
     """Tests form submission in the 'Confirm merge' view."""
 
-    def test_proceeds_on_button_click(self):
-        """Test that if a valid selection is made, the user is redirected to the change list."""
-        source_company = CompanyFactory()
+    @pytest.mark.parametrize('source_num_interactions', (0, 1, 3))
+    @pytest.mark.parametrize('source_num_contacts', (0, 1, 3))
+    def test_merge_succeeds(self, source_num_interactions, source_num_contacts):
+        """
+        Test that the merge succeeds and the source company is marked as a duplicate when the
+        source company has various amounts of contacts and interactions.
+        """
+        creation_time = datetime(2010, 12, 1, 15, 0, 10, tzinfo=utc)
+        with freeze_time(creation_time):
+            source_company = _company_factory(source_num_interactions, source_num_contacts)
         target_company = CompanyFactory()
+        source_interactions = list(source_company.interactions.all())
+        source_contacts = list(source_company.contacts.all())
 
-        confirm_merge_route_name = admin_urlname(Company._meta, 'merge-confirm')
-        confirm_merge_query_args = {
-            'source_company': str(source_company.pk),
-            'target_company': str(target_company.pk),
-        }
-        confirm_merge_url = reverse_with_query_string(
-            confirm_merge_route_name,
-            confirm_merge_query_args,
-        )
+        # Each interaction has a contact, so actual number of contacts is
+        # source_num_interactions + source_num_contacts
+        assert len(source_contacts) == source_num_interactions + source_num_contacts
 
-        response = self.client.post(
-            confirm_merge_url,
-            follow=True,
-            data={},
-        )
+        confirm_merge_url = _make_confirm_merge_url(source_company, target_company)
+
+        merge_time = datetime(2011, 2, 1, 14, 0, 10, tzinfo=utc)
+        with freeze_time(merge_time):
+            response = self.client.post(confirm_merge_url, follow=True)
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == _get_changelist_url()
 
-        changelist_route_name = admin_urlname(Company._meta, 'changelist')
-        changelist_url = reverse(changelist_route_name)
+        messages = list(response.context['messages'])
+        assert len(messages) == 1
+        assert messages[0].level == django_messages.SUCCESS
+        match = re.match(
+            rf'Merge complete – (?P<num_interactions>\d) (?P<interaction_noun>interactions?) '
+            rf'and (?P<num_contacts>\d) (?P<contact_noun>contacts?) moved\.',
+            messages[0].message,
+        )
+        assert match
+        assert match.groupdict() == {
+            'num_interactions': str(len(source_interactions)),
+            'num_contacts': str(len(source_contacts)),
+            'interaction_noun': 'interaction' if len(source_interactions) == 1 else 'interactions',
+            'contact_noun': 'contact' if len(source_contacts) == 1 else 'contacts',
+        }
 
-        assert response.redirect_chain[0][0] == changelist_url
+        for obj in chain(source_interactions, source_contacts):
+            obj.refresh_from_db()
+
+        assert all(obj.company == target_company for obj in source_interactions)
+        assert all(obj.modified_on == creation_time for obj in source_interactions)
+        assert all(obj.company == target_company for obj in source_contacts)
+        assert all(obj.modified_on == creation_time for obj in source_contacts)
+
+        source_company.refresh_from_db()
+
+        assert source_company.archived
+        assert source_company.archived_by == self.user
+        assert source_company.archived_on == merge_time
+        assert source_company.archived_reason == (
+            f'This record is no longer in use and its data has been transferred '
+            f'to {target_company} for the following reason: Duplicate record.'
+        )
+        assert source_company.transfer_reason == Company.TRANSFER_REASONS.duplicate
+        assert source_company.transferred_by == self.user
+        assert source_company.transferred_on == merge_time
+        assert source_company.transferred_to == target_company
+
+    def test_successful_merge_creates_revision(self):
+        """Test that a revision is created following a successful merge."""
+        source_company = CompanyFactory()
+        target_company = CompanyFactory()
+        source_contacts = ContactFactory.create_batch(2, company=source_company)
+
+        confirm_merge_url = _make_confirm_merge_url(source_company, target_company)
+
+        frozen_time = datetime(2011, 2, 1, 14, 0, 10, tzinfo=utc)
+        with freeze_time(frozen_time):
+            response = self.client.post(confirm_merge_url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == _get_changelist_url()
+
+        source_company_versions = Version.objects.get_for_object(source_company)
+        assert source_company_versions.count() == 1
+
+        reversion = source_company_versions[0].revision
+        assert reversion.date_created == frozen_time
+        assert reversion.get_comment() == REVERSION_REVISION_COMMENT
+        assert reversion.user == self.user
+
+        contact_0_versions = Version.objects.get_for_object(source_contacts[0])
+        assert contact_0_versions.count() == 1
+        assert contact_0_versions[0].revision == reversion
+
+        contact_1_versions = Version.objects.get_for_object(source_contacts[1])
+        assert contact_1_versions.count() == 1
+        assert contact_1_versions[0].revision == reversion
+
+    @pytest.mark.parametrize(
+        'source_company_factory,target_company_factory',
+        (
+            (
+                CompanyFactory,
+                ArchivedCompanyFactory,
+            ),
+            (
+                lambda: InvestmentProjectFactory().investor_company,
+                CompanyFactory,
+            ),
+            (
+                lambda: OrderFactory().company,
+                CompanyFactory,
+            ),
+            (
+                SubsidiaryFactory,
+                CompanyFactory,
+            ),
+            (
+                lambda: SubsidiaryFactory().global_headquarters,
+                CompanyFactory,
+            ),
+        ),
+    )
+    def test_merge_fails(self, source_company_factory, target_company_factory):
+        """
+        Test that the merge fails when the source company cannot be merged into the target company.
+        """
+        source_company = source_company_factory()
+        target_company = target_company_factory()
+        source_interactions = list(source_company.interactions.all())
+        source_contacts = list(source_company.contacts.all())
+
+        confirm_merge_url = _make_confirm_merge_url(source_company, target_company)
+
+        response = self.client.post(confirm_merge_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        messages = list(response.context['messages'])
+        assert len(messages) == 1
+        assert messages[0].level == django_messages.ERROR
+        assert messages[0].message == (
+            f'Merging failed – merging {source_company} into {target_company} is not allowed.'
+        )
+
+        for obj in chain(source_interactions, source_contacts):
+            obj.refresh_from_db()
+
+        assert all(obj.company == source_company for obj in source_interactions)
+        assert all(obj.company == source_company for obj in source_contacts)
+
+        source_company.refresh_from_db()
+
+        assert not source_company.archived
+        assert source_company.transfer_reason == ''
+        assert not source_company.transferred_by
+        assert not source_company.transferred_on
+        assert not source_company.transferred_to
+
+
+def _company_factory(num_interactions, num_contacts):
+    """Factory for a company that has companies and interactions."""
+    company = CompanyFactory()
+    ContactFactory.create_batch(num_contacts, company=company)
+    CompanyInteractionFactory.create_batch(num_interactions, company=company)
+    return company
+
+
+def _make_confirm_merge_url(source_company, target_company):
+    confirm_merge_route_name = admin_urlname(Company._meta, 'merge-confirm')
+    confirm_merge_query_args = {
+        'source_company': str(source_company.pk),
+        'target_company': str(target_company.pk),
+    }
+    return reverse_with_query_string(confirm_merge_route_name, confirm_merge_query_args)
+
+
+def _get_changelist_url():
+    changelist_route_name = admin_urlname(Company._meta, 'changelist')
+    return reverse(changelist_route_name)

--- a/datahub/company/test/test_merge.py
+++ b/datahub/company/test/test_merge.py
@@ -1,8 +1,18 @@
-import pytest
+from datetime import datetime
+from itertools import chain
 
-from datahub.company.merge import DuplicateCompanyMerger, MoveEntry
-from datahub.company.models import Contact
-from datahub.company.test.factories import ArchivedCompanyFactory, CompanyFactory, ContactFactory
+import pytest
+from django.utils.timezone import utc
+from freezegun import freeze_time
+
+from datahub.company.merge import DuplicateCompanyMerger, MergeResult, MoveEntry
+from datahub.company.models import Company, Contact
+from datahub.company.test.factories import (
+    AdviserFactory,
+    ArchivedCompanyFactory,
+    CompanyFactory,
+    ContactFactory,
+)
 from datahub.interaction.models import Interaction
 from datahub.interaction.test.factories import CompanyInteractionFactory
 
@@ -56,3 +66,63 @@ class TestDuplicateCompanyMerger:
 
         expected_planned_changes = (expected_move_entries, expected_should_archive)
         assert duplicate_merger.get_planned_changes() == expected_planned_changes
+
+    @pytest.mark.parametrize('source_num_interactions', (0, 1, 3))
+    @pytest.mark.parametrize('source_num_contacts', (0, 1, 3))
+    def test_merge_succeeds(self, source_num_interactions, source_num_contacts):
+        """
+        Tests that perform_merge() moves contacts and interactions to the target company,
+        and marks the source company as archived and transferred.
+        """
+        creation_time = datetime(2010, 12, 1, 15, 0, 10, tzinfo=utc)
+        with freeze_time(creation_time):
+            source_company = _company_factory(source_num_interactions, source_num_contacts)
+        target_company = CompanyFactory()
+        user = AdviserFactory()
+
+        source_interactions = list(source_company.interactions.all())
+        source_contacts = list(source_company.contacts.all())
+        # Each interaction has a contact, so actual number of contacts is
+        # source_num_interactions + source_num_contacts
+        assert len(source_contacts) == source_num_interactions + source_num_contacts
+
+        merger = DuplicateCompanyMerger(source_company, target_company)
+        merge_time = datetime(2011, 2, 1, 14, 0, 10, tzinfo=utc)
+
+        with freeze_time(merge_time):
+            result = merger.perform_merge(user)
+
+        assert result == MergeResult(
+            num_interactions_moved=len(source_interactions),
+            num_contacts_moved=len(source_contacts),
+        )
+
+        for obj in chain(source_interactions, source_contacts):
+            obj.refresh_from_db()
+
+        assert all(obj.company == target_company for obj in source_interactions)
+        assert all(obj.modified_on == creation_time for obj in source_interactions)
+        assert all(obj.company == target_company for obj in source_contacts)
+        assert all(obj.modified_on == creation_time for obj in source_contacts)
+
+        source_company.refresh_from_db()
+
+        assert source_company.archived
+        assert source_company.archived_by == user
+        assert source_company.archived_on == merge_time
+        assert source_company.archived_reason == (
+            f'This record is no longer in use and its data has been transferred '
+            f'to {target_company} for the following reason: Duplicate record.'
+        )
+        assert source_company.transfer_reason == Company.TRANSFER_REASONS.duplicate
+        assert source_company.transferred_by == user
+        assert source_company.transferred_on == merge_time
+        assert source_company.transferred_to == target_company
+
+
+def _company_factory(num_interactions, num_contacts):
+    """Factory for a company that has companies and interactions."""
+    company = CompanyFactory()
+    ContactFactory.create_batch(num_contacts, company=company)
+    CompanyInteractionFactory.create_batch(num_interactions, company=company)
+    return company


### PR DESCRIPTION
### Description of change

This implements the actual merging logic, so that the merging tool actually merges the two companies selected.

It also moves all the existing merging logic (that was on the model) to the DuplicateCompanyMerger class to keep it in one place.

I'd like to make the messages more specific about the reason for not allowing the merge, but I'll come back to that if I get time (it could get complicated).

Next up after this will be to handle the resulting Elasticsearch sync activity properly.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
