### PR TITLE
Clean up Companies House company search model

### DIFF
--- a/changelog/ch-search-model.internal
+++ b/changelog/ch-search-model.internal
@@ -1,0 +1,1 @@
+- The Companies House search model was optimised for better performance and maintainability.

--- a/changelog/ch-search-uri.api
+++ b/changelog/ch-search-uri.api
@@ -1,0 +1,1 @@
+- ``POST /v3/search/companieshousecompany``: The ``uri`` field was removed from responses as this was not being used by any client.

--- a/changelog/ch-search-uri.removal
+++ b/changelog/ch-search-uri.removal
@@ -1,0 +1,1 @@
+- ``POST /v3/search/companieshousecompany``: The ``uri`` field was removed from responses as this was not being used by any client.

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -1,6 +1,7 @@
-from elasticsearch_dsl import Date, Keyword, Text
+from elasticsearch_dsl import Date, Keyword, Object, Text
 
 from datahub.search import dict_utils, fields
+from datahub.search.inner_docs import UnindexedInnerIDName
 from datahub.search.models import BaseESModel
 
 
@@ -11,29 +12,30 @@ class CompaniesHouseCompany(BaseESModel):
     """Elasticsearch representation of CompaniesHouseCompany model."""
 
     id = Keyword()
-    company_category = fields.SortableCaseInsensitiveKeywordText()
-    company_number = fields.SortableCaseInsensitiveKeywordText()
-    company_status = fields.SortableCaseInsensitiveKeywordText()
-    incorporation_date = Date()
-    name = fields.SortableText(
-        copy_to=[
-            'name_keyword', 'name_trigram',
-        ],
+    company_category = Keyword(index=False)
+    company_number = fields.NormalizedKeyword()
+    company_status = Keyword(index=False)
+    incorporation_date = Date(index=False)
+    name = Text(
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+            'trigram': fields.TrigramText(),
+        },
     )
-    name_keyword = fields.SortableCaseInsensitiveKeywordText()
-    name_trigram = fields.TrigramText()
-    registered_address_1 = Text()
-    registered_address_2 = Text()
-    registered_address_town = fields.SortableCaseInsensitiveKeywordText()
-    registered_address_county = Text()
-    registered_address_postcode = Text(copy_to='registered_address_postcode_trigram')
-    registered_address_postcode_trigram = fields.TrigramText()
-    registered_address_country = fields.nested_id_name_field()
-    sic_code_1 = Text()
-    sic_code_2 = Text()
-    sic_code_3 = Text()
-    sic_code_4 = Text()
-    uri = Text()
+    registered_address_1 = Text(index=False)
+    registered_address_2 = Text(index=False)
+    registered_address_town = Text(index=False)
+    registered_address_county = Text(index=False)
+    registered_address_postcode = Text(
+        fields={
+            'trigram': fields.TrigramText(),
+        },
+    )
+    registered_address_country = Object(UnindexedInnerIDName)
+    sic_code_1 = Text(index=False)
+    sic_code_2 = Text(index=False)
+    sic_code_3 = Text(index=False)
+    sic_code_4 = Text(index=False)
 
     MAPPINGS = {
         'id': str,
@@ -43,8 +45,12 @@ class CompaniesHouseCompany(BaseESModel):
     SEARCH_FIELDS = (
         # to match names like A & B
         'name',
-        'name_trigram',
+        'name.trigram',
         'company_number',
+        'registered_address_postcode.trigram',
+        # Fields from previous version of mapping. TODO: Remove these once all environments have
+        # been updated to the new mapping
+        'name_trigram',
         'registered_address_postcode_trigram',
     )
 

--- a/datahub/search/inner_docs.py
+++ b/datahub/search/inner_docs.py
@@ -1,0 +1,8 @@
+from elasticsearch_dsl import InnerDoc, Keyword, Text
+
+
+class UnindexedInnerIDName(InnerDoc):
+    """InnerDoc for an unsearchable ID and name object."""
+
+    id = Keyword(index=False)
+    name = Text(index=False)


### PR DESCRIPTION
### Description of change

This depends on https://github.com/uktrade/data-hub-leeloo/pull/1317 so I have marked this as blocked for now.

This cleans up the Companies House company search model by:

- replacing a nested field with an object field
- making better use of multi-fields
- replacing `SortableCaseInsensitive` with `NormalizedKeyword`
- not indexing fields that are not searched on or sorted by
- removing the `uri` field

Another option for would've been `Object(enabled=False)` (essentially letting you put any old JSON object in it without any validation). However, I took the view that specifying the sub-fields with `index=False` was better as it provides some validation e.g. for date fields.

Locally these changes improve full-reindexing speeds for Companies House companies by about 17%.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
