### PR TITLE
Deprecate one_list_account_owner from the API

### DIFF
--- a/changelog/company/deprecate-one_list_account_owner.api
+++ b/changelog/company/deprecate-one_list_account_owner.api
@@ -1,0 +1,1 @@
+The field ``one_list_account_owner`` is deprecated and will be removed on or after November, 29. Please use ``GET  /company/<id>/one-list-group-core-team`` and get the item in the list with ``is_global_account_manager`` = True instead.


### PR DESCRIPTION
### Description of change

The frontend should use the new `/company/<id>/one-list-group-core-team`
endpoint and get the item with `is_global_account_manager` = True instead.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
