### PR TITLE
Update django redis cache connection configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `REDIS_BASE_URL`  | No | redis base URL without the db |
 | `REDIS_CACHE_DB`  | No | redis db for django cache (default 0) |
 | `REDIS_CELERY_DB`  | No | redis db for celery (default 1) |
+| `REDIS_SSL_CA_CERTS_PATH` | No | Location of SSL CA certs (default /etc/ssl/certs/ca-certificates.crt) |
 | `REPORT_AWS_ACCESS_KEY_ID` | No | Same use as AWS_ACCESS_KEY_ID, but for reports. |
 | `REPORT_AWS_SECRET_ACCESS_KEY` | No | Same use as AWS_SECRET_ACCESS_KEY, but for reports. |
 | `REPORT_AWS_REGION` | No | Same use as AWS_DEFAULT_REGION, but for reports. |

--- a/changelog/django-redis.internal
+++ b/changelog/django-redis.internal
@@ -1,0 +1,1 @@
+It is now possible to specify the location of SSL CA certificates for Django Redis cache client. Environment variable ``REDIS_SSL_CA_CERTS_PATH`` defaults to '/etc/ssl/certs/ca-certificates.crt'.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -327,6 +327,12 @@ if REDIS_BASE_URL:
             'LOCATION': f'{REDIS_BASE_URL}/{REDIS_CACHE_DB}',
             'OPTIONS': {
                 'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+                'CONNECTION_POOL_KWARGS': {
+                    'ssl_ca_certs': env(
+                        'REDIS_SSL_CA_CERTS_PATH',
+                        default='/etc/ssl/certs/ca-certificates.crt',
+                    ),
+                },
             }
         }
     }


### PR DESCRIPTION
### Description of change

This updates Django Redis cache client configuration to recognise SSL certificates.

I have tested these settings in the dev environment and cache no longer throws `CERTIFICATE_VERIFY_FAILED`  when used. 

The path to ca certs is configurable via `REDIS_SSL_CA_CERTS_PATH` environment variable, but it defaults to `/etc/ssl/certs/ca-certificates.crt` - this is where ca certs are located in our Docker image.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
