### PR TITLE
Set ATOMIC_REQUESTS to False for the mi database

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -174,7 +174,7 @@ DATABASES = {
     },
     'mi': {
         **env.db('MI_DATABASE_URL'),
-        'ATOMIC_REQUESTS': True,
+        'ATOMIC_REQUESTS': False,
         'CONN_MAX_AGE': env.int('MI_DATABASE_DATABASE_CONN_MAX_AGE', 0),
         'DISABLE_SERVER_SIDE_CURSORS': False,
         **MI_DATABASE_OPTIONS,


### PR DESCRIPTION
### Description of change

This sets `ATOMIC_REQUESTS` to False for the mi database.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
