### PR TITLE
Add lead adviser to OMIS CSV extract

### DIFF
--- a/changelog/omis/lead_adviser_export.feature
+++ b/changelog/omis/lead_adviser_export.feature
@@ -1,0 +1,1 @@
+``Lead adviser`` is now available in the OMIS CSV extract.

--- a/datahub/omis/order/query_utils.py
+++ b/datahub/omis/order/query_utils.py
@@ -1,0 +1,17 @@
+from django.db.models import CharField, OuterRef, Subquery
+
+from datahub.core.query_utils import get_full_name_expression
+from datahub.omis.order.models import OrderAssignee
+
+
+def get_lead_order_assignee_name_subquery():
+    """Get lead order assignee name subquery."""
+    subquery = OrderAssignee.objects.filter(
+        order=OuterRef('pk'),
+        is_lead=True,
+    ).annotate(
+        name=get_full_name_expression('adviser'),
+    ).values(
+        'name',
+    )
+    return Subquery(subquery, output_field=CharField())

--- a/datahub/omis/order/test/factories.py
+++ b/datahub/omis/order/test/factories.py
@@ -133,6 +133,24 @@ class OrderPaidFactory(OrderWithAcceptedQuoteFactory):
     status = OrderStatus.paid
 
 
+class OrderWithoutAssigneesFactory(OrderFactory):
+    """Order factory without assignees."""
+
+    @to_many_field
+    def assignees(self):
+        """No assignees for this order."""
+        return []
+
+
+class OrderWithoutLeadAssigneeFactory(OrderFactory):
+    """Order factory without assignees."""
+
+    @to_many_field
+    def assignees(self):
+        """Create non-lead assignees."""
+        return OrderAssigneeFactory.create_batch(2, order=self, is_lead=False)
+
+
 class OrderSubscriberFactory(factory.django.DjangoModelFactory):
     """Order Subscriber factory."""
 

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -36,6 +36,8 @@ from datahub.omis.order.test.factories import (
     OrderWithAcceptedQuoteFactory,
     OrderWithCancelledQuoteFactory,
     OrderWithOpenQuoteFactory,
+    OrderWithoutAssigneesFactory,
+    OrderWithoutLeadAssigneeFactory,
 )
 from datahub.omis.payment.constants import RefundStatus
 from datahub.omis.payment.test.factories import (
@@ -457,6 +459,8 @@ class TestOrderExportView(APITestMixin):
             OrderWithAcceptedQuoteFactory,
             OrderWithCancelledQuoteFactory,
             OrderWithOpenQuoteFactory,
+            OrderWithoutAssigneesFactory,
+            OrderWithoutLeadAssigneeFactory,
             ApprovedRefundFactory,
             ApprovedRefundFactory,
             RequestedRefundFactory,
@@ -529,6 +533,7 @@ class TestOrderExportView(APITestMixin):
                 'Contact link':
                     f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}'
                     f'/{order.contact.pk}',
+                'Lead adviser': get_attr_or_none(order.get_lead_assignee(), 'adviser.name'),
                 'Created by team': get_attr_or_none(order, 'created_by.dit_team.name'),
                 'Date created': order.created_on,
                 'Delivery date': order.delivery_date,

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -9,6 +9,7 @@ from datahub.core.query_utils import (
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.models import Order as DBOrder
+from datahub.omis.order.query_utils import get_lead_order_assignee_name_subquery
 from datahub.omis.payment.constants import RefundStatus
 from datahub.omis.payment.models import Refund
 from datahub.search.omis.models import Order
@@ -106,6 +107,7 @@ class SearchOrderExportAPIView(SearchOrderParams, SearchExportAPIView):
         company_link=get_front_end_url_expression('company', 'company__pk'),
         contact_name=get_full_name_expression('contact'),
         contact_link=get_front_end_url_expression('contact', 'contact__pk'),
+        lead_adviser=get_lead_order_assignee_name_subquery(),
     )
     field_titles = {
         'reference': 'Order reference',
@@ -123,6 +125,7 @@ class SearchOrderExportAPIView(SearchOrderParams, SearchExportAPIView):
         'contact_name': 'Contact',
         'contact__job_title': 'Contact job title',
         'contact_link': 'Contact link',
+        'lead_adviser': 'Lead adviser',
         'created_by__dit_team__name': 'Created by team',
         'created_on': 'Date created',
         'delivery_date': 'Delivery date',


### PR DESCRIPTION
### Description of change

This adds lead adviser to OMIS CSV extract.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
