### PR TITLE
Group Core Team

### DIFF
--- a/changelog/company/group-core-team.api
+++ b/changelog/company/group-core-team.api
@@ -1,0 +1,1 @@
+`GET  /company/<id>/core-team/` now returns the Core Team for the group that the company is part of. All companies in the group inherit that team from their Global Headquarters.

--- a/datahub/company/migrations/0001_squashed_0010_auto_20170807_1124.py
+++ b/datahub/company/migrations/0001_squashed_0010_auto_20170807_1124.py
@@ -102,7 +102,7 @@ class Migration(migrations.Migration):
                 ('account_manager', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='companies', to=settings.AUTH_USER_MODEL, help_text='Legacy field, do not use')),
                 ('archived_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
                 ('business_type', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='metadata.BusinessType')),
-                ('classification', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='metadata.CompanyClassification')),
+                ('classification', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='metadata.CompanyClassification', help_text='One List Tier')),
                 ('employee_range', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='metadata.EmployeeRange')),
                 ('export_to_countries', models.ManyToManyField(blank=True, related_name='company_export_to_countries', to='metadata.Country')),
                 ('future_interest_countries', models.ManyToManyField(blank=True, related_name='company_future_interest_countries', to='metadata.Country')),

--- a/datahub/company/test/admin/test_company.py
+++ b/datahub/company/test/admin/test_company.py
@@ -23,7 +23,7 @@ class TestChangeCompanyAdmin(AdminTestMixin):
     """Tests for the company admin change form."""
 
     def test_add_core_team_members(self):
-        """Test that core team members can be added to a company."""
+        """Test that Core Team members can be added to a company."""
         team_member_advisers = AdviserFactory.create_batch(2)
         team_size = len(team_member_advisers)
         company = CompanyFactory()
@@ -63,7 +63,7 @@ class TestChangeCompanyAdmin(AdminTestMixin):
         assert company.core_team_members.count() == team_size
 
     def test_delete_core_team_members(self):
-        """Test that core team members can be deleted from a company."""
+        """Test that Core Team members can be deleted from a company."""
         company = CompanyFactory()
         core_team_members = CompanyCoreTeamMemberFactory.create_batch(2, company=company)
         team_size = len(core_team_members)

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -75,7 +75,7 @@ class SubsidiaryFactory(CompanyFactory):
 
 
 class CompanyCoreTeamMemberFactory(factory.django.DjangoModelFactory):
-    """Company core team member factory."""
+    """Company Core Team member factory."""
 
     company = factory.SubFactory(CompanyFactory)
     adviser = factory.SubFactory(AdviserFactory)

--- a/datahub/company/test/test_models.py
+++ b/datahub/company/test/test_models.py
@@ -1,40 +1,107 @@
+import factory
 import pytest
 from django.conf import settings
 
-from datahub.company.models import Company
-from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
+from datahub.company.test.factories import (
+    AdviserFactory,
+    CompanyCoreTeamMemberFactory,
+    CompanyFactory,
+    ContactFactory,
+)
+
 
 # mark the whole module for db use
 pytestmark = pytest.mark.django_db
 
 
-def test_company_can_have_one_list_owner_assigned():
-    """Test that company can have one list owner assigned."""
-    company = CompanyFactory()
-    adviser = AdviserFactory()
+class TestCompany:
+    """Tests for the company model."""
 
-    assert company.one_list_account_owner is None  # Test that it's nullable
+    def test_get_absolute_url(self):
+        """Test that Company.get_absolute_url() returns the correct URL."""
+        company = CompanyFactory.build()
+        assert company.get_absolute_url() == (
+            f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.pk}'
+        )
 
-    company.one_list_account_owner = adviser
-    company.save()
-
-    # re-fetch object for completeness
-    company_refetch = Company.objects.get(pk=str(company.pk))
-
-    assert company_refetch.one_list_account_owner_id == adviser.pk
-
-
-def test_company_get_absolute_url():
-    """Test that Company.get_absolute_url() returns the correct URL."""
-    company = CompanyFactory.build()
-    assert company.get_absolute_url() == (
-        f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.pk}'
+    @pytest.mark.parametrize(
+        'build_global_headquarters',
+        (
+            lambda: CompanyFactory.build(),
+            lambda: None,
+        ),
+        ids=('as_subsidiary', 'as_global_headquarters'),
     )
