### PR TITLE
Add subsidiary to One List Corp test fixture

### DIFF
--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -227,6 +227,23 @@
     modified_on: '2017-11-26T11:00:00Z'
 
 - model: company.company
+  pk: 960e1fa9-cc25-478c-a548-a2e2047319bb
+  fields:
+    name: One List Subsidiary Ltd
+    business_type: 98d14e94-5d95-e211-a939-e4115bead28a  # Company
+    sector: 7ebb9fc6-5f95-e211-a939-e4115bead28a
+    registered_address_1: 100 Fordham Rd
+    registered_address_town: Hainault
+    registered_address_postcode: IG6 7SQ
+    registered_address_country: 80756b9a-5d95-e211-a939-e4115bead28a  # UK
+    uk_region: 874cd12a-6095-e211-a939-e4115bead28a
+    description: This is a dummy company for testing subsidiaries of One List GHQ
+    archived_documents_url_path: '/documents/123'
+    created_on: '2017-07-23T10:00:00Z'
+    modified_on: '2017-04-07T10:00:00Z'
+    global_headquarters: 375094ac-f79a-43e5-9c88-059a7caa17f0 # One List Corp
+
+- model: company.company
   pk: 346f78a5-1d23-4213-b4c2-bf48246a13c3
   fields:
     name: Archived Ltd


### PR DESCRIPTION
### Description of change
This will be used to test subsidiaries of One List companies to make sure they are inheriting tier and core team information.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
