### PR TITLE
Move queuing of sync tasks for related objects to Celery worker

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 web: python manage.py collectstatic --noinput && python manage.py distributed_migrate --noinput && python manage.py init_es && gunicorn config.wsgi --config config/gunicorn.py
 celeryworker: celery worker -A config -l info -Q celery
-celerylongrunning: celery worker -A config -l info -O fair --prefetch-multiplier 1 -Q celery,long-running
+celerylongrunning: celery worker -A config -l info -O fair --prefetch-multiplier 1 -Q long-running
 celerybeat: celery beat -A config -l info

--- a/datahub/search/contact/signals.py
+++ b/datahub/search/contact/signals.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_save
 from datahub.company.models import Company as DBCompany, Contact as DBContact
 from datahub.search.contact import ContactSearchApp
 from datahub.search.signals import SignalReceiver
-from datahub.search.sync_object import sync_object_async
+from datahub.search.sync_object import sync_object_async, sync_related_objects_async
 
 
 def contact_sync_es(instance):
@@ -16,8 +16,9 @@ def contact_sync_es(instance):
 
 def related_contact_sync_es(instance):
     """Sync related Company Contacts."""
-    for contact in instance.contacts.all():
-        contact_sync_es(contact)
+    transaction.on_commit(
+        lambda: sync_related_objects_async(instance, 'contacts'),
+    )
 
 
 receivers = (

--- a/datahub/search/interaction/signals.py
+++ b/datahub/search/interaction/signals.py
@@ -8,7 +8,7 @@ from datahub.search.deletion import delete_document
 from datahub.search.interaction import InteractionSearchApp
 from datahub.search.interaction.models import Interaction as ESInteraction
 from datahub.search.signals import SignalReceiver
-from datahub.search.sync_object import sync_object_async
+from datahub.search.sync_object import sync_object_async, sync_related_objects_async
 
 
 def sync_interaction_to_es(instance):
@@ -27,8 +27,9 @@ def remove_interaction_from_es(instance):
 
 def sync_related_interactions_to_es(instance):
     """Sync related interactions."""
-    for contact in instance.interactions.all():
-        sync_interaction_to_es(contact)
+    transaction.on_commit(
+        lambda: sync_related_objects_async(instance, 'interactions'),
+    )
 
 
 receivers = (

--- a/datahub/search/sync_object.py
+++ b/datahub/search/sync_object.py
@@ -3,10 +3,10 @@ from logging import getLogger
 from django.conf import settings
 
 from datahub.core.thread_pool import submit_to_thread_pool
+from datahub.search.apps import get_search_app_by_model
 from datahub.search.bulk_sync import sync_objects
 from datahub.search.migrate_utils import delete_from_secondary_indices_callback
-from datahub.search.tasks import sync_object_task
-
+from datahub.search.tasks import sync_object_task, sync_related_objects_task
 
 logger = getLogger(__name__)
 
@@ -42,10 +42,42 @@ def sync_object_async(search_app, pk):
     added to the new index and then deleted from the old index.
     """
     if settings.ENABLE_CELERY_ES_SYNC_OBJECT:
-        result = sync_object_task.apply_async(args=(search_app.name, str(pk)))
+        result = sync_object_task.apply_async(args=(search_app.name, pk))
         logger.info(
             f'Task {result.id} scheduled to synchronise object {pk} for search app '
             f'{search_app.name}',
         )
     else:
         submit_to_thread_pool(sync_object, search_app, pk)
+
+
+def sync_related_objects_async(related_obj, related_obj_field_name):
+    """
+    Syncs objects related to another object via a specified field.
+
+    For example, this function would sync the interactions of a company if given the following
+    arguments:
+        related_obj=company
+        related_obj_field_name='interactions'
+
+    This function is normally used by signal receivers to copy new or updated related objects to
+    Elasticsearch.
+    """
+    if settings.ENABLE_CELERY_ES_SYNC_OBJECT:
+        result = sync_related_objects_task.apply_async(
+            args=(
+                related_obj._meta.label,
+                str(related_obj.pk),
+                related_obj_field_name,
+            ),
+        )
+        logger.info(
+            f'Task {result.id} scheduled to synchronise {related_obj_field_name} for object'
+            f' {related_obj.pk}',
+        )
+    else:
+        related_manager = getattr(related_obj, related_obj_field_name)
+        queryset = related_manager.values_list('pk', flat=True)
+        search_app = get_search_app_by_model(related_manager.model)
+        for pk in queryset:
+            submit_to_thread_pool(sync_object, search_app, pk)

--- a/datahub/search/test/search_support/relatedmodel/models.py
+++ b/datahub/search/test/search_support/relatedmodel/models.py
@@ -15,7 +15,7 @@ class ESRelatedModel(BaseESModel):
     simpleton = fields.nested_id_name_field()
 
     MAPPINGS = {
-        'id': dict_utils.id_name_dict,
+        'simpleton': dict_utils.id_name_dict,
     }
 
     SEARCH_FIELDS = ()

--- a/datahub/search/test/test_sync_object.py
+++ b/datahub/search/test/test_sync_object.py
@@ -3,9 +3,11 @@ from unittest.mock import Mock
 import pytest
 from django.test import override_settings
 
-from datahub.search.sync_object import sync_object_async
-from datahub.search.test.search_support.models import SimpleModel
+from datahub.search.sync_object import sync_object_async, sync_related_objects_async
+from datahub.search.test.search_support.models import RelatedModel, SimpleModel
+from datahub.search.test.search_support.relatedmodel import RelatedModelSearchApp
 from datahub.search.test.search_support.simplemodel import SimpleModelSearchApp
+from datahub.search.test.utils import doc_exists
 
 
 @pytest.mark.django_db
@@ -20,11 +22,7 @@ def test_sync_object_task_syncs_using_thread_pool(monkeypatch, setup_es):
     sync_object_async(SimpleModelSearchApp, obj.pk)
     setup_es.indices.refresh()
 
-    assert setup_es.get(
-        index=SimpleModelSearchApp.es_model.get_write_index(),
-        doc_type=SimpleModelSearchApp.name,
-        id=obj.pk,
-    )
+    assert doc_exists(setup_es, SimpleModelSearchApp, obj.pk)
     sync_object_task_mock.apply_async.assert_not_called()
 
 
@@ -42,9 +40,56 @@ def test_sync_object_task_syncs_using_celery(monkeypatch, setup_es):
     sync_object_async(SimpleModelSearchApp, obj.pk)
     setup_es.indices.refresh()
 
-    assert setup_es.get(
-        index=SimpleModelSearchApp.es_model.get_write_index(),
-        doc_type=SimpleModelSearchApp.name,
-        id=obj.pk,
-    )
+    assert doc_exists(setup_es, SimpleModelSearchApp, obj.pk)
     submit_to_thread_pool_mock.assert_not_called()
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('synchronous_thread_pool')
+@override_settings(ENABLE_CELERY_ES_SYNC_OBJECT=False)
+def test_sync_related_objects_syncs_using_thread_pool(monkeypatch, setup_es):
+    """Test that related object can be synced to Elasticsearch using the thread pool."""
+    sync_related_objects_task_mock = Mock()
+    monkeypatch.setattr(
+        'datahub.search.sync_object.sync_related_objects_task',
+        sync_related_objects_task_mock,
+    )
+
+    simpleton = SimpleModel.objects.create()
+    relation_1 = RelatedModel.objects.create(simpleton=simpleton)
+    relation_2 = RelatedModel.objects.create(simpleton=simpleton)
+    unrelated_obj = RelatedModel.objects.create()
+
+    sync_related_objects_async(simpleton, 'relatedmodel_set')
+    setup_es.indices.refresh()
+
+    assert doc_exists(setup_es, RelatedModelSearchApp, relation_1.pk)
+    assert doc_exists(setup_es, RelatedModelSearchApp, relation_2.pk)
+    assert not doc_exists(setup_es, RelatedModelSearchApp, unrelated_obj.pk)
+
+    sync_related_objects_task_mock.apply_async.assert_not_called()
+
+
+@pytest.mark.django_db
+@override_settings(ENABLE_CELERY_ES_SYNC_OBJECT=True)
+def test_sync_related_objects_syncs_using_celery(monkeypatch, setup_es):
+    """Test that related object can be synced to Elasticsearch using Celery."""
+    submit_to_thread_pool_mock = Mock()
+    monkeypatch.setattr(
+        'datahub.search.sync_object.submit_to_thread_pool',
+        submit_to_thread_pool_mock,
+    )
+
+    simpleton = SimpleModel.objects.create()
+    relation_1 = RelatedModel.objects.create(simpleton=simpleton)
+    relation_2 = RelatedModel.objects.create(simpleton=simpleton)
+    unrelated_obj = RelatedModel.objects.create()
+
+    sync_related_objects_async(simpleton, 'relatedmodel_set')
+    setup_es.indices.refresh()
+
+    assert doc_exists(setup_es, RelatedModelSearchApp, relation_1.pk)
+    assert doc_exists(setup_es, RelatedModelSearchApp, relation_2.pk)
+    assert not doc_exists(setup_es, RelatedModelSearchApp, unrelated_obj.pk)
+
+    submit_to_thread_pool_mock.apply_async.assert_not_called()

--- a/datahub/search/test/utils.py
+++ b/datahub/search/test/utils.py
@@ -25,6 +25,15 @@ def create_mock_search_app(
     return mock
 
 
+def doc_exists(es_client, search_app, id_):
+    """Checks if a document exists for a specified search app."""
+    return es_client.exists(
+        index=search_app.es_model.get_write_index(),
+        doc_type=search_app.name,
+        id=id_,
+    )
+
+
 def _create_mock_es_model(
         current_mapping_hash,
         target_mapping_hash,


### PR DESCRIPTION
### Description of change

When saving a company, we resync all of its contacts and interactions. Similarly, saving a contact causes all of its interactions to be resynced.

As it turns out, queuing Celery tasks is relatively expensive. This moves the queuing of these tasks in the most common cases (when `ENABLE_CELERY_ES_SYNC_OBJECT` is `True`) to Celery to alleviate that load from the main process (and avoid delays when responding to requests that update companies and contacts).

I also stopped the `celerylongrunning` process listening to the default queue, as there would still be some risk of a sync object task getting stuck behind a long-running task (if it were listening to that queue).

It is also worth noting how priorities work with Celery when used with Redis (as the documentation is sparse). Essentially, priorities 0 to 2 means 'very high', 3 to 5 means 'high', 6 to 8 means 'low', and 9 and above means 'very low'. Hence, it only really makes sense to use priorities 0, 3, 6 and 9.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
