### PR TITLE
Populate company address celery task

### DIFF
--- a/changelog/company/populate-address.internal
+++ b/changelog/company/populate-address.internal
@@ -1,0 +1,1 @@
+A celery task to populate company address fields from trading and registered address fields was added to allow data to be migrated.

--- a/datahub/dbmaintenance/tasks.py
+++ b/datahub/dbmaintenance/tasks.py
@@ -2,7 +2,11 @@ from logging import getLogger
 
 from celery import shared_task
 from django.apps import apps
-from django.db.models import NOT_PROVIDED, Subquery
+from django.db.models import BooleanField, Case, ExpressionWrapper, NOT_PROVIDED, Q, Subquery, When
+from django.db.models import Value
+from django.db.models.functions import Coalesce
+
+from datahub.company.models import Company
 
 
 logger = getLogger(__name__)
@@ -59,4 +63,89 @@ def replace_null_with_default(model_label, field_name, default=None, batch_size=
     replace_null_with_default.apply_async(
         args=(model_label, field_name),
         kwargs={'default': default, 'batch_size': batch_size},
+    )
+
+
+@shared_task(acks_late=True)
+def populate_company_address_fields(batch_size=5000):
+    """
+    Task to populate company address fields from trading address or
+    registered address whichever is defined.
+    """
+    # Coalesce makes sure that both NULL and '' values are treated equally
+    base_queryset = Company.objects.annotate(
+        address_1_normalised=Coalesce('address_1', Value('')),
+        address_town_normalised=Coalesce('address_town', Value('')),
+        trading_address_1_normalised=Coalesce('trading_address_1', Value('')),
+        trading_address_town_normalised=Coalesce('trading_address_town', Value('')),
+        registered_address_1_normalised=Coalesce('registered_address_1', Value('')),
+        registered_address_2_normalised=Coalesce('registered_address_2', Value('')),
+        registered_address_town_normalised=Coalesce('registered_address_town', Value('')),
+        registered_address_county_normalised=Coalesce('registered_address_county', Value('')),
+        registered_address_postcode_normalised=Coalesce('registered_address_postcode', Value('')),
+        has_valid_trading_address=ExpressionWrapper(
+            ~Q(trading_address_1_normalised='')
+            & ~Q(trading_address_town_normalised='')
+            & Q(trading_address_country__isnull=False),
+            output_field=BooleanField(),
+        ),
+        has_registered_address=ExpressionWrapper(
+            ~Q(registered_address_1_normalised='')
+            | ~Q(registered_address_2_normalised='')
+            | ~Q(registered_address_town_normalised='')
+            | ~Q(registered_address_postcode_normalised='')
+            | ~Q(registered_address_county_normalised='')
+            | Q(registered_address_country__isnull=False),
+            output_field=BooleanField(),
+        ),
+    )
+
+    # Unevaluated subquery to select a batch of records
+    subquery = base_queryset.filter(
+        Q(has_registered_address=True) | Q(has_valid_trading_address=True),
+        address_1_normalised='',
+        address_town_normalised='',
+        address_country__isnull=True,
+    ).values(
+        'pk',
+    )[:batch_size]
+
+    num_updated = base_queryset.filter(
+        pk__in=Subquery(subquery),
+    ).update(
+        address_1=Case(
+            When(has_valid_trading_address=True, then='trading_address_1'),
+            default='registered_address_1',
+        ),
+        address_2=Case(
+            When(has_valid_trading_address=True, then='trading_address_2'),
+            default='registered_address_2',
+        ),
+        address_town=Case(
+            When(has_valid_trading_address=True, then='trading_address_town'),
+            default='registered_address_town',
+        ),
+        address_county=Case(
+            When(has_valid_trading_address=True, then='trading_address_county'),
+            default='registered_address_county',
+        ),
+        address_postcode=Case(
+            When(has_valid_trading_address=True, then='trading_address_postcode'),
+            default='registered_address_postcode',
+        ),
+        address_country=Case(
+            When(has_valid_trading_address=True, then='trading_address_country'),
+            default='registered_address_country',
+        ),
+    )
+
+    logger.info(f'Finished - populated {num_updated} companies')
+
+    # If there are definitely no more rows needing updating, return
+    if num_updated < batch_size:
+        return
+
+    # Schedule another task to update another batch of rows
+    populate_company_address_fields.apply_async(
+        kwargs={'batch_size': batch_size},
     )

--- a/datahub/dbmaintenance/test/test_tasks.py
+++ b/datahub/dbmaintenance/test/test_tasks.py
@@ -1,9 +1,12 @@
+import uuid
 from unittest.mock import Mock
 
 import pytest
 
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.constants import Country
 from datahub.core.test.support.models import NullableWithDefaultModel
-from datahub.dbmaintenance.tasks import replace_null_with_default
+from datahub.dbmaintenance.tasks import populate_company_address_fields, replace_null_with_default
 
 
 @pytest.mark.django_db
@@ -140,3 +143,278 @@ class TestReplaceNullWithDefault:
         with pytest.raises(ValueError) as excinfo:
             assert res.get()
         assert str(excinfo.value) == expected_error_msg
+
+
+@pytest.mark.django_db
+class TestPopulateCompanyAddressFields:
+    """Tests for the populate_company_address_fields task."""
+
+    @pytest.mark.parametrize(
+        'num_objects,batch_size,expected_batches',
+        (
+            (10, 4, 3),
+            (10, 5, 3),
+            (11, 6, 2),
+            (11, 12, 1),
+            (0, 5, 1),
+        ),
+    )
+    def test_batch(
+            self,
+            monkeypatch,
+            num_objects,
+            batch_size,
+            expected_batches,
+    ):
+        """Test that the batches are calculated correctly."""
+        initial_data_for_models_to_populate = {
+            'address_1': None,
+            'address_2': None,
+            'address_town': None,
+            'address_county': None,
+            'address_postcode': None,
+            'address_country_id': None,
+
+            'registered_address_1': '2',
+            'registered_address_2': 'Main Road',
+            'registered_address_town': 'London',
+            'registered_address_county': 'Greenwich',
+            'registered_address_postcode': 'SE10 9NN',
+            'registered_address_country_id': Country.united_kingdom.value.id,
+        }
+        initial_data_for_models_to_ignore = {
+            'address_1': None,
+            'address_2': None,
+            'address_town': None,
+            'address_county': None,
+            'address_postcode': None,
+            'address_country_id': None,
+
+            'registered_address_1': '',
+            'registered_address_2': None,
+            'registered_address_town': '',
+            'registered_address_county': None,
+            'registered_address_postcode': None,
+            'registered_address_country_id': None,
+
+            'trading_address_1': None,
+            'trading_address_2': None,
+            'trading_address_town': None,
+            'trading_address_county': None,
+            'trading_address_postcode': None,
+            'trading_address_country_id': None,
+        }
+
+        populate_company_address_fields_mock = Mock(
+            wraps=populate_company_address_fields,
+        )
+        monkeypatch.setattr(
+            'datahub.dbmaintenance.tasks.populate_company_address_fields',
+            populate_company_address_fields_mock,
+        )
+
+        CompanyFactory.create_batch(num_objects, **initial_data_for_models_to_populate)
+        CompanyFactory.create_batch(num_objects, **initial_data_for_models_to_ignore)
+
+        populate_company_address_fields_mock.apply_async(
+            kwargs={'batch_size': batch_size},
+        )
+
+        assert populate_company_address_fields_mock.apply_async.call_count == expected_batches
+
+    @pytest.mark.parametrize(
+        'initial_model_values,expected_model_values',
+        (
+            # address fields populated from trading address fields
+            (
+                {
+                    'address_1': None,
+                    'address_2': None,
+                    'address_town': None,
+                    'address_county': None,
+                    'address_postcode': None,
+                    'address_country_id': None,
+
+                    'registered_address_1': '2',
+                    'registered_address_2': 'Main Road',
+                    'registered_address_town': 'London',
+                    'registered_address_county': 'Greenwich',
+                    'registered_address_postcode': 'SE10 9NN',
+                    'registered_address_country_id': Country.united_kingdom.value.id,
+
+                    'trading_address_1': '1',
+                    'trading_address_2': 'Hello st.',
+                    'trading_address_town': 'Muckamore',
+                    'trading_address_county': 'Antrim',
+                    'trading_address_postcode': 'BT41 4QE',
+                    'trading_address_country_id': Country.ireland.value.id,
+                },
+                {
+                    'address_1': '1',
+                    'address_2': 'Hello st.',
+                    'address_town': 'Muckamore',
+                    'address_county': 'Antrim',
+                    'address_postcode': 'BT41 4QE',
+                    'address_country_id': uuid.UUID(Country.ireland.value.id),
+                },
+            ),
+
+            # address fields populated from registered address fields
+            (
+                {
+                    'address_1': '',
+                    'address_2': '',
+                    'address_town': '',
+                    'address_county': '',
+                    'address_postcode': '',
+                    'address_country_id': None,
+
+                    'registered_address_1': '2',
+                    'registered_address_2': 'Main Road',
+                    'registered_address_town': 'London',
+                    'registered_address_county': 'Greenwich',
+                    'registered_address_postcode': 'SE10 9NN',
+                    'registered_address_country_id': Country.united_kingdom.value.id,
+
+                    'trading_address_1': None,
+                    'trading_address_2': None,
+                    'trading_address_town': None,
+                    'trading_address_county': None,
+                    'trading_address_postcode': None,
+                    'trading_address_country_id': None,
+                },
+                {
+                    'address_1': '2',
+                    'address_2': 'Main Road',
+                    'address_town': 'London',
+                    'address_county': 'Greenwich',
+                    'address_postcode': 'SE10 9NN',
+                    'address_country_id': uuid.UUID(Country.united_kingdom.value.id),
+                },
+            ),
+
+            # address fields populated from registered address fields when trading address
+            # is incomplete (country is missing)
+            (
+                {
+                    'address_1': None,
+                    'address_2': None,
+                    'address_town': None,
+                    'address_county': None,
+                    'address_postcode': None,
+                    'address_country_id': None,
+
+                    'registered_address_1': '2',
+                    'registered_address_2': 'Main Road',
+                    'registered_address_town': 'London',
+                    'registered_address_county': 'Greenwich',
+                    'registered_address_postcode': 'SE10 9NN',
+                    'registered_address_country_id': Country.united_kingdom.value.id,
+
+                    'trading_address_1': '1',
+                    'trading_address_2': 'Hello st.',
+                    'trading_address_town': 'Muckamore',
+                    'trading_address_county': 'Antrim',
+                    'trading_address_postcode': 'BT41 4QE',
+                    'trading_address_country_id': None,
+                },
+                {
+                    'address_1': '2',
+                    'address_2': 'Main Road',
+                    'address_town': 'London',
+                    'address_county': 'Greenwich',
+                    'address_postcode': 'SE10 9NN',
+                    'address_country_id': uuid.UUID(Country.united_kingdom.value.id),
+                },
+            ),
+
+            # address fields populated from registered address fields when registered address
+            # is incomplete (only line 1 is populated)
+            (
+                {
+                    'address_1': None,
+                    'address_2': None,
+                    'address_town': None,
+                    'address_county': None,
+                    'address_postcode': None,
+                    'address_country_id': None,
+
+                    'registered_address_1': 'Street',
+                    'registered_address_2': None,
+                    'registered_address_town': '',
+                    'registered_address_county': None,
+                    'registered_address_postcode': None,
+                    'registered_address_country_id': None,
+
+                    'trading_address_1': None,
+                    'trading_address_2': None,
+                    'trading_address_town': None,
+                    'trading_address_county': None,
+                    'trading_address_postcode': None,
+                    'trading_address_country_id': None,
+                },
+                {
+                    'address_1': 'Street',
+                    'address_2': None,
+                    'address_town': '',
+                    'address_county': None,
+                    'address_postcode': None,
+                    'address_country_id': None,
+                },
+            ),
+        ),
+    )
+    def test_successful_run(
+        self,
+        initial_model_values,
+        expected_model_values,
+        caplog,
+    ):
+        """
+        Test that the task populates company address from trading or registered address
+        if address fields are blank.
+        """
+        caplog.set_level('INFO')
+
+        company = CompanyFactory(**initial_model_values)
+
+        # ignored because address is populated
+        CompanyFactory(
+            address_1='1 Main Street',
+            address_2=None,
+            address_town=None,
+            address_county=None,
+            address_postcode=None,
+            address_country_id=None,
+        )
+        # ignored because registered address is blank
+        CompanyFactory(
+            address_1=None,
+            address_2=None,
+            address_town=None,
+            address_county=None,
+            address_postcode=None,
+            address_country_id=None,
+
+            registered_address_1='',
+            registered_address_2=None,
+            registered_address_town='',
+            registered_address_county=None,
+            registered_address_postcode=None,
+            registered_address_country_id=None,
+
+            trading_address_1=None,
+            trading_address_2=None,
+            trading_address_town=None,
+            trading_address_county=None,
+            trading_address_postcode=None,
+            trading_address_country_id=None,
+        )
+
+        populate_company_address_fields.apply_async()
+
+        assert 'Finished - populated 1 companies' in caplog.text
+
+        company.refresh_from_db()
+        for field, value in expected_model_values.items():
+            assert getattr(company, field) == value


### PR DESCRIPTION
### Description of change

This adds a celery task called `populate_company_address_fields` which populates address fields from trading and registered address.

The initial version saved each company instance but it turned out to be a bit slow so I've created a second version which uses SQL UPDATEs instead.

I left both commits for you to have a look, I prefer the second (more efficient) one but please do let me know if you think that version one is better and I could revert to it.

The code could be better but it's just temporary so it's probably not worth it.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
