### PR TITLE
Tidy up search validation logic

### DIFF
--- a/datahub/search/companieshousecompany/views.py
+++ b/datahub/search/companieshousecompany/views.py
@@ -1,6 +1,6 @@
 from datahub.oauth.scopes import Scope
 from datahub.search.companieshousecompany.models import CompaniesHouseCompany
-from datahub.search.serializers import SearchSerializer
+from datahub.search.serializers import EntitySearchSerializer
 from datahub.search.views import SearchAPIView
 
 
@@ -9,4 +9,4 @@ class SearchCompaniesHouseCompanyAPIView(SearchAPIView):
 
     required_scopes = (Scope.internal_front_end,)
     entity = CompaniesHouseCompany
-    serializer_class = SearchSerializer
+    serializer_class = EntitySearchSerializer

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -2,14 +2,14 @@ from rest_framework import serializers
 
 from datahub.search.serializers import (
     AutocompleteSearchSerializer,
+    EntitySearchSerializer,
     IdNameSerializer,
-    SearchSerializer,
     SingleOrListField,
     StringUUIDField,
 )
 
 
-class SearchCompanySerializer(SearchSerializer):
+class SearchCompanySerializer(EntitySearchSerializer):
     """Serialiser used to validate company search POST bodies."""
 
     archived = serializers.BooleanField(required=False)

--- a/datahub/search/contact/serializers.py
+++ b/datahub/search/contact/serializers.py
@@ -1,13 +1,13 @@
 from rest_framework import serializers
 
 from datahub.search.serializers import (
-    SearchSerializer,
+    EntitySearchSerializer,
     SingleOrListField,
     StringUUIDField,
 )
 
 
-class SearchContactSerializer(SearchSerializer):
+class SearchContactSerializer(EntitySearchSerializer):
     """Serialiser used to validate contact search POST bodies."""
 
     archived = serializers.BooleanField(required=False)

--- a/datahub/search/event/serializers.py
+++ b/datahub/search/event/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from datahub.core.serializers import RelaxedDateTimeField
 from datahub.search.serializers import (
-    SearchSerializer,
+    EntitySearchSerializer,
     SingleOrListField,
     StringUUIDField,
 )
@@ -15,7 +15,7 @@ class NestedDisabledOnOrFilterSerializer(serializers.Serializer):
     after = RelaxedDateTimeField(required=False)
 
 
