### PR TITLE
Extend replace_null_with_default task to support specified values

### DIFF
--- a/datahub/dbmaintenance/test/test_tasks.py
+++ b/datahub/dbmaintenance/test/test_tasks.py
@@ -55,22 +55,88 @@ class TestReplaceNullWithDefault:
         assert NullableWithDefaultModel.objects.filter(nullable_with_default=False).count() == 10
 
     @pytest.mark.parametrize(
-        'field',
+        'num_objects,batch_size,expected_batches',
         (
-            'nullable_without_default',
-            'nullable_with_callable_default',
-            'non_nullable_with_default',
+            (10, 4, 3),
+            (10, 5, 3),
+            (11, 6, 2),
+            (11, 12, 1),
+            (0, 5, 1),
         ),
     )
-    def test_raises_error_on_invalid_field(self, monkeypatch, field):
+    def test_replaces_null_with_given_default(
+            self,
+            monkeypatch,
+            num_objects,
+            batch_size,
+            expected_batches,
+    ):
+        """Test that null values are replaced with the default value explicitly specified."""
+        replace_null_with_default_mock = Mock(
+            side_effect=replace_null_with_default,
+            wraps=replace_null_with_default,
+        )
+        monkeypatch.setattr(
+            'datahub.dbmaintenance.tasks.replace_null_with_default',
+            replace_null_with_default_mock,
+        )
+
+        objs = (
+            [NullableWithDefaultModel(nullable_without_default=None)] * num_objects
+            + [NullableWithDefaultModel(nullable_without_default=False)] * 10
+        )
+        NullableWithDefaultModel.objects.bulk_create(objs)
+
+        replace_null_with_default_mock.apply_async(
+            args=('support.NullableWithDefaultModel', 'nullable_without_default'),
+            kwargs={'default': True, 'batch_size': batch_size},
+        )
+
+        assert replace_null_with_default_mock.apply_async.call_count == expected_batches
+        assert NullableWithDefaultModel.objects.filter(
+            nullable_without_default__isnull=True,
+        ).count() == 0
+        assert NullableWithDefaultModel.objects.filter(
+            nullable_without_default=False,
+        ).count() == 10
+
+    @pytest.mark.parametrize(
+        'field,default,expected_error_msg',
+        (
+            (
+                'nullable_without_default',
+                None,
+                'nullable_without_default does not have a non-null default value',
+            ),
+            (
+                'nullable_with_callable_default',
+                None,
+                'callable defaults for nullable_with_callable_default are not supported',
+            ),
+            (
+                'non_nullable_with_default',
+                None,
+                'non_nullable_with_default is not nullable',
+            ),
+            (
+                'nullable_without_default',
+                str,
+                'callable defaults for nullable_without_default are not supported',
+            ),
+        ),
+    )
+    def test_raises_error_on_invalid_field(self, monkeypatch, field, default, expected_error_msg):
         """
         Test that an error is raised if:
-         - a model field without a default is specified
-         - a model field with a callable default is specified
-         - a non-nullable model field is specified
+         - a model field without a default is defined
+         - a model field with a callable default is defined
+         - a model field with a callable default is explicitly specified
+         - a non-nullable model field is defined
         """
         res = replace_null_with_default.apply_async(
             args=('support.NullableWithDefaultModel', field),
+            kwargs={'default': default},
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError) as excinfo:
             assert res.get()
+        assert str(excinfo.value) == expected_error_msg


### PR DESCRIPTION
### Description of change

This extends the `replace_null_with_default` task so that a default value can be explicitly specified instead of using the field's one.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
