### PR TITLE
Make notes optional for standard interactions and for service deliveries

### DIFF
--- a/changelog/interaction/notes-optional.api
+++ b/changelog/interaction/notes-optional.api
@@ -1,0 +1,1 @@
+``GET,POST /v3/interaction``, ``GET,PATCH /v3/interaction/<id>``: The notes field can now be left blank (as an empty string) for standard interactions and for service deliveries.

--- a/changelog/interaction/notes-optional.feature
+++ b/changelog/interaction/notes-optional.feature
@@ -1,0 +1,1 @@
+The notes field is now optional for standard interactions and for service deliveries.

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -216,7 +216,7 @@ class InteractionSerializer(serializers.ModelSerializer):
                 ValidationRule(
                     'required',
                     OperatorRule('notes', is_not_blank),
-                    when=OperatorRule('is_event', not_),
+                    when=EqualsRule('kind', Interaction.KINDS.policy_feedback),
                 ),
             ),
         ]

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -198,7 +198,6 @@ class TestAddInteraction(APITestMixin):
                     'dit_team': Team.healthcare_uk.value.id,
                 },
                 {
-                    'notes': ['This field is required.'],
                     'communication_channel': ['This field is required.'],
                 },
             ),

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -164,7 +164,6 @@ class TestAddServiceDelivery(APITestMixin):
                 },
                 {
                     'is_event': ['This field is required.'],
-                    'notes': ['This field is required.'],
                 },
             ),
 


### PR DESCRIPTION
### Description of change

This makes the notes field optional for interactions with kind `interaction` and `service_delivery`.
I have left it required for policy feedback interactions (for now) to avoid complicating any future migration of policy feedback data (following planned changes to the policy feedback functionality).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
