### PR TITLE
Rename onelist to one_list or one-list

### DIFF
--- a/changelog/company/group-core-team.api
+++ b/changelog/company/group-core-team.api
@@ -1,5 +1,5 @@
 The One List Core Team endpoint was changed:
 
-``GET /company/<id>/core-team`` was renamed to ``GET /company/<id>/onelist-group-core-team``. The old ``/core-team`` endpoint still exists but will be completely removed on or after November, 29.
+``GET /company/<id>/core-team`` was renamed to ``GET /company/<id>/one-list-group-core-team``. The old ``/core-team`` endpoint still exists but will be completely removed on or after November, 29.
 
-``GET /company/<id>/onelist-group-core-team`` now returns the Core Team for the group that the company is part of. All companies in the group inherit that team from their Global Headquarters.
+``GET /company/<id>/one-list-group-core-team`` now returns the Core Team for the group that the company is part of. All companies in the group inherit that team from their Global Headquarters.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -242,7 +242,7 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
             return self.global_headquarters
         return self
 
-    def get_onelist_group_core_team(self):
+    def get_one_list_group_core_team(self):
         """
         :returns: the One List Core Team for the group that this company is part of
             as a list of dicts with `adviser` and `is_global_account_manager`.

--- a/datahub/company/test/admin/test_company.py
+++ b/datahub/company/test/admin/test_company.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.django_db
 class TestChangeCompanyAdmin(AdminTestMixin):
     """Tests for the company admin change form."""
 
-    def test_add_onelist_core_team_members(self):
+    def test_add_one_list_core_team_members(self):
         """Test that One List Core Team members can be added to a company."""
         team_member_advisers = AdviserFactory.create_batch(2)
         team_size = len(team_member_advisers)
@@ -62,7 +62,7 @@ class TestChangeCompanyAdmin(AdminTestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert company.core_team_members.count() == team_size
 
-    def test_delete_onelist_core_team_members(self):
+    def test_delete_one_list_core_team_members(self):
         """Test that One List Core Team members can be deleted from a company."""
         company = CompanyFactory()
         core_team_members = CompanyCoreTeamMemberFactory.create_batch(2, company=company)
@@ -109,7 +109,7 @@ class TestOneListLink(AdminTestMixin):
     Tests for the one list export.
     """
 
-    def test_onelist_link_exists(self):
+    def test_one_list_link_exists(self):
         """
         Test that there is a link to export the one list on the company change list.
         """

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -1355,7 +1355,7 @@ class TestOneListGroupCoreTeam(APITestMixin):
         )
 
         url = reverse(
-            'api-v3:company:onelist-group-core-team',
+            'api-v3:company:one-list-group-core-team',
             kwargs={'pk': company.pk},
         )
         response = self.api_client.get(url)
@@ -1385,7 +1385,7 @@ class TestOneListGroupCoreTeam(APITestMixin):
         )
 
         url = reverse(
-            'api-v3:company:onelist-group-core-team',
+            'api-v3:company:one-list-group-core-team',
             kwargs={'pk': company.pk},
         )
         response = self.api_client.get(url)
@@ -1454,7 +1454,7 @@ class TestOneListGroupCoreTeam(APITestMixin):
         )
 
         url = reverse(
-            'api-v3:company:onelist-group-core-team',
+            'api-v3:company:one-list-group-core-team',
             kwargs={'pk': company.pk},
         )
         response = self.api_client.get(url)
@@ -1490,7 +1490,7 @@ class TestOneListGroupCoreTeam(APITestMixin):
         Test that if the company doesn't exist, the endpoint returns 404.
         """
         url = reverse(
-            'api-v3:company:onelist-group-core-team',
+            'api-v3:company:one-list-group-core-team',
             kwargs={'pk': '00000000-0000-0000-0000-000000000000'},
         )
         response = self.api_client.get(url)

--- a/datahub/company/test/test_models.py
+++ b/datahub/company/test/test_models.py
@@ -57,13 +57,13 @@ class TestCompany:
         (True, False),
         ids=lambda val: f'{"With" if val else "Without"} global account manager',
     )
-    def test_get_onelist_group_core_team(
+    def test_get_one_list_group_core_team(
         self,
         build_global_headquarters,
         with_global_account_manager,
     ):
         """
-        Test that `get_onelist_group_core_team` returns the Core Team of `self` if the company
+        Test that `get_one_list_group_core_team` returns the Core Team of `self` if the company
         has no `global_headquarters` or the one of its `global_headquarters` otherwise.
         """
         team_member_advisers = AdviserFactory.create_batch(
@@ -86,7 +86,7 @@ class TestCompany:
             adviser=factory.Iterator(team_member_advisers),
         )
 
-        core_team = company.get_onelist_group_core_team()
+        core_team = company.get_one_list_group_core_team()
         assert core_team == [
             {
                 'adviser': adviser,

--- a/datahub/company/urls.py
+++ b/datahub/company/urls.py
@@ -72,7 +72,7 @@ company_unarchive = CompanyViewSet.as_view({
     'post': 'unarchive',
 })
 
-onelist_group_core_team = OneListGroupCoreTeamViewSet.as_view({
+one_list_group_core_team = OneListGroupCoreTeamViewSet.as_view({
     'get': 'list',
 })
 
@@ -91,11 +91,11 @@ company_urls = [
     path('company/<uuid:pk>/unarchive', company_unarchive, name='unarchive'),
     path('company/<uuid:pk>/audit', company_audit, name='audit-item'),
     path('company/<uuid:pk>/timeline', company_timeline, name='timeline-collection'),
-    path('company/<uuid:pk>/core-team', onelist_group_core_team, name='core-team'),
+    path('company/<uuid:pk>/core-team', one_list_group_core_team, name='core-team'),
     path(
-        'company/<uuid:pk>/onelist-group-core-team',
-        onelist_group_core_team,
-        name='onelist-group-core-team',
+        'company/<uuid:pk>/one-list-group-core-team',
+        one_list_group_core_team,
+        name='one-list-group-core-team',
     ),
 ]
 

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -81,7 +81,7 @@ class OneListGroupCoreTeamViewSet(CoreViewSet):
     def list(self, request, *args, **kwargs):
         """Lists Core Team members."""
         company = self.get_object()
-        core_team = company.get_onelist_group_core_team()
+        core_team = company.get_one_list_group_core_team()
 
         serializer = self.get_serializer(core_team, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
### Description of change

Avoiding using one word for One List is less confusing so this renames onelist to one_list in variables and methods and to one-list in API endpoints.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
