### PR TITLE
Add interaction contacts and company consistency validation

### DIFF
--- a/changelog/interaction/contacts-company-consistency.api
+++ b/changelog/interaction/contacts-company-consistency.api
@@ -1,0 +1,3 @@
+``POST /v3/interaction``, ``PATCH /v3/interaction/<id>``: Additional validation was added to make sure that all
+``contacts`` belong to the specified ``company``. This validation only occurs when an interaction is created, or the
+``contacts`` or ``company`` field is updated.

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -23,6 +23,7 @@ from datahub.interaction.models import (
     ServiceDeliveryStatus,
 )
 from datahub.interaction.permissions import HasAssociatedInvestmentProjectValidator
+from datahub.interaction.validators import ContactsBelongToCompanyValidator
 from datahub.investment.serializers import NestedInvestmentProjectField
 from datahub.metadata.models import Service, Team
 
@@ -210,6 +211,7 @@ class InteractionSerializer(serializers.ModelSerializer):
         )
         validators = [
             HasAssociatedInvestmentProjectValidator(),
+            ContactsBelongToCompanyValidator(),
             RulesBasedValidator(
                 # Because contacts could come from either contact or contacts, this has to be at
                 # the object level

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -101,7 +101,7 @@ class TestAddInteraction(APITestMixin):
         """Test add a new interaction."""
         adviser = create_test_user(permission_codenames=permissions)
         company = CompanyFactory()
-        contact = ContactFactory()
+        contact = ContactFactory(company=company)
         communication_channel = random_obj_for_model(CommunicationChannel)
 
         url = reverse('api-v3:interaction:collection')
@@ -391,7 +391,7 @@ class TestAddInteraction(APITestMixin):
             dit_team=project_creator.dit_team,  # same dit team as the project creator
         )
         company = CompanyFactory()
-        contact = ContactFactory()
+        contact = ContactFactory(company=company)
         url = reverse('api-v3:interaction:collection')
         api_client = self.create_api_client(user=requester)
         response = api_client.post(

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -69,7 +69,7 @@ class TestAddServiceDelivery(APITestMixin):
         """Test add a new service delivery."""
         adviser = AdviserFactory()
         company = CompanyFactory()
-        contact = ContactFactory()
+        contact = ContactFactory(company=company)
         url = reverse('api-v3:interaction:collection')
         request_data = {
             'kind': Interaction.KINDS.service_delivery,

--- a/datahub/interaction/validators.py
+++ b/datahub/interaction/validators.py
@@ -1,0 +1,38 @@
+from rest_framework.exceptions import ValidationError
+
+from datahub.core.validate_utils import DataCombiner
+
+
+class ContactsBelongToCompanyValidator:
+    """Validates that an interaction's contacts belong to the interaction's company."""
+
+    def __init__(self):
+        """Initialises the validator."""
+        self.instance = None
+
+    def set_context(self, serializer):
+        """Saves a reference to the model object."""
+        self.instance = serializer.instance
+
+    def __call__(self, data):
+        """Performs validation."""
+        company_has_changed = not self.instance or (
+            'company' in data and data['company'] != self.instance.company
+        )
+
+        contacts_have_changed = not self.instance or (
+            'contacts' in data and set(data['contacts']) != set(self.instance.contacts.all())
+        )
+
+        if not (company_has_changed or contacts_have_changed):
+            return
+
+        combiner = DataCombiner(self.instance, data)
+        company = combiner.get_value('company')
+        contacts = combiner.get_value_to_many('contacts')
+
+        if any(contact.company != company for contact in contacts):
+            raise ValidationError(
+                'The interaction contacts must belong to the specified company.',
+                code='inconsistent_contacts_and_company',
+            )


### PR DESCRIPTION
### Description of change

This adds validation to interaction endpoints to check that all contacts belong to the company specified.

This validation is only performed when an interaction is created, or the contacts or company are updated.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
