### PR TITLE
Deprecate investment project search aggregations

### DIFF
--- a/changelog/investment/aggregations.api
+++ b/changelog/investment/aggregations.api
@@ -1,0 +1,1 @@
+``POST /v3/search/investment_project``: The ``aggregations`` property of responses is deprecated and will be removed on or after 17 January 2019.

--- a/changelog/investment/aggregations.removal
+++ b/changelog/investment/aggregations.removal
@@ -1,0 +1,1 @@
+``POST /v3/search/investment_project``: The ``aggregations`` property of responses is deprecated and will be removed on or after 17 January 2019.


### PR DESCRIPTION
### Description of change

This deprecates entity search aggregations (which was only turned on for `/v3/search/investment_project`) as they aren't being used.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
