### PR TITLE
Add subtotal_cost totals to search orders response

### DIFF
--- a/changelog/omis/search-result-subtotal-cost-total.api
+++ b/changelog/omis/search-result-subtotal-cost-total.api
@@ -1,0 +1,1 @@
+``POST /v3/search/order``: The response now contains ``summary`` property that includes a total value of filtered orders' subtotal cost (``total_subtotal_cost``)`.

--- a/changelog/omis/search-result-subtotal-cost-total.feature
+++ b/changelog/omis/search-result-subtotal-cost-total.feature
@@ -1,0 +1,1 @@
+Search response for OMIS orders now contains total subtotal cost for given query.

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -428,8 +428,7 @@ def test_limited_get_search_by_entity_query():
                         'term': {
                             '_type': 'company',
                         },
-                    },
-                    {
+                    }, {
                         'bool': {
                             'should': [
                                 {
@@ -439,8 +438,7 @@ def test_limited_get_search_by_entity_query():
                                             'boost': 2,
                                         },
                                     },
-                                },
-                                {
+                                }, {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
@@ -465,58 +463,59 @@ def test_limited_get_search_by_entity_query():
                         },
                     },
                 ],
-            },
-        },
-        'post_filter': {
-            'bool': {
-                'must': [
+                'filter': [
                     {
                         'bool': {
-                            'should': [
+                            'must': [
                                 {
-                                    'match': {
-                                        'address_town': {
-                                            'query': 'Woodside',
-                                            'operator': 'and',
+                                    'bool': {
+                                        'should': [
+                                            {
+                                                'match': {
+                                                    'address_town': {
+                                                        'query': 'Woodside',
+                                                        'operator': 'and',
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        'minimum_should_match': 1,
+                                    },
+                                }, {
+                                    'bool': {
+                                        'should': [
+                                            {
+                                                'match': {
+                                                    'trading_address_country.id': {
+                                                        'query':
+                                                            '80756b9a-5d95-e211-a939-e4115bead28a',
+                                                        'operator': 'and',
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        'minimum_should_match': 1,
+                                    },
+                                }, {
+                                    'range': {
+                                        'estimated_land_date': {
+                                            'lte': '2017-06-13T09:44:31.062870',
+                                            'gte': '2017-06-13T09:44:31.062870',
                                         },
                                     },
                                 },
                             ],
-                            'minimum_should_match': 1,
-                        },
-                    },
-                    {
-                        'bool': {
-                            'should': [
-                                {
-                                    'match': {
-                                        'trading_address_country.id': {
-                                            'query': '80756b9a-5d95-e211-a939-e4115bead28a',
-                                            'operator': 'and',
-                                        },
-                                    },
-                                },
-                            ],
-                            'minimum_should_match': 1,
-                        },
-                    },
-                    {
-                        'range': {
-                            'estimated_land_date': {
-                                'gte': '2017-06-13T09:44:31.062870',
-                                'lte': '2017-06-13T09:44:31.062870',
-                            },
                         },
                     },
                 ],
             },
         },
-        'from': 5,
-        'size': 5,
         'sort': [
             '_score',
             'id',
         ],
+        'from': 5,
+        'size': 5,
     }
 
 

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -367,8 +367,7 @@ def test_get_limited_search_by_entity_query():
                         'term': {
                             '_type': 'contact',
                         },
-                    },
-                    {
+                    }, {
                         'bool': {
                             'should': [
                                 {
@@ -378,8 +377,7 @@ def test_get_limited_search_by_entity_query():
                                             'boost': 2,
                                         },
                                     },
-                                },
-                                {
+                                }, {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
@@ -399,54 +397,57 @@ def test_get_limited_search_by_entity_query():
                         },
                     },
                 ],
-            },
-        },
-        'post_filter': {
-            'bool': {
-                'must': [
+                'filter': [
                     {
                         'bool': {
-                            'should': [
+                            'must': [
                                 {
-                                    'match': {
-                                        'address_town': {
-                                            'query': 'Woodside',
-                                            'operator': 'and',
+                                    'bool': {
+                                        'should': [
+                                            {
+                                                'match': {
+                                                    'address_town': {
+                                                        'query': 'Woodside',
+                                                        'operator': 'and',
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        'minimum_should_match': 1,
+                                    },
+                                }, {
+                                    'bool': {
+                                        'should': [
+                                            {
+                                                'match': {
+                                                    'trading_address_country.id': {
+                                                        'query':
+                                                            '80756b9a-5d95-e211-a939-e4115bead28a',
+                                                        'operator': 'and',
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        'minimum_should_match': 1,
+                                    },
+                                }, {
+                                    'range': {
+                                        'estimated_land_date': {
+                                            'gte': '2017-06-13T09:44:31.062870',
+                                            'lte': '2017-06-13T09:44:31.062870',
                                         },
                                     },
                                 },
                             ],
-                            'minimum_should_match': 1,
-                        },
-                    },
-                    {
-                        'bool': {
-                            'should': [{
-                                'match': {
-                                    'trading_address_country.id': {
-                                        'query': '80756b9a-5d95-e211-a939-e4115bead28a',
-                                        'operator': 'and',
-                                    },
-                                },
-                            }],
-                            'minimum_should_match': 1,
-                        },
-                    },
-                    {
-                        'range': {
-                            'estimated_land_date': {
-                                'gte': '2017-06-13T09:44:31.062870',
-                                'lte': '2017-06-13T09:44:31.062870',
-                            },
                         },
                     },
                 ],
             },
         },
-        'from': 5,
-        'size': 5,
         'sort': [
             '_score',
             'id',
         ],
+        'from': 5,
+        'size': 5,
     }

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -809,8 +809,7 @@ def test_limited_get_search_by_entity_query():
                         'term': {
                             '_type': 'investment_project',
                         },
-                    },
-                    {
+                    }, {
                         'bool': {
                             'should': [
                                 {
@@ -820,8 +819,7 @@ def test_limited_get_search_by_entity_query():
                                             'boost': 2,
                                         },
                                     },
-                                },
-                                {
+                                }, {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
@@ -842,56 +840,57 @@ def test_limited_get_search_by_entity_query():
                         },
                     },
                 ],
-            },
-        },
-        'post_filter': {
-            'bool': {
-                'must': [
+                'filter': [
                     {
                         'bool': {
-                            'should': [
+                            'must': [
                                 {
-                                    'match': {
-                                        'address_town': {
-                                            'query': 'Woodside',
-                                            'operator': 'and',
+                                    'bool': {
+                                        'should': [
+                                            {
+                                                'match': {
+                                                    'address_town': {
+                                                        'query': 'Woodside',
+                                                        'operator': 'and',
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        'minimum_should_match': 1,
+                                    },
+                                }, {
+                                    'bool': {
+                                        'should': [
+                                            {
+                                                'match': {
+                                                    'trading_address_country.id': {
+                                                        'query':
+                                                            '80756b9a-5d95-e211-a939-e4115bead28a',
+                                                        'operator': 'and',
+                                                    },
+                                                },
+                                            },
+                                        ],
+                                        'minimum_should_match': 1,
+                                    },
+                                }, {
+                                    'range': {
+                                        'estimated_land_date': {
+                                            'gte': '2017-06-13T09:44:31.062870',
+                                            'lte': '2017-06-13T09:44:31.062870',
                                         },
                                     },
                                 },
                             ],
-                            'minimum_should_match': 1,
-                        },
-                    },
-                    {
-                        'bool': {
-                            'should': [
-                                {
-                                    'match': {
-                                        'trading_address_country.id': {
-                                            'query': '80756b9a-5d95-e211-a939-e4115bead28a',
-                                            'operator': 'and',
-                                        },
-                                    },
-                                },
-                            ],
-                            'minimum_should_match': 1,
-                        },
-                    },
-                    {
-                        'range': {
-                            'estimated_land_date': {
-                                'gte': '2017-06-13T09:44:31.062870',
-                                'lte': '2017-06-13T09:44:31.062870',
-                            },
                         },
                     },
                 ],
             },
         },
-        'from': 5,
-        'size': 5,
         'sort': [
             '_score',
             'id',
         ],
+        'from': 5,
+        'size': 5,
     }

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -109,9 +109,8 @@ def get_search_by_entity_query(
     if permission_query:
         s = s.filter(permission_query)
 
-    s = s.post_filter(
-        Bool(must=must_filter),
-    )
+    s = s.filter(Bool(must=must_filter))
+
     return _apply_sorting_to_query(s, ordering)
 
 

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -154,7 +154,13 @@ class SearchAPIView(APIView):
             'results': [x.to_dict() for x in results.hits],
         }
 
+        response = self.enhance_response(results, response)
+
         return Response(data=response)
+
+    def enhance_response(self, results, response):
+        """Placeholder for a method to enhance the response with custom data."""
+        return response
 
 
 class SearchExportAPIView(SearchAPIView):


### PR DESCRIPTION
### Description of change

This adds a sum aggregation for `subtotal_cost` field in the OMIS order search.
~The sum must be calculated after the rows have been filtered that's why it is now possible to specify if filtering should occur before or after aggregation (`post_filter` boolean argument). This functionality should be removed once we remove the existing aggregations, because then we should just be able to use the filter instead of post_filter. This will be done in a separate PR.~
The sum is specific to OMIS only and there are no plans to use it anywhere else that's why the query has been modified in the view class of the order search.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
