### PR TITLE
Don't use stale data when bulk syncing to Elasticsearch

### DIFF
--- a/changelog/bulk-sync-prefetch.internal
+++ b/changelog/bulk-sync-prefetch.internal
@@ -1,0 +1,1 @@
+The performance of the `migrate_es` and `sync_es` management commands was improved in some cases by the use of prefetching for to-many fields.

--- a/changelog/stale-bulk-sync.internal
+++ b/changelog/stale-bulk-sync.internal
@@ -1,0 +1,1 @@
+The `migrate_es` and `sync_es` management commands were modified to avoid the use of stale data when copying data to Elasticsearch.

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -33,4 +33,8 @@ class CompanySearchApp(SearchApp):
         'trading_address_country',
         'turnover_range',
         'uk_region',
+    ).prefetch_related(
+        'contacts',
+        'export_to_countries',
+        'future_interest_countries',
     )

--- a/datahub/search/event/apps.py
+++ b/datahub/search/event/apps.py
@@ -19,4 +19,7 @@ class EventSearchApp(SearchApp):
         'lead_team',
         'uk_region',
         'service',
+    ).prefetch_related(
+        'related_programmes',
+        'teams',
     )

--- a/datahub/search/investment/apps.py
+++ b/datahub/search/investment/apps.py
@@ -1,6 +1,9 @@
+from django.db.models import Prefetch
+
 from datahub.investment.models import (
     InvestmentProject as DBInvestmentProject,
     InvestmentProjectPermission,
+    InvestmentProjectTeamMember,
 )
 from datahub.investment.permissions import (
     get_association_filters,
@@ -54,6 +57,14 @@ class InvestmentSearchApp(SearchApp):
         'specific_programme',
         'stage',
         'uk_company',
+    ).prefetch_related(
+        'actual_uk_regions',
+        'delivery_partners',
+        'uk_region_locations',
+        Prefetch(
+            'team_members',
+            queryset=InvestmentProjectTeamMember.objects.select_related('adviser__dit_team'),
+        ),
     )
 
     @classmethod

--- a/datahub/search/omis/apps.py
+++ b/datahub/search/omis/apps.py
@@ -1,4 +1,11 @@
-from datahub.omis.order.models import Order as DBOrder, OrderPermission
+from django.db.models import Prefetch
+
+from datahub.omis.order.models import (
+    Order as DBOrder,
+    OrderAssignee,
+    OrderPermission,
+    OrderSubscriber,
+)
 from datahub.search.apps import SearchApp
 from datahub.search.omis.models import Order
 from datahub.search.omis.views import SearchOrderAPIView, SearchOrderExportAPIView
@@ -19,4 +26,11 @@ class OrderSearchApp(SearchApp):
         'created_by',
         'primary_market',
         'sector',
+    ).prefetch_related(
+        'service_types',
+        Prefetch('assignees', queryset=OrderAssignee.objects.select_related('adviser__dit_team')),
+        Prefetch(
+            'subscribers',
+            queryset=OrderSubscriber.objects.select_related('adviser__dit_team'),
+        ),
     )


### PR DESCRIPTION
### Description of change

This makes a simple change to how bulk syncing works (as performed by the `sync_es` and `migrate_es` management commands) so that the server-side cursor is only used for fetching the IDs of the objects to sync and the objects themselves are fetched afresh when they are copied to Elasticsearch. This avoids stale data being copied to Elasticsearch.

This also readds prefetching of to-many fields that are copied to Elasticsearch (which in itself will improve performance).

I made the minimal changes needed to `MockQuerySet` for this – it would be nice to replace `MockQuerySet` with https://github.com/stphivos/django-mock-queries, but Django Mock Queries doesn't support `QuerySet.iterator()` at present so we can't use it yet.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
