### PR TITLE
Use match instead of match_phrase for keyword fields in search queries

### DIFF
--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -319,7 +319,7 @@ def test_get_basic_search_query():
             'bool': {
                 'should': [
                     {
-                        'match_phrase': {
+                        'match': {
                             'name.keyword': {
                                 'query': 'test',
                                 'boost': 2,
@@ -327,7 +327,7 @@ def test_get_basic_search_query():
                         },
                     },
                     {
-                        'match_phrase': {
+                        'match': {
                             'id': 'test',
                         },
                     },
@@ -442,7 +442,7 @@ def test_limited_get_search_by_entity_query():
                         'bool': {
                             'should': [
                                 {
-                                    'match_phrase': {
+                                    'match': {
                                         'name.keyword': {
                                             'query': 'test',
                                             'boost': 2,
@@ -450,7 +450,7 @@ def test_limited_get_search_by_entity_query():
                                     },
                                 },
                                 {
-                                    'match_phrase': {
+                                    'match': {
                                         'id': 'test',
                                     },
                                 },
@@ -502,9 +502,11 @@ def test_limited_get_search_by_entity_query():
                         'bool': {
                             'should': [
                                 {
-                                    'match_phrase': {
-                                        'trading_address_country.id':
-                                            '80756b9a-5d95-e211-a939-e4115bead28a',
+                                    'match': {
+                                        'trading_address_country.id': {
+                                            'query': '80756b9a-5d95-e211-a939-e4115bead28a',
+                                            'operator': 'and',
+                                        },
                                     },
                                 },
                             ],

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -258,7 +258,7 @@ def test_get_basic_search_query():
             'bool': {
                 'should': [
                     {
-                        'match_phrase': {
+                        'match': {
                             'name.keyword': {
                                 'query': 'test',
                                 'boost': 2,
@@ -266,7 +266,7 @@ def test_get_basic_search_query():
                         },
                     },
                     {
-                        'match_phrase': {
+                        'match': {
                             'id': 'test',
                         },
                     },
@@ -381,7 +381,7 @@ def test_get_limited_search_by_entity_query():
                         'bool': {
                             'should': [
                                 {
-                                    'match_phrase': {
+                                    'match': {
                                         'name.keyword': {
                                             'query': 'test',
                                             'boost': 2,
@@ -389,7 +389,7 @@ def test_get_limited_search_by_entity_query():
                                     },
                                 },
                                 {
-                                    'match_phrase': {
+                                    'match': {
                                         'id': 'test',
                                     },
                                 },
@@ -435,9 +435,11 @@ def test_get_limited_search_by_entity_query():
                     {
                         'bool': {
                             'should': [{
-                                'match_phrase': {
-                                    'trading_address_country.id':
-                                        '80756b9a-5d95-e211-a939-e4115bead28a',
+                                'match': {
+                                    'trading_address_country.id': {
+                                        'query': '80756b9a-5d95-e211-a939-e4115bead28a',
+                                        'operator': 'and',
+                                    },
                                 },
                             }],
                             'minimum_should_match': 1,

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -702,7 +702,7 @@ def test_get_basic_search_query():
             'bool': {
                 'should': [
                     {
-                        'match_phrase': {
+                        'match': {
                             'name.keyword': {
                                 'query': 'test',
                                 'boost': 2,
@@ -710,7 +710,7 @@ def test_get_basic_search_query():
                         },
                     },
                     {
-                        'match_phrase': {
+                        'match': {
                             'id': 'test',
                         },
                     },
@@ -825,7 +825,7 @@ def test_limited_get_search_by_entity_query():
                         'bool': {
                             'should': [
                                 {
-                                    'match_phrase': {
+                                    'match': {
                                         'name.keyword': {
                                             'query': 'test',
                                             'boost': 2,
@@ -833,7 +833,7 @@ def test_limited_get_search_by_entity_query():
                                     },
                                 },
                                 {
-                                    'match_phrase': {
+                                    'match': {
                                         'id': 'test',
                                     },
                                 },
@@ -881,9 +881,11 @@ def test_limited_get_search_by_entity_query():
                         'bool': {
                             'should': [
                                 {
-                                    'match_phrase': {
-                                        'trading_address_country.id':
-                                            '80756b9a-5d95-e211-a939-e4115bead28a',
+                                    'match': {
+                                        'trading_address_country.id': {
+                                            'query': '80756b9a-5d95-e211-a939-e4115bead28a',
+                                            'operator': 'and',
+                                        },
                                     },
                                 },
                             ],

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -7,7 +7,6 @@ from elasticsearch_dsl.query import (
     Exists,
     Match,
     MatchAll,
-    MatchPhrase,
     MultiMatch,
     Query,
     Range,
@@ -227,9 +226,9 @@ def _build_term_query(term, fields=None):
 
     should_query = [
         # Promote exact name match
-        MatchPhrase(**{'name.keyword': {'query': term, 'boost': 2}}),
+        Match(**{'name.keyword': {'query': term, 'boost': 2}}),
         # Exact match by id
-        MatchPhrase(id=term),
+        Match(id=term),
         # Cross match fields
         MultiMatch(
             query=term,
@@ -265,9 +264,6 @@ def _build_single_field_query(field, value):
     if value is None:
         parent_field = field.rsplit('.', maxsplit=1)[0]
         return _build_exists_query(f'{parent_field}_exists', False)
-
-    if any(field.endswith(suffix) for suffix in ('.id', '_keyword', '.keyword')):
-        return MatchPhrase(**{field: value})
 
     field_query = {
         'query': value,

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -36,8 +36,11 @@ class TestQueryBuilder:
                 'field_name.id',
                 'field value',
                 {
-                    'match_phrase': {
-                        'field_name.id': 'field value',
+                    'match': {
+                        'field_name.id': {
+                            'query': 'field value',
+                            'operator': 'and',
+                        },
                     },
                 },
             ),
@@ -45,8 +48,11 @@ class TestQueryBuilder:
                 'field_name.name.keyword',
                 'field value',
                 {
-                    'match_phrase': {
-                        'field_name.name.keyword': 'field value',
+                    'match': {
+                        'field_name.name.keyword': {
+                            'query': 'field value',
+                            'operator': 'and',
+                        },
                     },
                 },
             ),
@@ -164,7 +170,7 @@ class TestQueryBuilder:
                     'bool': {
                         'should': [
                             {
-                                'match_phrase': {
+                                'match': {
                                     'name.keyword': {
                                         'query': 'hello',
                                         'boost': 2,
@@ -172,7 +178,7 @@ class TestQueryBuilder:
                                 },
                             },
                             {
-                                'match_phrase': {
+                                'match': {
                                     'id': 'hello',
                                 },
                             },


### PR DESCRIPTION
### Description of change

This changes Elasticsearch queries to use `match` instead of `match_phrase` for keyword fields.

`match` and `match_phrase` are equivalent for keyword fields, so the main motivation for doing this is to remove some of the field-name-suffix-specific logic in `datahub.search.query_builder`.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
