### PR TITLE
Add missed news fragments to changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -70,6 +70,7 @@ Internal changes
 ----------------
 
 - Countries now have defined ISO codes.
+- Django Rest Framework was updated to version 3.9.0.
 
 API
 ---
@@ -120,6 +121,7 @@ Internal changes
   to ``Prospect``.
 - The ``countries.yaml`` fixture was updated to reflect the current production data.
 - It's not possible to change ``Countries`` and ``OverseasRegions`` from the django admin anymore. They will need to be updated using data migrations instead.
+- The Elasticsearch Python client libraries were updated to 6.x versions, as was the Docker image used during development.
 - A setting to sync updates to records to Elasticsearch using Celery (rather than the thread pool) was adding. This
   will improve performance when many records are updated at once, and increase reliability as failed synchronisation
   attempts are automatically retried. When the setting is enabled, Redis and Celery must be configured and running to
@@ -158,6 +160,12 @@ Features
 - **Investment** A new field ``exclude_from_investment_flow`` has been added to the ``InvestmentProjectStage`` metadata to
   indicate if a stage should be excluded from the investment flow. The field will be used to aid with
   deprecating and adding new stages.
+
+Internal changes
+----------------
+
+- Python was updated from version 3.6.6 to 3.6.7 in deployed environments.
+
 
 API
 ---

--- a/changelog/elasticsearch-6.3.internal
+++ b/changelog/elasticsearch-6.3.internal
@@ -1,1 +1,0 @@
-The Elasticsearch Python client libraries were updated to 6.x versions, as was the Docker image used during development.

--- a/changelog/python-3.6.7.internal
+++ b/changelog/python-3.6.7.internal
@@ -1,1 +1,0 @@
-Python was updated from version 3.6.6 to 3.6.7 in deployed environments.

--- a/changelog/update-drf-3.9.0.internal
+++ b/changelog/update-drf-3.9.0.internal
@@ -1,1 +1,0 @@
-Django Rest Framework was updated to version 3.9.0.


### PR DESCRIPTION
### Description of change

Some news fragments were missed as towncrier does not handle file names containing multiple full stops correctly. This retrospectively adds the missed news fragments to changelog.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
