### PR TITLE
Use name.trigram in search queries and remove name_trigram

### DIFF
--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -16,13 +16,11 @@ class CompaniesHouseCompany(BaseESModel):
     company_status = fields.NormalizedKeyword()
     incorporation_date = Date()
     name = Text(
-        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_trigram = fields.TrigramText()
     registered_address_1 = Text()
     registered_address_2 = Text()
     registered_address_town = fields.NormalizedKeyword()
@@ -44,7 +42,7 @@ class CompaniesHouseCompany(BaseESModel):
     SEARCH_FIELDS = (
         # to match names like A & B
         'name',
-        'name_trigram',
+        'name.trigram',
         'company_number',
         'registered_address_postcode_trigram',
     )

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -42,7 +42,6 @@ def test_mapping(setup_es):
                     'type': 'date',
                 },
                 'name': {
-                    'copy_to': ['name_trigram'],
                     'type': 'text',
                     'fields': {
                         'keyword': {
@@ -54,10 +53,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_trigram': {
-                    'analyzer': 'trigram_analyzer',
-                    'type': 'text',
                 },
                 'registered_address_1': {
                     'type': 'text',

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -71,13 +71,11 @@ class Company(BaseESModel):
     headquarter_type = fields.id_name_field()
     modified_on = Date()
     name = Text(
-        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_trigram = fields.TrigramText()
     reference_code = fields.NormalizedKeyword()
     registered_address_1 = Text()
     registered_address_2 = Text()
@@ -144,7 +142,7 @@ class Company(BaseESModel):
     SEARCH_FIELDS = (
         'id',
         'name',  # to find 2-letter words
-        'name_trigram',
+        'name.trigram',
         'company_number',
         'trading_names',  # to find 2-letter words
         'trading_names_trigram',

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -165,7 +165,6 @@ def test_mapping(setup_es):
                 'id': {'type': 'keyword'},
                 'modified_on': {'type': 'date'},
                 'name': {
-                    'copy_to': ['name_trigram'],
                     'type': 'text',
                     'fields': {
                         'keyword': {
@@ -177,10 +176,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_trigram': {
-                    'analyzer': 'trigram_analyzer',
-                    'type': 'text',
                 },
                 'reference_code': {
                     'normalizer': 'lowercase_asciifolding_normalizer',
@@ -349,7 +344,7 @@ def test_get_basic_search_query():
                                 'investor_company.name',
                                 'investor_company.name_trigram',
                                 'name',
-                                'name_trigram',
+                                'name.trigram',
                                 'organiser.name_trigram',
                                 'project_code_trigram',
                                 'reference_code',
@@ -451,7 +446,7 @@ def test_limited_get_search_by_entity_query():
                                         'fields': (
                                             'id',
                                             'name',
-                                            'name_trigram',
+                                            'name.trigram',
                                             'company_number',
                                             'trading_names',
                                             'trading_names_trigram',

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -51,7 +51,7 @@ class SearchCompanyParams:
     COMPOSITE_FILTERS = {
         'name': [
             'name',  # to find 2-letter words
-            'name_trigram',
+            'name.trigram',
             'trading_names',  # to find 2-letter words
             'trading_names_trigram',
         ],

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -46,14 +46,11 @@ class Contact(BaseESModel):
     )
     modified_on = Date()
     name = Text(
-        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    # field is being aggregated
-    name_trigram = fields.TrigramText()
     notes = fields.EnglishText()
     primary = Boolean()
     telephone_alternative = Text()
@@ -83,7 +80,7 @@ class Contact(BaseESModel):
     SEARCH_FIELDS = (
         'id',
         'name',
-        'name_trigram',
+        'name.trigram',
         'email',
         'email_alternative',
         'company.name',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -209,7 +209,6 @@ def test_mapping(setup_es):
                 'modified_on': {'type': 'date'},
                 'name': {
                     'type': 'text',
-                    'copy_to': ['name_trigram'],
                     'fields': {
                         'keyword': {
                             'normalizer': 'lowercase_asciifolding_normalizer',
@@ -220,10 +219,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_trigram': {
-                    'analyzer': 'trigram_analyzer',
-                    'type': 'text',
                 },
                 'notes': {
                     'analyzer': 'english_analyzer',
@@ -288,7 +283,7 @@ def test_get_basic_search_query():
                                 'investor_company.name',
                                 'investor_company.name_trigram',
                                 'name',
-                                'name_trigram',
+                                'name.trigram',
                                 'organiser.name_trigram',
                                 'project_code_trigram',
                                 'reference_code',
@@ -390,7 +385,7 @@ def test_get_limited_search_by_entity_query():
                                         'fields': (
                                             'id',
                                             'name',
-                                            'name_trigram',
+                                            'name.trigram',
                                             'email',
                                             'email_alternative',
                                             'company.name',

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -48,7 +48,7 @@ class SearchContactParams:
     COMPOSITE_FILTERS = {
         'name': [
             'name',
-            'name_trigram',
+            'name.trigram',
         ],
         'company_name': [
             'company.name',

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -26,13 +26,11 @@ class Event(BaseESModel):
     location_type = fields.id_name_field()
     modified_on = Date()
     name = Text(
-        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_trigram = fields.TrigramText()
     notes = fields.EnglishText()
     organiser = fields.contact_or_adviser_field('organiser')
     related_programmes = fields.id_name_partial_field('related_programmes')
@@ -58,7 +56,7 @@ class Event(BaseESModel):
     SEARCH_FIELDS = (
         'id',
         'name',
-        'name_trigram',
+        'name.trigram',
         'address_country.name_trigram',
         'address_postcode_trigram',
         'uk_region.name_trigram',

--- a/datahub/search/event/tests/test_elasticsearch.py
+++ b/datahub/search/event/tests/test_elasticsearch.py
@@ -87,9 +87,6 @@ def test_mapping(setup_es):
                 },
                 'modified_on': {'type': 'date'},
                 'name': {
-                    'copy_to': [
-                        'name_trigram',
-                    ],
                     'type': 'text',
                     'fields': {
                         'keyword': {
@@ -101,10 +98,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_trigram': {
-                    'analyzer': 'trigram_analyzer',
-                    'type': 'text',
                 },
                 'notes': {
                     'analyzer': 'english_analyzer',

--- a/datahub/search/event/views.py
+++ b/datahub/search/event/views.py
@@ -36,7 +36,7 @@ class SearchEventParams:
     }
 
     COMPOSITE_FILTERS = {
-        'name': ['name', 'name_trigram'],
+        'name': ['name', 'name.trigram'],
         'organiser_name': ['organiser.name', 'organiser.name_trigram'],
     }
 

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -104,13 +104,11 @@ class InvestmentProject(BaseESModel):
         'project_manager', include_dit_team=True,
     )
     name = Text(
-        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
             'trigram': fields.TrigramText(),
         },
     )
-    name_trigram = fields.TrigramText()
     new_tech_to_uk = Boolean()
     non_fdi_r_and_d_budget = Boolean()
     number_new_jobs = Integer()
@@ -192,7 +190,7 @@ class InvestmentProject(BaseESModel):
     SEARCH_FIELDS = (
         'id',
         'name',
-        'name_trigram',
+        'name.trigram',
         'uk_company.name',
         'uk_company.name_trigram',
         'investor_company.name',

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -372,9 +372,6 @@ def test_mapping(setup_es):
                 },
                 'modified_on': {'type': 'date'},
                 'name': {
-                    'copy_to': [
-                        'name_trigram',
-                    ],
                     'type': 'text',
                     'fields': {
                         'keyword': {
@@ -386,10 +383,6 @@ def test_mapping(setup_es):
                             'type': 'text',
                         },
                     },
-                },
-                'name_trigram': {
-                    'analyzer': 'trigram_analyzer',
-                    'type': 'text',
                 },
                 'new_tech_to_uk': {'type': 'boolean'},
                 'non_fdi_r_and_d_budget': {'type': 'boolean'},
@@ -732,7 +725,7 @@ def test_get_basic_search_query():
                                 'investor_company.name',
                                 'investor_company.name_trigram',
                                 'name',
-                                'name_trigram',
+                                'name.trigram',
                                 'organiser.name_trigram',
                                 'project_code_trigram',
                                 'reference_code',
@@ -834,7 +827,7 @@ def test_limited_get_search_by_entity_query():
                                         'fields': (
                                             'id',
                                             'name',
-                                            'name_trigram',
+                                            'name.trigram',
                                             'uk_company.name',
                                             'uk_company.name_trigram',
                                             'investor_company.name',

--- a/datahub/search/test/search_support/simplemodel/models.py
+++ b/datahub/search/test/search_support/simplemodel/models.py
@@ -12,16 +12,15 @@ class ESSimpleModel(BaseESModel):
 
     id = Keyword()
     name = Text(
-        copy_to=['name_trigram'],
         fields={
             'keyword': fields.NormalizedKeyword(),
+            'trigram': fields.TrigramText(),
         },
     )
-    name_trigram = fields.TrigramText()
 
     SEARCH_FIELDS = (
         'name',
-        'name_trigram',
+        'name.trigram',
     )
 
     class Meta:


### PR DESCRIPTION
### Description of change

This uses `name.trigram` in all search queries and removes `name_trigram` from the search models that had that field.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
