### PR TITLE
Add contacts to interaction search model

### DIFF
--- a/changelog/interaction/contact-filters.removal
+++ b/changelog/interaction/contact-filters.removal
@@ -1,0 +1,2 @@
+``POST /v3/search/interaction``: The ``contact`` and ``contact_name`` filters in request bodies are deprecated and will
+be removed on or after 28 February 2019.

--- a/changelog/interaction/contact-search.removal
+++ b/changelog/interaction/contact-search.removal
@@ -1,0 +1,2 @@
+``GET /v3/search``, ``POST /v3/search/interaction``: The ``contact`` field in responses is deprecated and will be removed on or
+after 28 February 2019. Please use ``contacts`` instead.

--- a/changelog/interaction/contact-sort-by.removal
+++ b/changelog/interaction/contact-sort-by.removal
@@ -1,0 +1,2 @@
+``POST /v3/search/interaction``: The ``contact.name`` value for the ``sortby`` query parameter is deprecated and will
+be removed on or after 28 February 2019.

--- a/changelog/interaction/contacts-in-search.api
+++ b/changelog/interaction/contacts-in-search.api
@@ -1,3 +1,3 @@
 ``GET /v3/search``, ``POST /v3/search/interaction``: ``contacts`` was added as an array field in search results.
 This field is intended to replace the ``contact`` field. The ``contact`` field is deprecated and will be removed
-on or after 21 February 2019.
+on or after 28 February 2019.

--- a/changelog/interaction/contacts-in-search.api
+++ b/changelog/interaction/contacts-in-search.api
@@ -1,0 +1,3 @@
+``GET /v3/search``, ``POST /v3/search/interaction``: ``contacts`` was added as an array field in search results.
+This field is intended to replace the ``contact`` field. The ``contact`` field is deprecated and will be removed
+on or after 21 February 2019.

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -11,7 +11,7 @@ def id_name_dict(obj):
 
 def id_name_list_of_dicts(manager):
     """Creates a list of dicts with ID and name keys from a manager."""
-    return [id_name_dict(obj) for obj in manager.all()]
+    return _list_of_dicts(id_name_dict, manager)
 
 
 def id_type_dict(obj):
@@ -72,6 +72,11 @@ def contact_or_adviser_dict(obj, include_dit_team=False):
         else:
             data['dit_team'] = {}
     return data
+
+
+def contact_or_adviser_list_of_dicts(manager):
+    """Creates a list of dicts from a manager for contacts or advisers."""
+    return _list_of_dicts(contact_or_adviser_dict, manager)
 
 
 def adviser_dict_with_team(obj):
@@ -144,3 +149,8 @@ def sector_dict(obj):
             'id': str(ancestor.id),
         } for ancestor in obj.get_ancestors()],
     }
+
+
+def _list_of_dicts(dict_factory, manager):
+    """Creates a list of dicts with ID and name keys from a manager."""
+    return [dict_factory(obj) for obj in manager.all()]

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -33,6 +33,7 @@ class InteractionSearchApp(SearchApp):
         'service_delivery_status',
         'event',
     ).prefetch_related(
+        'contacts',
         'policy_areas',
         'policy_issue_types',
     )

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -1,12 +1,28 @@
 from operator import attrgetter
 
-from elasticsearch_dsl import Boolean, Date, Double, Keyword
+from elasticsearch_dsl import Boolean, Date, Double, Keyword, Object, Text
 
 from datahub.search import dict_utils, fields
+from datahub.search.fields import TrigramText
 from datahub.search.models import BaseESModel
 
 
 DOC_TYPE = 'interaction'
+
+
+def _contact_field():
+    return Object(
+        properties={
+            'id': Keyword(index=False),
+            'first_name': Text(index=False),
+            'last_name': Text(index=False),
+            'name': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+        },
+    )
 
 
 class Interaction(BaseESModel):
@@ -17,6 +33,7 @@ class Interaction(BaseESModel):
     company_sector = fields.sector_field()
     communication_channel = fields.id_name_field()
     contact = fields.contact_or_adviser_field('contact')
+    contacts = _contact_field()
     created_on = Date()
     date = Date()
     dit_adviser = fields.contact_or_adviser_field('dit_adviser')
@@ -44,6 +61,7 @@ class Interaction(BaseESModel):
         'company': dict_utils.company_dict,
         'communication_channel': dict_utils.id_name_dict,
         'contact': dict_utils.contact_or_adviser_dict,
