### PR TITLE
Add delivery date filter to OMIS order search

### DIFF
--- a/changelog/omis/delivery-date-filter.api
+++ b/changelog/omis/delivery-date-filter.api
@@ -1,0 +1,1 @@
+``POST /v3/search/order``: ``delivery_date_before`` and ``delivery_date_after`` filters were added.

--- a/changelog/omis/delivery-date-filter.feature
+++ b/changelog/omis/delivery-date-filter.feature
@@ -1,0 +1,1 @@
+Less than or equal to and greater than or equal to filters were added for the delivery date field to OMIS order search.

--- a/datahub/core/serializers.py
+++ b/datahub/core/serializers.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from dateutil.parser import parse as dateutil_parse
 from django.apps import apps
 from django.core.exceptions import ObjectDoesNotExist
@@ -136,6 +138,9 @@ class NestedRelatedField(serializers.RelatedField):
             )
             for item in queryset
         )
+
+
+RelaxedDateField = partial(serializers.DateField, input_formats=('iso-8601', '%Y/%m/%d'))
 
 
 class RelaxedDateTimeField(serializers.Field):

--- a/datahub/core/test/test_serializers.py
+++ b/datahub/core/test/test_serializers.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest.mock import call, MagicMock, Mock
 from uuid import uuid4
 
@@ -6,7 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import IntegerField
 
-from datahub.core.serializers import NestedRelatedField, RelaxedURLField
+from datahub.core.serializers import NestedRelatedField, RelaxedDateField, RelaxedURLField
 
 
 class TestNestedRelatedField:
@@ -191,3 +192,23 @@ class TestNestedRelatedField:
         def test_url_field_output(self, input_website, expected_website):
             """Tests that RelaxedURLField prepends http:// when one is not stored."""
             assert RelaxedURLField().to_representation(input_website) == expected_website
+
+
+class TestRelaxedDateField:
+    """Tests for RelaxedDateField."""
+
+    @pytest.mark.parametrize(
+        'input_value,expected_date',
+        (
+            ('2018-01-10', date(2018, 1, 10)),
+            ('2018-1-10', date(2018, 1, 10)),
+            ('2018-10-1', date(2018, 10, 1)),
+            ('2018/01/10', date(2018, 1, 10)),
+            ('2018/1/10', date(2018, 1, 10)),
+            ('2018/10/1', date(2018, 10, 1)),
+        ),
+    )
+    def test_parses_dates(self, input_value, expected_date):
+        """Test that various input values are parsed and interpreted as the correct date."""
+        field = RelaxedDateField()
+        assert field.to_internal_value(input_value) == expected_date

--- a/datahub/search/omis/serializers.py
+++ b/datahub/search/omis/serializers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from datahub.core.serializers import RelaxedDateTimeField
+from datahub.core.serializers import RelaxedDateField, RelaxedDateTimeField
 from datahub.search.serializers import (
     SearchSerializer,
     SingleOrListField,
@@ -16,6 +16,8 @@ class SearchOrderSerializer(SearchSerializer):
     uk_region = SingleOrListField(child=StringUUIDField(), required=False)
     created_on_before = RelaxedDateTimeField(required=False)
     created_on_after = RelaxedDateTimeField(required=False)
+    delivery_date_before = RelaxedDateField(required=False)
+    delivery_date_after = RelaxedDateField(required=False)
     assigned_to_adviser = SingleOrListField(child=StringUUIDField(), required=False)
     assigned_to_team = SingleOrListField(child=StringUUIDField(), required=False)
     status = SingleOrListField(child=serializers.CharField(), required=False)

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -158,6 +158,21 @@ class TestSearchOrder(APITestMixin):
                 {'created_on_after': '2017-01-15'},
                 ['efgh'],
             ),
+            (  # filter by delivery_date_before and delivery_date_after
+                {
+                    'delivery_date_before': '2018-02-02',
+                    'delivery_date_after': '2018-02-01',
+                },
+                ['efgh'],
+            ),
+            (  # filter by delivery_date_before only
+                {'delivery_date_before': '2018-01-15'},
+                ['abcd'],
+            ),
+            (  # filter by delivery_date_after only
+                {'delivery_date_after': '2018-01-15'},
+                ['efgh'],
+            ),
             (  # filter by status
                 {'status': 'quote_awaiting_acceptance'},
                 ['efgh'],

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -30,6 +30,8 @@ class SearchOrderParams:
         'uk_region',
         'created_on_before',
         'created_on_after',
+        'delivery_date_before',
+        'delivery_date_after',
         'assigned_to_adviser',
         'assigned_to_team',
         'status',


### PR DESCRIPTION
### Description of change

This adds delivery date filters to `/v3/search/order`. Since the field only stores dates, and the filters in the front end are date filters, I added a `RelaxedDateField` serialiser field to use here as I couldn't see much logic in using `RelaxedDateTimeField`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
