### PR TITLE
Improved Audit History

### DIFF
--- a/changelog/company/improved_audit_history.api
+++ b/changelog/company/improved_audit_history.api
@@ -1,0 +1,1 @@
+GET ``/v3/company/<uuid:pk>/audit`` now returns string representation of any changes made to related objects rather than ids.

--- a/changelog/contact/improved_audit_history.api
+++ b/changelog/contact/improved_audit_history.api
@@ -1,0 +1,1 @@
+GET ``/v3/contact/<uuid:pk>/audit`` now returns string representation of any changes made to related objects rather than ids.

--- a/changelog/investment/improved_audit_history.api
+++ b/changelog/investment/improved_audit_history.api
@@ -1,0 +1,1 @@
+GET ``/v3/investment/<uuid:pk>/audit`` now returns string representation of any changes made to related objects rather than ids.

--- a/datahub/core/audit_utils.py
+++ b/datahub/core/audit_utils.py
@@ -1,0 +1,84 @@
+from django.core.exceptions import ValidationError
+from django.db import models
+
+
+def diff_versions(model_meta, old_version, new_version):
+    """
+    Audit versions comparision with the delta returned.
+
+    For related objects only the pk is stored in the audit history.
+    A user friendly representation of the related object (the object name)
+    is retrieved if the relationship still exists.
+
+    """
+    friendly_changes = {}
+    raw_changes = _get_changes(old_version, new_version)
+
+    for db_field_name, values in raw_changes.items():
+        field = _get_field_or_none(model_meta, db_field_name)
+        field_name = field.name if field else db_field_name
+        friendly_changes[field_name] = [_make_value_friendly(field, value) for value in values]
+    return friendly_changes
+
+
+def _get_changes(old_version, new_version):
+    """Compares dictionaries returning the delta between them."""
+    changes = {}
+
+    for field_name, new_value in new_version.items():
+        if field_name not in old_version:
+            changes[field_name] = [None, new_value]
+        else:
+            old_value = old_version[field_name]
+            if _are_values_different(old_value, new_value):
+                changes[field_name] = [old_value, new_value]
+    return changes
+
+
+def _are_values_different(old_value, new_value):
+    """Checks if the two values are different whilst treating a blank string the same as a None."""
+    old_value = old_value if old_value != '' else None
+    new_value = new_value if new_value != '' else None
+    return old_value != new_value
+
+
+def _get_field_or_none(model_meta, db_column_name):
+    """Gets a model field for a given model meta, if the field cannot be found returns None."""
+    try:
+        return model_meta.get_field(db_column_name)
+    except models.FieldDoesNotExist:
+        return None
+
+
+def _make_value_friendly(field, value):
+    """
+    Checks field and if required retrieves the object name from related model.
+
+    If the field is None or not a related field then the value can be
+    returned as the value is not an object pk.
+
+    For related objects the object name is then retrieved, for many to many and
+    one to many all values need to be retrieved individually.
+
+    """
+    if not field or not field.is_relation:
+        return value
+
+    if field.many_to_many or field.one_to_many:
+        return [
+            _get_object_name_for_pk(
+                field.related_model, one_value,
+            ) for one_value in value
+        ]
+    return _get_object_name_for_pk(field.related_model, value)
+
+
+def _get_object_name_for_pk(model, pk):
+    """
+    Gets the name for a given object pk or returns the pk if it cannot be found.
+    """
+    try:
+        result = model.objects.get(pk=pk)
+    except (model.DoesNotExist, ValueError, TypeError, ValidationError):
+        return pk
+    return str(result)

--- a/datahub/core/test/test_audit.py
+++ b/datahub/core/test/test_audit.py
@@ -8,28 +8,6 @@ from datahub.core.audit import AuditViewSet
 from datahub.core.test_utils import MockQuerySet
 
 
