### PR TITLE
Use Contact.name for the name field in Elasticsearch contact documents

### DIFF
--- a/datahub/company/models/contact.py
+++ b/datahub/company/models/contact.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from datahub.core import reversion
 from datahub.core.models import ArchivableModel, BaseModel
-from datahub.core.utils import get_front_end_url, StrEnum
+from datahub.core.utils import get_front_end_url, join_truthy_strings, StrEnum
 from datahub.metadata import models as metadata_models
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -87,7 +87,7 @@ class Contact(ArchivableModel, BaseModel):
     @property
     def name(self):
         """Full name."""
-        return f'{self.first_name} {self.last_name}'
+        return join_truthy_strings(self.first_name, self.last_name)
 
     def __str__(self):
         """Admin displayed human readable name."""

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -33,23 +33,16 @@ class Contact(BaseESModel):
     created_on = Date()
     email = fields.NormalizedKeyword()
     email_alternative = Text()
-    first_name = fields.SortableText(
-        copy_to=[
-            'name',
-            'name_keyword',
-            'name_trigram',
-        ],
-    )
+    first_name = fields.SortableText()
     job_title = fields.NormalizedKeyword()
-    last_name = fields.SortableText(
+    last_name = fields.SortableText()
+    modified_on = Date()
+    name = fields.SortableText(
         copy_to=[
-            'name',
             'name_keyword',
             'name_trigram',
         ],
     )
-    modified_on = Date()
-    name = fields.SortableText()
     name_keyword = fields.NormalizedKeyword()
     # field is being aggregated
     name_trigram = fields.TrigramText()

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -182,7 +182,6 @@ def test_mapping(setup_es):
                 },
                 'email_alternative': {'type': 'text'},
                 'first_name': {
-                    'copy_to': ['name', 'name_keyword', 'name_trigram'],
                     'fielddata': True,
                     'type': 'text',
                 },
@@ -192,12 +191,15 @@ def test_mapping(setup_es):
                     'type': 'keyword',
                 },
                 'last_name': {
-                    'copy_to': ['name', 'name_keyword', 'name_trigram'],
                     'fielddata': True,
                     'type': 'text',
                 },
                 'modified_on': {'type': 'date'},
-                'name': {'fielddata': True, 'type': 'text'},
+                'name': {
+                    'fielddata': True,
+                    'type': 'text',
+                    'copy_to': ['name_keyword', 'name_trigram'],
+                },
                 'name_keyword': {
                     'normalizer': 'lowercase_asciifolding_normalizer',
                     'type': 'keyword',

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -26,6 +26,7 @@ def test_contact_dbmodel_to_dict(setup_es):
         'archived_by',
         'first_name',
         'last_name',
+        'name',
         'job_title',
         'adviser',
         'primary',


### PR DESCRIPTION
### Description of change

This uses `Contact.name` instead of `copy_to` on `first_name` and `last_name` as the data source for the `name` field in Elasticsearch contact documents.

This is in preparation for using multi-fields. It also wasn't really doing the correct thing for `name_keyword` previously as it was storing multiple values which has the wrong behaviour when sorting.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
