### PR TITLE
Add command to delete investment projects

### DIFF
--- a/changelog/investment/delete_investment_project.internal
+++ b/changelog/investment/delete_investment_project.internal
@@ -1,0 +1,1 @@
+It is now possible to delete investment projects using added management command ``delete_investment_project``.

--- a/datahub/cleanup/management/commands/_base_command.py
+++ b/datahub/cleanup/management/commands/_base_command.py
@@ -10,13 +10,10 @@ from django.db.transaction import atomic
 from django.template.defaultfilters import capfirst
 
 from datahub.cleanup.query_utils import get_relations_to_delete, get_unreferenced_objects_query
+from datahub.core.exceptions import SimulationRollback
 from datahub.search.deletion import update_es_after_deletions
 
 logger = getLogger(__name__)
-
-
-class SimulationRollback(Exception):
-    """Used to roll back deletions during a simulation."""
 
 
 class BaseCleanupCommand(BaseCommand):

--- a/datahub/core/exceptions.py
+++ b/datahub/core/exceptions.py
@@ -29,3 +29,7 @@ class APIMethodNotAllowedException(APIException):
     status_code = status.HTTP_405_METHOD_NOT_ALLOWED
     default_detail = _('Method is not allowed.')
     default_code = 'method_not_allowed'
+
+
+class SimulationRollback(Exception):
+    """Used to roll back deletions during a simulation."""

--- a/datahub/dbmaintenance/management/commands/delete_investment_project.py
+++ b/datahub/dbmaintenance/management/commands/delete_investment_project.py
@@ -1,0 +1,40 @@
+from contextlib import ExitStack
+from logging import getLogger
+
+from django.db.transaction import atomic
+
+from datahub.core.exceptions import SimulationRollback
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.investment.models import InvestmentProject
+from datahub.search.deletion import update_es_after_deletions
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """Command to delete investment projects."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        investment_project_id = row['id']
+        investment_project = InvestmentProject.objects.get(pk=investment_project_id)
+
+        try:
+            with ExitStack() as stack:
+                if not simulate:
+                    stack.enter_context(update_es_after_deletions())
+
+                stack.enter_context(atomic())
+                total_deleted, deletions_by_model = investment_project.delete()
+                logger.info((
+                    f'{total_deleted} records deleted for investment project: '
+                    f'{investment_project_id}. Breakdown by model:'
+                ))
+                for deletion_model, model_deletion_count in deletions_by_model.items():
+                    logger.info(f'{deletion_model}: {model_deletion_count}')
+
+                if simulate:
+                    logger.info('Rolling back deletions...')
+                    raise SimulationRollback()
+        except SimulationRollback:
+            logger.info('Deletions rolled back')

--- a/datahub/dbmaintenance/test/commands/test_delete_investment_project.py
+++ b/datahub/dbmaintenance/test/commands/test_delete_investment_project.py
@@ -1,0 +1,103 @@
+from io import BytesIO
+
+import pytest
+from django.core.management import call_command
+
+from datahub.cleanup.query_utils import get_relations_to_delete
+from datahub.investment.models import InvestmentProject
+from datahub.investment.test.factories import InvestmentProjectFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def investment_projects_and_csv_content():
+    """Get investment projects and CSV content."""
+    investment_projects = InvestmentProjectFactory.create_batch(3)
+
+    csv_content = f"""id
+00000000-0000-0000-0000-000000000000
+{investment_projects[0].id}
+{investment_projects[2].id}
+"""
+    yield (investment_projects, csv_content.encode('utf-8'))
+
+
+def test_run(s3_stubber, caplog, investment_projects_and_csv_content):
+    """Test that the command deletes investment projects."""
+    caplog.set_level('ERROR')
+
+    investment_projects, csv_content = investment_projects_and_csv_content
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content)),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('delete_investment_project', bucket, object_key)
+
+    assert 'InvestmentProject matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+    deleted_projects = (investment_projects[0], investment_projects[2])
+    for investment_project in deleted_projects:
+        with pytest.raises(InvestmentProject.DoesNotExist):
+            investment_project.refresh_from_db()
+
+    investment_projects[1].refresh_from_db()
+    assert investment_projects[1].id is not None
+
+
+def test_simulate(s3_stubber, caplog, investment_projects_and_csv_content):
+    """Test that the command only simulates the actions if --simulate is passed in."""
+    caplog.set_level('INFO')
+
+    investment_projects, csv_content = investment_projects_and_csv_content
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(bytes(csv_content)),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    # Calculate the number of records to be deleted just for one investment project. Three projects
+    # tested have the same number of related records so it is enough to calculate just for one.
+    # 1 for the investment project itself plus related records
+    records_to_be_deleted = 1
+    relations_to_delete = get_relations_to_delete(InvestmentProject)
+    for related in relations_to_delete:
+        related_model = related.related_model
+        related_qs = related_model._base_manager.filter(
+            **{related.field.name: investment_projects[0].id},
+        )
+        related_qs_count = related_qs.count()
+        records_to_be_deleted += related_qs_count
+
+    call_command('delete_investment_project', bucket, object_key, simulate=True)
+
+    # In the test, two investment projects should be deleted
+    assert caplog.text.count(
+        f'{records_to_be_deleted} records deleted for investment project: ',
+    ) == 2
+    assert 'InvestmentProject matching query does not exist' in caplog.text
+
+    for investment_project in investment_projects:
+        investment_project.refresh_from_db()
+        assert investment_project.id is not None


### PR DESCRIPTION
### Description of change

This adds a management command that can delete investment projects found in the spreadsheet.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