+    def test_get_group_global_headquarters(self, build_global_headquarters):
+        """
+        Test that `get_group_global_headquarters` returns `self` if the company has
+        no `global_headquarters` or the `global_headquarters` otherwise.
+        """
+        company = CompanyFactory.build(
+            global_headquarters=build_global_headquarters(),
+        )
 
+        expected_group_global_headquarters = company.global_headquarters or company
+        assert company.get_group_global_headquarters() == expected_group_global_headquarters
 
-def test_contact_get_absolute_url():
-    """Test that Contact.get_absolute_url() returns the correct URL."""
-    contact = ContactFactory.build()
-    assert contact.get_absolute_url() == (
-        f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{contact.pk}'
+    @pytest.mark.parametrize(
+        'build_global_headquarters',
+        (
+            lambda gam: CompanyFactory(one_list_account_owner=gam),
+            lambda gam: None,
+        ),
+        ids=('as_subsidiary', 'as_global_headquarters'),
     )
+    @pytest.mark.parametrize(
+        'with_global_account_manager',
+        (True, False),
+        ids=lambda val: f'{"With" if val else "Without"} global account manager',
+    )
+    def test_get_onelist_group_core_team(
+        self,
+        build_global_headquarters,
+        with_global_account_manager,
+    ):
+        """
+        Test that `get_onelist_group_core_team` returns the Core Team of `self` if the company
+        has no `global_headquarters` or the one of its `global_headquarters` otherwise.
+        """
+        team_member_advisers = AdviserFactory.create_batch(
+            3,
+            first_name=factory.Iterator(
+                ('Adam', 'Barbara', 'Chris'),
+            ),
+        )
+        global_account_manager = team_member_advisers[0] if with_global_account_manager else None
+
+        global_headquarters = build_global_headquarters(global_account_manager)
+        company = CompanyFactory(
+            global_headquarters=global_headquarters,
+            one_list_account_owner=None if global_headquarters else global_account_manager,
+        )
+        group_global_headquarters = company.global_headquarters or company
+        CompanyCoreTeamMemberFactory.create_batch(
+            len(team_member_advisers),
+            company=group_global_headquarters,
+            adviser=factory.Iterator(team_member_advisers),
+        )
+
+        core_team = company.get_onelist_group_core_team()
+        assert core_team == [
+            {
+                'adviser': adviser,
+                'is_global_account_manager': adviser is global_account_manager,
+            }
+            for adviser in team_member_advisers
+        ]
+
+
+class TestContact:
+    """Tests for the contact model."""
+
+    def test_get_absolute_url(self):
+        """Test that Contact.get_absolute_url() returns the correct URL."""
+        contact = ContactFactory.build()
+        assert contact.get_absolute_url() == (
+            f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{contact.pk}'
+        )

--- a/datahub/company/urls.py
+++ b/datahub/company/urls.py
@@ -4,8 +4,12 @@ from django.urls import path
 
 from datahub.company.timeline.views import CompanyTimelineViewSet
 from datahub.company.views import (
-    CompaniesHouseCompanyViewSet, CompanyAuditViewSet, CompanyCoreTeamViewSet,
-    CompanyViewSet, ContactAuditViewSet, ContactViewSet,
+    CompaniesHouseCompanyViewSet,
+    CompanyAuditViewSet,
+    CompanyViewSet,
+    ContactAuditViewSet,
+    ContactViewSet,
+    GroupCoreTeamViewSet,
 )
 
 # CONTACT
@@ -68,7 +72,7 @@ company_unarchive = CompanyViewSet.as_view({
     'post': 'unarchive',
 })
 
-company_core_team = CompanyCoreTeamViewSet.as_view({
+company_core_team = GroupCoreTeamViewSet.as_view({
     'get': 'list',
 })
 


### PR DESCRIPTION
### Description of change

1. This adds the methods to the Company model:
   - ~`get_family_global_ultimate`~ ~`get_family_global_headquarters`~ `get_group_global_headquarters` which returns the ~Global Ultimate~ Global Headquarters in the ~family tree~ group a company is part of
   - ~`get_family_core_team`~ `get_group_core_team` which returns the Core Team for the ~family tree~ group a company is part of

2. And changes the endpoint `/company/<id>/core-team` to return the Core Team of the company's ~Global Ultimate~ Global Headquarters in case of subsidiaries.

A Core Team is usually assigned at the ~Global Ultimate~ Global Headquarters level and shared among all ~family members~ members of the group.

~Also note that I have started to use the new  _Global Ultimate_ name to refer to the old/legacy _Global HQ_ one.~

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