+        'contacts': dict_utils.contact_or_adviser_list_of_dicts,
         'dit_adviser': dict_utils.contact_or_adviser_dict,
         'dit_team': dict_utils.id_name_dict,
         'event': dict_utils.id_name_dict,

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -26,6 +26,7 @@ def test_interaction_to_dict(setup_es, factory_cls):
     interaction = factory_cls()
 
     result = Interaction.db_object_to_dict(interaction)
+    result['contacts'].sort(key=itemgetter('id'))
     result['policy_areas'].sort(key=itemgetter('id'))
     result['policy_issue_types'].sort(key=itemgetter('id'))
 
@@ -52,6 +53,15 @@ def test_interaction_to_dict(setup_es, factory_cls):
             'name': interaction.contact.name,
             'last_name': interaction.contact.last_name,
         },
+        'contacts': [
+            {
+                'id': str(obj.pk),
+                'first_name': obj.first_name,
+                'name': obj.name,
+                'last_name': obj.last_name,
+            }
+            for obj in sorted(interaction.contacts.all(), key=attrgetter('id'))
+        ],
         'is_event': interaction.is_event,
         'event': None,
         'service': {
@@ -111,6 +121,7 @@ def test_service_delivery_to_dict(setup_es):
     interaction = ServiceDeliveryFactory()
 
     result = Interaction.db_object_to_dict(interaction)
+    result['contacts'].sort(key=itemgetter('id'))
 
     assert result == {
         'id': interaction.pk,
@@ -135,6 +146,15 @@ def test_service_delivery_to_dict(setup_es):
             'name': interaction.contact.name,
             'last_name': interaction.contact.last_name,
         },
+        'contacts': [
+            {
+                'id': str(obj.pk),
+                'first_name': obj.first_name,
+                'name': obj.name,
+                'last_name': obj.last_name,
+            }
+            for obj in sorted(interaction.contacts.all(), key=attrgetter('id'))
+        ],
         'is_event': interaction.is_event,
         'event': None,
         'service': {

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -3,6 +3,7 @@ from collections import Counter
 from csv import DictReader
 from datetime import datetime
 from io import StringIO
+from operator import attrgetter, itemgetter
 from uuid import UUID
 
 import factory
@@ -224,7 +225,12 @@ class TestInteractionEntitySearchView(APITestMixin):
         response_data = response.json()
         interaction = interactions[0]
         assert response_data['count'] == 1
-        assert response_data['results'] == [{
+        results = response_data['results']
+
+        for result in results:
+            result['contacts'].sort(key=itemgetter('id'))
+
+        assert results == [{
             'id': str(interaction.pk),
             'kind': interaction.kind,
             'date': interaction.date.isoformat(),
@@ -247,6 +253,15 @@ class TestInteractionEntitySearchView(APITestMixin):
                 'name': interaction.contact.name,
                 'last_name': interaction.contact.last_name,
             },
+            'contacts': [
+                {
+                    'id': str(contact.pk),
+                    'first_name': contact.first_name,
+                    'name': contact.name,
+                    'last_name': contact.last_name,
+                }
+                for contact in sorted(interaction.contacts.all(), key=attrgetter('id'))
+            ],
             'is_event': None,
             'event': None,
             'service': {

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -172,6 +172,23 @@ def test_contact_or_adviser_dict_none_dit_team():
     }
 
 
+def test_contact_or_adviser_list_of_dicts():
+    """Test that contact_or_adviser_list_of_dicts returns a list of person dicts."""
+    data = [
+        {'id': '12', 'first_name': 'first A', 'last_name': 'last A', 'name': 'test A'},
+        {'id': '99', 'first_name': 'first B', 'last_name': 'last B', 'name': 'testing B'},
+    ]
+    objects = [mock.Mock(), mock.Mock()]
+    for obj, data_item in zip(objects, data):
+        obj.configure_mock(**data_item)
+
+    manager = mock.Mock(
+        all=mock.Mock(return_value=objects),
+    )
+
+    assert dict_utils.contact_or_adviser_list_of_dicts(manager) == data
+
+
 def test_ch_company_dict():
     """Tests ch_company_dict."""
     obj = mock.Mock()


### PR DESCRIPTION
### Description of change

This:

- adds `contacts` to the interaction search model
- deprecates contact sorting options in interaction search (these will be removed)
- deprecates contact filters in interaction search (these are not being used)

There's still some more logic to unpick, which will come in subsequent PRs.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
