### PR TITLE
Add name.keyword and name.trigram fields to search models

### DIFF
--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -19,6 +19,10 @@ class CompaniesHouseCompany(BaseESModel):
         copy_to=[
             'name_keyword', 'name_trigram',
         ],
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+            'trigram': fields.TrigramText(),
+        },
     )
     name_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -45,6 +45,16 @@ def test_mapping(setup_es):
                     'copy_to': ['name_keyword', 'name_trigram'],
                     'fielddata': True,
                     'type': 'text',
+                    'fields': {
+                        'keyword': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'name_keyword': {
                     'normalizer': 'lowercase_asciifolding_normalizer',

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -70,7 +70,13 @@ class Company(BaseESModel):
     global_headquarters = fields.id_name_field()
     headquarter_type = fields.id_name_field()
     modified_on = Date()
-    name = fields.SortableText(copy_to=['name_keyword', 'name_trigram'])
+    name = fields.SortableText(
+        copy_to=['name_keyword', 'name_trigram'],
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+            'trigram': fields.TrigramText(),
+        },
+    )
     name_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()
     reference_code = fields.NormalizedKeyword()

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -168,6 +168,16 @@ def test_mapping(setup_es):
                     'copy_to': ['name_keyword', 'name_trigram'],
                     'fielddata': True,
                     'type': 'text',
+                    'fields': {
+                        'keyword': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'name_keyword': {
                     'normalizer': 'lowercase_asciifolding_normalizer',

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -42,6 +42,10 @@ class Contact(BaseESModel):
             'name_keyword',
             'name_trigram',
         ],
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+            'trigram': fields.TrigramText(),
+        },
     )
     name_keyword = fields.NormalizedKeyword()
     # field is being aggregated

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -199,6 +199,16 @@ def test_mapping(setup_es):
                     'fielddata': True,
                     'type': 'text',
                     'copy_to': ['name_keyword', 'name_trigram'],
+                    'fields': {
+                        'keyword': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'name_keyword': {
                     'normalizer': 'lowercase_asciifolding_normalizer',

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -25,7 +25,13 @@ class Event(BaseESModel):
     lead_team = fields.id_name_field()
     location_type = fields.id_name_field()
     modified_on = Date()
-    name = fields.SortableText(copy_to=['name_keyword', 'name_trigram'])
+    name = fields.SortableText(
+        copy_to=['name_keyword', 'name_trigram'],
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+            'trigram': fields.TrigramText(),
+        },
+    )
     name_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()
     notes = fields.EnglishText()

--- a/datahub/search/event/tests/test_elasticsearch.py
+++ b/datahub/search/event/tests/test_elasticsearch.py
@@ -93,6 +93,16 @@ def test_mapping(setup_es):
                     ],
                     'fielddata': True,
                     'type': 'text',
+                    'fields': {
+                        'keyword': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'name_keyword': {
                     'normalizer': 'lowercase_asciifolding_normalizer',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -103,7 +103,13 @@ class InvestmentProject(BaseESModel):
     project_manager = fields.contact_or_adviser_field(
         'project_manager', include_dit_team=True,
     )
-    name = fields.SortableText(copy_to=['name_keyword', 'name_trigram'])
+    name = fields.SortableText(
+        copy_to=['name_keyword', 'name_trigram'],
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+            'trigram': fields.TrigramText(),
+        },
+    )
     name_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()
     new_tech_to_uk = Boolean()

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -378,6 +378,16 @@ def test_mapping(setup_es):
                     ],
                     'fielddata': True,
                     'type': 'text',
+                    'fields': {
+                        'keyword': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'name_keyword': {
                     'normalizer': 'lowercase_asciifolding_normalizer',


### PR DESCRIPTION
### Description of change

This adds `keyword` and `trigram` sub-fields to the `name` field for all models that have a `name` field.

Existing query logic remains unchanged so that the fields can first be populated with data. Once that is done, the query logic can be updated to use the new fields (and the old `name_keyword` and `name_trigram` fields can be removed).

These fields are all being tackled together as there is logic around `name_keyword` in `datahub.search.query_builder` that is common to all models.

I was on the fence about whether to define a new field with the sub-fields already defined (and use that). I decided against it when I wrote out the name of it (`TextWithNormalizedKeywordAndTrigram`) but could go with that approach if anyone feels strongly about it.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
