### PR TITLE
Remove likelihood_of_landing from investment APIs

### DIFF
--- a/changelog/investment/likelihood_of_landing_removal.api
+++ b/changelog/investment/likelihood_of_landing_removal.api
@@ -1,0 +1,1 @@
+The field ``likelihood_of_landing`` is deprecated and has been removed from all investment projects APIs, please use ``likelihood_to_land`` instead.

--- a/datahub/investment/serializers.py
+++ b/datahub/investment/serializers.py
@@ -36,7 +36,6 @@ CORE_FIELDS = (
     'estimated_land_date',
     'actual_land_date',
     'quotable_as_public_case_study',
-    'likelihood_of_landing',
     'likelihood_to_land',
     'priority',
     'approved_commitment_to_invest',
@@ -391,7 +390,6 @@ class IProjectSerializer(PermittedFieldsModelSerializer):
             'archived_reason',
             'archived_documents_url_path',
             'comments',
-            'likelihood_of_landing',
         )
 
 

--- a/datahub/investment/test/factories.py
+++ b/datahub/investment/test/factories.py
@@ -48,7 +48,6 @@ class InvestmentProjectFactory(factory.django.DjangoModelFactory):
     investor_company = factory.SubFactory(CompanyFactory)
     client_relationship_manager = factory.SubFactory(AdviserFactory)
     referral_source_adviser = factory.SubFactory(AdviserFactory)
-    likelihood_of_landing = 90
     likelihood_to_land_id = LikelihoodToLand.high.value.id
     archived_documents_url_path = factory.Faker('uri_path')
     created_on = now()

--- a/datahub/investment/test/test_views.py
+++ b/datahub/investment/test/test_views.py
@@ -85,7 +85,6 @@ class TestListView(APITestMixin):
             'estimated_land_date',
             'actual_land_date',
             'quotable_as_public_case_study',
-            'likelihood_of_landing',
             'likelihood_to_land',
             'priority',
             'approved_commitment_to_invest',
@@ -379,7 +378,6 @@ class TestCreateView(APITestMixin):
             'anonymous_description': 'project anon description',
             'estimated_land_date': '2020-12-12',
             'quotable_as_public_case_study': True,
-            'likelihood_of_landing': 60,
             'likelihood_to_land': {
                 'id': LikelihoodToLand.medium.value.id,
             },
@@ -433,7 +431,6 @@ class TestCreateView(APITestMixin):
             response_data['quotable_as_public_case_study']
             == request_data['quotable_as_public_case_study']
         )
-        assert response_data['likelihood_of_landing'] is None
         assert (
             response_data['likelihood_to_land']['id']
             == request_data['likelihood_to_land']['id']
@@ -626,7 +623,6 @@ class TestRetrieveView(APITestMixin):
         assert response_data['name'] == project.name
         assert response_data['description'] == project.description
         assert response_data['comments'] == project.comments
-        assert response_data['likelihood_of_landing'] == project.likelihood_of_landing
         assert response_data['likelihood_to_land'] == {
             'id': str(project.likelihood_to_land.id),
             'name': project.likelihood_to_land.name,
@@ -1742,7 +1738,6 @@ class TestPartialUpdateView(APITestMixin):
             allow_blank_estimated_land_date=False,
             allow_blank_possible_uk_regions=False,
             project_manager_first_assigned_on=None,
-            likelihood_of_landing=90,
         )
 
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})
@@ -1754,7 +1749,6 @@ class TestPartialUpdateView(APITestMixin):
                 'allow_blank_estimated_land_date': True,
                 'allow_blank_possible_uk_regions': True,
                 'project_manager_first_assigned_on': now(),
-                'likelihood_of_landing': 30,
             },
         )
 
@@ -1763,7 +1757,6 @@ class TestPartialUpdateView(APITestMixin):
         assert response.data['comments'] == 'old_comment'
         assert response.data['allow_blank_estimated_land_date'] is False
         assert response.data['allow_blank_possible_uk_regions'] is False
-        assert response.data['likelihood_of_landing'] == project.likelihood_of_landing
 
         project.refresh_from_db()
         assert project.project_manager_first_assigned_on is None

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -96,7 +96,6 @@ class InvestmentProject(BaseESModel):
     investment_type = fields.nested_id_name_field()
     investor_type = fields.nested_id_name_field()
     level_of_involvement = fields.nested_id_name_field()
-    likelihood_of_landing = Long()
     likelihood_to_land = fields.id_name_field()
     project_assurance_adviser = fields.nested_contact_or_adviser_field(
         'project_assurance_adviser', include_dit_team=True,

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -84,7 +84,6 @@ def test_investment_project_to_dict(setup_es):
         'proposal_deadline',
         'project_assurance_adviser',
         'team_members',
-        'likelihood_of_landing',
         'likelihood_to_land',
         'project_arrived_in_triage_on',
         'quotable_as_public_case_study',


### PR DESCRIPTION
### Description of change
This is to remove likelihood_of_landing the now deprecated field.
This just removes it from the investment API and search a PR will follow later to remove the field from the database.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
