### PR TITLE
Remove remaining fielddata uses in search

### DIFF
--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -21,6 +21,9 @@ class SearchCompanyParams:
     entity = Company
     serializer_class = SearchCompanySerializer
     autocomplete_serializer_class = AutocompleteSearchCompanySerializer
+    es_sort_by_remappings = {
+        'name': 'name.keyword',
+    }
 
     FILTER_FIELDS = (
         'archived',

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -33,13 +33,13 @@ class Contact(BaseESModel):
     created_on = Date()
     email = fields.NormalizedKeyword()
     email_alternative = Text()
-    first_name = fields.SortableText(
+    first_name = Text(
         fields={
             'keyword': fields.NormalizedKeyword(),
         },
     )
     job_title = fields.NormalizedKeyword()
-    last_name = fields.SortableText(
+    last_name = Text(
         fields={
             'keyword': fields.NormalizedKeyword(),
         },

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -182,7 +182,6 @@ def test_mapping(setup_es):
                 },
                 'email_alternative': {'type': 'text'},
                 'first_name': {
-                    'fielddata': True,
                     'type': 'text',
                     'fields': {
                         'keyword': {
@@ -197,7 +196,6 @@ def test_mapping(setup_es):
                     'type': 'keyword',
                 },
                 'last_name': {
-                    'fielddata': True,
                     'type': 'text',
                     'fields': {
                         'keyword': {

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -24,6 +24,8 @@ class SearchContactParams:
     entity = Contact
     serializer_class = SearchContactSerializer
     es_sort_by_remappings = {
+        'first_name': 'first_name.keyword',
+        'last_name': 'last_name.keyword',
         'name': 'name.keyword',
     }
 

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -23,6 +23,9 @@ class SearchContactParams:
     required_scopes = (Scope.internal_front_end,)
     entity = Contact
     serializer_class = SearchContactSerializer
+    es_sort_by_remappings = {
+        'name': 'name.keyword',
+    }
 
     FILTER_FIELDS = (
         'name',
@@ -70,7 +73,7 @@ class SearchContactAPIView(SearchContactParams, SearchAPIView):
 class SearchContactExportAPIView(SearchContactParams, SearchExportAPIView):
     """Company search export view."""
 
-    sort_by_remappings = {
+    db_sort_by_remappings = {
         'address_country.name': 'computed_country_name',
     }
     queryset = DBContact.objects.annotate(

--- a/datahub/search/dashboard/views.py
+++ b/datahub/search/dashboard/views.py
@@ -9,6 +9,7 @@ from datahub.search.execute_query import execute_search_query
 from datahub.search.interaction.apps import InteractionSearchApp
 from datahub.search.permissions import has_permissions_for_app
 from datahub.search.query_builder import get_search_by_entity_query, limit_search_query
+from datahub.search.utils import SearchOrdering, SortDirection
 
 
 class IntelligentHomepageView(APIView):
@@ -47,7 +48,7 @@ def _get_objects(request, limit, search_app, adviser_field):
             adviser_field: request.user.id,
             'created_on_exists': True,
         },
-        ordering='created_on:desc',
+        ordering=SearchOrdering('created_on', SortDirection.desc),
     )
     limited_query = limit_search_query(
         query,

--- a/datahub/search/event/views.py
+++ b/datahub/search/event/views.py
@@ -10,6 +10,9 @@ class SearchEventParams:
     required_scopes = (Scope.internal_front_end,)
     entity = Event
     serializer_class = SearchEventSerializer
+    es_sort_by_remappings = {
+        'name': 'name.keyword',
+    }
 
     FILTER_FIELDS = (
         'address_country',

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -11,7 +11,6 @@ NormalizedKeyword = partial(
 )
 TrigramText = partial(Text, analyzer='trigram_analyzer')
 EnglishText = partial(Text, analyzer='english_analyzer')
-SortableText = partial(Text, fielddata=True)
 
 
 class TextWithKeyword(Text):

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -6,6 +6,7 @@ from datahub.search.serializers import (
     SingleOrListField,
     StringUUIDField,
 )
+from datahub.search.utils import SearchOrdering, SortDirection
 
 
 class SearchInteractionSerializer(EntitySearchSerializer):
@@ -30,7 +31,7 @@ class SearchInteractionSerializer(EntitySearchSerializer):
     sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
     was_policy_feedback_provided = serializers.BooleanField(required=False)
 
-    DEFAULT_ORDERING = 'date:desc'
+    DEFAULT_ORDERING = SearchOrdering('date', SortDirection.desc)
 
     SORT_BY_FIELDS = (
         'company.name',

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -22,6 +22,9 @@ class SearchInvestmentProjectParams:
     required_scopes = (Scope.internal_front_end,)
     entity = InvestmentProject
     serializer_class = SearchInvestmentProjectSerializer
+    es_sort_by_remappings = {
+        'name': 'name.keyword',
+    }
 
     FILTER_FIELDS = (
         'adviser',

--- a/datahub/search/omis/serializers.py
+++ b/datahub/search/omis/serializers.py
@@ -6,6 +6,7 @@ from datahub.search.serializers import (
     SingleOrListField,
     StringUUIDField,
 )
+from datahub.search.utils import SearchOrdering, SortDirection
 
 
 class SearchOrderSerializer(EntitySearchSerializer):
@@ -34,7 +35,7 @@ class SearchOrderSerializer(EntitySearchSerializer):
     company = SingleOrListField(child=StringUUIDField(), required=False)
     company_name = serializers.CharField(required=False)
 
-    DEFAULT_ORDERING = 'created_on:desc'
+    DEFAULT_ORDERING = SearchOrdering('created_on', SortDirection.desc)
 
     SORT_BY_FIELDS = (
         'created_on',

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -16,9 +16,6 @@ from elasticsearch_dsl.query import (
 from datahub.search.apps import EXCLUDE_ALL, get_global_search_apps_as_mapping
 
 MAX_RESULTS = 10000
-FIELD_REMAPPING = {
-    'name': 'name.keyword',
-}
 
 
 class MatchNone(Query):
@@ -349,19 +346,12 @@ def _apply_sorting_to_query(query, ordering):
     if ordering is None:
         return query.sort('_score', 'id')
 
-    tokens = ordering.rsplit(':', maxsplit=1)
-    order = tokens[1] if len(tokens) > 1 else 'asc'
-    field_name = tokens[0]
-
     sort_params = {
-        'order': order,
-        'missing': '_first' if order == 'asc' else '_last',
+        'order': ordering.direction,
+        'missing': '_last' if ordering.is_descending else '_first',
     }
 
-    # remap field name if necessary
-    field_name = FIELD_REMAPPING.get(field_name, field_name)
-
     return query.sort(
-        {field_name: sort_params},
+        {ordering.field: sort_params},
         'id',
     )

--- a/datahub/search/test/search_support/simplemodel/serializers.py
+++ b/datahub/search/test/search_support/simplemodel/serializers.py
@@ -8,4 +8,4 @@ class SearchSimpleModelSerializer(EntitySearchSerializer):
 
     name = serializers.CharField(required=False)
 
-    SORT_BY_FIELDS = ('name', 'name.keyword')
+    SORT_BY_FIELDS = ('name',)

--- a/datahub/search/test/search_support/simplemodel/views.py
+++ b/datahub/search/test/search_support/simplemodel/views.py
@@ -11,6 +11,9 @@ class SearchSimpleModelParams:
     required_scopes = (Scope.internal_front_end,)
     entity = ESSimpleModel
     serializer_class = SearchSimpleModelSerializer
+    es_sort_by_remappings = {
+        'name': 'name.keyword',
+    }
 
     FILTER_FIELDS = ('name',)
 

--- a/datahub/search/test/test_fields.py
+++ b/datahub/search/test/test_fields.py
@@ -36,7 +36,7 @@ class TestNormalizedField(APITestMixin):
         response = api_client.post(
             url,
             data={
-                'sortby': 'name.keyword',
+                'sortby': 'name',
             },
         )
         response_data = response.json()

--- a/datahub/search/test/test_serializers.py
+++ b/datahub/search/test/test_serializers.py
@@ -32,20 +32,3 @@ class TestSingleOrListField:
             field.run_validation(['', ''])
 
         assert excinfo.value.get_codes() == {0: ['blank'], 1: ['blank']}
-
-
-class TestSerializerAttributes:
-    """Validates the field names specified in class attributes on serialiser classes."""
-
-    def test_sort_by_fields(self, search_app):
-        """Validate that the values of SORT_BY_FIELDS are valid field paths."""
-        view = search_app.view
-        mapping = search_app.es_model._doc_type.mapping
-
-        invalid_fields = {
-            field
-            for field in view.serializer_class.SORT_BY_FIELDS
-            if not mapping.resolve_field(field)
-        }
-
-        assert not invalid_fields

--- a/datahub/search/utils.py
+++ b/datahub/search/utils.py
@@ -1,4 +1,27 @@
 import json
+from typing import NamedTuple
+
+
+from datahub.core.utils import StrEnum
+
+
+class SortDirection(StrEnum):
+    """A direction for sorting."""
+
+    asc = 'asc'
+    desc = 'desc'
+
+
+class SearchOrdering(NamedTuple):
+    """An ordering for a search (i.e. a sort field and direction)."""
+
+    field: str
+    direction: SortDirection = SortDirection.asc
+
+    @property
+    def is_descending(self):
+        """Returns whether this is a descending sort."""
+        return self.direction == SortDirection.desc
 
 
 def get_model_fields(es_model):


### PR DESCRIPTION
### Description of change

This:

* moves the sort-by field remappings from `FIELD_REMAPPING` in `datahub.search.query_builder` to the search views so it can be customised for each view
* refactors the search serialisers to return a tuple for `sortby` so that it does not need to be split and joined all the time
* uses `first_name.keyword` and `last_name.keyword` for sorting contacts instead of `first_name` and `last_name`
* removes the remaining `fielddata` uses

I am not entirely happy with putting the remapping on the view, but it was picked as there was already a similar remapping on the export views. I think there is some potential refactoring of all the various attributes we have in various places (views, search models, serialisers, search apps etc.) but that would be a separate, larger job...

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
