### PR TITLE
Add `one_list_group_tier` field to GET company endpoint

### DIFF
--- a/changelog/company/one-list-group-tier.api
+++ b/changelog/company/one-list-group-tier.api
@@ -1,0 +1,1 @@
+`GET /v3/company/<uuid:pk>` and `GET /v3/company` now include the read-only field `one_list_group_tier` which is the One List Tier for the group, inherited from the Global Headquarters.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -242,6 +242,12 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
             return self.global_headquarters
         return self
 
+    def get_one_list_group_tier(self):
+        """
+        :returns: the One List Tier of the group this company is part of.
+        """
+        return self.get_group_global_headquarters().classification
+
     def get_one_list_group_core_team(self):
         """
         :returns: the One List Core Team for the group that this company is part of

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -9,8 +9,13 @@ from rest_framework import serializers
 
 from datahub.company.constants import BusinessTypeConstant
 from datahub.company.models import (
-    Advisor, CompaniesHouseCompany, Company, CompanyPermission,
-    Contact, ContactPermission, ExportExperienceCategory,
+    Advisor,
+    CompaniesHouseCompany,
+    Company,
+    CompanyPermission,
+    Contact,
+    ContactPermission,
+    ExportExperienceCategory,
 )
 from datahub.company.validators import (
     has_no_invalid_company_number_characters,
@@ -19,7 +24,9 @@ from datahub.company.validators import (
 from datahub.core.constants import Country
 from datahub.core.constants import HeadquarterType
 from datahub.core.serializers import (
-    NestedRelatedField, PermittedFieldsModelSerializer, RelaxedURLField,
+    NestedRelatedField,
+    PermittedFieldsModelSerializer,
+    RelaxedURLField,
 )
 from datahub.core.validate_utils import DataCombiner
 from datahub.core.validators import (
@@ -273,6 +280,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         meta_models.BusinessType, required=False, allow_null=True,
     )
     classification = NestedRelatedField(meta_models.CompanyClassification, read_only=True)
+    one_list_group_tier = serializers.SerializerMethodField()
     companies_house_data = NestedCompaniesHouseCompanySerializer(read_only=True)
     contacts = ContactSerializer(many=True, read_only=True)
     transferred_to = NestedRelatedField('company.Company', read_only=True)
@@ -370,6 +378,15 @@ class CompanySerializer(PermittedFieldsModelSerializer):
 
         return global_headquarters
 
+    def get_one_list_group_tier(self, obj):
+        """
+        :returns: the One List Tier for the group that company `obj` is part of.
+        """
+        one_list_tier = obj.get_one_list_group_tier()
+
+        field = NestedRelatedField(meta_models.CompanyClassification)
+        return field.to_representation(one_list_tier)
+
     class Meta:
         model = Company
         fields = (
@@ -407,6 +424,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'trading_address_country',
             'business_type',
             'classification',
+            'one_list_group_tier',
             'companies_house_data',
             'contacts',
             'employee_range',


### PR DESCRIPTION
### Description of change

This adds the field ~`onelist_group_tier`~ `one_list_group_tier` to the `GET /v3/company/<uuid:pk>` and `GET /v3/company` endpoints representing the One List Tier for the group, inherited from the Global Headquarters.

I've also refactored the tests to build the company used in the tests instead of building parts of it. This adds a few lambdas which don't look very pythonic but I think they make it clear what the intention is. Feel free to tell me if this looks too weird and I'll revert back to params with parts of the company instead.

The search does not return ~`onelist_group_tier`~ `one_list_group_tier` as it would have to be updated in cascade every time a Global HQ is updated and I want to avoid it unless necessary. 

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
