### PR TITLE
Company autocomplete search support

### DIFF
--- a/changelog/company/company_autocomplete_support.api
+++ b/changelog/company/company_autocomplete_support.api
@@ -1,0 +1,2 @@
+New endpoint ``GET /v3/search/company/autocomplete`` which supports a query argument of ``term`` that will
+return the ``id``, ``name`` and ``trading_name`` of any company matching the search query.

--- a/changelog/company/company_autocomplete_support.feature
+++ b/changelog/company/company_autocomplete_support.feature
@@ -1,0 +1,2 @@
+ Company autocomplete support has been added to be utilised on search pages and forms
+ when there is a need to add a company to another entity such as an investment project or interaction.

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -17,6 +17,7 @@ class SearchApp:
     bulk_batch_size = 2000
     view = None
     export_view = None
+    autocomplete_view = None
     queryset = None
     # A sequence of permissions. The user must have one of these permissions to perform searches.
     view_permissions = None

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -1,7 +1,11 @@
 from datahub.company.models import Company as DBCompany, CompanyPermission
 from datahub.search.apps import SearchApp
 from datahub.search.company.models import Company
-from datahub.search.company.views import SearchCompanyAPIView, SearchCompanyExportAPIView
+from datahub.search.company.views import (
+    CompanyAutocompleteSearchListAPIView,
+    SearchCompanyAPIView,
+    SearchCompanyExportAPIView,
+)
 
 
 class CompanySearchApp(SearchApp):
@@ -11,6 +15,7 @@ class CompanySearchApp(SearchApp):
     es_model = Company
     view = SearchCompanyAPIView
     export_view = SearchCompanyExportAPIView
