### PR TITLE
Add policy area filter to interaction search

### DIFF
--- a/changelog/interaction/add-policy-areas-search-filter.api
+++ b/changelog/interaction/add-policy-areas-search-filter.api
@@ -1,0 +1,1 @@
+``POST /v3/search/interaction``: ``policy_areas`` was added as a filter, accepting one or more policy area IDs that results should match one of.

--- a/changelog/interaction/add-policy-areas-search.api
+++ b/changelog/interaction/add-policy-areas-search.api
@@ -1,0 +1,1 @@
+``GET /v3/search``, ``POST /v3/search/interaction``: ``policy_areas`` was added to interaction search results.

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -9,6 +9,11 @@ def id_name_dict(obj):
     }
 
 
+def id_name_list_of_dicts(manager):
+    """Creates a list of dicts with ID and name keys from a manager."""
+    return [id_name_dict(obj) for obj in manager.all()]
+
+
 def id_type_dict(obj):
     """Creates dictionary with selected field from supplied object."""
     if obj is None:

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -63,6 +63,16 @@ def id_name_field():
     )
 
 
+def id_unindexed_name_field():
+    """Object field with id and unindexed name sub-fields."""
+    return Object(
+        properties={
+            'id': Keyword(),
+            'name': Keyword(index=False),
+        },
+    )
+
+
 def id_name_partial_field(field):
     """Object field with id and name sub-fields, and with partial matching on name."""
     return Object(

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -32,4 +32,6 @@ class InteractionSearchApp(SearchApp):
         'service',
         'service_delivery_status',
         'event',
+    ).prefetch_related(
+        'policy_areas',
     )

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -30,6 +30,7 @@ class Interaction(BaseESModel):
     modified_on = Date()
     net_company_receipt = Double()
     notes = fields.EnglishText()
+    policy_areas = fields.id_unindexed_name_field()
     service = fields.id_name_field()
     service_delivery_status = fields.id_name_field()
     subject = fields.NormalizedKeyword(
@@ -46,6 +47,7 @@ class Interaction(BaseESModel):
         'dit_team': dict_utils.id_name_dict,
         'event': dict_utils.id_name_dict,
         'investment_project': dict_utils.id_name_dict,
+        'policy_areas': dict_utils.id_name_list_of_dicts,
         'service': dict_utils.id_name_dict,
         'service_delivery_status': dict_utils.id_name_dict,
     }

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -24,6 +24,7 @@ class SearchInteractionSerializer(SearchSerializer):
     dit_team = SingleOrListField(child=StringUUIDField(), required=False)
     communication_channel = SingleOrListField(child=StringUUIDField(), required=False)
     investment_project = SingleOrListField(child=StringUUIDField(), required=False)
+    policy_areas = SingleOrListField(child=StringUUIDField(), required=False)
     service = SingleOrListField(child=StringUUIDField(), required=False)
     sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     was_policy_feedback_provided = serializers.BooleanField(required=False)

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -1,3 +1,5 @@
+from operator import attrgetter, itemgetter
+
 import pytest
 
 from datahub.interaction.test.factories import (
@@ -23,7 +25,9 @@ pytestmark = pytest.mark.django_db
 def test_interaction_to_dict(setup_es, factory_cls):
     """Test converting an interaction to a dict."""
     interaction = factory_cls()
+
     result = Interaction.db_object_to_dict(interaction)
+    result['policy_areas'].sort(key=itemgetter('id'))
 
     assert result == {
         'id': interaction.pk,
@@ -81,6 +85,12 @@ def test_interaction_to_dict(setup_es, factory_cls):
                 'id': str(ancestor.pk),
             } for ancestor in interaction.investment_project.sector.get_ancestors()],
         } if interaction.investment_project else None,
+        'policy_areas': [
+            {
+                'id': str(obj.pk),
+                'name': obj.name,
+            } for obj in sorted(interaction.policy_areas.all(), key=attrgetter('id'))
+        ],
         'service_delivery_status': None,
         'grant_amount_offered': None,
         'net_company_receipt': None,
@@ -140,6 +150,7 @@ def test_service_delivery_to_dict(setup_es):
         'communication_channel': None,
         'investment_project': None,
         'investment_project_sector': None,
