### PR TITLE
Add management command to delete all Elasticsearch indices

### DIFF
--- a/changelog/delete-all-indices.internal
+++ b/changelog/delete-all-indices.internal
@@ -1,0 +1,2 @@
+A management command to delete all Elasticsearch indices matching the configured index name prefix was added. This is intended for use on GOV.UK PaaS when required as GOV.UK PaaS Elasticsearch does not allow deletions
+using wildcards.

--- a/datahub/search/management/commands/delete_all_es_indices.py
+++ b/datahub/search/management/commands/delete_all_es_indices.py
@@ -1,0 +1,56 @@
+from logging import getLogger
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from datahub.search.elasticsearch import get_client
+
+logger = getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """Command for deleting all Elasticsearch indexes matching the configured index name prefix."""
+
+    help = """Irrevocably deletes all Elasticsearch indices under the configured index name prefix.
+
+This is intended for use on GOV.UK PaaS as GOV.UK PaaS Elasticsearch does not allow deletions
+using wildcards.
+
+Don't use this unless you really mean to delete all of the app's indices!
+"""
+    confirm_msg = """
+This operation cannot be undone.
+Are you sure you want to do this?
+
+    Type 'yes' to continue, or 'no' to cancel: """
+
+    def add_arguments(self, parser):
+        """
+        Add no-input argument to the command.
+        """
+        parser.add_argument(
+            '--noinput', '--no-input', action='store_false', dest='interactive',
+            help='Tells Django to NOT prompt the user for input of any kind.',
+        )
+
+    def handle(self, *args, **options):
+        """Executes the command."""
+        interactive = options['interactive']
+
+        client = get_client()
+        index_statistics = client.cat.indices(index=f'{settings.ES_INDEX_PREFIX}-*', format='json')
+        indices = sorted(item['index'] for item in index_statistics)
+
+        if not indices:
+            logger.info(f'No matching Elasticsearch indices to delete!')
+            return
+
+        formatted_index_list = '\n'.join(indices)
+        logger.info(f'Deleting the following Elasticsearch indices:\n{formatted_index_list}')
+
+        confirmed = not interactive or (input(self.confirm_msg) == 'yes')
+        if confirmed:
+            client.indices.delete(','.join(indices))
+            logger.info('Elasticsearch indices deleted')
+        else:
+            logger.info('Command cancelled')

--- a/datahub/search/test/commands/test_delete_all_es_indices.py
+++ b/datahub/search/test/commands/test_delete_all_es_indices.py
@@ -1,0 +1,83 @@
+from unittest.mock import Mock
+
+import pytest
+from django.core import management
+from django.test import override_settings
+
+from datahub.search.management.commands import delete_all_es_indices
+
+CAT_INDICES_MOCK_DATA = [
+    {
+        'health': 'yellow',
+        'status': 'open',
+        'index': 'test-datahub-interaction-ec946a2e4301393aa5fdd9f109b60cf6',
+        'uuid': 'i2Lm4K3kSOufk8Ev7YHtdg',
+        'pri': '5',
+        'rep': '1',
+        'docs.count': '16703',
+        'docs.deleted': '4472',
+        'store.size': '32.3mb',
+        'pri.store.size': '32.3mb',
+    },
+    {
+        'health': 'yellow',
+        'status': 'open',
+        'index': 'test-datahub-companieshousecompany-f4c973f676d15e228905d28394b914f2',
+        'uuid': 'PlqfWiw2QIGFmfBOZELhfg',
+        'pri': '5',
+        'rep': '1',
+        'docs.count': '4263083',
+        'docs.deleted': '0',
+        'store.size': '1.8gb',
+        'pri.store.size': '1.8gb',
+    },
+]
+
+
+@override_settings(ES_INDEX_PREFIX='test-datahub')
+@pytest.mark.parametrize('interactive', (True, False))
+def test_deletes_matching_indices(mock_es_client, interactive, monkeypatch):
+    """Test that indices matching the ES_INDEX_PREFIX prefix are deleted."""
+    mocked_input = Mock(return_value='yes')
+    monkeypatch.setattr('builtins.input', mocked_input)
+    mock_es_client.return_value.cat.indices.return_value = CAT_INDICES_MOCK_DATA
+
+    management.call_command(
+        delete_all_es_indices.Command(),
+        interactive=interactive,
+    )
+
+    mock_es_client.return_value.cat.indices.assert_called_once_with(
+        index='test-datahub-*',
+        format='json',
+    )
+    mock_es_client.return_value.indices.delete.assert_called_once_with(
+        'test-datahub-companieshousecompany-f4c973f676d15e228905d28394b914f2,'
+        'test-datahub-interaction-ec946a2e4301393aa5fdd9f109b60cf6',
+    )
+    assert mocked_input.call_count == (1 if interactive else 0)
+
+
+@override_settings(ES_INDEX_PREFIX='test-datahub')
+def test_skips_deleting_if_no_matching_indices(mock_es_client):
+    """Test that if no indices match, no attempt to delete indices is made."""
+    mock_es_client.return_value.cat.indices.return_value = []
+
+    management.call_command(delete_all_es_indices.Command())
+
+    mock_es_client.return_value.indices.delete.assert_not_called()
+
+
+def test_skips_deleting_if_not_confirmed(mock_es_client, monkeypatch):
+    """
+    Test that if the user types 'no' when asked to confirm the action, the command
+    exits without deleting.
+    """
+    mocked_input = Mock(return_value='no')
+    monkeypatch.setattr('builtins.input', mocked_input)
+    mock_es_client.return_value.cat.indices.return_value = CAT_INDICES_MOCK_DATA
+
+    management.call_command(delete_all_es_indices.Command(), interactive=True)
+
+    mock_es_client.return_value.indices.delete.assert_not_called()
+    mocked_input.assert_called()


### PR DESCRIPTION
### Description of change

This adds a management command to delete all Elasticsearch indices that match the configured index name prefix.

This is intended for use on GOV.UK PaaS (when required) as GOV.UK PaaS Elasticsearch does not allow deletions using wildcards.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
