### PR TITLE
MI dashboard pipeline cleanup

### DIFF
--- a/changelog/mi-dashboard-pipeline-delete-records.feature
+++ b/changelog/mi-dashboard-pipeline-delete-records.feature
@@ -1,0 +1,1 @@
+The MI dashboard pipeline task now deletes records from MI database that no longer exist in the source query.

--- a/changelog/mi-dashboard-task-reschedule.internal
+++ b/changelog/mi-dashboard-task-reschedule.internal
@@ -1,0 +1,1 @@
+The MI dashboard pipeline was rescheduled to run at around 3 AM each night.

--- a/changelog/mi-dashboard-task-reschedule.internal
+++ b/changelog/mi-dashboard-task-reschedule.internal
@@ -1,1 +1,1 @@
-The MI dashboard pipeline was rescheduled to run at around 3 AM each night.
+The MI dashboard pipeline was rescheduled to run at around 1 AM each night.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -381,7 +381,7 @@ if REDIS_BASE_URL:
         CELERY_BEAT_SCHEDULE['mi_dashboard_feed'] = {
             'task': 'datahub.mi_dashboard.tasks.mi_investment_project_etl_pipeline',
             'args': ('2018/2019', ),
-            'schedule': crontab(minute=0, hour=3),
+            'schedule': crontab(minute=0, hour=1),
         }
 
     CELERY_WORKER_LOG_FORMAT = (

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -381,7 +381,7 @@ if REDIS_BASE_URL:
         CELERY_BEAT_SCHEDULE['mi_dashboard_feed'] = {
             'task': 'datahub.mi_dashboard.tasks.mi_investment_project_etl_pipeline',
             'args': ('2018/2019', ),
-            'schedule': crontab(minute=0, hour=2),
+            'schedule': crontab(minute=0, hour=3),
         }
 
     CELERY_WORKER_LOG_FORMAT = (

--- a/datahub/mi_dashboard/pipelines.py
+++ b/datahub/mi_dashboard/pipelines.py
@@ -93,7 +93,7 @@ class ETLBase:
 
         :returns: a list of ID values.
         """
-        return self.get_source_query().values(self.get_model()._meta.pk.name)
+        return self.get_source_query().values_list('pk', flat=True)
 
     def clean(self) -> int:
         """
@@ -103,7 +103,7 @@ class ETLBase:
         """
         # we need to materialise ids query so that Django doesn't attempt
         # to create a query across the different databases
-        ids = (row['id'] for row in self.get_ids())
+        ids = list(self.get_ids())
         deleted, _ = self.destination.objects.exclude(pk__in=ids).delete()
 
         return deleted


### PR DESCRIPTION
### Description of change

This enhances the pipeline so that the projects that don't exist in the result of the source query are being deleted from the MI dashboard database. This enables the dashboard to have more accurate data.

The method this is done is a bit naive but I think it should be performant enough.

This also changes the time the task is run from 2 AM to ~3 AM~1 AM.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
