### PR TITLE
Deprecate classification from the API

### DIFF
--- a/changelog/company/deprecate-classification.api
+++ b/changelog/company/deprecate-classification.api
@@ -1,0 +1,1 @@
+The field ``classification`` is deprecated and will be removed on or after November, 29. Please use `one_list_group_tier` instead.


### PR DESCRIPTION
### Description of change

The frontend should use the new ~`onelist_group_tier`~ `one_list_group_tier` field instead which takes into account a tier inherited from the Global Headquarters as well.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
