### PR TITLE
Add ability to clean up old investment projects

### DIFF
--- a/changelog/investment/delete_old_records.feature
+++ b/changelog/investment/delete_old_records.feature
@@ -1,0 +1,1 @@
+Investment projects that have not been updated in the last ten years can now be deleted using the `delete_old_records` management command.

--- a/datahub/cleanup/management/commands/delete_old_records.py
+++ b/datahub/cleanup/management/commands/delete_old_records.py
@@ -5,10 +5,13 @@ from django.utils.timezone import utc
 
 from datahub.cleanup.cleanup_config import DatetimeLessThanCleanupFilter, ModelCleanupConfig
 from datahub.cleanup.management.commands._base_command import BaseCleanupCommand
+from datahub.investment.models import InvestmentProject
 from datahub.omis.order.models import Order
 
 
 INTERACTION_EXPIRY_PERIOD = relativedelta(years=10)
+INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF = datetime(2013, 11, 23, tzinfo=utc)  # 2013-11-22 + 1 day
+INVESTMENT_PROJECT_EXPIRY_PERIOD = relativedelta(years=10)
 ORDER_MODIFIED_ON_CUT_OFF = datetime(2014, 7, 12, tzinfo=utc)  # 2014-07-11 + 1 day
 ORDER_EXPIRY_PERIOD = relativedelta(years=7)
 
@@ -33,6 +36,59 @@ class Command(BaseCleanupCommand):
         'interaction.Interaction': ModelCleanupConfig(
             (
                 DatetimeLessThanCleanupFilter('date', INTERACTION_EXPIRY_PERIOD),
+            ),
+        ),
+        # There are no investment projects in the live system with a modified-on date
+        # before 2013-11-22, because of a bulk event in the legacy system (this was
+        # probably when data was imported into that system from another legacy system).
+        #
+        # Hence, we check various other fields in addition to just modified_on as modified_on is
+        # not reliable before INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF.
+        'investment.InvestmentProject': ModelCleanupConfig(
+            (
+                DatetimeLessThanCleanupFilter(
+                    'modified_on',
+                    INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF,
+                ),
+                DatetimeLessThanCleanupFilter('created_on', INVESTMENT_PROJECT_EXPIRY_PERIOD),
+                DatetimeLessThanCleanupFilter(
+                    'actual_land_date',
+                    INVESTMENT_PROJECT_EXPIRY_PERIOD,
+                    include_null=True,
+                ),
+                DatetimeLessThanCleanupFilter(
+                    'date_abandoned',
+                    INVESTMENT_PROJECT_EXPIRY_PERIOD,
+                    include_null=True,
+                ),
+                DatetimeLessThanCleanupFilter(
+                    'date_lost',
+                    INVESTMENT_PROJECT_EXPIRY_PERIOD,
+                    include_null=True,
+                ),
+            ),
+            relation_filter_mapping={
+                InvestmentProject._meta.get_field('evidence_documents'): (
+                    DatetimeLessThanCleanupFilter('modified_on', INVESTMENT_PROJECT_EXPIRY_PERIOD),
+                ),
+                InvestmentProject._meta.get_field('proposition'): (
+                    DatetimeLessThanCleanupFilter('modified_on', INVESTMENT_PROJECT_EXPIRY_PERIOD),
+                ),
+                # We simply don't delete any records that have any interactions or are
+                # referred to by another project.
+                # (Instead, we wait for the referencing objects to expire themselves.)
+                InvestmentProject._meta.get_field('interactions'): (),
+                # The related_name for this field is '+', so we reference the field indirectly
+                InvestmentProject._meta.get_field(
+                    'associated_non_fdi_r_and_d_project',
+                ).remote_field: (),
+            },
+            # These relations do not have any datetime fields to check – we just want them to be
+            # deleted along with expired records.
+            excluded_relations=(
+                InvestmentProject._meta.get_field('team_members'),
+                InvestmentProject._meta.get_field('stage_log'),
+                InvestmentProject._meta.get_field('investmentprojectcode'),
             ),
         ),
         # There are no orders in the live system with a modified-on date before

--- a/datahub/cleanup/management/commands/delete_old_records.py
+++ b/datahub/cleanup/management/commands/delete_old_records.py
@@ -22,6 +22,13 @@ class Command(BaseCleanupCommand):
         'argument.'
     )
 
