### PR TITLE
Remove fielddata from name fields in search models

### DIFF
--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -15,7 +15,7 @@ class CompaniesHouseCompany(BaseESModel):
     company_number = fields.NormalizedKeyword()
     company_status = fields.NormalizedKeyword()
     incorporation_date = Date()
-    name = fields.SortableText(
+    name = Text(
         copy_to=[
             'name_keyword', 'name_trigram',
         ],

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -43,7 +43,6 @@ def test_mapping(setup_es):
                 },
                 'name': {
                     'copy_to': ['name_keyword', 'name_trigram'],
-                    'fielddata': True,
                     'type': 'text',
                     'fields': {
                         'keyword': {

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -70,7 +70,7 @@ class Company(BaseESModel):
     global_headquarters = fields.id_name_field()
     headquarter_type = fields.id_name_field()
     modified_on = Date()
-    name = fields.SortableText(
+    name = Text(
         copy_to=['name_keyword', 'name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -166,7 +166,6 @@ def test_mapping(setup_es):
                 'modified_on': {'type': 'date'},
                 'name': {
                     'copy_to': ['name_keyword', 'name_trigram'],
-                    'fielddata': True,
                     'type': 'text',
                     'fields': {
                         'keyword': {

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -33,9 +33,17 @@ class Contact(BaseESModel):
     created_on = Date()
     email = fields.NormalizedKeyword()
     email_alternative = Text()
-    first_name = fields.SortableText()
+    first_name = fields.SortableText(
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+        },
+    )
     job_title = fields.NormalizedKeyword()
-    last_name = fields.SortableText()
+    last_name = fields.SortableText(
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+        },
+    )
     modified_on = Date()
     name = Text(
         copy_to=[

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -37,7 +37,7 @@ class Contact(BaseESModel):
     job_title = fields.NormalizedKeyword()
     last_name = fields.SortableText()
     modified_on = Date()
-    name = fields.SortableText(
+    name = Text(
         copy_to=[
             'name_keyword',
             'name_trigram',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -196,7 +196,6 @@ def test_mapping(setup_es):
                 },
                 'modified_on': {'type': 'date'},
                 'name': {
-                    'fielddata': True,
                     'type': 'text',
                     'copy_to': ['name_keyword', 'name_trigram'],
                     'fields': {

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -184,6 +184,12 @@ def test_mapping(setup_es):
                 'first_name': {
                     'fielddata': True,
                     'type': 'text',
+                    'fields': {
+                        'keyword': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                    },
                 },
                 'id': {'type': 'keyword'},
                 'job_title': {
@@ -193,6 +199,12 @@ def test_mapping(setup_es):
                 'last_name': {
                     'fielddata': True,
                     'type': 'text',
+                    'fields': {
+                        'keyword': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                    },
                 },
                 'modified_on': {'type': 'date'},
                 'name': {

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -25,7 +25,7 @@ class Event(BaseESModel):
     lead_team = fields.id_name_field()
     location_type = fields.id_name_field()
     modified_on = Date()
-    name = fields.SortableText(
+    name = Text(
         copy_to=['name_keyword', 'name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),

--- a/datahub/search/event/tests/test_elasticsearch.py
+++ b/datahub/search/event/tests/test_elasticsearch.py
@@ -91,7 +91,6 @@ def test_mapping(setup_es):
                         'name_keyword',
                         'name_trigram',
                     ],
-                    'fielddata': True,
                     'type': 'text',
                     'fields': {
                         'keyword': {

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -103,7 +103,7 @@ class InvestmentProject(BaseESModel):
     project_manager = fields.contact_or_adviser_field(
         'project_manager', include_dit_team=True,
     )
-    name = fields.SortableText(
+    name = Text(
         copy_to=['name_keyword', 'name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -376,7 +376,6 @@ def test_mapping(setup_es):
                         'name_keyword',
                         'name_trigram',
                     ],
-                    'fielddata': True,
                     'type': 'text',
                     'fields': {
                         'keyword': {

--- a/datahub/search/test/search_support/simplemodel/models.py
+++ b/datahub/search/test/search_support/simplemodel/models.py
@@ -1,4 +1,4 @@
-from elasticsearch_dsl import Keyword
+from elasticsearch_dsl import Keyword, Text
 
 from datahub.search import fields
 from datahub.search.models import BaseESModel
@@ -11,7 +11,7 @@ class ESSimpleModel(BaseESModel):
     """Elasticsearch representation of SimpleModel model."""
 
     id = Keyword()
-    name = fields.SortableText(copy_to=['name_keyword', 'name_normalized_keyword', 'name_trigram'])
+    name = Text(copy_to=['name_keyword', 'name_normalized_keyword', 'name_trigram'])
     name_keyword = fields.NormalizedKeyword()
     name_normalized_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()


### PR DESCRIPTION
### Description of change

This changes all `name` fields on search models to use `Text` instead of `SortableText` so that they no longer use `fielddata`. (The logic in `datahub.search.query_builder` sorts by `name_keyword` if you try to sort by `name`, so there wasn't any reason for these fields to use `SortableText`.)

This also adds keyword sub-fields to `Contact.first_name` and `Contact.last_name` in preparation for removing `fielddata` from them.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
