### PR TITLE
Only call load_constants_to_database once

### DIFF
--- a/datahub/company/signals.py
+++ b/datahub/company/signals.py
@@ -10,7 +10,11 @@ from datahub.metadata.models import BusinessType
 logger = logging.getLogger(__name__)
 
 
-@receiver(post_migrate, dispatch_uid='company_business_type_post_migrate')
+@receiver(
+    post_migrate,
+    sender=BusinessType._meta.app_config,
+    dispatch_uid='company_business_type_post_migrate',
+)
 def company_business_type_post_migrate(sender, **kwargs):
     """
     Ensures all business types are loaded to the database.

--- a/datahub/company/test/test_signals.py
+++ b/datahub/company/test/test_signals.py
@@ -1,6 +1,9 @@
+from unittest import mock
 from uuid import UUID
 
 import pytest
+from django.core.management.sql import emit_post_migrate_signal
+from django.db import DEFAULT_DB_ALIAS
 
 from datahub.company.constants import BusinessTypeConstant
 from datahub.metadata.models import BusinessType
@@ -8,9 +11,28 @@ from datahub.metadata.models import BusinessType
 pytestmark = pytest.mark.django_db
 
 
-def test_company_business_type_post_migrate():
-    """Test that business types have been correctly loaded."""
-    loaded_business_types = {(obj.id, obj.name) for obj in BusinessType.objects.all()}
-    expected_business_types = {(UUID(obj.value.id), obj.value.name)
-                               for obj in BusinessTypeConstant}
-    assert loaded_business_types == expected_business_types
+class TestCompanyBusinessTypePostMigrate:
+    """
+    Tests for the `company_business_type_post_migrate` signal receiver.
+    """
+
+    def test_db_in_sync(self):
+        """
+        Test that business types have been correctly loaded.
+        """
+        loaded_business_types = {
+            (obj.id, obj.name) for obj in BusinessType.objects.all()
+        }
+        expected_business_types = {
+            (UUID(obj.value.id), obj.value.name)
+            for obj in BusinessTypeConstant
+        }
+        assert loaded_business_types == expected_business_types
+
+    @mock.patch('datahub.company.signals.load_constants_to_database')
+    def test_only_called_once(self, mocked_load_constants_to_database):
+        """
+        Test that load_constants_to_database is only called once.
+        """
+        emit_post_migrate_signal(verbosity=1, interactive=False, db=DEFAULT_DB_ALIAS)
+        mocked_load_constants_to_database.assert_called_once()


### PR DESCRIPTION
### Description of change

The post_migrate signal receiver `company_business_type_post_migrate` is called after each individual django app is migrated.

*Before:*
`load_constants_to_database` was called multiple times as well.

*After:*
`load_constants_to_database` is only called once after migrating the `metadata` django app.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