+    autocomplete_view = CompanyAutocompleteSearchListAPIView
     view_permissions = (f'company.{CompanyPermission.view_company}',)
     export_permission = f'company.{CompanyPermission.export_company}'
     queryset = DBCompany.objects.select_related(

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -1,6 +1,12 @@
 from rest_framework import serializers
 
-from datahub.search.serializers import SearchSerializer, SingleOrListField, StringUUIDField
+from datahub.search.serializers import (
+    AutocompleteSearchSerializer,
+    IdNameSerializer,
+    SearchSerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
 
 
 class SearchCompanySerializer(SearchSerializer):
@@ -45,3 +51,22 @@ class SearchCompanySerializer(SearchSerializer):
         'uk_based',
         'uk_region.name',
     )
+
+
+class AutocompleteSearchCompanySerializer(AutocompleteSearchSerializer):
+    """Autocomplete search serializer for companies."""
+
+    name = serializers.CharField()
+    trading_name = serializers.CharField()
+    trading_address_1 = serializers.CharField()
+    trading_address_2 = serializers.CharField()
+    trading_address_town = serializers.CharField()
+    trading_address_county = serializers.CharField()
+    trading_address_country = IdNameSerializer()
+    trading_address_postcode = serializers.CharField()
+    registered_address_1 = serializers.CharField()
+    registered_address_2 = serializers.CharField()
+    registered_address_town = serializers.CharField()
+    registered_address_county = serializers.CharField()
+    registered_address_country = IdNameSerializer()
+    registered_address_postcode = serializers.CharField()

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -277,6 +277,7 @@ def test_indexed_doc(setup_es):
         'registered_address_postcode',
         'registered_address_town',
         'sector',
+        'suggest',
         'trading_address_1',
         'trading_address_2',
         'trading_address_country',

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -1,67 +1,104 @@
+from collections import Counter
+
 import pytest
 
 from datahub.company.test.factories import CompanyFactory
-from datahub.search.company.models import Company as ESCompany
+from datahub.search.company.models import Company as ESCompany, get_suggestions
 
 pytestmark = pytest.mark.django_db
 
 
-def test_company_dbmodel_to_dict(setup_es):
-    """Tests conversion of db model to dict."""
-    company = CompanyFactory()
+class TestCompanyElasticModel:
+    """Test for the company elasticsearch model"""
 
-    result = ESCompany.db_object_to_dict(company)
+    def test_company_dbmodel_to_dict(self, setup_es):
+        """Tests conversion of db model to dict."""
+        company = CompanyFactory()
 
-    keys = {
-        'archived',
-        'archived_by',
-        'archived_on',
-        'archived_reason',
-        'business_type',
-        'companies_house_data',
-        'company_number',
-        'contacts',
-        'created_on',
-        'description',
-        'employee_range',
-        'export_experience_category',
-        'export_to_countries',
-        'future_interest_countries',
-        'headquarter_type',
-        'id',
-        'modified_on',
-        'name',
-        'global_headquarters',
-        'reference_code',
-        'registered_address_1',
-        'registered_address_2',
-        'registered_address_country',
-        'registered_address_county',
-        'registered_address_postcode',
-        'registered_address_town',
-        'sector',
-        'trading_address_1',
-        'trading_address_2',
-        'trading_address_country',
-        'trading_address_county',
-        'trading_address_postcode',
-        'trading_address_town',
-        'trading_name',
-        'turnover_range',
-        'uk_based',
-        'uk_region',
-        'vat_number',
-        'duns_number',
-        'website',
-    }
+        result = ESCompany.db_object_to_dict(company)
 
-    assert set(result.keys()) == keys
+        keys = {
+            'archived',
+            'archived_by',
+            'archived_on',
+            'archived_reason',
+            'business_type',
+            'companies_house_data',
+            'company_number',
+            'contacts',
+            'created_on',
+            'description',
+            'employee_range',
+            'export_experience_category',
+            'export_to_countries',
+            'future_interest_countries',
+            'headquarter_type',
+            'id',
+            'modified_on',
+            'name',
+            'global_headquarters',
+            'reference_code',
+            'registered_address_1',
+            'registered_address_2',
+            'registered_address_country',
+            'registered_address_county',
+            'registered_address_postcode',
+            'registered_address_town',
+            'sector',
+            'suggest',
+            'trading_address_1',
+            'trading_address_2',
+            'trading_address_country',
+            'trading_address_county',
+            'trading_address_postcode',
+            'trading_address_town',
+            'trading_name',
+            'turnover_range',
+            'uk_based',
+            'uk_region',
+            'vat_number',
+            'duns_number',
+            'website',
+        }
 
+        assert set(result.keys()) == keys
 
-def test_company_dbmodels_to_es_documents(setup_es):
-    """Tests conversion of db models to Elasticsearch documents."""
-    companies = CompanyFactory.create_batch(2)
+    def test_company_dbmodels_to_es_documents(self, setup_es):
+        """Tests conversion of db models to Elasticsearch documents."""
+        companies = CompanyFactory.create_batch(2)
 
-    result = ESCompany.db_objects_to_es_documents(companies)
+        result = ESCompany.db_objects_to_es_documents(companies)
 
-    assert len(list(result)) == len(companies)
+        assert len(list(result)) == len(companies)
+
+    @pytest.mark.parametrize(
+        'name,trading_name,archived,expected_suggestions',
+        (
+            (
+                'Hello Hello uk',
+                'Good Hello us',
+                False,
+                ['Good Hello us', 'uk', 'us', 'Hello', 'Hello Hello uk', 'Good'],
+            ),
+            (
+                'Hello      gb',
+                None,
+                False,
+                ['Hello', 'gb', 'Hello      gb'],
+            ),
+            (
+                'Hello      gb',
+                None,
+                True,
+                [],
+            ),
+
+        ),
+    )
+    def test_company_get_suggestions(self, name, trading_name, archived, expected_suggestions):
+        """Test get an autocomplete search suggestions for a company"""
+        db_company = CompanyFactory(name=name, alias=trading_name, archived=archived)
+
+        result = get_suggestions(db_company)
+
+        assert Counter(result) == Counter(expected_suggestions)

--- a/datahub/search/company/test/test_serializers.py
+++ b/datahub/search/company/test/test_serializers.py
@@ -1,0 +1,90 @@
+import pytest
+from elasticsearch_dsl.utils import AttrDict
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.core import constants
+from datahub.search.company.models import Company as ESCompany
+from datahub.search.company.serializers import AutocompleteSearchCompanySerializer
+
+
+pytestmark = pytest.mark.django_db
+
+
+class TestAutocompleteSearchCompanySerializer:
+    """Tests for the autocomplete search company serializer."""
+
+    def test_serializer_uses_source_if_present(self):
+        """
+        Tests the serializer can handle the data object within a
+        _source parameter as this is how elasticsearch returns the documents.
+        """
+        company = CompanyFactory(name='Company name 1', alias='Company trading name 1')
+        elasticsearch_company_dict = ESCompany.es_document(company)
+
+        assert '_source' in elasticsearch_company_dict
+        assert 'id' not in elasticsearch_company_dict
+        assert 'id' in elasticsearch_company_dict['_source']
+
+        serializer = AutocompleteSearchCompanySerializer(
+            AttrDict(elasticsearch_company_dict),
+        )
+        assert serializer.data['id'] == str(company.id)
+        assert serializer.data['name'] == company.name
+        assert serializer.data['trading_name'] == company.alias
+
+    def test_serializer_without_source(self):
+        """
+        Tests the serializer can handle data not within a _source parameter
+        """
+        company = CompanyFactory(name='Company name 1', alias='Company trading name 1')
+        elasticsearch_company_dict = ESCompany.db_object_to_dict(company)
+
+        assert '_source' not in elasticsearch_company_dict
+        assert 'id' in elasticsearch_company_dict
+
+        serializer = AutocompleteSearchCompanySerializer(
+            AttrDict(elasticsearch_company_dict),
+        )
+        assert serializer.data['id'] == str(company.id)
+        assert serializer.data['name'] == company.name
+        assert serializer.data['trading_name'] == company.alias
+
+    def test_serializer_returns_trading_and_registered_addresses_if(self):
+        """Tests the serializer returns both the trading and registered addresses."""
+        company = CompanyFactory(
+            trading_address_1='Trading address 1',
+            trading_address_2='Trading address 2',
+            trading_address_town='Trading address town',
+            trading_address_county='Trading address county',
+            trading_address_country_id=constants.Country.ireland.value.id,
+            trading_address_postcode='TR12DI',
+            registered_address_1='Registered address 1',
+            registered_address_2='Registered address 2',
+            registered_address_town='Registered address town',
+            registered_address_county='Registered address county',
+            registered_address_country_id=constants.Country.japan.value.id,
+            registered_address_postcode='RE12DI',
+        )
+
+        elasticsearch_company_dict = ESCompany.es_document(company)
+        serializer = AutocompleteSearchCompanySerializer(
+            AttrDict(elasticsearch_company_dict),
+        )
+        data = serializer.data
+
+        assert data['trading_address_1'] == company.trading_address_1
+        assert data['trading_address_2'] == company.trading_address_2
+        assert data['trading_address_town'] == company.trading_address_town
+        assert data['trading_address_county'] == company.trading_address_county
+        assert data['trading_address_postcode'] == company.trading_address_postcode
+        assert data['trading_address_country']['name'] == company.trading_address_country.name
+
+        assert data['registered_address_1'] == company.registered_address_1
+        assert data['registered_address_2'] == company.registered_address_2
+        assert data['registered_address_town'] == company.registered_address_town
+        assert data['registered_address_county'] == company.registered_address_county
+        assert data['registered_address_postcode'] == company.registered_address_postcode
+        assert (
+            data['registered_address_country']['name']
+            == company.registered_address_country.name
+        )

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -5,8 +5,11 @@ from datahub.core.query_utils import get_front_end_url_expression
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.oauth.scopes import Scope
 from datahub.search.company.models import Company
-from datahub.search.company.serializers import SearchCompanySerializer
-from datahub.search.views import SearchAPIView, SearchExportAPIView
+from datahub.search.company.serializers import (
+    AutocompleteSearchCompanySerializer,
+    SearchCompanySerializer,
+)
+from datahub.search.views import AutocompleteSearchListAPIView, SearchAPIView, SearchExportAPIView
 
 
 class SearchCompanyParams:
@@ -15,6 +18,7 @@ class SearchCompanyParams:
     required_scopes = (Scope.internal_front_end,)
     entity = Company
     serializer_class = SearchCompanySerializer
+    autocomplete_serializer_class = AutocompleteSearchCompanySerializer
 
     FILTER_FIELDS = (
         'archived',
@@ -73,3 +77,25 @@ class SearchCompanyExportAPIView(SearchCompanyParams, SearchExportAPIView):
         'turnover_range__name': 'Annual turnover',
         'upper_headquarter_type_name': 'Headquarter type',
     }
+
+
+class CompanyAutocompleteSearchListAPIView(SearchCompanyParams, AutocompleteSearchListAPIView):
+    """Company autocomplete search view."""
+
+    document_fields = [
+        'id',
+        'name',
+        'trading_name',
+        'trading_address_1',
+        'trading_address_2',
+        'trading_address_town',
+        'trading_address_county',
+        'trading_address_country',
+        'trading_address_postcode',
+        'registered_address_1',
+        'registered_address_2',
+        'registered_address_town',
+        'registered_address_county',
+        'registered_address_country',
+        'registered_address_postcode',
+    ]

--- a/datahub/search/execute_query.py
+++ b/datahub/search/execute_query.py
@@ -1,0 +1,11 @@
+from datahub.search.query_builder import build_autocomplete_query
+
+
+def execute_autocomplete_query(es_model, keyword_search, limit, only_return_fields=None):
+    """Executes the query for autocomplete search returning all suggested documents."""
+    autocomplete_search = build_autocomplete_query(
+        es_model, keyword_search, limit, only_return_fields,
+    )
+
+    results = autocomplete_search.execute()
+    return results.suggest.autocomplete[0].options

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -107,6 +107,19 @@ def get_search_by_entity_query(
     return s
 
 
+def build_autocomplete_query(es_model, keyword_search, limit, only_return_fields):
+    """Builds the query for autocomplete search and applies source filtering."""
+    index = es_model.get_read_alias()
+    autocomplete_search = es_model.search(index=index)
+    if only_return_fields:
+        autocomplete_search = autocomplete_search.extra(_source={'include': only_return_fields})
+    return autocomplete_search.suggest(
+        'autocomplete',
+        keyword_search,
+        completion={'field': 'suggest', 'size': limit},
+    )
+
+
 def limit_search_query(query, offset=0, limit=100):
     """Limits search query to the page defined by offset and limit."""
     limit = _clip_limit(offset, limit)

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -45,6 +45,13 @@ class LimitOffsetSerializer(serializers.Serializer):
     limit = serializers.IntegerField(default=api_settings.PAGE_SIZE, min_value=1)
 
 
+class IdNameSerializer(serializers.Serializer):
+    """Serializer to return metadata constant with id and name."""
+
+    id = StringUUIDField()
+    name = serializers.CharField()
+
+
 class SearchSerializer(LimitOffsetSerializer):
     """Serialiser used to validate search POST bodies."""
 
@@ -88,3 +95,13 @@ class SearchSerializer(LimitOffsetSerializer):
             raise serializers.ValidationError(errors)
 
         return val
+
+
+class AutocompleteSearchSerializer(serializers.Serializer):
+    """Base serializer for autocomplete search."""
+
+    id = serializers.UUIDField()
+
+    def to_representation(self, instance):
+        """Uses the _source property instead of the instance if one present."""
+        return super().to_representation(getattr(instance, '_source', instance))

--- a/datahub/search/test/test_execute_query.py
+++ b/datahub/search/test/test_execute_query.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from datahub.search.company.apps import CompanySearchApp
+from datahub.search.execute_query import execute_autocomplete_query
+
+
+class TestExecuteQueryBuilder:
+    """Tests for executing search queries."""
+
+    def test_successful_execute_autocomplete_search_query(self):
+        """Test for executing an autocomplete search query."""
+        fake_result = [{'_source': []}]
+        suggest = mock.Mock(autocomplete=[mock.Mock(options=fake_result)])
+        mocked_es_response = mock.MagicMock(suggest=suggest)
+        with mock.patch('elasticsearch_dsl.Search.execute') as mock_es_execute:
+            mock_es_execute.return_value = mocked_es_response
+            result = execute_autocomplete_query(CompanySearchApp.es_model, 'hello', 10)
+        assert result == fake_result
+        assert mock_es_execute.called

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -3,288 +3,327 @@ from unittest import mock
 
 import pytest
 
+from datahub.search.company.apps import CompanySearchApp
 from datahub.search.query_builder import (
     _build_entity_permission_query,
     _build_field_query,
     _build_term_query,
     _split_date_range_fields,
+    build_autocomplete_query,
     get_basic_search_query,
 )
 
 
-@pytest.mark.parametrize(
-    'field,value,expected',
-    (
+class TestQueryBuilder:
+    """Tests for query building and executing functions."""
+
+    @pytest.mark.parametrize(
+        'field,value,expected',
         (
-            'field_name',
-            'field value',
-            {
-                'match': {
-                    'field_name': {
-                        'query': 'field value',
-                        'operator': 'and',
+            (
+                'field_name',
+                'field value',
+                {
+                    'match': {
+                        'field_name': {
+                            'query': 'field value',
+                            'operator': 'and',
+                        },
                     },
                 },
-            },
-        ),
-        (
-            'field_name.id',
-            'field value',
-            {
-                'match_phrase': {
-                    'field_name.id': 'field value',
-                },
-            },
-        ),
-        (
-            'field_name.name_keyword',
-            'field value',
-            {
-                'match_phrase': {
-                    'field_name.name_keyword': 'field value',
-                },
-            },
-        ),
-        (
-            'field_name.prop',
-            'field value',
-            {
-                'match': {
-                    'field_name.prop': {
-                        'query': 'field value',
-                        'operator': 'and',
+            ),
+            (
+                'field_name.id',
+                'field value',
+                {
+                    'match_phrase': {
+                        'field_name.id': 'field value',
                     },
                 },
-            },
-        ),
-        (
-            'field_name_exists',
-            True,
-            {
-                'bool': {
-                    'must': [
-                        {
-                            'exists': {
-                                'field': 'field_name',
-                            },
-                        },
-                    ],
+            ),
+            (
+                'field_name.name_keyword',
+                'field value',
+                {
+                    'match_phrase': {
+                        'field_name.name_keyword': 'field value',
+                    },
                 },
-            },
-        ),
-        (
-            'field_name_exists',
-            False,
-            {
-                'bool': {
-                    'must_not': [
-                        {
-                            'exists': {
-                                'field': 'field_name',
-                            },
+            ),
+            (
+                'field_name.prop',
+                'field value',
+                {
+                    'match': {
+                        'field_name.prop': {
+                            'query': 'field value',
+                            'operator': 'and',
                         },
-                    ],
+                    },
                 },
-            },
-        ),
-        (
-            'field_name',
-            None,
-            {
-                'bool': {
-                    'must_not': [
-                        {
-                            'exists': {
-                                'field': 'field_name',
-                            },
-                        },
-                    ],
-                },
-            },
-        ),
-        (
-            'field_name_exists',
-            None,
-            {
-                'bool': {
-                    'must_not': [
-                        {
-                            'exists': {
-                                'field': 'field_name',
-                            },
-                        },
-                    ],
-                },
-            },
-        ),
-        (
-            'field_name',
-            ['field value 1', 'field value 2'],
-            {
-                'bool': {
-                    'minimum_should_match': 1,
-                    'should': [
-                        {
-                            'match': {
-                                'field_name': {
-                                    'query': 'field value 1',
-                                    'operator': 'and',
+            ),
+            (
+                'field_name_exists',
+                True,
+                {
+                    'bool': {
+                        'must': [
+                            {
+                                'exists': {
+                                    'field': 'field_name',
                                 },
                             },
-                        },
-                        {
-                            'match': {
-                                'field_name': {
-                                    'query': 'field value 2',
-                                    'operator': 'and',
+                        ],
+                    },
+                },
+            ),
+            (
+                'field_name_exists',
+                False,
+                {
+                    'bool': {
+                        'must_not': [
+                            {
+                                'exists': {
+                                    'field': 'field_name',
                                 },
                             },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
-        ),
-    ),
-)
-def test_build_field_query(field, value, expected):
-    """Test for the _build_field_query function."""
-    assert _build_field_query(field, value).to_dict() == expected
-
-
-@pytest.mark.parametrize(
-    'term,expected',
-    (
-        (
-            'hello',
-            {
-                'bool': {
-                    'should': [
-                        {
-                            'match_phrase': {
-                                'name_keyword': {
-                                    'query': 'hello',
-                                    'boost': 2,
+            ),
+            (
+                'field_name',
+                None,
+                {
+                    'bool': {
+                        'must_not': [
+                            {
+                                'exists': {
+                                    'field': 'field_name',
                                 },
                             },
-                        },
-                        {
-                            'match_phrase': {
-                                'id': 'hello',
-                            },
-                        },
-                        {
-                            'multi_match': {
-                                'query': 'hello',
-                                'fields': ('country.id', 'sector'),
-                                'type': 'cross_fields',
-                                'operator': 'and',
-                            },
-                        },
-                    ],
+                        ],
+                    },
                 },
-            },
+            ),
+            (
+                'field_name_exists',
+                None,
+                {
+                    'bool': {
+                        'must_not': [
+                            {
+                                'exists': {
+                                    'field': 'field_name',
+                                },
+                            },
+                        ],
+                    },
+                },
+            ),
+            (
+                'field_name',
+                ['field value 1', 'field value 2'],
+                {
+                    'bool': {
+                        'minimum_should_match': 1,
+                        'should': [
+                            {
+                                'match': {
+                                    'field_name': {
+                                        'query': 'field value 1',
+                                        'operator': 'and',
+                                    },
+                                },
+                            },
+                            {
+                                'match': {
+                                    'field_name': {
+                                        'query': 'field value 2',
+                                        'operator': 'and',
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                },
+            ),
         ),
-        (
-            '',
-            {
-                'match_all': {},
-            },
-        ),
-    ),
-)
-def test_build_term_query(term, expected):
-    """Tests search term query."""
-    query = _build_term_query(term, fields=('country.id', 'sector'))
-    assert query.to_dict() == expected
-
-
-@pytest.mark.parametrize(
-    'offset,limit,expected_size', (
-        (8950, 1000, 1000),
-        (9950, 1000, 50),
-        (10000, 1000, 0),
-    ),
-)
-def test_offset_near_max_results(offset, limit, expected_size):
-    """Tests limit clipping when near max_results."""
-    query = get_basic_search_query(
-        'test', entities=(mock.Mock(),), offset=offset, limit=limit,
     )
+    def test_build_field_query(self, field, value, expected):
+        """Test for the _build_field_query function."""
+        assert _build_field_query(field, value).to_dict() == expected
 
-    query_dict = query.to_dict()
-    assert query_dict['from'] == offset
-    assert query_dict['size'] == expected_size
-
-
-def test_date_range_fields():
-    """Tests date range fields."""
-    now = datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)
-    fields = {
-        'estimated_land_date_after': now,
-        'estimated_land_date_before': now,
-        'adviser.id': 1234,
-    }
-
-    filters, ranges = _split_date_range_fields(fields)
-
-    assert filters == {
-        'adviser.id': 1234,
-    }
-    assert ranges == {
-        'estimated_land_date': {
-            'gte': now,
-            'lte': now,
-        },
-    }
-
-
-@pytest.mark.parametrize(
-    'filters,expected',
-    (
-        # An empty list of conditions should mean that there are no conditions that would permit
-        # access.
+    @pytest.mark.parametrize(
+        'term,expected',
         (
-            [],
-            {
-                'match_none': {},
-            },
-        ),
-        (
-            None,
-            None,
-        ),
-        (
-            [
-                ('field_name', 'field value'),
-            ],
-            {
-                'bool': {
-                    'should': [
-                        {'term': {'field_name': 'field value'}},
-                    ],
+            (
+                'hello',
+                {
+                    'bool': {
+                        'should': [
+                            {
+                                'match_phrase': {
+                                    'name_keyword': {
+                                        'query': 'hello',
+                                        'boost': 2,
+                                    },
+                                },
+                            },
+                            {
+                                'match_phrase': {
+                                    'id': 'hello',
+                                },
+                            },
+                            {
+                                'multi_match': {
+                                    'query': 'hello',
+                                    'fields': ('country.id', 'sector'),
+                                    'type': 'cross_fields',
+                                    'operator': 'and',
+                                },
+                            },
+                        ],
+                    },
                 },
-            },
-        ),
-        (
-            [
-                ('field_name1', 'field value 1'),
-                ('field_name2', 'field value 2'),
-            ],
-            {
-                'bool': {
-                    'should': [
-                        {'term': {'field_name1': 'field value 1'}},
-                        {'term': {'field_name2': 'field value 2'}},
-                    ],
+            ),
+            (
+                '',
+                {
+                    'match_all': {},
                 },
-            },
+            ),
         ),
-    ),
-)
-def test_build_entity_permission_query_no_conditions(filters, expected):
-    """Test for the _build_entity_permission_query function."""
-    query = _build_entity_permission_query(permission_filters=filters)
-    if expected is None:
-        assert query is None
-    else:
+    )
+    def test_build_term_query(self, term, expected):
+        """Tests search term query."""
+        query = _build_term_query(term, fields=('country.id', 'sector'))
         assert query.to_dict() == expected
+
+    @pytest.mark.parametrize(
+        'offset,limit,expected_size', (
+            (8950, 1000, 1000),
+            (9950, 1000, 50),
+            (10000, 1000, 0),
+        ),
+    )
+    def test_offset_near_max_results(self, offset, limit, expected_size):
+        """Tests limit clipping when near max_results."""
+        query = get_basic_search_query(
+            'test', entities=(mock.Mock(),), offset=offset, limit=limit,
+        )
+
+        query_dict = query.to_dict()
+        assert query_dict['from'] == offset
+        assert query_dict['size'] == expected_size
+
+    def test_date_range_fields(self):
+        """Tests date range fields."""
+        now = datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)
+        fields = {
+            'estimated_land_date_after': now,
+            'estimated_land_date_before': now,
+            'adviser.id': 1234,
+        }
+
+        filters, ranges = _split_date_range_fields(fields)
+
+        assert filters == {
+            'adviser.id': 1234,
+        }
+        assert ranges == {
+            'estimated_land_date': {
+                'gte': now,
+                'lte': now,
+            },
+        }
+
+    @pytest.mark.parametrize(
+        'filters,expected',
+        (
+            # An empty list of conditions should mean that there are no conditions
+            # that would permit access.
+            (
+                [],
+                {
+                    'match_none': {},
+                },
+            ),
+            (
+                None,
+                None,
+            ),
+            (
+                [
+                    ('field_name', 'field value'),
+                ],
+                {
+                    'bool': {
+                        'should': [
+                            {'term': {'field_name': 'field value'}},
+                        ],
+                    },
+                },
+            ),
+            (
+                [
+                    ('field_name1', 'field value 1'),
+                    ('field_name2', 'field value 2'),
+                ],
+                {
+                    'bool': {
+                        'should': [
+                            {'term': {'field_name1': 'field value 1'}},
+                            {'term': {'field_name2': 'field value 2'}},
+                        ],
+                    },
+                },
+            ),
+        ),
+    )
+    def test_build_entity_permission_query_no_conditions(self, filters, expected):
+        """Test for the _build_entity_permission_query function."""
+        query = _build_entity_permission_query(permission_filters=filters)
+        if expected is None:
+            assert query is None
+        else:
+            assert query.to_dict() == expected
+
+    @pytest.mark.parametrize(
+        'keyword,size,only_fields,expected',
+        (
+            (
+                'hello',
+                20,
+                None,
+                {
+                    'suggest': {
+                        'autocomplete': {
+                            'completion': {'field': 'suggest', 'size': 20},
+                            'text': 'hello',
+                        },
+                    },
+                },
+            ),
+            (
+                'goodbye',
+                1,
+                ['id', 'name'],
+                {
+                    '_source': {'include': ['id', 'name']},
+                    'suggest': {
+                        'autocomplete': {
+                            'completion': {'field': 'suggest', 'size': 1},
+                            'text': 'goodbye',
+                        },
+                    },
+                },
+            ),
+        ),
+    )
+    def test_build_autocomplete_search_query(self, keyword, size, only_fields, expected):
+        """Test for building an autocomplete search query."""
+        query = build_autocomplete_query(CompanySearchApp.es_model, keyword, size, only_fields)
+        assert query.to_dict() == expected
+        assert query._index == [CompanySearchApp.es_model.get_read_alias()]

--- a/datahub/search/urls.py
+++ b/datahub/search/urls.py
@@ -5,6 +5,7 @@ from django.urls import path
 from datahub.search.apps import get_search_apps
 from datahub.search.views import SearchBasicAPIView
 
+
 urlpatterns = [
     path('search', SearchBasicAPIView.as_view(), name='basic'),
 ]
@@ -22,4 +23,11 @@ for search_app in get_search_apps():
             f'search/{search_app.name}/export',
             search_app.export_view.as_view(search_app=search_app),
             name=f'{search_app.name}-export',
+        ))
+
+    if search_app.autocomplete_view:
+        urlpatterns.append(path(
+            f'search/{search_app.name}/autocomplete',
+            search_app.autocomplete_view.as_view(search_app=search_app),
+            name=f'{search_app.name}-autocomplete-search',
         ))


### PR DESCRIPTION
### Description of change
To support autocomplete or type-ahead for companies I've utilised the elasticsearch completion suggester and added it to the company elastic search model. It seems to work quite nicely (tested locally with 100K of companies) but am happy to rework any aspect of it as I am aware this sort of field uses more server memory etc. The completion suggestions are just what I think will work best am happy to add and remove values based on anyone else's recommendations. Completion suggestions also supports fuzzy matching which for the moment I have not used. I think the index will need to be rebuilt as the the mapping has changed.

### How to test
- Reindex some companies
- Go to http://localhost:8000/v3/search/company/quick?q=mar

I've found adding https://pypi.org/project/django-elasticsearch-debug-toolbar/ to the debug tool bar helped me work out what queries were being executed ie a double execution of the query. (For some reason when you click to view the json in chrome the link doesn't work so Ive had to inspect and remove the display class)


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
