### PR TITLE
Remove default from Company.address_postcode

### DIFF
--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -183,7 +183,7 @@ class Company(ArchivableModel, BaseModel, CompanyAbstract):
         on_delete=models.PROTECT,
         related_name='company_address_country',
     )
-    address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True, null=True, default='')
+    address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
 
     # will eventually become obsolete when the migration to solely address and registered
     # address is completed


### PR DESCRIPTION
### Description of change

It was mistakenly on the model definition. The migration is correct and doesn't need updating.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
