### PR TITLE
Show global account manager for one list group in investment export

### DIFF
--- a/changelog/investment/gam_export.api
+++ b/changelog/investment/gam_export.api
@@ -1,0 +1,1 @@
+The global account manager field in the ``POST /v3/search/investment_project/export`` response body now inherits the value from the investor company's Global Headquarters in case of subsidiaries.

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Max
+from django.db.models import Case, Max, When
 
 from datahub.core.query_utils import (
     get_aggregate_subquery,
@@ -112,8 +112,14 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectParams, SearchExportA
             DBInvestmentProject,
             'actual_uk_regions__name',
         ),
-        investor_company_global_account_manager=get_full_name_expression(
-            'investor_company__one_list_account_owner',
+        investor_company_global_account_manager=Case(
+            When(
+                investor_company__global_headquarters__isnull=False,
+                then=get_full_name_expression(
+                    'investor_company__global_headquarters__one_list_account_owner',
+                ),
+            ),
+            default=get_full_name_expression('investor_company__one_list_account_owner'),
         ),
         client_relationship_manager_name=get_full_name_expression('client_relationship_manager'),
         project_manager_name=get_full_name_expression('project_manager'),


### PR DESCRIPTION
### Description of change

Before the search investment project export was only showing the global account manager for the specific investor company.

It is now inheriting the value from the Global Headquarters of the investor company if it exists.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