-class SearchEventSerializer(SearchSerializer):
+class SearchEventSerializer(EntitySearchSerializer):
     """Serialiser used to validate Event search POST bodies.
 
     Nested disabled_on filters use "or" operator. For example if you want to

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -2,13 +2,13 @@ from rest_framework import serializers
 
 from datahub.core.serializers import RelaxedDateTimeField
 from datahub.search.serializers import (
-    SearchSerializer,
+    EntitySearchSerializer,
     SingleOrListField,
     StringUUIDField,
 )
 
 
-class SearchInteractionSerializer(SearchSerializer):
+class SearchInteractionSerializer(EntitySearchSerializer):
     """Serialiser used to validate interaction search POST bodies."""
 
     kind = SingleOrListField(child=serializers.CharField(), required=False)

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -3,13 +3,13 @@ from rest_framework import serializers
 from datahub.core.serializers import RelaxedDateTimeField
 from datahub.investment.models import InvestmentProject
 from datahub.search.serializers import (
-    SearchSerializer,
+    EntitySearchSerializer,
     SingleOrListField,
     StringUUIDField,
 )
 
 
-class SearchInvestmentProjectSerializer(SearchSerializer):
+class SearchInvestmentProjectSerializer(EntitySearchSerializer):
     """Serialiser used to validate investment project search POST bodies."""
 
     adviser = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/omis/serializers.py
+++ b/datahub/search/omis/serializers.py
@@ -2,13 +2,13 @@ from rest_framework import serializers
 
 from datahub.core.serializers import RelaxedDateField, RelaxedDateTimeField
 from datahub.search.serializers import (
-    SearchSerializer,
+    EntitySearchSerializer,
     SingleOrListField,
     StringUUIDField,
 )
 
 
-class SearchOrderSerializer(SearchSerializer):
+class SearchOrderSerializer(EntitySearchSerializer):
     """Serialiser used to validate OMIS search POST bodies."""
 
     primary_market = SingleOrListField(child=StringUUIDField(), required=False)

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -52,7 +52,7 @@ class IdNameSerializer(serializers.Serializer):
     name = serializers.CharField()
 
 
-class SearchSerializer(LimitOffsetSerializer):
+class EntitySearchSerializer(LimitOffsetSerializer):
     """Serialiser used to validate search POST bodies."""
 
     SORT_BY_FIELDS = []

--- a/datahub/search/test/search_support/simplemodel/serializers.py
+++ b/datahub/search/test/search_support/simplemodel/serializers.py
@@ -1,9 +1,9 @@
 from rest_framework import serializers
 
-from datahub.search.serializers import SearchSerializer
+from datahub.search.serializers import EntitySearchSerializer
 
 
-class SearchSimpleModelSerializer(SearchSerializer):
+class SearchSimpleModelSerializer(EntitySearchSerializer):
     """Serialiser used to validate simple model search POST bodies."""
 
     name = serializers.CharField(required=False)

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -211,10 +211,13 @@ class TestSearch(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert response.json() == [
-            'Entity is not one of company, contact, event, interaction, investment_project, '
-            'order, simplemodel, relatedmodel',
-        ]
+        assert response.json() == {
+            'entity':
+                [
+                    'Entity is not one of company, contact, event, interaction, '
+                    'investment_project, order, simplemodel, relatedmodel',
+                ],
+        }
 
     def test_search_results_quality(self, setup_es, setup_data):
         """Tests quality of results."""

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -26,7 +26,7 @@ from datahub.search.query_builder import (
     get_search_by_entity_query,
     limit_search_query,
 )
-from datahub.search.serializers import SearchSerializer
+from datahub.search.serializers import EntitySearchSerializer
 from datahub.user_event_log.constants import USER_EVENT_TYPES
 from datahub.user_event_log.utils import record_user_event
 
@@ -119,7 +119,7 @@ class SearchAPIView(APIView):
     # filter must exist in FILTER_FIELDS
     COMPOSITE_FILTERS = {}
 
-    serializer_class = SearchSerializer
+    serializer_class = EntitySearchSerializer
     entity = None
 
     http_method_names = ('post',)

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -7,7 +7,6 @@ from django.utils.text import capfirst
 from django.utils.timezone import now
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework.exceptions import ValidationError
-from rest_framework.fields import empty
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -138,22 +137,7 @@ class SearchAPIView(APIView):
         """Validate and clean data."""
         serializer = self.serializer_class(data=data)
         serializer.is_valid(raise_exception=True)
-        validated_data = serializer.validated_data
-
-        # prepare default values
-        cleaned_data = {
-            k: v.default for k, v in serializer.fields.items()
-            if v.default is not empty
-        }
-        if serializer.DEFAULT_ORDERING:
-            cleaned_data['sortby'] = serializer.DEFAULT_ORDERING
-
-        # update with validated data
-        cleaned_data.update({
-            k: v for k, v in validated_data.items()
-            if k in data
-        })
-        return cleaned_data
+        return serializer.validated_data
 
     def get_base_query(self, request, validated_data):
         """Gets a filtered Elasticsearch query for the provided search parameters."""

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.utils.text import capfirst
 from django.utils.timezone import now
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
-from rest_framework.exceptions import ValidationError
 from rest_framework.generics import ListAPIView
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -14,7 +13,7 @@ from rest_framework.views import APIView
 from datahub.core.csv import create_csv_response
 from datahub.core.exceptions import DataHubException
 from datahub.oauth.scopes import Scope
-from datahub.search.apps import get_global_search_apps_as_mapping, get_search_apps
+from datahub.search.apps import get_search_apps
 from datahub.search.execute_query import execute_autocomplete_query, execute_search_query
 from datahub.search.permissions import (
     has_permissions_for_app,
@@ -26,7 +25,7 @@ from datahub.search.query_builder import (
     get_search_by_entity_query,
     limit_search_query,
 )
-from datahub.search.serializers import EntitySearchSerializer
+from datahub.search.serializers import BasicSearchSerializer, EntitySearchSerializer
 from datahub.user_event_log.constants import USER_EVENT_TYPES
 from datahub.user_event_log.utils import record_user_event
 
@@ -41,43 +40,19 @@ class SearchBasicAPIView(APIView):
     required_scopes = (Scope.internal_front_end,)
     http_method_names = ('get',)
 
-    SORT_BY_FIELDS = (
-        'created_on',
-        'name',
-    )
-
-    DEFAULT_ENTITY = 'company'
-
     def get(self, request, format=None):
         """Performs basic search."""
-        if 'term' not in request.query_params:
-            raise ValidationError('Missing required "term" field.')
-        term = request.query_params['term']
-
-        global_search_models = get_global_search_apps_as_mapping()
-        entity = request.query_params.get('entity', self.DEFAULT_ENTITY)
-        search_app = global_search_models.get(entity)
-        if not search_app:
-            raise ValidationError(
-                f'Entity is not one of {", ".join(global_search_models)}',
-            )
-
-        sortby = request.query_params.get('sortby')
-        if sortby:
-            field = sortby.rsplit(':')[0]
-            if field not in self.SORT_BY_FIELDS:
-                raise ValidationError(f'"sortby" field is not one of {self.SORT_BY_FIELDS}.')
-
-        offset = int(request.query_params.get('offset', 0))
-        limit = int(request.query_params.get('limit', 100))
+        serializer = BasicSearchSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+        validated_params = serializer.validated_data
 
         query = get_basic_search_query(
-            term=term,
-            entities=(search_app.es_model,),
+            term=validated_params['term'],
+            entities=(validated_params['entity'],),
             permission_filters_by_entity=dict(_get_permission_filters(request)),
-            ordering=sortby,
-            offset=offset,
-            limit=limit,
+            ordering=validated_params['sortby'],
+            offset=validated_params['offset'],
+            limit=validated_params['limit'],
         )
 
         results = execute_search_query(query)


### PR DESCRIPTION
### Description of change

This:
- removes some unnecessary defaults logic in the entity search view
- moves the global search query argument validation logic to a serialiser to simplify the view and share logic with entity search

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
