### PR TITLE
Add ability to clean up old contacts

### DIFF
--- a/changelog/contact/delete_old_records.feature
+++ b/changelog/contact/delete_old_records.feature
@@ -1,0 +1,1 @@
+Contacts that have not been updated in the last ten years can now be deleted using the `delete_old_records` management command.

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -326,7 +326,7 @@ def test_mappings(model_label, config):
             for relation in mapping['relations']
         }
         assert related_models_in_config == related_models_in_mapping, (
-            'Missing test cases for relation filters for model  {model_label} detected'
+            f'Missing test cases for relation filters for model {model_label} detected'
         )
 
 

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -12,6 +12,9 @@ from freezegun import freeze_time
 
 from datahub.cleanup.management.commands import delete_old_records
 from datahub.cleanup.management.commands.delete_old_records import (
+    ARCHIVED_CONTACT_EXPIRY_PERIOD,
+    CONTACT_EXPIRY_PERIOD,
+    CONTACT_MODIFIED_ON_CUT_OFF,
     INTERACTION_EXPIRY_PERIOD,
     INVESTMENT_PROJECT_EXPIRY_PERIOD,
     INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF,
@@ -19,6 +22,7 @@ from datahub.cleanup.management.commands.delete_old_records import (
     ORDER_MODIFIED_ON_CUT_OFF,
 )
 from datahub.cleanup.query_utils import get_relations_to_delete
+from datahub.company.test.factories import ContactFactory
 from datahub.core.exceptions import DataHubException
 from datahub.core.model_helpers import get_related_fields
 from datahub.interaction.test.factories import (
@@ -34,18 +38,100 @@ from datahub.omis.payment.test.factories import (
     PaymentFactory,
     PaymentGatewaySessionFactory,
 )
+from datahub.omis.quote.test.factories import QuoteFactory
 from datahub.search.apps import get_search_app_by_model
 
 
 FROZEN_TIME = datetime(2018, 6, 1, 2, tzinfo=utc)
 
 
+CONTACT_DELETE_BEFORE_DATETIME = FROZEN_TIME - CONTACT_EXPIRY_PERIOD
+CONTACT_ARCHIVED_ON_DELETE_BEFORE_DATETIME = FROZEN_TIME - ARCHIVED_CONTACT_EXPIRY_PERIOD
 INTERACTION_DELETE_BEFORE_DATETIME = FROZEN_TIME - INTERACTION_EXPIRY_PERIOD
 INVESTMENT_PROJECT_DELETE_BEFORE_DATETIME = FROZEN_TIME - INVESTMENT_PROJECT_EXPIRY_PERIOD
 ORDER_DELETE_BEFORE_DATETIME = FROZEN_TIME - ORDER_EXPIRY_PERIOD
 
 
 MAPPING = {
+    'company.Contact': {
+        'factory': ContactFactory,
+        'implicitly_deletable_models': set(),
+        'expired_objects_kwargs': [
+            {
+                'created_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': CONTACT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'archived_on': None,
+            },
+            {
+                'created_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': CONTACT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'archived_on': CONTACT_ARCHIVED_ON_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+            },
+        ],
+        'unexpired_objects_kwargs': [
+            {
+                'created_on': CONTACT_DELETE_BEFORE_DATETIME,
+                'modified_on': CONTACT_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                'archived_on': None,
+            },
+            {
+                'created_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                'modified_on': CONTACT_MODIFIED_ON_CUT_OFF,
+                'archived_on': None,
+            },
+            {
+                'created_on': CONTACT_DELETE_BEFORE_DATETIME,
+                'modified_on': CONTACT_MODIFIED_ON_CUT_OFF,
+                'archived_on': CONTACT_ARCHIVED_ON_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+            },
+        ],
+        'relations': [
+            {
+                'factory': CompanyInteractionFactory,
+                'field': 'contact',
+                'expired_objects_kwargs': [],
+                'unexpired_objects_kwargs': [
+                    {
+                        'created_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                        'modified_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                    },
+                ],
+            },
+            {
+                'factory': InvestmentProjectFactory,
+                'field': 'client_contacts',
+                'expired_objects_kwargs': [],
+                'unexpired_objects_kwargs': [
+                    {
+                        'created_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                        'modified_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                    },
+                ],
+            },
+            {
+                'factory': OrderFactory,
+                'field': 'contact',
+                'expired_objects_kwargs': [],
+                'unexpired_objects_kwargs': [
+                    {
+                        'created_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                        'modified_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                    },
+                ],
+            },
+            {
+                'factory': QuoteFactory,
+                'field': 'accepted_by',
+                'expired_objects_kwargs': [],
+                'unexpired_objects_kwargs': [
+                    {
+                        'created_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                        'modified_on': CONTACT_DELETE_BEFORE_DATETIME - relativedelta(days=1),
+                    },
+                ],
+            },
+        ],
+    },
     'interaction.Interaction': {
         'factory': CompanyInteractionFactory,
         'implicitly_deletable_models': set(),
@@ -407,10 +493,14 @@ def test_run(
     total_model_records = 1
 
     if relation_mapping:
+        relation_model = relation_mapping['factory']._meta.get_model_class()
+        relation_field = relation_model._meta.get_field(relation_mapping['field'])
+        relation_factory_arg = [obj] if relation_field.many_to_many else obj
+
         _create_model_obj(
             relation_mapping['factory'],
             **relation_factory_kwargs,
-            **{relation_mapping['field']: obj},
+            **{relation_mapping['field']: relation_factory_arg},
         )
         if relation_mapping['factory']._meta.get_model_class() is model:
             total_model_records += 1


### PR DESCRIPTION
### Description of change

This adds support for contacts to the delete_old_records management command.

The criteria for deletion are:
- not modified since 22 July 2014
- created more than ten years ago
- if it has an archiving date, this is more than eight years ago
- no interactions, investment projects, OMIS orders or OMIS quotes (we wait for those to expire first where they exist)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
