### PR TITLE
Use name.keyword in search queries and remove name_keyword

### DIFF
--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -16,15 +16,12 @@ class CompaniesHouseCompany(BaseESModel):
     company_status = fields.NormalizedKeyword()
     incorporation_date = Date()
     name = Text(
-        copy_to=[
-            'name_keyword', 'name_trigram',
-        ],
+        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()
     registered_address_1 = Text()
     registered_address_2 = Text()

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -42,7 +42,7 @@ def test_mapping(setup_es):
                     'type': 'date',
                 },
                 'name': {
-                    'copy_to': ['name_keyword', 'name_trigram'],
+                    'copy_to': ['name_trigram'],
                     'type': 'text',
                     'fields': {
                         'keyword': {
@@ -54,10 +54,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_keyword': {
-                    'normalizer': 'lowercase_asciifolding_normalizer',
-                    'type': 'keyword',
                 },
                 'name_trigram': {
                     'analyzer': 'trigram_analyzer',

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -71,13 +71,12 @@ class Company(BaseESModel):
     headquarter_type = fields.id_name_field()
     modified_on = Date()
     name = Text(
-        copy_to=['name_keyword', 'name_trigram'],
+        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()
     reference_code = fields.NormalizedKeyword()
     registered_address_1 = Text()

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -165,7 +165,7 @@ def test_mapping(setup_es):
                 'id': {'type': 'keyword'},
                 'modified_on': {'type': 'date'},
                 'name': {
-                    'copy_to': ['name_keyword', 'name_trigram'],
+                    'copy_to': ['name_trigram'],
                     'type': 'text',
                     'fields': {
                         'keyword': {
@@ -177,10 +177,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_keyword': {
-                    'normalizer': 'lowercase_asciifolding_normalizer',
-                    'type': 'keyword',
                 },
                 'name_trigram': {
                     'analyzer': 'trigram_analyzer',
@@ -324,7 +320,7 @@ def test_get_basic_search_query():
                 'should': [
                     {
                         'match_phrase': {
-                            'name_keyword': {
+                            'name.keyword': {
                                 'query': 'test',
                                 'boost': 2,
                             },
@@ -447,7 +443,7 @@ def test_limited_get_search_by_entity_query():
                             'should': [
                                 {
                                     'match_phrase': {
-                                        'name_keyword': {
+                                        'name.keyword': {
                                             'query': 'test',
                                             'boost': 2,
                                         },

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -46,16 +46,12 @@ class Contact(BaseESModel):
     )
     modified_on = Date()
     name = Text(
-        copy_to=[
-            'name_keyword',
-            'name_trigram',
-        ],
+        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_keyword = fields.NormalizedKeyword()
     # field is being aggregated
     name_trigram = fields.TrigramText()
     notes = fields.EnglishText()

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -209,7 +209,7 @@ def test_mapping(setup_es):
                 'modified_on': {'type': 'date'},
                 'name': {
                     'type': 'text',
-                    'copy_to': ['name_keyword', 'name_trigram'],
+                    'copy_to': ['name_trigram'],
                     'fields': {
                         'keyword': {
                             'normalizer': 'lowercase_asciifolding_normalizer',
@@ -220,10 +220,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_keyword': {
-                    'normalizer': 'lowercase_asciifolding_normalizer',
-                    'type': 'keyword',
                 },
                 'name_trigram': {
                     'analyzer': 'trigram_analyzer',
@@ -263,7 +259,7 @@ def test_get_basic_search_query():
                 'should': [
                     {
                         'match_phrase': {
-                            'name_keyword': {
+                            'name.keyword': {
                                 'query': 'test',
                                 'boost': 2,
                             },
@@ -386,7 +382,7 @@ def test_get_limited_search_by_entity_query():
                             'should': [
                                 {
                                     'match_phrase': {
-                                        'name_keyword': {
+                                        'name.keyword': {
                                             'query': 'test',
                                             'boost': 2,
                                         },

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -26,13 +26,12 @@ class Event(BaseESModel):
     location_type = fields.id_name_field()
     modified_on = Date()
     name = Text(
-        copy_to=['name_keyword', 'name_trigram'],
+        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()
     notes = fields.EnglishText()
     organiser = fields.contact_or_adviser_field('organiser')

--- a/datahub/search/event/tests/test_elasticsearch.py
+++ b/datahub/search/event/tests/test_elasticsearch.py
@@ -88,7 +88,6 @@ def test_mapping(setup_es):
                 'modified_on': {'type': 'date'},
                 'name': {
                     'copy_to': [
-                        'name_keyword',
                         'name_trigram',
                     ],
                     'type': 'text',
@@ -102,10 +101,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_keyword': {
-                    'normalizer': 'lowercase_asciifolding_normalizer',
-                    'type': 'keyword',
                 },
                 'name_trigram': {
                     'analyzer': 'trigram_analyzer',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -104,13 +104,12 @@ class InvestmentProject(BaseESModel):
         'project_manager', include_dit_team=True,
     )
     name = Text(
-        copy_to=['name_keyword', 'name_trigram'],
+        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_keyword = fields.NormalizedKeyword()
     name_trigram = fields.TrigramText()
     new_tech_to_uk = Boolean()
     non_fdi_r_and_d_budget = Boolean()

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -373,7 +373,6 @@ def test_mapping(setup_es):
                 'modified_on': {'type': 'date'},
                 'name': {
                     'copy_to': [
-                        'name_keyword',
                         'name_trigram',
                     ],
                     'type': 'text',
@@ -387,10 +386,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_keyword': {
-                    'normalizer': 'lowercase_asciifolding_normalizer',
-                    'type': 'keyword',
                 },
                 'name_trigram': {
                     'analyzer': 'trigram_analyzer',
@@ -708,7 +703,7 @@ def test_get_basic_search_query():
                 'should': [
                     {
                         'match_phrase': {
-                            'name_keyword': {
+                            'name.keyword': {
                                 'query': 'test',
                                 'boost': 2,
                             },
@@ -831,7 +826,7 @@ def test_limited_get_search_by_entity_query():
                             'should': [
                                 {
                                     'match_phrase': {
-                                        'name_keyword': {
+                                        'name.keyword': {
                                             'query': 'test',
                                             'boost': 2,
                                         },

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -8,7 +8,7 @@ from datahub.search.apps import EXCLUDE_ALL, get_global_search_apps_as_mapping
 
 MAX_RESULTS = 10000
 FIELD_REMAPPING = {
-    'name': 'name_keyword',
+    'name': 'name.keyword',
 }
 
 
@@ -211,7 +211,7 @@ def _build_term_query(term, fields=None):
 
     should_query = [
         # Promote exact name match
-        MatchPhrase(name_keyword={'query': term, 'boost': 2}),
+        MatchPhrase(**{'name.keyword': {'query': term, 'boost': 2}}),
         # Exact match by id
         MatchPhrase(id=term),
         # Cross match fields
@@ -250,7 +250,7 @@ def _build_single_field_query(field, value):
         parent_field = field.rsplit('.', maxsplit=1)[0]
         return _build_exists_query(f'{parent_field}_exists', False)
 
-    if any(field.endswith(suffix) for suffix in ('.id', '_keyword')):
+    if any(field.endswith(suffix) for suffix in ('.id', '_keyword', '.keyword')):
         return Q('match_phrase', **{field: value})
 
     field_query = {

--- a/datahub/search/test/search_support/simplemodel/models.py
+++ b/datahub/search/test/search_support/simplemodel/models.py
@@ -11,9 +11,12 @@ class ESSimpleModel(BaseESModel):
     """Elasticsearch representation of SimpleModel model."""
 
     id = Keyword()
-    name = Text(copy_to=['name_keyword', 'name_normalized_keyword', 'name_trigram'])
-    name_keyword = fields.NormalizedKeyword()
-    name_normalized_keyword = fields.NormalizedKeyword()
+    name = Text(
+        copy_to=['name_trigram'],
+        fields={
+            'keyword': fields.NormalizedKeyword(),
+        },
+    )
     name_trigram = fields.TrigramText()
 
     SEARCH_FIELDS = (

--- a/datahub/search/test/search_support/simplemodel/serializers.py
+++ b/datahub/search/test/search_support/simplemodel/serializers.py
@@ -8,4 +8,4 @@ class SearchSimpleModelSerializer(SearchSerializer):
 
     name = serializers.CharField(required=False)
 
-    SORT_BY_FIELDS = ('name', 'name_normalized_keyword')
+    SORT_BY_FIELDS = ('name', 'name.keyword')

--- a/datahub/search/test/test_fields.py
+++ b/datahub/search/test/test_fields.py
@@ -36,7 +36,7 @@ class TestNormalizedField(APITestMixin):
         response = api_client.post(
             url,
             data={
-                'sortby': 'name_normalized_keyword',
+                'sortby': 'name.keyword',
             },
         )
         response_data = response.json()

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -42,11 +42,11 @@ class TestQueryBuilder:
                 },
             ),
             (
-                'field_name.name_keyword',
+                'field_name.name.keyword',
                 'field value',
                 {
                     'match_phrase': {
-                        'field_name.name_keyword': 'field value',
+                        'field_name.name.keyword': 'field value',
                     },
                 },
             ),
@@ -165,7 +165,7 @@ class TestQueryBuilder:
                         'should': [
                             {
                                 'match_phrase': {
-                                    'name_keyword': {
+                                    'name.keyword': {
                                         'query': 'hello',
                                         'boost': 2,
                                     },


### PR DESCRIPTION
### Description of change

This uses `name.keyword` in all search queries and removes `name_keyword` from the search models that had that field.

I am not a fan of having logic around specific fields in `datahub.search.query_builder` (not least because not all search models have a `name` field). However, for now that logic remains there.

I am also not sure why we need to use `match_phrase` with keyword fields instead of sticking with `match` throughout but, again, that can be looked at separately.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
