### PR TITLE
Add 'investor company town or city' to investment project CSV export

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -132,7 +132,7 @@ Internal changes
 API
 ---
 
-- **Interactions** ``POST /v3/search/investment_project/export`` now always excludes policy feedback interactions (regardless of the current user's permissions).
+- **Interactions** ``POST /v3/search/interaction/export`` now always excludes policy feedback interactions (regardless of the current user's permissions).
 
 Database schema
 ---------------

--- a/changelog/investment/add-investor-town-to-export.api
+++ b/changelog/investment/add-investor-town-to-export.api
@@ -1,0 +1,1 @@
+``POST /v3/search/investment_project/export``: the field 'Investor company town or city' was added to the CSV output.

--- a/changelog/investment/add-investor-town-to-export.feature
+++ b/changelog/investment/add-investor-town-to-export.feature
@@ -1,0 +1,1 @@
+Exports of search results now include the town or city of the investor company.

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -831,6 +831,7 @@ class TestInvestmentProjectExportView(APITestMixin):
                 'Project reference': project.project_code,
                 'Project name': project.name,
                 'Investor company': project.investor_company.name,
+                'Investor company town or city': project.investor_company.registered_address_town,
                 'Country of origin':
                     get_attr_or_none(project, 'investor_company.registered_address_country.name'),
                 'Investment type': get_attr_or_none(project, 'investment_type.name'),

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -115,6 +115,7 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectParams, SearchExportA
         'computed_project_code': 'Project reference',
         'name': 'Project name',
         'investor_company__name': 'Investor company',
+        'investor_company__registered_address_town': 'Investor company town or city',
         'investor_company__registered_address_country__name': 'Country of origin',
         'investment_type__name': 'Investment type',
         'status_name': 'Status',


### PR DESCRIPTION
### Description of change

This adds the investor company town or city to the CSV export for investment projects.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
