### PR TITLE
Route the complete_model_migration Celery task to the long-running queue

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -296,11 +296,6 @@ if REDIS_BASE_URL:
     CELERY_BROKER_TRANSPORT_OPTIONS = {
         'visibility_timeout': int(timedelta(hours=9).total_seconds())
     }
-    CELERY_TASK_ROUTES = {
-        'datahub.search.tasks.sync_model': {
-            'queue': 'long-running'
-        }
-    }
     CELERY_BEAT_SCHEDULE = {
         'refresh_pending_payment_gateway_sessions': {
             'task': 'datahub.omis.payment.tasks.refresh_pending_payment_gateway_sessions',

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -26,7 +26,7 @@ def sync_all_models():
         )
 
 
-@shared_task(acks_late=True, priority=9)
+@shared_task(acks_late=True, priority=9, queue='long-running')
 def sync_model(search_app_name):
     """
     Task that syncs a single model to Elasticsearch.
@@ -96,7 +96,14 @@ def sync_related_objects_task(
         sync_object_task.apply_async(args=(search_app.name, pk), priority=self.priority)
 
 
-@shared_task(bind=True, acks_late=True, priority=7, max_retries=5, default_retry_delay=60)
+@shared_task(
+    bind=True,
+    acks_late=True,
+    priority=7,
+    max_retries=5,
+    default_retry_delay=60,
+    queue='long-running',
+)
 def complete_model_migration(self, search_app_name, new_mapping_hash):
     """
     Completes a migration by performing a full resync, updating aliases and removing old indices.

--- a/requirements.in
+++ b/requirements.in
@@ -39,6 +39,7 @@ aws-requests-auth==0.4.2
 
 # Celery
 celery==4.2.1
+billiard==3.5.0.4  # pinned due to https://github.com/celery/billiard/issues/260
 
 # Testing and dev
 pytest==4.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via pytest
 aws-requests-auth==0.4.2
 backcall==0.1.0           # via ipython
-billiard==3.5.0.5         # via celery
+billiard==3.5.0.4
 boto3==1.9.59
 botocore==1.12.59         # via boto3, s3transfer
 celery==4.2.1


### PR DESCRIPTION
### Description of change

This routes the `complete_model_migration` Celery task to the long-running queue so that it doesn't block short-running tasks in the default queue. This also downgrades billiards to version 3.5.0.4 due to celery/billiard#260.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
