### PR TITLE
Replace nested fields with object fields in company search model

### DIFF
--- a/changelog/company/remove-nested-search.internal
+++ b/changelog/company/remove-nested-search.internal
@@ -1,0 +1,1 @@
+All nested fields were replaced with object fields in the company search model for improved maintainability and performance.

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -57,21 +57,21 @@ class Company(BaseESModel):
 
     id = Keyword()
     archived = Boolean()
-    archived_by = fields.nested_contact_or_adviser_field('archived_by')
+    archived_by = fields.contact_or_adviser_field('archived_by')
     archived_on = Date()
     archived_reason = Text()
-    business_type = fields.nested_id_name_field()
-    companies_house_data = fields.nested_ch_company_field()
+    business_type = fields.id_name_field()
+    companies_house_data = fields.ch_company_field()
     company_number = fields.SortableCaseInsensitiveKeywordText()
-    contacts = fields.nested_contact_or_adviser_field('contacts')
+    contacts = fields.contact_or_adviser_field('contacts')
     created_on = Date()
     description = fields.EnglishText()
-    employee_range = fields.nested_id_name_field()
-    export_experience_category = fields.nested_id_name_field()
-    export_to_countries = fields.nested_id_name_field()
-    future_interest_countries = fields.nested_id_name_field()
-    global_headquarters = fields.nested_id_name_field()
-    headquarter_type = fields.nested_id_name_field()
+    employee_range = fields.id_name_field()
+    export_experience_category = fields.id_name_field()
+    export_to_countries = fields.id_name_field()
+    future_interest_countries = fields.id_name_field()
+    global_headquarters = fields.id_name_field()
+    headquarter_type = fields.id_name_field()
     modified_on = Date()
     name = fields.SortableText(copy_to=['name_keyword', 'name_trigram'])
     name_keyword = fields.SortableCaseInsensitiveKeywordText()
@@ -81,7 +81,7 @@ class Company(BaseESModel):
     registered_address_2 = Text()
     registered_address_town = fields.SortableCaseInsensitiveKeywordText()
     registered_address_county = Text()
-    registered_address_country = fields.nested_id_name_partial_field(
+    registered_address_country = fields.id_name_partial_field(
         'registered_address_country',
     )
     registered_address_postcode = Text(
@@ -90,7 +90,7 @@ class Company(BaseESModel):
         ],
     )
     registered_address_postcode_trigram = fields.TrigramText()
-    sector = fields.nested_sector_field()
+    sector = fields.sector_field()
     trading_address_1 = Text()
     trading_address_2 = Text()
     trading_address_town = fields.SortableCaseInsensitiveKeywordText()
@@ -99,7 +99,7 @@ class Company(BaseESModel):
         copy_to=['trading_address_postcode_trigram'],
     )
     trading_address_postcode_trigram = fields.TrigramText()
-    trading_address_country = fields.nested_id_name_partial_field(
+    trading_address_country = fields.id_name_partial_field(
         'trading_address_country',
     )
     trading_name = fields.SortableText(
@@ -114,8 +114,8 @@ class Company(BaseESModel):
         copy_to=['trading_names_trigram'],
     )
     trading_names_trigram = fields.TrigramText()
-    turnover_range = fields.nested_id_name_field()
-    uk_region = fields.nested_id_name_field()
+    turnover_range = fields.id_name_field()
+    uk_region = fields.id_name_field()
     uk_based = Boolean()
     vat_number = Keyword(index=False)
     duns_number = Keyword()

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -25,7 +25,6 @@ def test_mapping(setup_es):
             'properties': {
                 'archived': {'type': 'boolean'},
                 'archived_by': {
-                    'include_in_parent': True,
                     'properties': {
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
@@ -49,12 +48,11 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'archived_on': {'type': 'date'},
                 'archived_reason': {'type': 'text'},
                 'business_type': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -63,7 +61,7 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'companies_house_data': {
                     'properties': {
@@ -74,7 +72,7 @@ def test_mapping(setup_es):
                         },
                         'id': {'type': 'keyword'},
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'company_number': {
                     'analyzer': 'lowercase_keyword_analyzer',
@@ -82,7 +80,6 @@ def test_mapping(setup_es):
                     'type': 'text',
                 },
                 'contacts': {
-                    'include_in_parent': True,
                     'properties': {
                         'first_name': {
                             'analyzer': 'lowercase_keyword_analyzer',
@@ -106,7 +103,7 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'created_on': {'type': 'date'},
                 'description': {
@@ -115,7 +112,6 @@ def test_mapping(setup_es):
                 },
                 'duns_number': {'type': 'keyword'},
                 'employee_range': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -124,10 +120,9 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'export_experience_category': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -136,10 +131,9 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'export_to_countries': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -148,10 +142,9 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'future_interest_countries': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -160,10 +153,9 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'global_headquarters': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -172,10 +164,9 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'headquarter_type': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -184,7 +175,7 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'id': {'type': 'keyword'},
                 'modified_on': {'type': 'date'},
@@ -210,7 +201,6 @@ def test_mapping(setup_es):
                 'registered_address_1': {'type': 'text'},
                 'registered_address_2': {'type': 'text'},
                 'registered_address_country': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -224,7 +214,7 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'registered_address_county': {'type': 'text'},
                 'registered_address_postcode': {
@@ -241,12 +231,10 @@ def test_mapping(setup_es):
                     'type': 'text',
                 },
                 'sector': {
-                    'include_in_parent': True,
                     'properties': {
                         'ancestors': {
-                            'include_in_parent': True,
                             'properties': {'id': {'type': 'keyword'}},
-                            'type': 'nested',
+                            'type': 'object',
                         },
                         'id': {'type': 'keyword'},
                         'name': {
@@ -255,7 +243,7 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'suggest': {
                     'analyzer': 'simple',
@@ -267,7 +255,6 @@ def test_mapping(setup_es):
                 'trading_address_1': {'type': 'text'},
                 'trading_address_2': {'type': 'text'},
                 'trading_address_country': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -281,7 +268,7 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'trading_address_county': {'type': 'text'},
                 'trading_address_postcode': {
@@ -320,7 +307,6 @@ def test_mapping(setup_es):
                     'type': 'text',
                 },
                 'turnover_range': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -329,11 +315,10 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'uk_based': {'type': 'boolean'},
                 'uk_region': {
-                    'include_in_parent': True,
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
@@ -342,7 +327,7 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                    'type': 'nested',
+                    'type': 'object',
                 },
                 'vat_number': {
                     'index': False,

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -167,9 +167,9 @@ def nested_company_field(field):
     )
 
 
-def nested_ch_company_field():
-    """Nested field for lists of objects with id and company_number sub-fields."""
-    return Nested(properties={
+def ch_company_field():
+    """Object field with id and company_number sub-fields."""
+    return Object(properties={
         'id': Keyword(),
         'company_number': SortableCaseInsensitiveKeywordText(),
     })


### PR DESCRIPTION
### Description of change

This replaces nested fields with object fields in the company search model as it was not necessary to use nested fields in any of the cases it was used.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
