### PR TITLE
Remove Investment aggregates

### DIFF
--- a/changelog/investment/aggregations.api
+++ b/changelog/investment/aggregations.api
@@ -1,0 +1,1 @@
+``POST /v3/search/investment_project``: The ``aggregations`` property of responses was removed.

--- a/changelog/investment/aggregations.removal
+++ b/changelog/investment/aggregations.removal
@@ -1,0 +1,1 @@
+``POST /v3/search/investment_project``: The ``aggregations`` property of responses was removed.

--- a/datahub/search/company/test/test_views.py
+++ b/datahub/search/company/test/test_views.py
@@ -425,17 +425,6 @@ class TestSearch(APITestMixin):
                 UUID(company['id']) for company in response.data['results']
             ] == ids[start:end]
 
-    @mock.patch('datahub.search.query_builder._add_aggs_to_query')
-    def test_company_search_no_aggregations(self, _add_aggs_to_query, setup_data):
-        """Tests if no aggregation occurs."""
-        url = reverse('api-v3:search:company')
-        response = self.api_client.post(url)
-
-        assert _add_aggs_to_query.call_count == 0
-
-        assert response.status_code == status.HTTP_200_OK
-        assert 'aggregations' not in response.data
-
     def test_search_company_no_filters(self, setup_data):
         """Tests case where there is no filters provided."""
         url = reverse('api-v3:search:company')

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -759,52 +759,6 @@ class TestSearch(APITestMixin):
             for investment_project in response.data['results']
         }
 
-    def test_search_investment_project_aggregates(self, setup_es):
-        """Tests aggregates in investment project search."""
-        url = reverse('api-v3:search:investment_project')
-
-        InvestmentProjectFactory(
-            name='Pear 1',
-            stage_id=constants.InvestmentProjectStage.active.value.id,
-        )
-        InvestmentProjectFactory(
-            name='Pear 2',
-            stage_id=constants.InvestmentProjectStage.prospect.value.id,
-        )
-        InvestmentProjectFactory(
-            name='Pear 3',
-            stage_id=constants.InvestmentProjectStage.prospect.value.id,
-        )
-        InvestmentProjectFactory(
-            name='Pear 4',
-            stage_id=constants.InvestmentProjectStage.won.value.id,
-        )
-
-        setup_es.indices.refresh()
-
-        response = self.api_client.post(
-            url,
-            data={
-                'original_query': 'Pear',
-                'stage': [
-                    constants.InvestmentProjectStage.prospect.value.id,
-                    constants.InvestmentProjectStage.active.value.id,
-                ],
-            },
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 3
-        assert len(response.data['results']) == 3
-        assert 'aggregations' in response.data
-
-        stages = [
-            {'key': constants.InvestmentProjectStage.prospect.value.id, 'doc_count': 2},
-            {'key': constants.InvestmentProjectStage.active.value.id, 'doc_count': 1},
-            {'key': constants.InvestmentProjectStage.won.value.id, 'doc_count': 1},
-        ]
-        assert all(stage in response.data['aggregations']['stage'] for stage in stages)
-
 
 class TestSearchPermissions(APITestMixin):
     """Tests search view permissions."""

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -23,8 +23,6 @@ class SearchInvestmentProjectParams:
     entity = InvestmentProject
     serializer_class = SearchInvestmentProjectSerializer
 
-    include_aggregations = True
-
     FILTER_FIELDS = (
         'adviser',
         'client_relationship_manager',

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -81,7 +81,6 @@ def get_search_by_entity_query(
         permission_filters=None,
         entity=None,
         ordering=None,
-        aggregation_fields=None,
 ):
     """
     Performs filtered search for given terms in given entity.
@@ -111,11 +110,7 @@ def get_search_by_entity_query(
     s = s.post_filter(
         Bool(must=must_filter),
     )
-    s = _apply_sorting_to_query(s, ordering)
-    if aggregation_fields:
-        s = _add_aggs_to_query(s, aggregation_fields)
-
-    return s
+    return _apply_sorting_to_query(s, ordering)
 
 
 def build_autocomplete_query(es_model, keyword_search, limit, only_return_fields):
@@ -369,14 +364,3 @@ def _apply_sorting_to_query(query, ordering):
         {field_name: sort_params},
         'id',
     )
-
-
-def _add_aggs_to_query(query, aggregation_fields):
-    """Applies aggregates to the query."""
-    for field in aggregation_fields:
-        # skip range and "query" filters as we can't aggregate them
-        if any(field.endswith(x) for x in ('_before', '_after', '_trigram', '_exists')):
-            continue
-
-        query.aggs.bucket(field, 'terms', field=field)
-    return query


### PR DESCRIPTION
### Description of change

This removes deprecated aggregates from the investment entity search response and from the entity search.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
