### PR TITLE
Use one_list_tier instead of classification in business logic

### DIFF
--- a/changelog/companyclassification_table.db
+++ b/changelog/companyclassification_table.db
@@ -1,0 +1,1 @@
+The table ``metadata_companyclassification`` is deprecated, please check the _Deprecations_ section for more details.

--- a/changelog/companyclassification_table.removal
+++ b/changelog/companyclassification_table.removal
@@ -1,0 +1,1 @@
+The table ``metadata_companyclassification`` is deprecated and will be deleted on or after December 13. Please use ``company_onelisttier`` instead.

--- a/datahub/company/admin_reports.py
+++ b/datahub/company/admin_reports.py
@@ -46,18 +46,18 @@ class OneListReport(QuerySetReport):
     permissions_required = ('company.view_company',)
     queryset = Company.objects.filter(
         headquarter_type_id=constants.HeadquarterType.ghq.value.id,
-        classification__id__isnull=False,
+        one_list_tier_id__isnull=False,
         one_list_account_owner_id__isnull=False,
     ).annotate(
         primary_contact_name=get_full_name_expression('one_list_account_owner'),
         url=get_front_end_url_expression('company', 'pk'),
     ).order_by(
-        'classification__order',
+        'one_list_tier__order',
         'name',
     )
     field_titles = {
         'name': 'Account Name',
-        'classification__name': 'Tier',
+        'one_list_tier__name': 'Tier',
         'sector__segment': 'Sector',
         'primary_contact_name': 'Primary Contact',
         'one_list_account_owner__telephone_number': 'Contact Number',

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -274,7 +274,7 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
         """
         :returns: the One List Tier of the group this company is part of.
         """
-        return self.get_group_global_headquarters().classification
+        return self.get_group_global_headquarters().one_list_tier
 
     def get_one_list_group_core_team(self):
         """

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -16,6 +16,7 @@ from datahub.company.models import (
     Contact,
     ContactPermission,
     ExportExperienceCategory,
+    OneListTier,
 )
 from datahub.company.validators import (
     has_no_invalid_company_number_characters,
@@ -381,7 +382,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         """
         one_list_tier = obj.get_one_list_group_tier()
 
-        field = NestedRelatedField(meta_models.CompanyClassification)
+        field = NestedRelatedField(OneListTier)
         return field.to_representation(one_list_tier)
 
     def get_one_list_group_global_account_manager(self, obj):

--- a/datahub/company/test/test_admin_report.py
+++ b/datahub/company/test/test_admin_report.py
@@ -8,10 +8,10 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from datahub.company.admin_reports import AllAdvisersReport, OneListReport
+from datahub.company.models import OneListTier
 from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core import constants
-from datahub.core.test_utils import AdminTestMixin, create_test_user, random_obj_for_model
-from datahub.metadata.models import CompanyClassification
+from datahub.core.test_utils import AdminTestMixin, create_test_user
 from datahub.metadata.test.factories import TeamFactory
 
 pytestmark = pytest.mark.django_db
@@ -45,25 +45,25 @@ class TestReportAdmin(AdminTestMixin):
         CompanyFactory.create_batch(
             2,
             headquarter_type_id=constants.HeadquarterType.ghq.value.id,
-            classification=random_obj_for_model(CompanyClassification),
+            one_list_tier=OneListTier.objects.first(),
             one_list_account_owner=AdviserFactory(),
         )
         # ignored because headquarter_type is None
         CompanyFactory(
             headquarter_type=None,
-            classification=random_obj_for_model(CompanyClassification),
+            one_list_tier=OneListTier.objects.first(),
             one_list_account_owner=AdviserFactory(),
         )
-        # ignored because classification is None
+        # ignored because one_list_tier is None
         CompanyFactory(
             headquarter_type_id=constants.HeadquarterType.ghq.value.id,
-            classification=None,
+            one_list_tier=None,
             one_list_account_owner=AdviserFactory(),
         )
         # ignored because one_list_account_owner is None
         CompanyFactory(
             headquarter_type_id=constants.HeadquarterType.ghq.value.id,
-            classification=random_obj_for_model(CompanyClassification),
+            one_list_tier=OneListTier.objects.first(),
             one_list_account_owner=None,
         )
 
@@ -115,34 +115,34 @@ def test_one_list_report_generation():
     companies = CompanyFactory.create_batch(
         2,
         headquarter_type_id=constants.HeadquarterType.ghq.value.id,
-        classification=factory.Iterator(
-            CompanyClassification.objects.all(),  # keeps the ordering
+        one_list_tier=factory.Iterator(
+            OneListTier.objects.all(),  # keeps the ordering
         ),
         one_list_account_owner=AdviserFactory(),
     )
     # ignored because headquarter_type is None
     CompanyFactory(
         headquarter_type=None,
-        classification=random_obj_for_model(CompanyClassification),
+        one_list_tier=OneListTier.objects.first(),
         one_list_account_owner=AdviserFactory(),
     )
-    # ignored because classification is None
+    # ignored because one_list_tier is None
     CompanyFactory(
         headquarter_type_id=constants.HeadquarterType.ghq.value.id,
-        classification=None,
+        one_list_tier=None,
         one_list_account_owner=AdviserFactory(),
     )
     # ignored because one_list_account_owner is None
     CompanyFactory(
         headquarter_type_id=constants.HeadquarterType.ghq.value.id,
-        classification=random_obj_for_model(CompanyClassification),
+        one_list_tier=OneListTier.objects.first(),
         one_list_account_owner=None,
     )
 
     report = OneListReport()
     assert list(report.rows()) == [{
         'name': company.name,
-        'classification__name': company.classification.name,
+        'one_list_tier__name': company.one_list_tier.name,
         'sector__segment': company.sector.segment,
         'primary_contact_name': company.one_list_account_owner.name,
         'one_list_account_owner__telephone_number':

--- a/datahub/company/test/test_models.py
+++ b/datahub/company/test/test_models.py
@@ -2,13 +2,13 @@ import factory
 import pytest
 from django.conf import settings
 
+from datahub.company.models import OneListTier
 from datahub.company.test.factories import (
     AdviserFactory,
     CompanyFactory,
     ContactFactory,
     OneListCoreTeamMemberFactory,
 )
-from datahub.metadata.models import CompanyClassification
 
 
 # mark the whole module for db use
@@ -50,22 +50,22 @@ class TestCompany:
         (
             # subsidiary with Global Headquarters on the One List
             lambda one_list_tier: CompanyFactory(
-                classification=None,
-                global_headquarters=CompanyFactory(classification=one_list_tier),
+                one_list_tier=None,
+                global_headquarters=CompanyFactory(one_list_tier=one_list_tier),
             ),
             # subsidiary with Global Headquarters not on the One List
             lambda one_list_tier: CompanyFactory(
-                classification=None,
-                global_headquarters=CompanyFactory(classification=None),
+                one_list_tier=None,
+                global_headquarters=CompanyFactory(one_list_tier=None),
             ),
             # single company on the One List
             lambda one_list_tier: CompanyFactory(
-                classification=one_list_tier,
+                one_list_tier=one_list_tier,
                 global_headquarters=None,
             ),
             # single company not on the One List
             lambda one_list_tier: CompanyFactory(
-                classification=None,
+                one_list_tier=None,
                 global_headquarters=None,
             ),
         ),
@@ -82,12 +82,12 @@ class TestCompany:
         if company has no `global_headquarters` or the one of its `global_headquarters`
         otherwise.
         """
-        one_list_tier = CompanyClassification.objects.first()
+        one_list_tier = OneListTier.objects.first()
 
         company = build_company(one_list_tier)
 
         group_global_headquarters = company.global_headquarters or company
-        if not group_global_headquarters.classification:
+        if not group_global_headquarters.one_list_tier:
             assert not company.get_one_list_group_tier()
         else:
             assert company.get_one_list_group_tier() == one_list_tier
@@ -152,29 +152,29 @@ class TestCompany:
         (
             # subsidiary with Global Headquarters on the One List
             lambda one_list_tier, gam: CompanyFactory(
-                classification=None,
+                one_list_tier=None,
                 global_headquarters=CompanyFactory(
-                    classification=one_list_tier,
+                    one_list_tier=one_list_tier,
                     one_list_account_owner=gam,
                 ),
             ),
             # subsidiary with Global Headquarters not on the One List
             lambda one_list_tier, gam: CompanyFactory(
-                classification=None,
+                one_list_tier=None,
                 global_headquarters=CompanyFactory(
-                    classification=None,
+                    one_list_tier=None,
                     one_list_account_owner=None,
                 ),
             ),
             # single company on the One List
             lambda one_list_tier, gam: CompanyFactory(
-                classification=one_list_tier,
+                one_list_tier=one_list_tier,
                 one_list_account_owner=gam,
                 global_headquarters=None,
             ),
             # single company not on the One List
             lambda one_list_tier, gam: CompanyFactory(
-                classification=None,
+                one_list_tier=None,
                 global_headquarters=None,
                 one_list_account_owner=None,
             ),
@@ -193,7 +193,7 @@ class TestCompany:
         `global_headquarters` or the one of its `global_headquarters` otherwise.
         """
         global_account_manager = AdviserFactory()
-        one_list_tier = CompanyClassification.objects.first()
+        one_list_tier = OneListTier.objects.first()
 
         company = build_company(one_list_tier, global_account_manager)
 

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -40,7 +40,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
     queryset = Company.objects.select_related(
         'archived_by',
         'business_type',
-        'classification',
+        'one_list_tier',
         'transferred_to',
         'employee_range',
         'export_experience_category',
@@ -54,7 +54,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
         'global_headquarters__one_list_account_owner__dit_team',
         'global_headquarters__one_list_account_owner__dit_team__uk_region',
         'global_headquarters__one_list_account_owner__dit_team__country',
-        'global_headquarters__classification',
+        'global_headquarters__one_list_tier',
         'registered_address_country',
         'trading_address_country',
         'turnover_range',

--- a/datahub/dbmaintenance/test/commands/test_update_one_list_fields.py
+++ b/datahub/dbmaintenance/test/commands/test_update_one_list_fields.py
@@ -6,9 +6,9 @@ import pytest
 from django.core.management import call_command
 from reversion.models import Version
 
+from datahub.company.models import OneListTier
 from datahub.company.test.factories import AdviserFactory, CompanyFactory
 from datahub.core.test_utils import random_obj_for_model, random_obj_for_queryset
-from datahub.metadata.models import CompanyClassification
 
 pytestmark = pytest.mark.django_db
 
@@ -49,40 +49,40 @@ def test_run(s3_stubber, caplog, reset_unmatched):
     """
     caplog.set_level('ERROR')
 
-    new_classification = random_obj_for_model(CompanyClassification)
+    new_one_list_tier = random_obj_for_model(OneListTier)
     one_list_companies = CompanyFactory.create_batch(
         8,
-        classification=factory.LazyFunction(
+        one_list_tier=factory.LazyFunction(
             lambda: random_obj_for_queryset(
-                CompanyClassification.objects.exclude(pk=new_classification.pk),
+                OneListTier.objects.exclude(pk=new_one_list_tier.pk),
             ),
         ),
         one_list_account_owner=factory.SubFactory(AdviserFactory),
     )
     non_one_list_companies = CompanyFactory.create_batch(
         3,
-        classification=None,
+        one_list_tier=None,
         one_list_account_owner=None,
     )
 
     for company in chain(one_list_companies, non_one_list_companies):
-        save_prev_fields(company, 'classification_id', 'one_list_account_owner_id')
+        save_prev_fields(company, 'one_list_tier_id', 'one_list_account_owner_id')
 
     advisers = AdviserFactory.create_batch(4)
 
     bucket = 'test_bucket'
     object_key = 'test_key'
-    csv_content = f"""id,classification_id,one_list_account_owner_id
+    csv_content = f"""id,one_list_tier_id,one_list_account_owner_id
 00000000-0000-0000-0000-000000000000,test,test
-{one_list_companies[0].pk},{one_list_companies[0].classification_id},{one_list_companies[0].one_list_account_owner_id}
-{one_list_companies[1].pk},{one_list_companies[1].classification_id},{advisers[0].pk}
-{one_list_companies[2].pk},{new_classification.pk},{one_list_companies[2].one_list_account_owner_id}
+{one_list_companies[0].pk},{one_list_companies[0].one_list_tier_id},{one_list_companies[0].one_list_account_owner_id}
+{one_list_companies[1].pk},{one_list_companies[1].one_list_tier_id},{advisers[0].pk}
+{one_list_companies[2].pk},{new_one_list_tier.pk},{one_list_companies[2].one_list_account_owner_id}
 {one_list_companies[3].pk},null,null
 {one_list_companies[4].pk},00000000-0000-0000-0000-000000000000,{advisers[1].pk}
-{one_list_companies[5].pk},{new_classification.pk},00000000-0000-0000-0000-000000000000
-{non_one_list_companies[0].pk},{new_classification.pk},{advisers[2].pk}
+{one_list_companies[5].pk},{new_one_list_tier.pk},00000000-0000-0000-0000-000000000000
+{non_one_list_companies[0].pk},{new_one_list_tier.pk},{advisers[2].pk}
 {non_one_list_companies[1].pk},00000000-0000-0000-0000-000000000000,{advisers[3].pk}
-{non_one_list_companies[2].pk},{new_classification.pk},00000000-0000-0000-0000-000000000000
+{non_one_list_companies[2].pk},{new_one_list_tier.pk},00000000-0000-0000-0000-000000000000
 """
 
     s3_stubber.add_response(
@@ -102,65 +102,65 @@ def test_run(s3_stubber, caplog, reset_unmatched):
     # assert exceptions
     assert len(caplog.records) == 5
     assert 'Company matching query does not exist' in caplog.records[0].exc_text
-    assert 'CompanyClassification matching query does not exist' in caplog.records[1].exc_text
+    assert 'OneListTier matching query does not exist' in caplog.records[1].exc_text
     assert 'Advisor matching query does not exist' in caplog.records[2].exc_text
-    assert 'CompanyClassification matching query does not exist' in caplog.records[3].exc_text
+    assert 'OneListTier matching query does not exist' in caplog.records[3].exc_text
     assert 'Advisor matching query does not exist' in caplog.records[4].exc_text
 
     # one_list_companies[0]: nothing changed
-    assert_did_not_change(one_list_companies[0], 'classification_id', 'one_list_account_owner_id')
+    assert_did_not_change(one_list_companies[0], 'one_list_tier_id', 'one_list_account_owner_id')
 
     # one_list_companies[1]: only one_list_account_owner_id changed
     assert_changed(one_list_companies[1], 'one_list_account_owner_id')
-    assert_did_not_change(one_list_companies[1], 'classification_id')
+    assert_did_not_change(one_list_companies[1], 'one_list_tier_id')
     assert one_list_companies[1].one_list_account_owner == advisers[0]
 
-    # one_list_companies[2]: only classification_id changed
+    # one_list_companies[2]: only one_list_tier_id changed
     assert_did_not_change(one_list_companies[2], 'one_list_account_owner_id')
-    assert_changed(one_list_companies[2], 'classification_id')
-    assert one_list_companies[2].classification == new_classification
+    assert_changed(one_list_companies[2], 'one_list_tier_id')
+    assert one_list_companies[2].one_list_tier == new_one_list_tier
 
     # one_list_companies[3]: all changed
-    assert_changed(one_list_companies[3], 'classification_id', 'one_list_account_owner_id')
-    assert one_list_companies[3].classification_id is None
+    assert_changed(one_list_companies[3], 'one_list_tier_id', 'one_list_account_owner_id')
+    assert one_list_companies[3].one_list_tier_id is None
     assert one_list_companies[3].one_list_account_owner_id is None
 
     # one_list_companies[4]: nothing changed
-    assert_did_not_change(one_list_companies[4], 'classification_id', 'one_list_account_owner_id')
+    assert_did_not_change(one_list_companies[4], 'one_list_tier_id', 'one_list_account_owner_id')
 
     # one_list_companies[5]: nothing changed
-    assert_did_not_change(one_list_companies[5], 'classification_id', 'one_list_account_owner_id')
+    assert_did_not_change(one_list_companies[5], 'one_list_tier_id', 'one_list_account_owner_id')
 
     # non_one_list_companies[0]: all changed
-    assert_changed(non_one_list_companies[0], 'classification_id', 'one_list_account_owner_id')
+    assert_changed(non_one_list_companies[0], 'one_list_tier_id', 'one_list_account_owner_id')
     assert non_one_list_companies[0].one_list_account_owner == advisers[2]
-    assert non_one_list_companies[0].classification == new_classification
+    assert non_one_list_companies[0].one_list_tier == new_one_list_tier
 
     # non_one_list_companies[1]: nothing changed
     assert_did_not_change(
-        non_one_list_companies[1], 'classification_id', 'one_list_account_owner_id',
+        non_one_list_companies[1], 'one_list_tier_id', 'one_list_account_owner_id',
     )
 
     # non_one_list_companies[2]: nothing changed
     assert_did_not_change(
-        non_one_list_companies[2], 'classification_id', 'one_list_account_owner_id',
+        non_one_list_companies[2], 'one_list_tier_id', 'one_list_account_owner_id',
     )
 
     # one_list_companies[6] / [7]: if reset_unmatched == False => nothing changed else all changed
     if reset_unmatched:
-        assert_changed(one_list_companies[6], 'classification_id', 'one_list_account_owner_id')
-        assert_changed(one_list_companies[7], 'classification_id', 'one_list_account_owner_id')
-        assert one_list_companies[6].classification is None
+        assert_changed(one_list_companies[6], 'one_list_tier_id', 'one_list_account_owner_id')
+        assert_changed(one_list_companies[7], 'one_list_tier_id', 'one_list_account_owner_id')
+        assert one_list_companies[6].one_list_tier is None
         assert one_list_companies[6].one_list_account_owner is None
 
-        assert one_list_companies[7].classification is None
+        assert one_list_companies[7].one_list_tier is None
         assert one_list_companies[7].one_list_account_owner is None
     else:
         assert_did_not_change(
-            one_list_companies[6], 'classification_id', 'one_list_account_owner_id',
+            one_list_companies[6], 'one_list_tier_id', 'one_list_account_owner_id',
         )
         assert_did_not_change(
-            one_list_companies[7], 'classification_id', 'one_list_account_owner_id',
+            one_list_companies[7], 'one_list_tier_id', 'one_list_account_owner_id',
         )
 
 
@@ -169,40 +169,40 @@ def test_simulate(s3_stubber, caplog, reset_unmatched):
     """Test that the command simulates updates if --simulate is passed in."""
     caplog.set_level('ERROR')
 
-    new_classification = random_obj_for_model(CompanyClassification)
+    new_one_list_tier = random_obj_for_model(OneListTier)
     one_list_companies = CompanyFactory.create_batch(
         8,
-        classification=factory.LazyFunction(
+        one_list_tier=factory.LazyFunction(
             lambda: random_obj_for_queryset(
-                CompanyClassification.objects.exclude(pk=new_classification.pk),
+                OneListTier.objects.exclude(pk=new_one_list_tier.pk),
             ),
         ),
         one_list_account_owner=factory.SubFactory(AdviserFactory),
     )
     non_one_list_companies = CompanyFactory.create_batch(
         3,
-        classification=None,
+        one_list_tier=None,
         one_list_account_owner=None,
     )
 
     for company in chain(one_list_companies, non_one_list_companies):
-        save_prev_fields(company, 'classification_id', 'one_list_account_owner_id')
+        save_prev_fields(company, 'one_list_tier_id', 'one_list_account_owner_id')
 
     advisers = AdviserFactory.create_batch(4)
 
     bucket = 'test_bucket'
     object_key = 'test_key'
-    csv_content = f"""id,classification_id,one_list_account_owner_id
+    csv_content = f"""id,one_list_tier_id,one_list_account_owner_id
 00000000-0000-0000-0000-000000000000,test,test
-{one_list_companies[0].pk},{one_list_companies[0].classification_id},{one_list_companies[0].one_list_account_owner_id}
-{one_list_companies[1].pk},{one_list_companies[1].classification_id},{advisers[0].pk}
-{one_list_companies[2].pk},{new_classification.pk},{one_list_companies[2].one_list_account_owner_id}
+{one_list_companies[0].pk},{one_list_companies[0].one_list_tier_id},{one_list_companies[0].one_list_account_owner_id}
+{one_list_companies[1].pk},{one_list_companies[1].one_list_tier_id},{advisers[0].pk}
+{one_list_companies[2].pk},{new_one_list_tier.pk},{one_list_companies[2].one_list_account_owner_id}
 {one_list_companies[3].pk},null,null
 {one_list_companies[4].pk},00000000-0000-0000-0000-000000000000,{advisers[1].pk}
-{one_list_companies[5].pk},{new_classification.pk},00000000-0000-0000-0000-000000000000
-{non_one_list_companies[0].pk},{new_classification.pk},{advisers[2].pk}
+{one_list_companies[5].pk},{new_one_list_tier.pk},00000000-0000-0000-0000-000000000000
+{non_one_list_companies[0].pk},{new_one_list_tier.pk},{advisers[2].pk}
 {non_one_list_companies[1].pk},00000000-0000-0000-0000-000000000000,{advisers[3].pk}
-{non_one_list_companies[2].pk},{new_classification.pk},00000000-0000-0000-0000-000000000000
+{non_one_list_companies[2].pk},{new_one_list_tier.pk},00000000-0000-0000-0000-000000000000
 """
 
     s3_stubber.add_response(
@@ -228,30 +228,30 @@ def test_simulate(s3_stubber, caplog, reset_unmatched):
     # assert exceptions
     assert len(caplog.records) == 5
     assert 'Company matching query does not exist' in caplog.records[0].exc_text
-    assert 'CompanyClassification matching query does not exist' in caplog.records[1].exc_text
+    assert 'OneListTier matching query does not exist' in caplog.records[1].exc_text
     assert 'Advisor matching query does not exist' in caplog.records[2].exc_text
-    assert 'CompanyClassification matching query does not exist' in caplog.records[3].exc_text
+    assert 'OneListTier matching query does not exist' in caplog.records[3].exc_text
     assert 'Advisor matching query does not exist' in caplog.records[4].exc_text
 
     # assert that nothing really changed
     for company in chain(one_list_companies, non_one_list_companies):
-        assert_did_not_change(company, 'classification_id', 'one_list_account_owner_id')
+        assert_did_not_change(company, 'one_list_tier_id', 'one_list_account_owner_id')
 
 
 def test_audit_log(s3_stubber, caplog):
     """Test that reversion revisions are created."""
-    classifications = CompanyClassification.objects.order_by('?')[:2]
+    one_list_tiers = OneListTier.objects.order_by('?')[:2]
     company_without_change, company_with_change = CompanyFactory.create_batch(
         2,
-        classification=classifications[0],
+        one_list_tier=one_list_tiers[0],
         one_list_account_owner=AdviserFactory(),
     )
 
     bucket = 'test_bucket'
     object_key = 'test_key'
-    csv_content = f"""id,classification_id,one_list_account_owner_id
-{company_without_change.pk},{company_without_change.classification_id},{company_without_change.one_list_account_owner_id}
-{company_with_change.pk},{classifications[1].pk},{AdviserFactory().pk}
+    csv_content = f"""id,one_list_tier_id,one_list_account_owner_id
+{company_without_change.pk},{company_without_change.one_list_tier_id},{company_without_change.one_list_account_owner_id}
+{company_with_change.pk},{one_list_tiers[1].pk},{AdviserFactory().pk}
 """
 
     s3_stubber.add_response(
@@ -275,4 +275,4 @@ def test_audit_log(s3_stubber, caplog):
     versions = Version.objects.get_for_object(company_with_change)
     assert versions.count() == 1
     comment = versions[0].revision.get_comment()
-    assert comment == 'Classification and One List account owner correction.'
+    assert comment == 'One List tier and One List account owner correction.'

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -16,7 +16,6 @@ class CompanySearchApp(SearchApp):
     queryset = DBCompany.objects.select_related(
         'archived_by',
         'business_type',
-        'classification',
         'employee_range',
         'export_experience_category',
         'headquarter_type',

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -994,7 +994,7 @@ class TestInvestmentProjectExportView(APITestMixin):
             name='project for subsidiary',
             investor_company=CompanyFactory(
                 global_headquarters=CompanyFactory(
-                    classification_id=OneListTier.objects.first().id,
+                    one_list_tier_id=OneListTier.objects.first().id,
                     one_list_account_owner=AdviserFactory(),
                 ),
             ),


### PR DESCRIPTION
### Description of change

This changes the codebase so that the `one_list_tier` company field is used instead of the classification one which will be removed soon.
This also deprecates the table `metadata_companyclassification`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
