### PR TITLE
Fully switch to PostgreSQL 10 and Elasticsearch 6.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@ version: 2.1
 
 job_defaults: &job_defaults
   parameters:
+    python_image:
+      type: string
+
     es_image:
       type: string
 
@@ -37,7 +40,7 @@ job_defaults: &job_defaults
   working_directory: ~/app
 
   docker:
-    - image: python:3.6
+    - image: <<parameters.python_image>>
 
     - image: <<parameters.es_image>>
 
@@ -89,28 +92,19 @@ job_defaults: &job_defaults
             command: |
               wget -O codecov.sh https://codecov.io/bash
               bash ./codecov.sh -t ${COV_TOKEN}
+
 jobs:
-
-  build_es_63_pg_96:
-    <<: *job_defaults
-
-  build_es_64_pg_10:
+  default_build:
     <<: *job_defaults
 
 workflows:
   version: 2
 
-  Elasticsearch 6.3 and PostgreSQL 9.6:
+  Default build:
     jobs:
-      - build_es_63_pg_96:
+      - default_build:
           publish_coverage: true
-          postgres_image: postgres:9.6
-          mi_postgres_image: postgres:9.6
-          es_image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
-
-  Elasticsearch 6.4 and PostgreSQL 10:
-    jobs:
-      - build_es_64_pg_10:
+          python_image: python:3.6
           postgres_image: postgres:10
           mi_postgres_image: postgres:9.6
-          es_image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+          es_image: docker.elastic.co/elasticsearch/elasticsearch:6.4.3

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
 Dependencies:
 
 -   Python 3.6.x
--   PostgreSQL 9.6
+-   PostgreSQL 10 (note: PostgreSQL 9.6 is used for the MI database)
 -   redis 3.2
--   Elasticsearch 6.3
+-   Elasticsearch 6.4
 
 1.  Clone the repository:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     command: celery worker -A config -l info -Q celery -B
 
   postgres:
-    image: postgres:9.6
+    image: postgres:10
     restart: always
     environment:
       - POSTGRES_DB=datahub
@@ -40,7 +40,7 @@ services:
       - POSTGRES_DB=mi
 
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.3
     restart: always
     ports:
       - "9200:9200"


### PR DESCRIPTION
### Description of change

This updates the CircleCI config, README and docker-compose-yml to fully switch to PostgreSQL 10 and Elasticsearch 6.4.

Do we need to add a step to the 'Native installation' section about creating the MI database?

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
