### PR TITLE
Fix audit history when a related object has a null value

### DIFF
--- a/changelog/audit.bugfix
+++ b/changelog/audit.bugfix
@@ -1,0 +1,1 @@
+A bug for audit history where a related entity has a null value and cannot be iterated over was fixed.

--- a/datahub/core/audit_utils.py
+++ b/datahub/core/audit_utils.py
@@ -61,7 +61,7 @@ def _make_value_friendly(field, value):
     one to many all values need to be retrieved individually.
 
     """
-    if not field or not field.is_relation:
+    if not field or not field.is_relation or not value:
         return value
 
     if field.many_to_many or field.one_to_many:

--- a/datahub/core/test/test_audit_utils.py
+++ b/datahub/core/test/test_audit_utils.py
@@ -82,6 +82,7 @@ def test_get_changes(old_version, new_version, expected_result):
         ('proofreader', 'value', 'fake', 1),
         ('name', 'value', 'value', 0),
         ('authors', ['value1', 'value2'], ['fake', 'fake'], 2),
+        ('authors', None, None, 0),
     ),
 )
 @unittest.mock.patch('datahub.core.audit_utils._get_object_name_for_pk')


### PR DESCRIPTION
### Description of change
This is fix for the audit history bug. When a related object is not iterable an error occurs.

Added a check if not value before attempting to loop.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