+        'policy_areas': [],
         'service_delivery_status': {
             'id': str(interaction.service_delivery_status.pk),
             'name': interaction.service_delivery_status.name,

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -262,6 +262,7 @@ class TestInteractionEntitySearchView(APITestMixin):
             },
             'investment_project': None,
             'investment_project_sector': None,
+            'policy_areas': [],
             'service_delivery_status': None,
             'grant_amount_offered': None,
             'net_company_receipt': None,

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -23,7 +23,12 @@ from datahub.core.test_utils import (
     get_attr_or_none,
     random_obj_for_queryset,
 )
-from datahub.interaction.models import CommunicationChannel, Interaction, InteractionPermission
+from datahub.interaction.models import (
+    CommunicationChannel,
+    Interaction,
+    InteractionPermission,
+    PolicyArea,
+)
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
     CompanyInteractionFactoryWithPolicyFeedback,
@@ -581,6 +586,59 @@ class TestInteractionEntitySearchView(APITestMixin):
         results = response_data['results']
         result_ids = {result['communication_channel']['id'] for result in results}
         assert result_ids == {str(communication_channels[1].pk)}
+
+    def test_filter_by_policy_areas(self, setup_es):
+        """Tests filtering interactions by policy area."""
+        policy_areas = list(PolicyArea.objects.order_by('?')[:2])
+        expected_policy_area = policy_areas[0]
+        other_policy_area = policy_areas[1]
+
+        policy_area_factory_values = [
+            [expected_policy_area, other_policy_area],
+            [expected_policy_area, other_policy_area],
+            [expected_policy_area],
+            [expected_policy_area],
+            [expected_policy_area],
+        ]
+
+        expected_interactions = CompanyInteractionFactoryWithPolicyFeedback.create_batch(
+            5,
+            policy_areas=factory.Iterator(policy_area_factory_values),
+        )
+
+        # Unrelated interactions
+        CompanyInteractionFactoryWithPolicyFeedback.create_batch(
+            6,
+            policy_areas=[other_policy_area],
+        )
+        CompanyInteractionFactory.create_batch(6)
+
+        setup_es.indices.refresh()
+
+        url = reverse('api-v3:search:interaction')
+        request_data = {
+            'original_query': '',
+            'policy_areas': expected_policy_area.pk,
+        }
+        response = self.api_client.post(url, request_data)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        results = response_data['results']
+        expected_ids = {str(interaction.pk) for interaction in expected_interactions}
+
+        assert response_data['count'] == 5
+        assert Counter(
+            policy_area['id']
+            for result in results
+            for policy_area in result['policy_areas']
+        ) == {
+            str(expected_policy_area.pk): 5,
+            # two interactions had both policy areas
+            str(other_policy_area.pk): 2,
+        }
+        assert {result['id'] for result in results} == expected_ids
 
     def test_filter_by_service(self, setup_es):
         """Tests filtering interaction by service."""

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -32,6 +32,7 @@ class SearchInteractionParams:
         'date_before',
         'communication_channel',
         'investment_project',
+        'policy_areas',
         'sector_descends',
         'service',
         'was_policy_feedback_provided',
@@ -44,6 +45,7 @@ class SearchInteractionParams:
         'dit_team': 'dit_team.id',
         'communication_channel': 'communication_channel.id',
         'investment_project': 'investment_project.id',
+        'policy_areas': 'policy_areas.id',
         'service': 'service.id',
     }
 

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -19,6 +19,23 @@ def test_id_name_dict():
     }
 
 
+def test_id_name_list_of_dicts():
+    """Test that id_name_list_of_dicts returns a list of dicts with ID and name keys."""
+    data = [
+        {'id': '12', 'name': 'test A'},
+        {'id': '99', 'name': 'testing B'},
+    ]
+    objects = [mock.Mock(), mock.Mock()]
+    for obj, data_item in zip(objects, data):
+        obj.configure_mock(**data_item)
+
+    manager = mock.Mock(
+        all=mock.Mock(return_value=objects),
+    )
+
+    assert dict_utils.id_name_list_of_dicts(manager) == data
+
+
 def test_id_type_dict():
     """Tests _id_type_dict."""
     obj = mock.Mock()


### PR DESCRIPTION
### Description of change

This adds policy areas to the interaction search model and adds a filter for it to interaction search.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
