### PR TITLE
Add command to unarchive and change status of investment projects

### DIFF
--- a/changelog/investment/unarchive_status_command.internal
+++ b/changelog/investment/unarchive_status_command.internal
@@ -1,0 +1,1 @@
+It is now possible to unarchive and update status of investment projects using added management command ``update_investment_project_archive_state``.

--- a/datahub/dbmaintenance/management/commands/update_investment_project_archived_state.py
+++ b/datahub/dbmaintenance/management/commands/update_investment_project_archived_state.py
@@ -1,0 +1,48 @@
+from logging import getLogger
+
+import reversion
+
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.investment.models import InvestmentProject
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """Command to unarchive and update the investment_project.status."""
+
+    STATUS_MAP = {
+        'Unarchive, change status to Abandoned': InvestmentProject.STATUSES.abandoned,
+        'Unarchive, change status to Lost': InvestmentProject.STATUSES.lost,
+        'Unarchive, change status to Ongoing': InvestmentProject.STATUSES.ongoing,
+        'Unarchive, change status to Dormant': InvestmentProject.STATUSES.dormant,
+        'Unarchive, change status to Delayed': InvestmentProject.STATUSES.delayed,
+    }
+
+    def _process_row(self, row, simulate=False, ignore_old_regions=False, **options):
+        """Process one single row."""
+        pk = parse_uuid(row['id'])
+        investment_project = InvestmentProject.objects.get(pk=pk)
+
+        if investment_project.archived_on:
+            action_required = row['Action Required']
+            if action_required in self.STATUS_MAP:
+                investment_project.status = self.STATUS_MAP[action_required]
+            else:
+                logger.warning((
+                    f'Not updating project {pk} as its desired status '
+                    f'could not be derived from [{action_required}].'
+                ))
+                return
+        else:
+            logger.warning(f'Not updating project {pk} as it is already unarchived.')
+            return
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            # unarchive performs save
+            investment_project.unarchive()
+            reversion.set_comment('Investment Project was unarchived and has changed its status.')

--- a/datahub/dbmaintenance/test/commands/test_update_investment_project_archive_state.py
+++ b/datahub/dbmaintenance/test/commands/test_update_investment_project_archive_state.py
@@ -1,0 +1,166 @@
+from io import BytesIO
+
+import pytest
+from django.core.management import call_command
+from reversion.models import Version
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.investment.models import InvestmentProject
+from datahub.investment.test.factories import InvestmentProjectFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def investment_projects_and_csv_content():
+    """Prepare archived investment projects and csv content."""
+    investment_projects = InvestmentProjectFactory.create_batch(
+        6,
+        status=InvestmentProject.STATUSES.ongoing,
+    )
+
+    for project in investment_projects:
+        project.archive(user=AdviserFactory())
+
+    csv_content = f"""id,Action Required
+00000000-0000-0000-0000-000000000000,
+{investment_projects[0].pk},
+{investment_projects[1].pk},"Unarchive, change status to Abandoned"
+{investment_projects[2].pk},"Unarchive, change status to Lost"
+{investment_projects[3].pk},"Unarchive, change status to Dormant"
+{investment_projects[4].pk},"Unarchive, change status to Whatever"
+{investment_projects[5].pk},"Unarchive, change status to Delayed"
+"""
+    yield (investment_projects, csv_content)
+
+
+def test_run(s3_stubber, caplog, investment_projects_and_csv_content):
+    """
+    Test that the command updates the specified records
+    (ignoring ones with errors and warnings).
+    """
+    caplog.set_level('WARNING')
+
+    investment_projects, csv_content = investment_projects_and_csv_content
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_investment_project_archived_state', bucket, object_key)
+
+    for project in investment_projects:
+        project.refresh_from_db()
+
+    assert 'InvestmentProject matching query does not exist' in caplog.text
+    assert (
+        f'Not updating project {investment_projects[0].pk} '
+        f'as its desired status could not be derived from [].'
+    ) in caplog.text
+    assert (
+        f'Not updating project {investment_projects[4].pk} '
+        f'as its desired status could not be derived from '
+        f'[Unarchive, change status to Whatever].'
+    ) in caplog.text
+    assert len(caplog.records) == 3
+
+    assert [(project.archived, project.status) for project in investment_projects] == [
+        (True, InvestmentProject.STATUSES.ongoing),     # not updated
+        (False, InvestmentProject.STATUSES.abandoned),
+        (False, InvestmentProject.STATUSES.lost),
+        (False, InvestmentProject.STATUSES.dormant),
+        (True, InvestmentProject.STATUSES.ongoing),     # not updated
+        (False, InvestmentProject.STATUSES.delayed),
+    ]
+
+
+def test_simulate(s3_stubber, caplog, investment_projects_and_csv_content):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('WARNING')
+
+    investment_projects, csv_content = investment_projects_and_csv_content
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_investment_project_archived_state', bucket, object_key, simulate=True)
+
+    for project in investment_projects:
+        project.refresh_from_db()
+
+    assert 'InvestmentProject matching query does not exist' in caplog.text
+    assert (
+        f'Not updating project {investment_projects[0].pk} '
+        f'as its desired status could not be derived from [].'
+    ) in caplog.text
+    assert (
+        f'Not updating project {investment_projects[4].pk} '
+        f'as its desired status could not be derived from '
+        f'[Unarchive, change status to Whatever].'
+    ) in caplog.text
+    assert len(caplog.records) == 3
+
+    assert [(project.archived, project.status) for project in investment_projects] == [
+        (True, InvestmentProject.STATUSES.ongoing),
+        (True, InvestmentProject.STATUSES.ongoing),
+        (True, InvestmentProject.STATUSES.ongoing),
+        (True, InvestmentProject.STATUSES.ongoing),
+        (True, InvestmentProject.STATUSES.ongoing),
+        (True, InvestmentProject.STATUSES.ongoing),
+    ]
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    project_with_change = InvestmentProjectFactory(status=InvestmentProject.STATUSES.ongoing)
+    project_with_change.archive(user=AdviserFactory())
+    project_without_change = InvestmentProjectFactory(status=InvestmentProject.STATUSES.abandoned)
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,Action Required
+{project_with_change.pk},"Unarchive, change status to Abandoned"
+{project_without_change.pk},"Unarchive, change status to Abandoned"
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_investment_project_archived_state', bucket, object_key)
+
+    versions = Version.objects.get_for_object(project_without_change)
+    assert versions.count() == 0
+
+    versions = Version.objects.get_for_object(project_with_change)
+    assert versions.count() == 1
+    comment = versions[0].revision.get_comment()
+    assert comment == 'Investment Project was unarchived and has changed its status.'


### PR DESCRIPTION
### Description of change

This adds a management command that can unarchive and update the status of investment projects found in the spreadsheet.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
