### PR TITLE
Move id field search logic to SEARCH_FIELDS on search models

### DIFF
--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -42,7 +42,6 @@ class CompaniesHouseCompany(BaseESModel):
     }
 
     SEARCH_FIELDS = (
-        'id',
         # to match names like A & B
         'name',
         'name_trigram',

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -42,6 +42,7 @@ class CompaniesHouseCompany(BaseESModel):
     }
 
     SEARCH_FIELDS = (
+        'id',
         # to match names like A & B
         'name',
         'name_trigram',

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -142,6 +142,7 @@ class Company(BaseESModel):
     }
 
     SEARCH_FIELDS = (
+        'id',
         'name',  # to find 2-letter words
         'name_trigram',
         'company_number',

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -327,11 +327,6 @@ def test_get_basic_search_query():
                         },
                     },
                     {
-                        'match': {
-                            'id': 'test',
-                        },
-                    },
-                    {
                         'multi_match': {
                             'query': 'test',
                             'fields': [
@@ -350,6 +345,7 @@ def test_get_basic_search_query():
                                 'email_alternative',
                                 'event.name',
                                 'event.name_trigram',
+                                'id',
                                 'investor_company.name',
                                 'investor_company.name_trigram',
                                 'name',
@@ -450,14 +446,10 @@ def test_limited_get_search_by_entity_query():
                                     },
                                 },
                                 {
-                                    'match': {
-                                        'id': 'test',
-                                    },
-                                },
-                                {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
+                                            'id',
                                             'name',
                                             'name_trigram',
                                             'company_number',

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -81,6 +81,7 @@ class Contact(BaseESModel):
     }
 
     SEARCH_FIELDS = (
+        'id',
         'name',
         'name_trigram',
         'email',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -266,11 +266,6 @@ def test_get_basic_search_query():
                         },
                     },
                     {
-                        'match': {
-                            'id': 'test',
-                        },
-                    },
-                    {
                         'multi_match': {
                             'query': 'test',
                             'fields': [
@@ -289,6 +284,7 @@ def test_get_basic_search_query():
                                 'email_alternative',
                                 'event.name',
                                 'event.name_trigram',
+                                'id',
                                 'investor_company.name',
                                 'investor_company.name_trigram',
                                 'name',
@@ -389,14 +385,10 @@ def test_get_limited_search_by_entity_query():
                                     },
                                 },
                                 {
-                                    'match': {
-                                        'id': 'test',
-                                    },
-                                },
-                                {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
+                                            'id',
                                             'name',
                                             'name_trigram',
                                             'email',

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -56,6 +56,7 @@ class Event(BaseESModel):
     COMPUTED_MAPPINGS = {}
 
     SEARCH_FIELDS = (
+        'id',
         'name',
         'name_trigram',
         'address_country.name_trigram',

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -63,6 +63,7 @@ class Interaction(BaseESModel):
     }
 
     SEARCH_FIELDS = (
+        'id',
         'company.name',
         'company.name_trigram',
         'contact.name',

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -190,6 +190,7 @@ class InvestmentProject(BaseESModel):
     }
 
     SEARCH_FIELDS = (
+        'id',
         'name',
         'name_trigram',
         'uk_company.name',

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -710,11 +710,6 @@ def test_get_basic_search_query():
                         },
                     },
                     {
-                        'match': {
-                            'id': 'test',
-                        },
-                    },
-                    {
                         'multi_match': {
                             'query': 'test',
                             'fields': [
@@ -733,6 +728,7 @@ def test_get_basic_search_query():
                                 'email_alternative',
                                 'event.name',
                                 'event.name_trigram',
+                                'id',
                                 'investor_company.name',
                                 'investor_company.name_trigram',
                                 'name',
@@ -833,14 +829,10 @@ def test_limited_get_search_by_entity_query():
                                     },
                                 },
                                 {
-                                    'match': {
-                                        'id': 'test',
-                                    },
-                                },
-                                {
                                     'multi_match': {
                                         'query': 'test',
                                         'fields': (
+                                            'id',
                                             'name',
                                             'name_trigram',
                                             'uk_company.name',

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -88,6 +88,7 @@ class Order(BaseESModel):
     }
 
     SEARCH_FIELDS = (
+        'id',
         'reference_trigram',
         'company.name',
         'company.name_trigram',

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -227,8 +227,6 @@ def _build_term_query(term, fields=None):
     should_query = [
         # Promote exact name match
         Match(**{'name.keyword': {'query': term, 'boost': 2}}),
-        # Exact match by id
-        Match(id=term),
         # Cross match fields
         MultiMatch(
             query=term,

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -178,11 +178,6 @@ class TestQueryBuilder:
                                 },
                             },
                             {
-                                'match': {
-                                    'id': 'hello',
-                                },
-                            },
-                            {
                                 'multi_match': {
                                     'query': 'hello',
                                     'fields': ('country.id', 'sector'),


### PR DESCRIPTION
### Description of change

Previously, there was specific logic for querying the `id` field in `datahub.search.query_builder`.

This removes that logic and instead adds `id` to `SEARCH_FIELDS` on each search models. This should have the same net effect and reduces the logic tied to specific fields in `datahub.search.query_builder`.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
