### PR TITLE
Add OMIS order invoices to the admin site

### DIFF
--- a/changelog/omis/invoices-admin-site.internal
+++ b/changelog/omis/invoices-admin-site.internal
@@ -1,0 +1,1 @@
+OMIS order invoices can now be viewed and searched for by invoice number and order reference in the admin site.

--- a/changelog/omis/search-omis-orders-by-invoice-number.internal
+++ b/changelog/omis/search-omis-orders-by-invoice-number.internal
@@ -1,0 +1,1 @@
+OMIS orders can now be searched for by the current invoice number for the order in the admin site.

--- a/datahub/omis/invoice/admin.py
+++ b/datahub/omis/invoice/admin.py
@@ -1,0 +1,59 @@
+from django.contrib import admin
+
+from datahub.core.admin import BaseModelAdminMixin, get_change_link, ViewOnlyAdmin
+from datahub.omis.invoice.models import Invoice
+from datahub.omis.order.models import Order
+
+
+@admin.register(Invoice)
+class InvoiceAdmin(BaseModelAdminMixin, ViewOnlyAdmin):
+    """View-only admin for invoices."""
+
+    list_display = (
+        'invoice_number',
+        'order_reference',
+        'created_on',
+    )
+    search_fields = ('order_reference', 'invoice_number')
+    fields = (
+        'id',
+        'created',
+        'modified',
+        'invoice_number',
+        'po_number',
+        'order_link',
+        'billing_company_name',
+        'billing_contact_name',
+        'billing_address_1',
+        'billing_address_2',
+        'billing_address_town',
+        'billing_address_county',
+        'billing_address_postcode',
+        'billing_address_country',
+        'invoice_company_name',
+        'invoice_address_1',
+        'invoice_address_2',
+        'invoice_address_town',
+        'invoice_address_county',
+        'invoice_address_postcode',
+        'invoice_address_country',
+        'invoice_vat_number',
+        'payment_due_date',
+        'contact_email',
+        'vat_status',
+        'vat_number',
+        'vat_verified',
+        'net_cost',
+        'subtotal_cost',
+        'vat_cost',
+        'total_cost',
+    )
+
+    def order_link(self, obj):
+        """Returns a link to the order change page."""
+        order = Order.objects.filter(reference=obj.order_reference).first()
+        if order:
+            return get_change_link(order)
+        return obj.order_reference
+
+    order_link.short_description = 'order'

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -20,7 +20,12 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 from django.views.decorators.csrf import csrf_protect
 
-from datahub.core.admin import BaseModelAdminMixin, get_change_url, ViewAndChangeOnlyAdmin
+from datahub.core.admin import (
+    BaseModelAdminMixin,
+    get_change_link,
+    get_change_url,
+    ViewAndChangeOnlyAdmin,
+)
 from datahub.core.exceptions import APIConflictException
 from datahub.omis.order import validators
 from datahub.omis.order.models import CancellationReason, Order
@@ -73,6 +78,7 @@ class OrderAdmin(BaseModelAdminMixin, ViewAndChangeOnlyAdmin):
     readonly_fields = (
         'id',
         'reference',
+        'invoice_link',
         'created',
         'modified',
         'public_token',
@@ -117,10 +123,17 @@ class OrderAdmin(BaseModelAdminMixin, ViewAndChangeOnlyAdmin):
         'archived_documents_url_path',
         'uk_advisers',
         'post_advisers',
-        'invoice',
     )
     _editable_fields = ('sector', 'uk_region')
     fields = readonly_fields + _editable_fields
+
+    def invoice_link(self, obj):
+        """Returns a link to the invoice change page."""
+        if obj.invoice:
+            return get_change_link(obj.invoice)
+        return ''
+
+    invoice_link.short_description = 'Current invoice'
 
     def completed(self, order):
         """:returns: completed on/by details."""

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -67,7 +67,7 @@ class OrderAdmin(BaseModelAdminMixin, ViewAndChangeOnlyAdmin):
     """Admin for orders."""
 
     list_display = ('reference', 'company', 'status', 'created_on', 'modified_on')
-    search_fields = ('reference',)
+    search_fields = ('reference', 'invoice__invoice_number')
     list_filter = ('status',)
 
     readonly_fields = (
@@ -117,6 +117,7 @@ class OrderAdmin(BaseModelAdminMixin, ViewAndChangeOnlyAdmin):
         'archived_documents_url_path',
         'uk_advisers',
         'post_advisers',
+        'invoice',
     )
     _editable_fields = ('sector', 'uk_region')
     fields = readonly_fields + _editable_fields


### PR DESCRIPTION
### Description of change

This adds additional OMIS order invoice functionality to the admin site:

- adds invoices to the admin site as view-only and with the ability to search for invoices by invoice number
- adds 'Current invoice' as a field for orders with a link to the admin change page for the invoice
- adds the ability to search for orders by the current invoice number

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
