### PR TITLE
Update various dependencies

### DIFF
--- a/changelog/update-deps.internal
+++ b/changelog/update-deps.internal
@@ -1,0 +1,1 @@
+Various dependencies were updated.

--- a/requirements.in
+++ b/requirements.in
@@ -22,19 +22,19 @@ python-dateutil==2.7.5
 
 # Persistency layer
 psycopg2==2.7.6.1
-psycogreen==1.0
+psycogreen==1.0.1
 
-boto3==1.9.59
+boto3==1.9.71
 
 notifications-python-client==5.2.0
 
 # REDIS
 django-redis==4.9.1
-redis==2.10.6  # redis 3.x is not compatible with kombu<4.3
+redis==2.10.6
 
 # ES
 elasticsearch==6.3.1
-elasticsearch-dsl==6.3.0
+elasticsearch-dsl==6.3.1
 aws-requests-auth==0.4.2
 
 # Celery
@@ -42,11 +42,11 @@ celery==4.2.1
 billiard==3.5.0.4  # pinned due to https://github.com/celery/billiard/issues/260
 
 # Testing and dev
-pytest==4.0.1
+pytest==4.0.2
 pytest-django==3.4.4
 pytest-sugar==0.9.2
 pytest-cov==2.6.0
-pytest-xdist==1.24.1
+pytest-xdist==1.25.0
 ipython==7.2.0
 ipdb==0.11
 factory-boy==2.11.1
@@ -54,7 +54,7 @@ freezegun==0.3.11
 requests-mock==1.5.2
 django-debug-toolbar==1.11
 werkzeug==0.14.1  # Required by runserver_plus - useful for local dev
-pip-tools==3.1.0
+pip-tools==3.2.0
 piprot==0.9.10
 towncrier==18.6.0
 
@@ -74,6 +74,6 @@ pydocstyle==2.1.1
 gunicorn==19.9.0
 gevent==1.3.7
 mohawk==0.3.4
-raven==6.9.0
-requests==2.20.1
+raven==6.10.0
+requests==2.21.0
 requests_toolbelt==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ attrs==18.2.0             # via pytest
 aws-requests-auth==0.4.2
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4
-boto3==1.9.59
-botocore==1.12.59         # via boto3, s3transfer
+boto3==1.9.71
+botocore==1.12.71         # via boto3, s3transfer
 celery==4.2.1
 certifi==2018.11.29       # via requests
 chardet==3.0.4
@@ -37,11 +37,11 @@ django==2.1.4
 djangorestframework==3.9.0
 docopt==0.6.2             # via docopt, notifications-python-client
 docutils==0.14            # via botocore, docutils
-elasticsearch-dsl==6.3.0
+elasticsearch-dsl==6.3.1
 elasticsearch==6.3.1
 execnet==1.5.0            # via pytest-xdist
 factory-boy==2.11.1
-faker==1.0.0              # via factory-boy
+faker==1.0.1              # via factory-boy
 flake8-blind-except==0.1.1
 flake8-commas==2.0.0
 flake8-debugger==3.1.0
@@ -57,21 +57,21 @@ future==0.17.1            # via notifications-python-client
 gevent==1.3.7
 greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
-idna==2.7                 # via requests
+idna==2.8                 # via requests
 incremental==17.5.0       # via towncrier
 ipdb==0.11
 ipython-genutils==0.2.0   # via ipython-genutils, traitlets
 ipython==7.2.0
-jedi==0.13.1              # via ipython
+jedi==0.13.2              # via ipython
 jinja2==2.10              # via towncrier
 jmespath==0.9.3           # via boto3, botocore, jmespath
-kombu==4.2.1              # via celery
+kombu==4.2.2.post1        # via celery
 lxml==4.2.5
 markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via flake8, mccabe
 mohawk==0.3.4
 monotonic==1.5            # via notifications-python-client
-more-itertools==4.3.0     # via pytest
+more-itertools==5.0.0     # via pytest
 notifications-python-client==5.2.0
 oauthlib==2.1.0           # via django-oauth-toolkit
 packaging==18.0           # via pytest-sugar
@@ -79,37 +79,37 @@ parso==0.3.1              # via jedi
 pep8-naming==0.7.0
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==3.1.0
+pip-tools==3.2.0
 piprot==0.9.10
 pluggy==0.8.0             # via pytest
 prompt-toolkit==2.0.7     # via ipython
-psycogreen==1.0
+psycogreen==1.0.1
 psycopg2==2.7.6.1
 ptyprocess==0.6.0         # via pexpect
 py==1.7.0                 # via pytest
 pycodestyle==2.4.0        # via flake8, flake8-debugger, flake8-import-order, flake8-print
 pydocstyle==2.1.1
 pyflakes==2.0.0           # via flake8
-pygments==2.3.0           # via ipython
-pyjwt==1.7.0              # via notifications-python-client
+pygments==2.3.1           # via ipython
+pyjwt==1.7.1              # via notifications-python-client
 pyparsing==2.3.0          # via packaging
 pytest-cov==2.6.0
 pytest-django==3.4.4
 pytest-forked==0.2        # via pytest-xdist
 pytest-sugar==0.9.2
-pytest-xdist==1.24.1
-pytest==4.0.1
+pytest-xdist==1.25.0
+pytest==4.0.2
 python-dateutil==2.7.5
 pytz==2018.7              # via celery, django
 pyyaml==3.13
-raven==6.9.0
+raven==6.10.0
 redis==2.10.6
 requests-futures==0.9.9   # via piprot
 requests-mock==1.5.2
-requests==2.20.1
+requests==2.21.0
 requests_toolbelt==0.8.0
 s3transfer==0.1.13        # via boto3
-six==1.11.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mohawk, more-itertools, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest, pytest-xdist, python-dateutil, requests-mock, six, traitlets
+six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mohawk, more-itertools, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest, pytest-xdist, python-dateutil, requests-mock, traitlets
 snowballstemmer==1.2.1    # via pydocstyle, snowballstemmer
 sqlparse==0.2.4           # via django-debug-toolbar, sqlparse
 termcolor==1.1.0          # via pytest-sugar, termcolor


### PR DESCRIPTION
### Description of change

This updates various dependencies. Change logs:

- https://github.com/requests/requests/blob/master/HISTORY.md
- https://github.com/boto/boto3/blob/develop/CHANGELOG.rst
- https://elasticsearch-dsl.readthedocs.io/en/latest/Changelog.html
- https://docs.pytest.org/en/latest/changelog.html
- https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst
- https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md
- https://github.com/getsentry/raven-python/blob/master/CHANGELOG.md
- https://bitbucket.org/dvarrazzo/psycogreen/compare/rel-1.0.1..rel-1.0
- https://github.com/celery/kombu/blob/4.2/Changelog

Kombu 4.2.2-post1 should fix the compatibility problem with 3.x versions of the `redis` package, but I've left upgrading the Redis client to another PR.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
