### PR TITLE
Allow updating a company's trading_names list field

### DIFF
--- a/changelog/company/patch-trading-names.api
+++ b/changelog/company/patch-trading-names.api
@@ -1,0 +1,1 @@
+``PATCH /v3/company/<uuid:pk>``: when updating trading names, the PATCH array field ``trading_names`` should be used instead of the deprecated string field ``trading_name``.

--- a/changelog/company/trading-name-api.removal
+++ b/changelog/company/trading-name-api.removal
@@ -1,0 +1,1 @@
+``PATCH /v3/company/<uuid:pk>``: the PATCH string field ``trading_name`` is deprecated and will be removed on or after January 24. Please use the array field ``trading_names`` instead.

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -513,7 +513,6 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'reference_code',
             'transfer_reason',
             'duns_number',
-            'trading_names',
             'turnover',
             'is_turnover_estimated',
             'number_of_employees',
@@ -522,6 +521,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         dnb_read_only_fields = [
             'name',
             'trading_name',
+            'trading_names',
             'company_number',
             'vat_number',
             'registered_address_1',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -639,7 +639,7 @@ class TestUpdateCompany(APITestMixin):
             archived_documents_url_path='old_path',
             one_list_tier=one_list_tier,
             one_list_account_owner=one_list_gam,
-            duns_number='000000001',
+            duns_number=None,
             turnover=100,
             is_turnover_estimated=False,
             number_of_employees=95,
@@ -671,7 +671,7 @@ class TestUpdateCompany(APITestMixin):
             'name': company.one_list_tier.name,
         }
         assert response_data['one_list_group_global_account_manager']['id'] == str(one_list_gam.id)
-        assert response_data['duns_number'] == '000000001'
+        assert response_data['duns_number'] is None
         assert response_data['turnover'] == 100
         assert not response_data['is_turnover_estimated']
         assert response_data['number_of_employees'] == 95


### PR DESCRIPTION
### Description of change

This allows editing `trading_names` via API and deprecates the `trading_name` PATCH field so that it can be completely deleted from the API.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
