### PR TITLE
 Optimise performance of clean-up management commands 

### DIFF
--- a/changelog/cleanup-optimisation.bugfix
+++ b/changelog/cleanup-optimisation.bugfix
@@ -1,0 +1,1 @@
+The ``delete_old_records`` and ``delete_orphans`` management commands were optimised to use less memory and be faster when run without the ``--simulate`` or ``--only-print-queries`` arguments.

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -81,7 +81,6 @@ class Company(BaseESModel):
     }
 
     MAPPINGS = {
-        'id': str,
         'archived_by': dict_utils.contact_or_adviser_dict,
         'business_type': dict_utils.id_name_dict,
         'classification': dict_utils.id_name_dict,

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -61,7 +61,6 @@ class Contact(BaseESModel):
     title = fields.nested_id_name_field()
 
     MAPPINGS = {
-        'id': str,
         'adviser': dict_utils.contact_or_adviser_dict,
         'archived_by': dict_utils.contact_or_adviser_dict,
         'company': dict_utils.company_dict,

--- a/datahub/search/deletion.py
+++ b/datahub/search/deletion.py
@@ -115,7 +115,7 @@ class Collector:
         model = instance.__class__
         es_model = get_search_app_by_model(model).es_model
 
-        es_doc = es_model.es_document(instance)
+        es_doc = es_model.es_document(instance, include_index=False, include_source=False)
         self.deletions[model].append(es_doc)
 
     def _delete_from_es(self):

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -37,7 +37,6 @@ class Event(BaseESModel):
     uk_region = fields.nested_id_name_partial_field('uk_region')
 
     MAPPINGS = {
-        'id': str,
         'address_country': dict_utils.id_name_dict,
         'event_type': dict_utils.id_name_dict,
         'lead_team': dict_utils.id_name_dict,

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -38,7 +38,6 @@ class Interaction(BaseESModel):
     subject_english = fields.EnglishText()
 
     MAPPINGS = {
-        'id': str,
         'company': dict_utils.company_dict,
         'communication_channel': dict_utils.id_name_dict,
         'contact': dict_utils.contact_or_adviser_dict,

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -20,7 +20,7 @@ def test_interaction_to_dict(setup_es, factory_cls):
     result = Interaction.db_object_to_dict(interaction)
 
     assert result == {
-        'id': str(interaction.pk),
+        'id': interaction.pk,
         'kind': interaction.kind,
         'date': interaction.date,
         'company': {
@@ -89,7 +89,7 @@ def test_service_delivery_to_dict(setup_es):
     result = Interaction.db_object_to_dict(interaction)
 
     assert result == {
-        'id': str(interaction.pk),
+        'id': interaction.pk,
         'kind': interaction.kind,
         'date': interaction.date,
         'company': {
@@ -148,4 +148,4 @@ def test_interactions_to_es_documents(setup_es):
 
     result = Interaction.db_objects_to_es_documents(interactions)
 
-    assert {item['_id'] for item in result} == {str(item.pk) for item in interactions}
+    assert {item['_id'] for item in result} == {item.pk for item in interactions}

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -140,7 +140,6 @@ class InvestmentProject(BaseESModel):
     will_new_jobs_last_two_years = Boolean()
 
     MAPPINGS = {
-        'id': str,
         'actual_uk_regions': lambda col: [
             dict_utils.id_name_dict(c) for c in col.all()
         ],

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -132,9 +132,9 @@ class BaseESModel(Document):
             associate_index_with_alias(cls.get_read_alias(), cls.get_write_index())
 
     @classmethod
-    def es_document(cls, dbmodel, index=None):
+    def es_document(cls, db_object, index=None):
         """Creates Elasticsearch document."""
-        source = cls.db_object_to_dict(dbmodel)
+        source = cls.db_object_to_dict(db_object)
 
         return {
             '_index': index or cls.get_write_alias(),
@@ -144,26 +144,26 @@ class BaseESModel(Document):
         }
 
     @classmethod
-    def db_object_to_dict(cls, dbmodel):
+    def db_object_to_dict(cls, db_object):
         """Converts a DB model object to a dictionary suitable for Elasticsearch."""
         mapped_values = (
-            (col, fn, getattr(dbmodel, col)) for col, fn in cls.MAPPINGS.items()
+            (col, fn, getattr(db_object, col)) for col, fn in cls.MAPPINGS.items()
         )
         fields = get_model_non_mapped_field_names(cls)
 
         result = {
             **{col: fn(val) if val is not None else None for col, fn, val in mapped_values},
-            **{col: fn(dbmodel) for col, fn in cls.COMPUTED_MAPPINGS.items()},
-            **{field: getattr(dbmodel, field) for field in fields},
+            **{col: fn(db_object) for col, fn in cls.COMPUTED_MAPPINGS.items()},
+            **{field: getattr(db_object, field) for field in fields},
         }
 
         return result
 
     @classmethod
-    def db_objects_to_es_documents(cls, dbmodels, index=None):
+    def db_objects_to_es_documents(cls, db_objects, index=None):
         """Converts DB model objects to Elasticsearch documents."""
-        for dbmodel in dbmodels:
-            yield cls.es_document(dbmodel, index=index)
+        for db_object in db_objects:
+            yield cls.es_document(db_object, index=index)
 
 
 def _get_write_index(indices):

--- a/datahub/search/models.py
+++ b/datahub/search/models.py
@@ -132,16 +132,25 @@ class BaseESModel(Document):
             associate_index_with_alias(cls.get_read_alias(), cls.get_write_index())
 
     @classmethod
-    def es_document(cls, db_object, index=None):
-        """Creates Elasticsearch document."""
-        source = cls.db_object_to_dict(db_object)
+    def es_document(cls, db_object, index=None, include_index=True, include_source=True):
+        """
+        Creates a dict representation an Elasticsearch document.
 
-        return {
-            '_index': index or cls.get_write_alias(),
+        include_index and include_source can be set to False when the _index and/or _source keys
+        aren't required (e.g. when using `datahub.search.deletion.delete_documents()`).
+        """
+        doc = {
             '_type': cls._doc_type.name,
-            '_id': source.get('id'),
-            '_source': source,
+            '_id': db_object.pk,
         }
+
+        if include_index:
+            doc['_index'] = index or cls.get_write_alias()
+
+        if include_source:
+            doc['_source'] = cls.db_object_to_dict(db_object)
+
+        return doc
 
     @classmethod
     def db_object_to_dict(cls, db_object):

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -64,7 +64,6 @@ class Order(BaseESModel):
     billing_address_country = fields.nested_id_name_field()
 
     MAPPINGS = {
-        'id': str,
         'company': dict_utils.company_dict,
         'contact': dict_utils.contact_or_adviser_dict,
         'created_by': dict_utils.adviser_dict_with_team,

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -35,7 +35,7 @@ def test_order_to_dict(Factory):
     result = ESOrder.db_object_to_dict(order)
 
     assert result == {
-        'id': str(order.pk),
+        'id': order.pk,
         'company': {
             'id': str(order.company.pk),
             'name': order.company.name,
@@ -167,4 +167,4 @@ def test_orders_to_es_documents():
 
     result = ESOrder.db_objects_to_es_documents(orders)
 
-    assert {item['_id'] for item in result} == {str(item.pk) for item in orders}
+    assert {item['_id'] for item in result} == {item.pk for item in orders}

--- a/datahub/search/test/search_support/simplemodel/models.py
+++ b/datahub/search/test/search_support/simplemodel/models.py
@@ -15,10 +15,6 @@ class ESSimpleModel(BaseESModel):
     name_keyword = fields.SortableCaseInsensitiveKeywordText()
     name_trigram = fields.TrigramText()
 
-    MAPPINGS = {
-        'id': str,
-    }
-
     SEARCH_FIELDS = (
         'name',
         'name_trigram',

--- a/datahub/search/test/test_deletion.py
+++ b/datahub/search/test/test_deletion.py
@@ -83,7 +83,7 @@ def test_collector(monkeypatch, setup_es):
     sync_object(SimpleModelSearchApp, str(obj.pk))
     setup_es.indices.refresh()
 
-    es_doc = ESSimpleModel.es_document(obj)
+    es_doc = ESSimpleModel.es_document(obj, include_index=False, include_source=False)
 
     assert SimpleModel.objects.count() == 1
 


### PR DESCRIPTION
### Description of change

This optimises the performance of the `delete_old_records` and `delete_orphans` management commands by omitting the `_source` (and `_index`) keys when creating Elasticsearch documents to pass to `datahub.search.deletion.delete_documents()`.

This also removes some unnecessary UUID to string conversions as UUIDs are handled correctly by elasticsearch-py already: https://github.com/elastic/elasticsearch-py/blob/656842feaf0476e26cdb4e9d4871e1e3ad4735d2/elasticsearch/serializer.py#L32-L33

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
