### PR TITLE
Remove the field classification from company endpoints

### DIFF
--- a/changelog/classification.api
+++ b/changelog/classification.api
@@ -1,0 +1,1 @@
+The field ``classification`` was removed from all company API endpoints.

--- a/changelog/classification.removal
+++ b/changelog/classification.removal
@@ -1,0 +1,1 @@
+The field ``classification`` was removed from all company API endpoints.

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -279,7 +279,6 @@ class CompanySerializer(PermittedFieldsModelSerializer):
     business_type = NestedRelatedField(
         meta_models.BusinessType, required=False, allow_null=True,
     )
-    classification = NestedRelatedField(meta_models.CompanyClassification, read_only=True)
     one_list_group_tier = serializers.SerializerMethodField()
     companies_house_data = NestedCompaniesHouseCompanySerializer(read_only=True)
     contacts = ContactSerializer(many=True, read_only=True)
@@ -434,7 +433,6 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'trading_address_postcode',
             'trading_address_country',
             'business_type',
-            'classification',
             'one_list_group_tier',
             'companies_house_data',
             'contacts',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -276,7 +276,6 @@ class TestGetCompany(APITestMixin):
                 'id': str(company.business_type.id),
                 'name': company.business_type.name,
             },
-            'classification': None,
             'one_list_group_tier': None,
             'company_number': '123',
             'contacts': [],
@@ -367,7 +366,6 @@ class TestGetCompany(APITestMixin):
             registered_address_town='Fooland',
             registered_address_country_id=Country.united_states.value.id,
             headquarter_type_id=HeadquarterType.ukhq.value.id,
-            classification=random_obj_for_model(CompanyClassification),
         )
 
         url = reverse('api-v3:company:item', kwargs={'pk': company.id})
@@ -387,10 +385,6 @@ class TestGetCompany(APITestMixin):
         assert response.data['registered_address_county'] is None
         assert response.data['registered_address_postcode'] is None
         assert response.data['headquarter_type']['id'] == HeadquarterType.ukhq.value.id
-        assert response.data['classification'] == {
-            'id': str(company.classification.pk),
-            'name': company.classification.name,
-        }
 
     def test_get_company_without_registered_country(self):
         """Tests the company item view for a company without a registered
@@ -647,7 +641,6 @@ class TestUpdateCompany(APITestMixin):
             data={
                 'reference_code': 'XYZ',
                 'archived_documents_url_path': 'new_path',
-                'classification': different_one_list_tier.id,
                 'one_list_group_tier': different_one_list_tier.id,
                 'one_list_group_global_account_manager': different_one_list_gam.id,
                 'duns_number': '000000002',
@@ -657,10 +650,6 @@ class TestUpdateCompany(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['reference_code'] == 'ORG-345645'
         assert response.data['archived_documents_url_path'] == 'old_path'
-        assert response.data['classification'] == {
-            'id': str(company.classification.id),
-            'name': company.classification.name,
-        }
         assert response.data['one_list_group_tier'] == {
             'id': str(company.classification.id),
             'name': company.classification.name,

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -19,7 +19,6 @@ class Company(BaseESModel):
     archived_on = Date()
     archived_reason = Text()
     business_type = fields.nested_id_name_field()
-    classification = fields.nested_id_name_field()
     companies_house_data = fields.nested_ch_company_field()
     company_number = fields.SortableCaseInsensitiveKeywordText()
     contacts = fields.nested_contact_or_adviser_field('contacts')
@@ -84,7 +83,6 @@ class Company(BaseESModel):
     MAPPINGS = {
         'archived_by': dict_utils.contact_or_adviser_dict,
         'business_type': dict_utils.id_name_dict,
-        'classification': dict_utils.id_name_dict,
         'companies_house_data': dict_utils.ch_company_dict,
         'contacts': lambda col: [dict_utils.contact_or_adviser_dict(c) for c in col.all()],
         'employee_range': dict_utils.id_name_dict,

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -30,7 +30,6 @@ class SearchCompanySerializer(SearchSerializer):
         'archived',
         'archived_by',
         'business_type.name',
-        'classification.name',
         'companies_house_data.company_number',
         'company_number',
         'created_on',

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -1,3 +1,8 @@
+import pytest
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.search import elasticsearch
+from datahub.search.company import CompanySearchApp
 from datahub.search.company.models import Company as ESCompany
 from datahub.search.query_builder import (
     get_basic_search_query,
@@ -224,4 +229,73 @@ def test_limited_get_search_by_entity_query():
             '_score',
             'id',
         ],
+    }
+
+
+@pytest.mark.django_db
+def test_indexed_doc(setup_es):
+    """Test the ES data of an indexed company."""
+    company = CompanyFactory()
+
+    doc = ESCompany.es_document(company)
+    elasticsearch.bulk(actions=(doc, ), chunk_size=1)
+
+    setup_es.indices.refresh()
+
+    indexed_company = setup_es.get(
+        index=CompanySearchApp.es_model.get_write_index(),
+        doc_type=CompanySearchApp.name,
+        id=company.pk,
+    )
+
+    source = indexed_company.pop('_source')
+    assert set(source.keys()) == {
+        'archived',
+        'archived_by',
+        'archived_on',
+        'archived_reason',
+        'business_type',
+        'companies_house_data',
+        'company_number',
+        'contacts',
+        'created_on',
+        'description',
+        'employee_range',
+        'export_experience_category',
+        'export_to_countries',
+        'future_interest_countries',
+        'headquarter_type',
+        'id',
+        'modified_on',
+        'name',
+        'one_list_account_owner',
+        'global_headquarters',
+        'reference_code',
+        'registered_address_1',
+        'registered_address_2',
+        'registered_address_country',
+        'registered_address_county',
+        'registered_address_postcode',
+        'registered_address_town',
+        'sector',
+        'trading_address_1',
+        'trading_address_2',
+        'trading_address_country',
+        'trading_address_county',
+        'trading_address_postcode',
+        'trading_address_town',
+        'trading_name',
+        'turnover_range',
+        'uk_based',
+        'uk_region',
+        'vat_number',
+        'duns_number',
+        'website',
+    }
+    assert indexed_company == {
+        '_id': str(company.pk),
+        '_index': CompanySearchApp.es_model.get_target_index_name(),
+        '_type': CompanySearchApp.name,
+        '_version': indexed_company['_version'],
+        'found': True,
     }

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -18,7 +18,6 @@ def test_company_dbmodel_to_dict(setup_es):
         'archived_on',
         'archived_reason',
         'business_type',
-        'classification',
         'companies_house_data',
         'company_number',
         'contacts',


### PR DESCRIPTION
### Description of change

This removes the `classification` field from all company endpoints as the clients should use the new `one_list_group_tier` instead.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
