### PR TITLE
Deprecate company classification metadata endpoint

### DIFF
--- a/changelog/deprecate-company-classification.api
+++ b/changelog/deprecate-company-classification.api
@@ -1,0 +1,1 @@
+The endpoint `/metadata/company-classification/` is deprecated as not currently necessary. It will be completely removed on or after November, 29.


### PR DESCRIPTION
### Description of change

It is not currently used by the frontend and deprecating/removing it will make renaming things easier later on.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
