### PR TITLE
Change Elasticsearch 6.4 CircleCI build to use PostgreSQL 10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@ job_defaults: &job_defaults
     es_image:
       type: string
 
+    postgres_image:
+      type: string
+
     publish_coverage:
       type: boolean
       default: false
@@ -35,7 +38,7 @@ job_defaults: &job_defaults
 
     - image: <<parameters.es_image>>
 
-    - image: postgres:9.6
+    - image: <<parameters.postgres_image>>
       environment:
         POSTGRES_DB=datahub
   steps:
@@ -79,22 +82,24 @@ job_defaults: &job_defaults
               bash ./codecov.sh -t ${COV_TOKEN}
 jobs:
 
-  build_es_63:
+  build_es_63_pg_96:
     <<: *job_defaults
 
-  build_es_64:
+  build_es_64_pg_10:
     <<: *job_defaults
 
 workflows:
   version: 2
 
-  Elasticsearch 6.3:
+  Elasticsearch 6.3 and PostgreSQL 9.6:
     jobs:
-      - build_es_63:
+      - build_es_63_pg_96:
           publish_coverage: true
+          postgres_image: postgres:9.6
           es_image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
 
-  Elasticsearch 6.4:
+  Elasticsearch 6.4 and PostgreSQL 10:
     jobs:
-      - build_es_64:
+      - build_es_64_pg_10:
+          postgres_image: postgres:10
           es_image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2


### PR DESCRIPTION
### Description of change

This is planned to be our environment when we migrate to GOV.UK PaaS London. I was going to add this as a third build, but it didn't seem worth clogging up CircleCI with an extra build.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
