### PR TITLE
Add policy issue type filter to interaction search

### DIFF
--- a/changelog/interaction/add-policy-issue-types-search-filter.api
+++ b/changelog/interaction/add-policy-issue-types-search-filter.api
@@ -1,0 +1,1 @@
+``POST /v3/search/interaction``: ``policy_issue_types`` was added as a filter, accepting one or more policy issue type IDs that results should match one of.

--- a/changelog/interaction/add-policy-issue-types-search.api
+++ b/changelog/interaction/add-policy-issue-types-search.api
@@ -1,0 +1,1 @@
+``GET /v3/search``, ``POST /v3/search/interaction``: ``policy_issue_types`` was added to interaction search results.

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -34,4 +34,5 @@ class InteractionSearchApp(SearchApp):
         'event',
     ).prefetch_related(
         'policy_areas',
+        'policy_issue_types',
     )

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -31,6 +31,7 @@ class Interaction(BaseESModel):
     net_company_receipt = Double()
     notes = fields.EnglishText()
     policy_areas = fields.id_unindexed_name_field()
+    policy_issue_types = fields.id_unindexed_name_field()
     service = fields.id_name_field()
     service_delivery_status = fields.id_name_field()
     subject = fields.NormalizedKeyword(
@@ -48,6 +49,7 @@ class Interaction(BaseESModel):
         'event': dict_utils.id_name_dict,
         'investment_project': dict_utils.id_name_dict,
         'policy_areas': dict_utils.id_name_list_of_dicts,
+        'policy_issue_types': dict_utils.id_name_list_of_dicts,
         'service': dict_utils.id_name_dict,
         'service_delivery_status': dict_utils.id_name_dict,
     }

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -25,6 +25,7 @@ class SearchInteractionSerializer(SearchSerializer):
     communication_channel = SingleOrListField(child=StringUUIDField(), required=False)
     investment_project = SingleOrListField(child=StringUUIDField(), required=False)
     policy_areas = SingleOrListField(child=StringUUIDField(), required=False)
+    policy_issue_types = SingleOrListField(child=StringUUIDField(), required=False)
     service = SingleOrListField(child=StringUUIDField(), required=False)
     sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     was_policy_feedback_provided = serializers.BooleanField(required=False)

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -28,6 +28,7 @@ def test_interaction_to_dict(setup_es, factory_cls):
 
     result = Interaction.db_object_to_dict(interaction)
     result['policy_areas'].sort(key=itemgetter('id'))
+    result['policy_issue_types'].sort(key=itemgetter('id'))
 
     assert result == {
         'id': interaction.pk,
@@ -91,6 +92,12 @@ def test_interaction_to_dict(setup_es, factory_cls):
                 'name': obj.name,
             } for obj in sorted(interaction.policy_areas.all(), key=attrgetter('id'))
         ],
+        'policy_issue_types': [
+            {
+                'id': str(obj.pk),
+                'name': obj.name,
+            } for obj in sorted(interaction.policy_issue_types.all(), key=attrgetter('id'))
+        ],
         'service_delivery_status': None,
         'grant_amount_offered': None,
         'net_company_receipt': None,
@@ -151,6 +158,7 @@ def test_service_delivery_to_dict(setup_es):
         'investment_project': None,
         'investment_project_sector': None,
         'policy_areas': [],
+        'policy_issue_types': [],
         'service_delivery_status': {
             'id': str(interaction.service_delivery_status.pk),
             'name': interaction.service_delivery_status.name,

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -28,6 +28,7 @@ from datahub.interaction.models import (
     Interaction,
     InteractionPermission,
     PolicyArea,
+    PolicyIssueType,
 )
 from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
@@ -579,29 +580,40 @@ class TestInteractionEntitySearchView(APITestMixin):
         result_ids = {result['communication_channel']['id'] for result in results}
         assert result_ids == {str(communication_channels[1].pk)}
 
-    def test_filter_by_policy_areas(self, setup_es):
-        """Tests filtering interactions by policy area."""
-        policy_areas = list(PolicyArea.objects.order_by('?')[:2])
-        expected_policy_area = policy_areas[0]
-        other_policy_area = policy_areas[1]
+    @pytest.mark.parametrize(
+        'field,field_model',
+        (
+            ('policy_areas', PolicyArea),
+            ('policy_issue_types', PolicyIssueType),
+        ),
+    )
+    def test_filter_by_policy_fields(self, setup_es, field, field_model):
+        """
+        Tests filtering interactions by:
+        - policy area
+        - policy issue type
+        """
+        values = list(field_model.objects.order_by('?')[:2])
+        expected_field_value = values[0]
+        other_field_value = values[1]
 
-        policy_area_factory_values = [
-            [expected_policy_area, other_policy_area],
-            [expected_policy_area, other_policy_area],
-            [expected_policy_area],
-            [expected_policy_area],
-            [expected_policy_area],
+        factory_values = [
+            [expected_field_value, other_field_value],
+            [expected_field_value, other_field_value],
+            [expected_field_value],
+            [expected_field_value],
+            [expected_field_value],
         ]
 
         expected_interactions = CompanyInteractionFactoryWithPolicyFeedback.create_batch(
             5,
-            policy_areas=factory.Iterator(policy_area_factory_values),
+            **{field: factory.Iterator(factory_values)},
         )
 
         # Unrelated interactions
         CompanyInteractionFactoryWithPolicyFeedback.create_batch(
             6,
-            policy_areas=[other_policy_area],
+            **{field: [other_field_value]},
         )
         CompanyInteractionFactory.create_batch(6)
 
@@ -610,10 +622,9 @@ class TestInteractionEntitySearchView(APITestMixin):
         url = reverse('api-v3:search:interaction')
         request_data = {
             'original_query': '',
-            'policy_areas': expected_policy_area.pk,
+            field: expected_field_value.pk,
         }
         response = self.api_client.post(url, request_data)
-
         assert response.status_code == status.HTTP_200_OK
 
         response_data = response.json()
@@ -622,13 +633,13 @@ class TestInteractionEntitySearchView(APITestMixin):
 
         assert response_data['count'] == 5
         assert Counter(
-            policy_area['id']
+            value['id']
             for result in results
-            for policy_area in result['policy_areas']
+            for value in result[field]
         ) == {
-            str(expected_policy_area.pk): 5,
-            # two interactions had both policy areas
-            str(other_policy_area.pk): 2,
+            str(expected_field_value.pk): 5,
+            # two interactions had both values
+            str(other_field_value.pk): 2,
         }
         assert {result['id'] for result in results} == expected_ids
 

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -268,6 +268,7 @@ class TestInteractionEntitySearchView(APITestMixin):
             'investment_project': None,
             'investment_project_sector': None,
             'policy_areas': [],
+            'policy_issue_types': [],
             'service_delivery_status': None,
             'grant_amount_offered': None,
             'net_company_receipt': None,

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -33,6 +33,7 @@ class SearchInteractionParams:
         'communication_channel',
         'investment_project',
         'policy_areas',
+        'policy_issue_types',
         'sector_descends',
         'service',
         'was_policy_feedback_provided',
@@ -46,6 +47,7 @@ class SearchInteractionParams:
         'communication_channel': 'communication_channel.id',
         'investment_project': 'investment_project.id',
         'policy_areas': 'policy_areas.id',
+        'policy_issue_types': 'policy_issue_types.id',
         'service': 'service.id',
     }
 


### PR DESCRIPTION
### Description of change

This adds policy issue type to the interaction search model and adds a filter for it to interaction search.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
