### PR TITLE
Delete /core-team endpoint

### DIFF
--- a/changelog/company/core_team_api_deleted.api
+++ b/changelog/company/core_team_api_deleted.api
@@ -1,0 +1,1 @@
+The endpont ``/company/<uuid:pk>/core-team`` was deleted, please use ``/company/<uuid:pk>/one-list-group-core-team`` instead.

--- a/changelog/company/core_team_api_deleted.removal
+++ b/changelog/company/core_team_api_deleted.removal
@@ -1,0 +1,1 @@
+The endpont ``/company/<uuid:pk>/core-team`` was deleted, please use ``/company/<uuid:pk>/one-list-group-core-team`` instead.

--- a/datahub/company/urls.py
+++ b/datahub/company/urls.py
@@ -91,7 +91,6 @@ company_urls = [
     path('company/<uuid:pk>/unarchive', company_unarchive, name='unarchive'),
     path('company/<uuid:pk>/audit', company_audit, name='audit-item'),
     path('company/<uuid:pk>/timeline', company_timeline, name='timeline-collection'),
-    path('company/<uuid:pk>/core-team', one_list_group_core_team, name='core-team'),
     path(
         'company/<uuid:pk>/one-list-group-core-team',
         one_list_group_core_team,


### PR DESCRIPTION
### Description of change

This deletes `/company/<uuid:pk>/core-team` which was previously replaced by `/company/<uuid:pk>/one-list-group-core-team`.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
