### PR TITLE
 Use execute_search_query() for /dashboard/homepage/ endpoint

### DIFF
--- a/datahub/search/dashboard/views.py
+++ b/datahub/search/dashboard/views.py
@@ -5,6 +5,7 @@ from rest_framework.views import APIView
 from datahub.oauth.scopes import Scope
 from datahub.search.contact.apps import ContactSearchApp
 from datahub.search.dashboard.serializers import HomepageSerializer
+from datahub.search.execute_query import execute_search_query
 from datahub.search.interaction.apps import InteractionSearchApp
 from datahub.search.permissions import has_permissions_for_app
 from datahub.search.query_builder import get_search_by_entity_query, limit_search_query
@@ -48,10 +49,11 @@ def _get_objects(request, limit, search_app, adviser_field):
         },
         ordering='created_on:desc',
     )
-    results = limit_search_query(
+    limited_query = limit_search_query(
         query,
         offset=0,
         limit=limit,
-    ).execute()
+    )
+    results = execute_search_query(limited_query)
 
     return [result.to_dict() for result in results.hits]

--- a/datahub/search/execute_query.py
+++ b/datahub/search/execute_query.py
@@ -1,4 +1,12 @@
+from logging import getLogger
+
+from django.conf import settings
+from raven.contrib.django.models import client
+
 from datahub.search.query_builder import build_autocomplete_query
+
+
+logger = getLogger(__name__)
 
 
 def execute_autocomplete_query(es_model, keyword_search, limit, only_return_fields=None):
@@ -9,3 +17,25 @@ def execute_autocomplete_query(es_model, keyword_search, limit, only_return_fiel
 
     results = autocomplete_search.execute()
     return results.suggest.autocomplete[0].options
+
+
+def execute_search_query(query):
+    """
+    Executes an Elasticsearch query using the globally configured request timeout.
+
+    (A warning is also logged if the query takes longer than a set threshold.)
+    """
+    response = query.params(request_timeout=settings.ES_SEARCH_REQUEST_TIMEOUT).execute()
+
+    if response.took >= settings.ES_SEARCH_REQUEST_WARNING_THRESHOLD * 1000:
+        logger.warning(f'Elasticsearch query took a long time ({response.took/1000:.2f} seconds)')
+        client.captureMessage(
+            'Elasticsearch query took a long time',
+            extra={
+                'query': query.to_dict(),
+                'took': response.took,
+                'timed_out': response.timed_out,
+            },
+        )
+
+    return response


### PR DESCRIPTION
### Description of change

This makes sure `/dashboard/homepage/` uses the global Elasticsearch request timeout and that warnings for lengthy queries are logged.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
