### PR TITLE
Always start Celery when using docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,13 @@ services:
       - "8000:8000"
     volumes:
       - .:/app
-    entrypoint: |
-        dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -timeout 60s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 60s
     env_file: docker-compose.env
     depends_on:
       - postgres
       - es
       - redis
-    links:
-      - postgres
-      - es
-      - redis
+      - celery
     command: /app/start.sh
 
   celery:
@@ -26,13 +22,9 @@ services:
       context: .
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://leeloo:8000 -timeout 60s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 60s
     env_file: docker-compose.env
-    depends_on:
-      - leeloo
-    links:
-      - leeloo
-    command: celery worker -A config -l info -B
+    command: celery worker -A config -l info -Q celery -B
 
   postgres:
     image: postgres:9.6
@@ -45,8 +37,6 @@ services:
     restart: always
     ports:
       - "9200:9200"
-    environment:
-      - ES_JAVA_OPTS=-Xms750m -Xmx750m
 
   redis:
     image: redis:3.2


### PR DESCRIPTION
### Description of change

This makes a few changes to docker-compose.yml:
- adds celery as a dependency of leeloo so that Celery is started when using `start-uat.sh`
- removes links as they are deprecated (and aren't apparently needed)
- removes the `-Xms750m -Xmx750m` Java arguments for Elasticsearch as they are similar to the defaults I am getting (defaults for me are `-Xms1g -Xmx1g` – if someone still needs the old values they can go back in)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
