### PR TITLE
Add completed on filter to OMIS order search

### DIFF
--- a/changelog/omis/completed-on-filter.api
+++ b/changelog/omis/completed-on-filter.api
@@ -1,0 +1,1 @@
+``POST /v3/search/order``: ``completed_on_before`` and ``completed_on_after`` filters were added. These only accept dates without a time component. Timestamps on the dates specified will be included in the results.

--- a/changelog/omis/completed-on-filter.feature
+++ b/changelog/omis/completed-on-filter.feature
@@ -1,0 +1,1 @@
+Less than or equal to and greater than or equal to filters were added for the completed on field to OMIS order search.

--- a/datahub/search/omis/serializers.py
+++ b/datahub/search/omis/serializers.py
@@ -14,6 +14,12 @@ class SearchOrderSerializer(SearchSerializer):
     primary_market = SingleOrListField(child=StringUUIDField(), required=False)
     sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     uk_region = SingleOrListField(child=StringUUIDField(), required=False)
+    # Note that completed_on is a DateTime field, but we only allow filtering using whole dates
+    # for simplicity
+    # Elasticsearch sets the time component for completed_on_before to 23:59:59.999
+    # automatically
+    completed_on_before = RelaxedDateField(required=False)
+    completed_on_after = RelaxedDateField(required=False)
     created_on_before = RelaxedDateTimeField(required=False)
     created_on_after = RelaxedDateTimeField(required=False)
     delivery_date_before = RelaxedDateField(required=False)

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -69,6 +69,7 @@ def setup_data(setup_es):
             contact=contact,
             discount_value=0,
             delivery_date=dateutil_parse('2018-01-01').date(),
+            completed_on=dateutil_parse('2018-05-01T13:00:00Z'),
             vat_verified=False,
         )
         OrderSubscriberFactory(
@@ -98,6 +99,7 @@ def setup_data(setup_es):
             contact=contact,
             discount_value=0,
             delivery_date=dateutil_parse('2018-02-01').date(),
+            completed_on=dateutil_parse('2018-06-01T13:00:00Z'),
             vat_verified=False,
         )
         OrderSubscriberFactory(
@@ -142,6 +144,31 @@ class TestSearchOrder(APITestMixin):
             (  # filter by uk region
                 {'uk_region': constants.UKRegion.east_midlands.value.id},
                 ['efgh'],
+            ),
+            (  # filter by completed_on_before and completed_on_after
+               # note that both dates are inclusive
+                {
+                    'completed_on_before': '2018-06-01',
+                    'completed_on_after': '2018-05-01',
+                    'sortby': 'created_on:asc',
+                },
+                ['abcd', 'efgh'],
+            ),
+            (  # filter by completed_on_before only
+                {'completed_on_before': '2018-05-01'},
+                ['abcd'],
+            ),
+            (  # filter by completed_on_before only
+                {'completed_on_before': '2018-04-30'},
+                [],
+            ),
+            (  # filter by completed_on_after only
+                {'completed_on_after': '2018-06-01'},
+                ['efgh'],
+            ),
+            (  # filter by completed_on_after only
+                {'completed_on_after': '2018-06-02'},
+                [],
             ),
             (  # filter by a range of date for created_on
                 {

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -28,6 +28,8 @@ class SearchOrderParams:
         'primary_market',
         'sector_descends',
         'uk_region',
+        'completed_on_before',
+        'completed_on_after',
         'created_on_before',
         'created_on_after',
         'delivery_date_before',


### PR DESCRIPTION
### Description of change

There is a bit of a subtlety here: in the front end this will be a date filter (with times) but the field itself includes times. Any timestamps on the before date need to be included in the results. This is already the behaviour in Elasticsearch when you perform range queries with dates (rather than full timestamps) in the query.

I have used `RelaxedDate` here on the serialiser bearing in mind the above. Although it would be unlikely, if, for some reason, we decide to add time filtering as well in the future, we could potentially change the serialiser field to accept dates or timestamps.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
