### PR TITLE
Make some Company API fields read-only if duns_number set

### DIFF
--- a/changelog/company/dnb_readonly_fields.api
+++ b/changelog/company/dnb_readonly_fields.api
@@ -1,0 +1,23 @@
+``PATCH /v3/company/<uuid:pk>``: the following fields are now read-only if the company has a non-blank ``duns_number`` field:
+    - name
+    - trading_name
+    - company_number
+    - vat_number
+    - registered_address_1
+    - registered_address_2
+    - registered_address_town
+    - registered_address_county
+    - registered_address_postcode
+    - registered_address_country
+    - website
+    - trading_address_1
+    - trading_address_2
+    - trading_address_town
+    - trading_address_county
+    - trading_address_postcode
+    - trading_address_country
+    - business_type
+    - employee_range
+    - turnover_range
+    - headquarter_type
+    - global_headquarters

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -317,6 +317,17 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         models.URLField: RelaxedURLField,
     }
 
+    def __init__(self, *args, **kwargs):
+        """
+        Make some of the fields read_only if the instance has a duns_number set.
+        This is because those values come from an external source
+        and we don't want users to override them.
+        """
+        super().__init__(*args, **kwargs)
+        if self.instance and not isinstance(self.instance, list) and self.instance.duns_number:
+            for field in self.Meta.dnb_read_only_fields:
+                self.fields[field].read_only = True
+
     def validate(self, data):
         """Performs cross-field validation."""
         combiner = DataCombiner(self.instance, data)
@@ -454,6 +465,30 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'transfer_reason',
             'duns_number',
         )
+        dnb_read_only_fields = [
+            'name',
+            'trading_name',
+            'company_number',
+            'vat_number',
+            'registered_address_1',
+            'registered_address_2',
+            'registered_address_town',
+            'registered_address_county',
+            'registered_address_postcode',
+            'registered_address_country',
+            'website',
+            'trading_address_1',
+            'trading_address_2',
+            'trading_address_town',
+            'trading_address_county',
+            'trading_address_postcode',
+            'trading_address_country',
+            'business_type',
+            'employee_range',
+            'turnover_range',
+            'headquarter_type',
+            'global_headquarters',
+        ]
         validators = [
             RequiredUnlessAlreadyBlankValidator('sector', 'business_type'),
             RulesBasedValidator(

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -47,7 +47,6 @@ class CompanyFactory(factory.django.DjangoModelFactory):
     business_type_id = BusinessTypeConstant.private_limited_company.value.id
     sector_id = constants.Sector.aerospace_assembly_aircraft.value.id
     archived = False
-    duns_number = factory.Faker('numerify', text='#########')
     uk_region_id = constants.UKRegion.england.value.id
     export_experience_category = factory.LazyFunction(
         ExportExperienceCategory.objects.order_by('?').first,


### PR DESCRIPTION
### Description of change

This changes the Company PATCH API endpoint to make some of the fields read-only if the company instance has a `duns_number` set.

This is to avoid users overriding values coming from an external source.

The `duns_number` field can only be changed via the Django Admin at the moment.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
