### PR TITLE
Fix non-deterministic tests using random trading_names data

### DIFF
--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -218,10 +218,10 @@ class TestSearch(APITestMixin):
 
     def test_search_results_quality(self, setup_es, setup_data):
         """Tests quality of results."""
-        CompanyFactory(name='The Risk Advisory Group')
-        CompanyFactory(name='The Advisory Group')
-        CompanyFactory(name='The Advisory')
-        CompanyFactory(name='The Advisories')
+        CompanyFactory(name='The Risk Advisory Group', trading_names=[])
+        CompanyFactory(name='The Advisory Group', trading_names=[])
+        CompanyFactory(name='The Advisory', trading_names=[])
+        CompanyFactory(name='The Advisories', trading_names=[])
 
         setup_es.indices.refresh()
 
@@ -248,10 +248,10 @@ class TestSearch(APITestMixin):
 
     def test_search_partial_match(self, setup_es, setup_data):
         """Tests partial matching."""
-        CompanyFactory(name='Veryuniquename1')
-        CompanyFactory(name='Veryuniquename2')
-        CompanyFactory(name='Veryuniquename3')
-        CompanyFactory(name='Veryuniquename4')
+        CompanyFactory(name='Veryuniquename1', trading_names=[])
+        CompanyFactory(name='Veryuniquename2', trading_names=[])
+        CompanyFactory(name='Veryuniquename3', trading_names=[])
+        CompanyFactory(name='Veryuniquename4', trading_names=[])
 
         setup_es.indices.refresh()
 
@@ -279,10 +279,10 @@ class TestSearch(APITestMixin):
 
     def test_search_hyphen_match(self, setup_es, setup_data):
         """Tests hyphen query."""
-        CompanyFactory(name='t-shirt')
-        CompanyFactory(name='tshirt')
-        CompanyFactory(name='electronic shirt')
-        CompanyFactory(name='t and e and a')
+        CompanyFactory(name='t-shirt', trading_names=[])
+        CompanyFactory(name='tshirt', trading_names=[])
+        CompanyFactory(name='electronic shirt', trading_names=[])
+        CompanyFactory(name='t and e and a', trading_names=[])
 
         setup_es.indices.refresh()
 


### PR DESCRIPTION
### Description of change

Some search tests randomly failed because the random generated value of `trading_names` was affecting the logic.

This makes sure the value of `trading_names` is not used.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
