### PR TITLE
Don't allow multiple contacts for event service deliveries

### DIFF
--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -79,6 +79,9 @@ class InteractionSerializer(serializers.ModelSerializer):
         'one_contact_field': ugettext_lazy(
             'Only one of contact and contacts should be provided.',
         ),
+        'too_many_contacts_for_event_service_delivery': ugettext_lazy(
+            'Only one contact can be provided for event service deliveries.',
+        ),
     }
 
     company = NestedRelatedField(Company)
@@ -267,6 +270,11 @@ class InteractionSerializer(serializers.ModelSerializer):
                 ValidationRule(
                     'required',
                     OperatorRule('event', bool),
+                    when=OperatorRule('is_event', bool),
+                ),
+                ValidationRule(
+                    'too_many_contacts_for_event_service_delivery',
+                    OperatorRule('contacts', lambda value: len(value) <= 1),
                     when=OperatorRule('is_event', bool),
                 ),
                 ValidationRule(


### PR DESCRIPTION
### Description of change

This prevents multiple contacts being added to event service deliveries.

This is because it would complicate the event attendees view in the front end, where services deliveries are displayed as a list of contacts.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
