### PR TITLE
Remove one_list_account_owner from company endpoints

### DIFF
--- a/changelog/company/one_list_account_owner.api
+++ b/changelog/company/one_list_account_owner.api
@@ -1,0 +1,1 @@
+The field ``one_list_account_owner`` was removed from all company API endpoints, please use ``one_list_group_global_account_manager`` instead.

--- a/changelog/company/one_list_account_owner.removal
+++ b/changelog/company/one_list_account_owner.removal
@@ -1,0 +1,1 @@
+The field ``one_list_account_owner`` was removed from all company API endpoints, please use ``one_list_group_global_account_manager`` instead.

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -295,9 +295,6 @@ class CompanySerializer(PermittedFieldsModelSerializer):
     headquarter_type = NestedRelatedField(
         meta_models.HeadquarterType, required=False, allow_null=True,
     )
-    one_list_account_owner = NestedAdviserWithTeamField(
-        required=False, allow_null=True,
-    )
     one_list_group_global_account_manager = serializers.SerializerMethodField()
     global_headquarters = NestedRelatedField(
         'company.Company', required=False, allow_null=True,
@@ -440,7 +437,6 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'export_to_countries',
             'future_interest_countries',
             'headquarter_type',
-            'one_list_account_owner',
             'one_list_group_global_account_manager',
             'global_headquarters',
             'sector',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -297,16 +297,6 @@ class TestGetCompany(APITestMixin):
             'future_interest_countries': [],
             'headquarter_type': None,
             'modified_on': format_date_or_datetime(company.modified_on),
-            'one_list_account_owner': {
-                'id': str(company.one_list_account_owner.pk),
-                'name': company.one_list_account_owner.name,
-                'first_name': company.one_list_account_owner.first_name,
-                'last_name': company.one_list_account_owner.last_name,
-                'dit_team': {
-                    'id': str(company.one_list_account_owner.dit_team.id),
-                    'name': company.one_list_account_owner.dit_team.name,
-                },
-            },
             'one_list_group_global_account_manager': {
                 'id': str(company.one_list_account_owner.pk),
                 'name': company.one_list_account_owner.name,

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -34,7 +34,6 @@ class Company(BaseESModel):
     name = fields.SortableText(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = fields.SortableCaseInsensitiveKeywordText()
     name_trigram = fields.TrigramText()
-    one_list_account_owner = fields.nested_contact_or_adviser_field('one_list_account_owner')
     reference_code = fields.SortableCaseInsensitiveKeywordText()
     registered_address_1 = Text()
     registered_address_2 = Text()
@@ -91,7 +90,6 @@ class Company(BaseESModel):
         'future_interest_countries': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'global_headquarters': dict_utils.id_name_dict,
         'headquarter_type': dict_utils.id_name_dict,
-        'one_list_account_owner': dict_utils.contact_or_adviser_dict,
         'registered_address_country': dict_utils.id_name_dict,
         'sector': dict_utils.sector_dict,
         'trading_address_country': dict_utils.id_name_dict,

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -268,7 +268,6 @@ def test_indexed_doc(setup_es):
         'id',
         'modified_on',
         'name',
-        'one_list_account_owner',
         'global_headquarters',
         'reference_code',
         'registered_address_1',

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -31,7 +31,6 @@ def test_company_dbmodel_to_dict(setup_es):
         'id',
         'modified_on',
         'name',
-        'one_list_account_owner',
         'global_headquarters',
         'reference_code',
         'registered_address_1',


### PR DESCRIPTION
### Description of change

This removes the `one_list_account_owner` field from all company endpoints as the client should use the new `one_list_group_global_account_manager` instead.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
