### PR TITLE
Add was_policy_feedback_provided filter to interaction search

### DIFF
--- a/changelog/interaction/was-policy-feedback-provided-filter.api
+++ b/changelog/interaction/was-policy-feedback-provided-filter.api
@@ -1,0 +1,1 @@
+``POST /v3/search/interaction``: A new boolean filter, ``was_policy_feedback_provided``, was added.

--- a/changelog/interaction/was-policy-feedback-provided-filter.feature
+++ b/changelog/interaction/was-policy-feedback-provided-filter.feature
@@ -1,0 +1,1 @@
+It's now possible to filter interactions by whether they contain policy feedback when searching for interactions.

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -36,6 +36,7 @@ class Interaction(BaseESModel):
         copy_to=['subject_english'],
     )
     subject_english = fields.EnglishText()
+    was_policy_feedback_provided = Boolean()
 
     MAPPINGS = {
         'company': dict_utils.company_dict,
@@ -55,6 +56,8 @@ class Interaction(BaseESModel):
             'investment_project.sector',
         ),
         'is_event': attrgetter('is_event'),
+        # TODO: Remove once Interaction.was_policy_feedback_provided is no longer nullable
+        'was_policy_feedback_provided': lambda obj: bool(obj.was_policy_feedback_provided),
     }
 
     SEARCH_FIELDS = (

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -26,6 +26,7 @@ class SearchInteractionSerializer(SearchSerializer):
     investment_project = SingleOrListField(child=StringUUIDField(), required=False)
     service = SingleOrListField(child=StringUUIDField(), required=False)
     sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
+    was_policy_feedback_provided = serializers.BooleanField(required=False)
 
     DEFAULT_ORDERING = 'date:desc'
 

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -2,6 +2,7 @@ import pytest
 
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
+    CompanyInteractionFactoryWithPolicyFeedback,
     InvestmentProjectInteractionFactory,
     ServiceDeliveryFactory,
 )
@@ -12,7 +13,12 @@ pytestmark = pytest.mark.django_db
 
 @pytest.mark.parametrize(
     'factory_cls',
-    (CompanyInteractionFactory, InvestmentProjectInteractionFactory),
+    (
+        CompanyInteractionFactory,
+        InvestmentProjectInteractionFactory,
+        CompanyInteractionFactoryWithPolicyFeedback,
+        lambda: CompanyInteractionFactory(was_policy_feedback_provided=None),
+    ),
 )
 def test_interaction_to_dict(setup_es, factory_cls):
     """Test converting an interaction to a dict."""
@@ -78,6 +84,7 @@ def test_interaction_to_dict(setup_es, factory_cls):
         'service_delivery_status': None,
         'grant_amount_offered': None,
         'net_company_receipt': None,
+        'was_policy_feedback_provided': bool(interaction.was_policy_feedback_provided),
         'created_on': interaction.created_on,
         'modified_on': interaction.modified_on,
     }
@@ -139,6 +146,7 @@ def test_service_delivery_to_dict(setup_es):
         },
         'grant_amount_offered': interaction.grant_amount_offered,
         'net_company_receipt': interaction.net_company_receipt,
+        'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
         'created_on': interaction.created_on,
         'modified_on': interaction.modified_on,
     }

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -34,6 +34,7 @@ class SearchInteractionParams:
         'investment_project',
         'sector_descends',
         'service',
+        'was_policy_feedback_provided',
     )
 
     REMAP_FIELDS = {


### PR DESCRIPTION
### Description of change

This adds a boolean filter for `was_policy_feedback_provided` to interaction search.

I wanted to map None values to False while we still have them – I had to use COMPUTED_MAPPINGS on the ES model for this as MAPPINGS does not pass None to the mapping function.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
