### PR TITLE
Add contacts__id filter to GET /v3/interaction

### DIFF
--- a/changelog/interaction/interaction-filter-by-contact.api
+++ b/changelog/interaction/interaction-filter-by-contact.api
@@ -1,0 +1,3 @@
+``GET /v3/interaction``: ``contacts__id`` was added as a query parameter to support filtering by contact ID for
+interactions with multiple contacts. The previous ``contact_id`` filter is deprecated and will be removed on or after
+21 February 2019.

--- a/changelog/interaction/interaction-filter-by-contact.removal
+++ b/changelog/interaction/interaction-filter-by-contact.removal
@@ -1,0 +1,2 @@
+``GET /v3/interaction``: The ``contact_id`` query parameter is deprecated and will be removed on or after
+21 February 2019. Please use ``contacts__id`` instead.

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -339,8 +339,12 @@ class TestListInteractions(APITestMixin):
         assert response.data['count'] == 2
         assert {i['id'] for i in response.data['results']} == {str(i.id) for i in interactions}
 
-    def test_filtered_by_contact(self):
-        """List of interactions filtered by contact"""
+    def test_filter_by_contact_legacy(self):
+        """
+        Test filtering interactions by contact (using the legacy contact_id field).
+
+        TODO Remove once contact_id filter removed.
+        """
         contact1 = ContactFactory()
         contact2 = ContactFactory()
 
@@ -349,6 +353,21 @@ class TestListInteractions(APITestMixin):
 
         url = reverse('api-v3:interaction:collection')
         response = self.api_client.get(url, data={'contact_id': contact2.id})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+        assert {i['id'] for i in response.data['results']} == {str(i.id) for i in interactions}
+
+    def test_filter_by_contact(self):
+        """Test filtering interactions by contact (using contacts__id)."""
+        contact1 = ContactFactory()
+        contact2 = ContactFactory()
+
+        CompanyInteractionFactory.create_batch(3, contacts=[contact1])
+        interactions = CompanyInteractionFactory.create_batch(2, contacts=[contact1, contact2])
+
+        url = reverse('api-v3:interaction:collection')
+        response = self.api_client.get(url, data={'contacts__id': contact2.id})
 
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] == 2

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -29,7 +29,13 @@ class InteractionViewSet(CoreViewSet):
         IsAssociatedToInvestmentProjectInteractionFilter,
         OrderingFilter,
     )
-    filterset_fields = ['company_id', 'contact_id', 'event_id', 'investment_project_id']
+    filterset_fields = [
+        'company_id',
+        'contact_id',
+        'contacts__id',
+        'event_id',
+        'investment_project_id',
+    ]
     ordering_fields = (
         'company__name',
         'contact__first_name',


### PR DESCRIPTION
### Description of change

This adds a `contacts__id` filter to `GET /v3/interaction` that supports filtering interactions by contact for interactions with multiple contacts. This replaces the previous `contact_id` filter.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
