### PR TITLE
Add ability to clean up old companies and contacts

### DIFF
--- a/changelog/company/delete_old_records.feature
+++ b/changelog/company/delete_old_records.feature
@@ -1,0 +1,1 @@
+Companies that have not been updated in the last ten years can now be deleted using the ``delete_old_records`` management command.

--- a/changelog/contact/delete_old_records.feature
+++ b/changelog/contact/delete_old_records.feature
@@ -1,0 +1,1 @@
+Contacts that have not been updated in the last ten years can now be deleted using the ``delete_old_records`` management command.

--- a/datahub/cleanup/management/commands/delete_old_records.py
+++ b/datahub/cleanup/management/commands/delete_old_records.py
@@ -5,11 +5,13 @@ from django.utils.timezone import utc
 
 from datahub.cleanup.cleanup_config import DatetimeLessThanCleanupFilter, ModelCleanupConfig
 from datahub.cleanup.management.commands._base_command import BaseCleanupCommand
-from datahub.company.models import Contact
+from datahub.company.models import Company, Contact
 from datahub.investment.models import InvestmentProject
 from datahub.omis.order.models import Order
 from datahub.omis.quote.models import Quote
 
+COMPANY_MODIFIED_ON_CUT_OFF = datetime(2013, 8, 19, tzinfo=utc)  # 2013-08-18 + 1 day
+COMPANY_EXPIRY_PERIOD = relativedelta(years=10)
 CONTACT_MODIFIED_ON_CUT_OFF = datetime(2014, 7, 22, tzinfo=utc)  # 2014-07-21 + 1 day
 CONTACT_EXPIRY_PERIOD = relativedelta(years=10)
 INTERACTION_EXPIRY_PERIOD = relativedelta(years=10)
