### PR TITLE
Fix MI dashboard country URL

### DIFF
--- a/changelog/mi-dashboard-country-url.bugfix
+++ b/changelog/mi-dashboard-country-url.bugfix
@@ -1,0 +1,1 @@
+Country URL in the MI dashboard is now assembled correctly.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -412,7 +412,7 @@ DATAHUB_FRONTEND_URL_PREFIXES = {
     'order': f'{DATAHUB_FRONTEND_BASE_URL}/omis',
 
     'mi_fdi_dashboard_country': (
-        f'{DATAHUB_FRONTEND_BASE_URL}/{urlencode(MI_FDI_DASHBOARD_COUNTRY_URL_PARAMS)}'
+        f'{DATAHUB_FRONTEND_BASE_URL}/investment-projects?{urlencode(MI_FDI_DASHBOARD_COUNTRY_URL_PARAMS)}'
     )
 }
 


### PR DESCRIPTION
### Description of change

This adds missing `investment-projects?` to the country URL.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