+    # For each configuration, the combination of excluded_relations and the keys of
+    # relation_filter_mapping should cover all related fields for the model (as
+    # returned by get_related_fields()). This is to make sure that no relation is
+    # missed, and there is a test that checks that all relations are covered.
+    #
+    # If a field should not be excluded, but should not be filtered, it should be added
+    # to relation_filter_mapping with an empty list of filters.
     CONFIGS = {
         'interaction.Interaction': ModelCleanupConfig(
             (

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -13,13 +13,21 @@ from freezegun import freeze_time
 from datahub.cleanup.management.commands import delete_old_records
 from datahub.cleanup.management.commands.delete_old_records import (
     INTERACTION_EXPIRY_PERIOD,
+    INVESTMENT_PROJECT_EXPIRY_PERIOD,
+    INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF,
     ORDER_EXPIRY_PERIOD,
     ORDER_MODIFIED_ON_CUT_OFF,
 )
 from datahub.cleanup.query_utils import get_relations_to_delete
 from datahub.core.exceptions import DataHubException
 from datahub.core.model_helpers import get_related_fields
-from datahub.interaction.test.factories import CompanyInteractionFactory
+from datahub.interaction.test.factories import (
+    CompanyInteractionFactory,
+    InvestmentProjectInteractionFactory,
+)
+from datahub.investment.evidence.test.factories import EvidenceDocumentFactory
+from datahub.investment.proposition.test.factories import PropositionFactory
+from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.omis.order.test.factories import OrderFactory
 from datahub.omis.payment.test.factories import (
     ApprovedRefundFactory,
@@ -33,6 +41,7 @@ FROZEN_TIME = datetime(2018, 6, 1, 2, tzinfo=utc)
 
 
 INTERACTION_DELETE_BEFORE_DATETIME = FROZEN_TIME - INTERACTION_EXPIRY_PERIOD
+INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME = FROZEN_TIME - INVESTMENT_PROJECT_EXPIRY_PERIOD
 ORDER_DELETE_BEFORE_DATETIME = FROZEN_TIME - ORDER_EXPIRY_PERIOD
 
 
@@ -40,15 +49,148 @@ MAPPING = {
     'interaction.Interaction': {
         'factory': CompanyInteractionFactory,
         'implicitly_deletable_models': set(),
-        'expired_object_kwargs': {
-            'date': INTERACTION_DELETE_BEFORE_DATETIME - relativedelta(days=1),
-        },
+        'expired_objects_kwargs': [
+            {
+                'date': INTERACTION_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+            },
+        ],
         'unexpired_objects_kwargs': [
             {
                 'date': INTERACTION_DELETE_BEFORE_DATETIME,
             },
         ],
         'relations': [],
+    },
+    'investment.InvestmentProject': {
+        'factory': InvestmentProjectFactory,
+        'implicitly_deletable_models': {
+            'evidence.EvidenceDocument',
+            'investment.InvestmentProjectCode',
+            'investment.InvestmentProjectStageLog',
+            'investment.InvestmentProjectTeamMember',
+            'investment.InvestmentProject_business_activities',
+            'investment.InvestmentProject_client_contacts',
+            'proposition.Proposition',
+        },
+        'expired_objects_kwargs': [
+            {
+                'created_on': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'actual_land_date': None,
+                'date_abandoned': None,
+                'date_lost': None,
+            },
+            {
+                'created_on': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'actual_land_date':
+                    INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'date_abandoned': None,
+                'date_lost': None,
+            },
+            {
+                'created_on': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'actual_land_date': None,
+                'date_abandoned':
+                    INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'date_lost': None,
+            },
+            {
+                'created_on': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'actual_land_date': None,
+                'date_abandoned': None,
+                'date_lost': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+            },
+        ],
+        'unexpired_objects_kwargs': [
+            {
+                'created_on': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF,
+                'actual_land_date': None,
+                'date_abandoned': None,
+                'date_lost': None,
+            },
+            {
+                'created_on': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME,
+                'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'actual_land_date': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME,
+                'date_abandoned': None,
+                'date_lost': None,
+            },
+            {
+                'created_on': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'actual_land_date': None,
+                'date_abandoned': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME,
+                'date_lost': None,
+            },
+            {
+                'created_on': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'actual_land_date': None,
+                'date_abandoned': None,
+                'date_lost': INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME,
+            },
+        ],
+        'relations': [
+            {
+                'factory': PropositionFactory,
+                'field': 'investment_project',
+                'expired_objects_kwargs': [
+                    {
+                        'modified_on':
+                            INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                    },
+                ],
+                'unexpired_objects_kwargs': [
+                    {
+                        'modified_on':
+                            INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME,
+                    },
+                ],
+            },
+            {
+                'factory': EvidenceDocumentFactory,
+                'field': 'investment_project',
+                'expired_objects_kwargs': [
+                    {
+                        'modified_on':
+                            INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                    },
+                ],
+                'unexpired_objects_kwargs': [
+                    {
+                        'modified_on':
+                            INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME,
+                    },
+                ],
+            },
+            {
+                'factory': InvestmentProjectFactory,
+                'field': 'associated_non_fdi_r_and_d_project',
+                'expired_objects_kwargs': [],
+                'unexpired_objects_kwargs': [
+                    {
+                        'created_on':
+                            INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                        'modified_on': INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF,
+                    },
+                ],
+            },
+            {
+                'factory': InvestmentProjectInteractionFactory,
+                'field': 'investment_project',
+                'expired_objects_kwargs': [],
+                'unexpired_objects_kwargs': [
+                    {
+                        'modified_on':
+                            INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                    },
+                ],
+            },
+        ],
     },
     'order.Order': {
         'factory': OrderFactory,
@@ -60,10 +202,12 @@ MAPPING = {
             'omis-payment.Refund',
             'omis-payment.PaymentGatewaySession',
         },
-        'expired_object_kwargs': {
-            'created_on': ORDER_DELETE_BEFORE_DATETIME - relativedelta(days=1),
-            'modified_on': ORDER_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
-        },
+        'expired_objects_kwargs': [
+            {
+                'created_on': ORDER_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': ORDER_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+            },
+        ],
         'unexpired_objects_kwargs': [
             {
                 'created_on': ORDER_DELETE_BEFORE_DATETIME - relativedelta(days=1),
@@ -219,12 +363,14 @@ def test_configs(model_label, config):
 def _generate_run_args():
     """Flattens MAPPING so it can be used to parametrise the test_run() test."""
     for model_label, mapping in MAPPING.items():
-        expired_object_kwargs = mapping['expired_object_kwargs']
 
-        yield model_label, expired_object_kwargs, None, None, True
+        for kwargs in mapping['expired_objects_kwargs']:
+            yield model_label, kwargs, None, None, True
 
         for kwargs in mapping['unexpired_objects_kwargs']:
             yield model_label, kwargs, None, None, False
+
+        expired_object_kwargs = mapping['expired_objects_kwargs'][0]
 
         for relation_mapping in mapping['relations']:
             for relation_kwargs in relation_mapping['expired_objects_kwargs']:
@@ -322,7 +468,7 @@ def test_simulate(model_name, config, track_return_values, setup_es):
     model_factory = mapping['factory']
 
     for _ in range(3):
-        _create_model_obj(model_factory, **mapping['expired_object_kwargs'])
+        _create_model_obj(model_factory, **mapping['expired_objects_kwargs'][0])
 
     setup_es.indices.refresh()
 
@@ -372,7 +518,7 @@ def test_only_print_queries(model_name, config, monkeypatch, caplog):
     model_factory = mapping['factory']
 
     for _ in range(3):
-        _create_model_obj(model_factory, **mapping['expired_object_kwargs'])
+        _create_model_obj(model_factory, **mapping['expired_objects_kwargs'][0])
 
     management.call_command(command, model_name, only_print_queries=True)
 
@@ -406,7 +552,7 @@ def test_with_es_exception(mocked_bulk):
     mapping = MAPPING[model_name]
     model_factory = MAPPING[model_name]['factory']
 
-    _create_model_obj(model_factory, **mapping['expired_object_kwargs'])
+    _create_model_obj(model_factory, **mapping['expired_objects_kwargs'][0])
 
     with pytest.raises(DataHubException):
         management.call_command(command, model_name)

--- a/datahub/investment/evidence/test/factories.py
+++ b/datahub/investment/evidence/test/factories.py
@@ -2,7 +2,8 @@ import uuid
 
 import factory
 
-from datahub.investment.evidence.models import EvidenceTag
+from datahub.investment.evidence.models import EvidenceDocument, EvidenceTag
+from datahub.investment.test.factories import InvestmentProjectFactory
 
 
 class EvidenceTagFactory(factory.django.DjangoModelFactory):
@@ -13,3 +14,14 @@ class EvidenceTagFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = EvidenceTag
+
+
+class EvidenceDocumentFactory(factory.django.DjangoModelFactory):
+    """Evidence document factory."""
+
+    original_filename = factory.Faker('file_name')
+    investment_project = factory.SubFactory(InvestmentProjectFactory)
+    comment = factory.Faker('paragraph', nb_sentences=3)
+
+    class Meta:
+        model = EvidenceDocument


### PR DESCRIPTION
### Description of change

This adds support for investment projects to the delete_old_records management command.

Because we don't have any modified-on data for investment projects prior to November 2013, this uses various other date fields to make an inference about when the order was last modified prior to that date.

The criteria for deletion are:
- not modified since 23 November 2013
- created more than ten years ago
- if it has an actual land date, this is more than ten years ago
- if it has a date that the project was lost, this is more than ten years ago
- if it has a date that the project was abandoned, this is more than ten years ago
- no propositions modified in the last ten years
- no evidence documents modified in the last ten years
- no interactions
- not referenced by another project (as an associated non-FDI R&D project)

This also adds a test to make that that `ModelCleanupConfig`s for `delete_old_records` cover all relations (to make sure nothing gets missed, especially when new related models are created).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