-def test_audit_log_diff_algo():
-    """Test simple diff algorithm."""
-    given = {
-        'old': {
-            'field1': 'val1',
-            'field2': 'val2',
-        },
-        'new': {
-            'field1': 'val1',
-            'field2': 'new-val',
-            'field3': 'added',
-        },
-    }
-
-    expected = {
-        'field2': ['val2', 'new-val'],
-        'field3': [None, 'added'],
-    }
-
-    assert AuditViewSet._diff_versions(given['old'], given['new']) == expected
-
-
 @pytest.mark.parametrize(
     'num_versions,offset,limit,exp_results,exp_next,exp_previous',
     (
@@ -60,8 +38,8 @@ def test_audit_log_pagination(
             'limit': limit,
         },
     )
-    serializer = AuditViewSet(request=request)
-    response = serializer.create_response(instance)
+    view_set = AuditViewSet(request=request)
+    response = view_set.create_response(instance)
     results = response.data['results']
 
     assert response.data['count'] == max(num_versions - 1, 0)
@@ -79,7 +57,7 @@ class _VersionQuerySetStub(MockQuerySet):
 
     def __init__(self, count):
         """Initialises the instance, creating some stub version instances to return as results."""
-        items = [MagicMock(id=n) for n in range(count)]
+        items = [MagicMock(id=n, field_dict={}) for n in range(count)]
         super().__init__(items)
 
 

--- a/datahub/core/test/test_audit_utils.py
+++ b/datahub/core/test/test_audit_utils.py
@@ -1,0 +1,121 @@
+import unittest.mock
+
+import pytest
+
+from datahub.core.audit_utils import (
+    _are_values_different,
+    _get_changes,
+    _get_field_or_none,
+    _get_object_name_for_pk,
+    _make_value_friendly,
+    diff_versions,
+)
+from datahub.core.test.support.factories import BookFactory
+from datahub.core.test.support.models import Book
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_audit_diff_versions():
+    """Test audit diff versions."""
+    given = {
+        'old': {
+            'date_published': 'val1',
+            'name': 'val2',
+            'contact_email': 'contact',
+            'old_email': 'hello',
+            'telephone_number': None,
+            'old_field': '1',
+        },
+        'new': {
+            'date_published': 'val1',
+            'name': 'new-val',
+            'genre': 'added',
+            'telephone_number': '',
+            'old_field': '2',
+        },
+    }
+
+    expected = {
+        'name': ['val2', 'new-val'],
+        'genre': [None, 'added'],
+        'old_field': ['1', '2'],
+    }
+
+    result = diff_versions(Book._meta, given['old'], given['new'])
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    'old_value,new_value,expected_result',
+    (
+        ('', None, False),
+        ('', False, True),
+        ('hello', 'hello', False),
+        (None, None, False),
+        ('', '', False),
+    ),
+)
+def test_are_values_different(old_value, new_value, expected_result):
+    """Tests two values are different but that a blank string is treated as a None."""
+    assert _are_values_different(old_value, new_value) == expected_result
+
+
+@pytest.mark.parametrize(
+    'old_version,new_version,expected_result',
+    (
+        ({}, {}, {}),
+        ({}, {'hello': 1}, {'hello': [None, 1]}),
+        ({'hello': 1}, {}, {}),
+        ({'hello': None}, {'hello': ''}, {}),
+    ),
+)
+def test_get_changes(old_version, new_version, expected_result):
+    """Tests get changes between two dictionaries"""
+    assert _get_changes(old_version, new_version) == expected_result
+
+
+@pytest.mark.parametrize(
+    'field_name,values,expected_result,number_of_times_get_repr_called',
+    (
+        ('proofreader', 'value', 'fake', 1),
+        ('name', 'value', 'value', 0),
+        ('authors', ['value1', 'value2'], ['fake', 'fake'], 2),
+    ),
+)
+@unittest.mock.patch('datahub.core.audit_utils._get_object_name_for_pk')
+def test_make_value_friendly(
+    mock_get_repr, field_name, values, expected_result, number_of_times_get_repr_called,
+):
+    """
+    Tests get a friendly value for a given field and return object name.
+    Tests foreign key, many to many and char fields.
+    """
+    mock_get_repr.return_value = 'fake'
+    field = _get_field_or_none(Book._meta, field_name)
+    result = _make_value_friendly(field, values)
+    assert mock_get_repr.call_count == number_of_times_get_repr_called
+    assert result == expected_result
+
+
+class TestGetObjectNameForPk:
+    """Tests get object name or value for pk."""
+
+    def test_object_name_returned_for_existing_object(self):
+        """Test the object name is returned for an existing object."""
+        book = BookFactory()
+        assert _get_object_name_for_pk(Book, book.pk) == str(book)
+
+    @pytest.mark.parametrize(
+        'value',
+        (
+            'hello',
+            'c33f4ce3-051a-11e9-aa56-c82a140516f8',
+            1,
+            [],
+        ),
+    )
+    def test_value_returned_when_object_no_longer_exists(self, value):
+        """Test value is returned when an object no longer exists or value not a pk."""
+        assert _get_object_name_for_pk(Book, value) == value


### PR DESCRIPTION
### Description of change
Improved audit history. Related objects will now return their string representation instead of the object ids. I think this could be improved further by adding caching and also by adding a get_serializer method on models so the data could be consistent with other end points. So this is just a start and means changes can be surfaced.

This also fixes the issue where erroneous fields appear as changed just because the values went from a None to a empty string. These are now filtered out making the audit a true reflection of user changes.

This approach was taken from https://github.com/etianen/django-reversion/issues/508#issuecomment-213116320

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
