### PR TITLE
Add NormalizedKeyword Elasticsearch field

### DIFF
--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -13,6 +13,12 @@ from elasticsearch_dsl.connections import connections
 logger = getLogger(__name__)
 
 
+# Normalises values to improve sorting (by keeping e, E, è, ê etc. together)
+lowercase_asciifolding_normalizer = analysis.normalizer(
+    'lowercase_asciifolding_normalizer',
+    filter=('lowercase', 'asciifolding'),
+)
+
 lowercase_keyword_analyzer = analysis.CustomAnalyzer(
     'lowercase_keyword_analyzer',
     tokenizer='keyword',

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -2,6 +2,16 @@ from functools import partial
 
 from elasticsearch_dsl import Keyword, Nested, Object, Text
 
+from datahub.search.elasticsearch import lowercase_asciifolding_normalizer
+
+# Keyword with normalisation to improve sorting (by keeping e, E, è, ê etc. together).
+# This should be used in preference to SortableCaseInsensitiveKeywordText
+NormalizedKeyword = partial(
+    Keyword,
+    normalizer=lowercase_asciifolding_normalizer,
+)
+# Avoid using as this uses fielddata=True. NormalizedKeyword will have better behaviour
+# for sorting
 SortableCaseInsensitiveKeywordText = partial(
     Text,
     analyzer='lowercase_keyword_analyzer',

--- a/datahub/search/test/search_support/simplemodel/models.py
+++ b/datahub/search/test/search_support/simplemodel/models.py
@@ -11,8 +11,9 @@ class ESSimpleModel(BaseESModel):
     """Elasticsearch representation of SimpleModel model."""
 
     id = Keyword()
-    name = fields.SortableText(copy_to=['name_keyword', 'name_trigram'])
+    name = fields.SortableText(copy_to=['name_keyword', 'name_normalized_keyword', 'name_trigram'])
     name_keyword = fields.SortableCaseInsensitiveKeywordText()
+    name_normalized_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()
 
     SEARCH_FIELDS = (

--- a/datahub/search/test/search_support/simplemodel/serializers.py
+++ b/datahub/search/test/search_support/simplemodel/serializers.py
@@ -8,4 +8,4 @@ class SearchSimpleModelSerializer(SearchSerializer):
 
     name = serializers.CharField(required=False)
 
-    SORT_BY_FIELDS = ('name',)
+    SORT_BY_FIELDS = ('name', 'name_normalized_keyword')

--- a/datahub/search/test/test_fields.py
+++ b/datahub/search/test/test_fields.py
@@ -1,0 +1,51 @@
+from random import shuffle
+
+from django.urls import reverse
+
+from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.search.sync_object import sync_object
+from datahub.search.test.search_support.models import SimpleModel
+from datahub.search.test.search_support.simplemodel import SimpleModelSearchApp
+
+
+class TestNormalizedField(APITestMixin):
+    """Tests the behaviour of NormalizedKeyword."""
+
+    def test_sorting(self, setup_es):
+        """Test to demonstrate how NormalizedKeyword sorts."""
+        names = [
+            'Alice',
+            'Barbara',
+            'barbara 2',
+            'Álice 2',
+            'ａlice 3',
+        ]
+        shuffle(names)
+
+        for name in names:
+            obj = SimpleModel(name=name)
+            obj.save()
+            sync_object(SimpleModelSearchApp, obj.pk)
+
+        setup_es.indices.refresh()
+
+        user = create_test_user(permission_codenames=['view_simplemodel'])
+        api_client = self.create_api_client(user=user)
+        url = reverse('api-v3:search:simplemodel')
+
+        response = api_client.post(
+            url,
+            data={
+                'sortby': 'name_normalized_keyword',
+            },
+        )
+        response_data = response.json()
+        results = response_data['results']
+
+        assert [result['name'] for result in results] == [
+            'Alice',
+            'Álice 2',
+            'ａlice 3',
+            'Barbara',
+            'barbara 2',
+        ]


### PR DESCRIPTION
### Description of change

This adds `NormalizedKeyword` as an intended replacement for `SortableCaseInsensitiveKeywordText`. The advantage is that it is a keyword field and does not use `fielddata=True`, and as well as the `lowercase` filter, it uses the `asciifolding` filter so that characters with plain Latin counterparts (e.g. Latin letters with diacritics and full-width characters like ａ) are kept together.

This field is not used anywhere yet, this just adds it so it is available to be used.

The normailiser does not need to be manually added to the index settings as elasticsearch-dsl-py does that automatically if the field is used.

Note that the [ICU analysis plugin](https://www.elastic.co/guide/en/elasticsearch/plugins/6.5/analysis-icu.html) is available both on AWS and GOV.UK PaaS and has a lot of useful stuff in it that would also improve sorting and searching. However, I'm not sure we have a strong need for it right now, so I haven't used it here.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
