### PR TITLE
Add level_of_involvement_simplified investment project filter

### DIFF
--- a/changelog/investment/involvement-admin.feature
+++ b/changelog/investment/involvement-admin.feature
@@ -1,0 +1,1 @@
+``Involvements`` section in Django admin is now view only as values for level of involvement are not meant to be changed.

--- a/changelog/investment/involvement.api
+++ b/changelog/investment/involvement.api
@@ -1,0 +1,3 @@
+``GET /v3/investment/<uuid:pk>/`` endpoint now includes ``level_of_involvement_simplified`` field in the response.
+
+``POST /v3/search/investment_project/``: new filter ``level_of_involvement_simplified`` was added.

--- a/changelog/investment/involvement.feature
+++ b/changelog/investment/involvement.feature
@@ -1,0 +1,3 @@
+New read-only field ``level_of_involvement_simplified`` has been added that contains simplified information about the
+level of involvement. It has one of three values: ``unspecified``, ``not_involved`` and ``involved`` derived
+from ``level_of_involvement`` field. This field can be filtered by using the search endpoint.

--- a/datahub/investment/admin.py
+++ b/datahub/investment/admin.py
@@ -19,7 +19,7 @@ from datahub.investment.models import (
     Involvement,
     SpecificProgramme,
 )
-from datahub.metadata.admin import DisableableMetadataAdmin
+from datahub.metadata.admin import DisableableMetadataAdmin, ReadOnlyMetadataAdmin
 
 
 @admin.register(InvestmentProject)
@@ -89,11 +89,13 @@ class InvestmentProjectTeamMemberAdmin(VersionAdmin):
     )
 
 
+admin.site.register(Involvement, ReadOnlyMetadataAdmin)
+
+
 admin.site.register(
     (
         InvestmentDeliveryPartner,
         InvestorType,
-        Involvement,
         SpecificProgramme,
     ),
     DisableableMetadataAdmin,

--- a/datahub/investment/models.py
+++ b/datahub/investment/models.py
@@ -18,6 +18,7 @@ from datahub.core.models import (
     BaseModel,
 )
 from datahub.core.utils import get_front_end_url, StrEnum
+from datahub.investment import constants
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -87,6 +88,12 @@ class IProjectAbstract(models.Model):
         ('lost', 'Lost'),
         ('abandoned', 'Abandoned'),
         ('won', 'Won'),
+    )
+
+    INVOLVEMENT = Choices(
+        ('unspecified', 'Unspecified'),
+        ('not_involved', 'Not involved'),
+        ('involved', 'Involved'),
     )
 
     name = models.CharField(max_length=MAX_LENGTH)
@@ -228,6 +235,18 @@ class IProjectAbstract(models.Model):
         if self.client_relationship_manager:
             return self.client_relationship_manager.dit_team
         return None
+
+    @property
+    def level_of_involvement_simplified(self):
+        """Returns simplified level of involvement for the Investment Project."""
+        if self.level_of_involvement_id is None:
+            return self.INVOLVEMENT.unspecified
+
+        not_involved = uuid.UUID(constants.Involvement.no_involvement.value.id)
+        if self.level_of_involvement_id == not_involved:
+            return self.INVOLVEMENT.not_involved
+
+        return self.INVOLVEMENT.involved
 
 
 class IProjectValueAbstract(models.Model):

--- a/datahub/investment/serializers.py
+++ b/datahub/investment/serializers.py
@@ -79,6 +79,7 @@ CORE_FIELDS = (
     'modified_on',
     'comments',
     'country_investment_originates_from',
+    'level_of_involvement_simplified',
 )
 
 VALUE_FIELDS = (

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -71,6 +71,7 @@ class TestListView(APITestMixin):
         response_data = response.json()
         assert response_data['count'] == 1
         assert response_data['results'][0]['id'] == str(project.id)
+        assert response_data['results'][0]['level_of_involvement_simplified'] == 'not_involved'
         assert response_data['results'][0].keys() == {
             'id',
             'incomplete_fields',
@@ -168,6 +169,7 @@ class TestListView(APITestMixin):
             'project_arrived_in_triage_on',
             'proposal_deadline',
             'stage_log',
+            'level_of_involvement_simplified',
         }
 
     def test_list_is_sorted_by_created_on_desc(self):

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -138,6 +138,7 @@ class InvestmentProject(BaseESModel):
     uk_company_decided = Boolean()
     uk_region_locations = fields.nested_id_name_field()
     will_new_jobs_last_two_years = Boolean()
+    level_of_involvement_simplified = Keyword()
 
     MAPPINGS = {
         'actual_uk_regions': lambda col: [

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from datahub.core.serializers import RelaxedDateTimeField
+from datahub.investment.models import InvestmentProject
 from datahub.search.serializers import (
     SearchSerializer,
     SingleOrListField,
@@ -28,6 +29,10 @@ class SearchInvestmentProjectSerializer(SearchSerializer):
     stage = SingleOrListField(child=StringUUIDField(), required=False)
     status = SingleOrListField(child=serializers.CharField(), required=False)
     uk_region_location = SingleOrListField(child=StringUUIDField(), required=False)
+    level_of_involvement_simplified = SingleOrListField(
+        child=serializers.ChoiceField(choices=InvestmentProject.INVOLVEMENT),
+        required=False,
+    )
 
     SORT_BY_FIELDS = (
         'actual_land_date',

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -96,6 +96,7 @@ def test_investment_project_to_dict(setup_es):
         'date_lost',
         'country_lost_to',
         'country_investment_originates_from',
+        'level_of_involvement_simplified',
     }
 
     assert set(result.keys()) == keys

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -43,6 +43,7 @@ class SearchInvestmentProjectParams:
         'stage',
         'status',
         'uk_region_location',
+        'level_of_involvement_simplified',
     )
 
     REMAP_FIELDS = {


### PR DESCRIPTION
### Description of change

This adds ~``involvement``~ ``level_of_involvement_simplified`` read-only computed field that is derived from ``level_of_involvement``. We need a way to filter the investment projects so for example only projects with any level of involvement are visible. ~``involvement``~ ``level_of_involvement_simplified`` field maps `level_of_involvement` to three possible values - `unspecified` if it is `None`, `no_involvement` if equals `no_involvement` constant and `some_involvement` for anything else.
Filtering by `level_of_involvement` wouldn't be practical due to number of possible involvement levels.
~I am not too happy with the choice of the field name, but couldn't think of any better.~

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