@@ -36,6 +38,29 @@ class Command(BaseCleanupCommand):
     # If a field should not be excluded, but should not be filtered, it should be added
     # to relation_filter_mapping with an empty list of filters.
     CONFIGS = {
+        # There were multiple large bulk updates of contacts in the legacy system on and just
+        # before 2013-08-18, and so modified-on dates are not reliable prior to
+        # COMPANY_MODIFIED_ON_CUT_OFF.
+        'company.Company': ModelCleanupConfig(
+            (
+                DatetimeLessThanCleanupFilter('created_on', COMPANY_EXPIRY_PERIOD),
+                DatetimeLessThanCleanupFilter('modified_on', COMPANY_MODIFIED_ON_CUT_OFF),
+            ),
+            relation_filter_mapping={
+                # Companies are not deleted if they have any related records via these relations.
+                # Apart from for one_list_core_team_members, we wait for related records to expire
+                # before we delete the relevant companies
+                Company._meta.get_field('contacts'): (),
+                Company._meta.get_field('interactions'): (),
+                Company._meta.get_field('intermediate_investment_projects'): (),
+                Company._meta.get_field('investee_projects'): (),
+                Company._meta.get_field('investor_investment_projects'): (),
+                Company._meta.get_field('one_list_core_team_members'): (),
+                Company._meta.get_field('orders'): (),
+                Company._meta.get_field('subsidiaries'): (),
+                Company._meta.get_field('transferred_from'): (),
+            },
+        ),
         # There were multiple large bulk updates of contacts in the legacy system on and just
         # before 2014-07-21, and so modified-on dates are not reliable prior to
         # CONTACT_MODIFIED_ON_CUT_OFF.

--- a/datahub/cleanup/management/commands/delete_old_records.py
+++ b/datahub/cleanup/management/commands/delete_old_records.py
@@ -5,10 +5,13 @@ from django.utils.timezone import utc
 
 from datahub.cleanup.cleanup_config import DatetimeLessThanCleanupFilter, ModelCleanupConfig
 from datahub.cleanup.management.commands._base_command import BaseCleanupCommand
+from datahub.company.models import Contact
 from datahub.investment.models import InvestmentProject
 from datahub.omis.order.models import Order
+from datahub.omis.quote.models import Quote
 
-
+CONTACT_MODIFIED_ON_CUT_OFF = datetime(2014, 7, 22, tzinfo=utc)  # 2014-07-21 + 1 day
+CONTACT_EXPIRY_PERIOD = relativedelta(years=10)
 INTERACTION_EXPIRY_PERIOD = relativedelta(years=10)
 INVESTMENT_PROJECT_MODIFIED_ON_CUT_OFF = datetime(2013, 11, 23, tzinfo=utc)  # 2013-11-22 + 1 day
 INVESTMENT_PROJECT_EXPIRY_PERIOD = relativedelta(years=10)
@@ -33,6 +36,24 @@ class Command(BaseCleanupCommand):
     # If a field should not be excluded, but should not be filtered, it should be added
     # to relation_filter_mapping with an empty list of filters.
     CONFIGS = {
+        # There were multiple large bulk updates of contacts in the legacy system on and just
+        # before 2014-07-21, and so modified-on dates are not reliable prior to
+        # CONTACT_MODIFIED_ON_CUT_OFF.
+        'company.Contact': ModelCleanupConfig(
+            (
+                DatetimeLessThanCleanupFilter('created_on', CONTACT_EXPIRY_PERIOD),
+                DatetimeLessThanCleanupFilter('modified_on', CONTACT_MODIFIED_ON_CUT_OFF),
+            ),
+            relation_filter_mapping={
+                # Contacts are not deleted if they have any related interactions, investment
+                # projects, OMIS orders or OMIS quotes. We wait for those records to expire
+                # before we delete the related contacts.
+                Contact._meta.get_field('interactions'): (),
+                Contact._meta.get_field('investment_projects'): (),
+                Contact._meta.get_field('orders'): (),
+                Quote._meta.get_field('accepted_by').remote_field: (),
+            },
+        ),
         'interaction.Interaction': ModelCleanupConfig(
             (
                 DatetimeLessThanCleanupFilter('date', INTERACTION_EXPIRY_PERIOD),

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -326,7 +326,7 @@ def test_mappings(model_label, config):
             for relation in mapping['relations']
         }
         assert related_models_in_config == related_models_in_mapping, (
-            'Missing test cases for relation filters for model  {model_label} detected'
+            f'Missing test cases for relation filters for model {model_label} detected'
         )
 
 

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -417,10 +417,14 @@ def test_configs(model_label, config):
         - (config.relation_filter_mapping or {}).keys()
         - set(config.excluded_relations)
     )
-    fields_for_error_message = [_format_field(field) for field in field_missing_from_config]
+    fields_for_error_message = '\n'.join(
+        (_format_field(field) for field in field_missing_from_config),
+    )
     assert not field_missing_from_config, (
-        f'The following related fields are missing from the config for {model_label}: '
-        f'{fields_for_error_message}. Please add them to the ModelCleanupConfig in either '
+        f'The following related fields are missing from the config for {model_label}:\n'
+        f'{fields_for_error_message}.\n'
+        f'\n'
+        f' Please add them to the ModelCleanupConfig in either '
         f'relation_filter_mapping or excluded_relations.\n'
         f'\n'
         f'Only add the model to excluded_relations if its existence should not affect '


### PR DESCRIPTION
### Description of change

This adds support for companies and contacts to the delete_old_records management command.

The criteria for deleting companies are:
- not modified since 19 August 2013
- created more than ten years ago
- ~if it has an archiving date, this is more than eight years ago~
- no related records (we wait for those to expire first where they exist)

The criteria for deleting contacts are:
- not modified since 22 July 2014
- created more than ten years ago
- ~if it has an archiving date, this is more than eight years ago~
- no interactions, investment projects, OMIS orders or OMIS quotes (we wait for those to expire first where they exist)

This replaces https://github.com/uktrade/data-hub-leeloo/pull/1276

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
