### PR TITLE
Update various dependencies

### DIFF
--- a/changelog/update-deps.internal
+++ b/changelog/update-deps.internal
@@ -1,0 +1,1 @@
+Updated various dependencies.

--- a/requirements.in
+++ b/requirements.in
@@ -7,7 +7,7 @@ Django==2.1.5
 djangorestframework==3.9.1
 django-admin-ip-restrictor==0.2.1
 django-environ==0.4.5
-django-extensions==2.1.4
+django-extensions==2.1.5
 django-filter==2.1.0
 django-reversion==3.0.3
 django-pglocks==1.0.2
@@ -25,13 +25,13 @@ python-dateutil==2.7.5
 psycopg2==2.7.7
 psycogreen==1.0.1
 
-boto3==1.9.84
+boto3==1.9.86
 
 notifications-python-client==5.2.0
 
 # REDIS
 django-redis==4.10.0
-redis==3.0.1
+redis==3.1.0
 
 # ES
 elasticsearch==6.3.1
@@ -43,11 +43,11 @@ celery==4.2.1
 billiard==3.5.0.4  # pinned due to https://github.com/celery/billiard/issues/260
 
 # Testing and dev
-pytest==4.1.1
-pytest-django==3.4.5
+pytest==4.2.0
+pytest-django==3.4.7
 pytest-sugar==0.9.2
 pytest-cov==2.6.1
-pytest-xdist==1.26.0
+pytest-xdist==1.26.1
 ipython==7.2.0
 ipdb==0.11
 factory-boy==2.11.1
@@ -55,12 +55,12 @@ freezegun==0.3.11
 requests-mock==1.5.2
 django-debug-toolbar==1.11
 werkzeug==0.14.1  # Required by runserver_plus - useful for local dev
-pip-tools==3.2.0
+pip-tools==3.3.2
 piprot==0.9.10
 towncrier==18.6.0
 
 # Code static analysis
-flake8==3.6.0
+flake8==3.7.4
 flake8-blind-except==0.1.1
 flake8-commas==2.0.0
 flake8-debugger==3.1.0
@@ -77,4 +77,4 @@ gevent==1.4.0
 mohawk==0.3.4
 raven==6.10.0
 requests==2.21.0
-requests_toolbelt==0.8.0
+requests_toolbelt==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,26 +4,26 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-amqp==2.4.0               # via kombu
+amqp==2.4.1               # via kombu
 apipkg==1.5               # via execnet
-atomicwrites==1.2.1       # via pytest
+atomicwrites==1.3.0       # via pytest
 attrs==18.2.0             # via pytest
 aws-requests-auth==0.4.2
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4
-boto3==1.9.84
-botocore==1.12.84         # via boto3, s3transfer
+boto3==1.9.86
+botocore==1.12.86         # via boto3, s3transfer
 celery==4.2.1
 certifi==2018.11.29       # via requests
 chardet==3.0.4
 click==7.0                # via pip-tools, towncrier
 coverage==4.5.2           # via pytest-cov
 cssselect==1.0.3
-decorator==4.3.0          # via ipython, traitlets
+decorator==4.3.2          # via ipython, traitlets
 django-admin-ip-restrictor==0.2.1
 django-debug-toolbar==1.11
 django-environ==0.4.5
-django-extensions==2.1.4
+django-extensions==2.1.5
 django-filter==2.1.0
 django-ipware==2.1.0      # via django-admin-ip-restrictor
 django-js-asset==1.1.0    # via django-mptt
@@ -39,6 +39,7 @@ docopt==0.6.2             # via docopt, notifications-python-client
 docutils==0.14            # via botocore, docutils
 elasticsearch-dsl==6.3.1
 elasticsearch==6.3.1
+entrypoints==0.3          # via flake8
 execnet==1.5.0            # via pytest-xdist
 factory-boy==2.11.1
 faker==1.0.2              # via factory-boy
@@ -51,7 +52,7 @@ flake8-polyfill==1.0.2    # via flake8-docstrings, pep8-naming
 flake8-print==3.1.0
 flake8-quotes==1.0.0
 flake8-string-format==0.2.3
-flake8==3.6.0
+flake8==3.7.4
 freezegun==0.3.11
 future==0.17.1            # via notifications-python-client
 gevent==1.4.0
@@ -79,35 +80,35 @@ parso==0.3.2              # via jedi
 pep8-naming==0.7.0
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
-pip-tools==3.2.0
+pip-tools==3.3.2
 piprot==0.9.10
 pluggy==0.8.1             # via pytest
-prompt-toolkit==2.0.7     # via ipython
+prompt-toolkit==2.0.8     # via ipython
 psycogreen==1.0.1
 psycopg2==2.7.7
 ptyprocess==0.6.0         # via pexpect
 py==1.7.0                 # via pytest
-pycodestyle==2.4.0        # via flake8, flake8-debugger, flake8-import-order, flake8-print
+pycodestyle==2.5.0        # via flake8, flake8-debugger, flake8-import-order, flake8-print
 pydocstyle==2.1.1
-pyflakes==2.0.0           # via flake8
+pyflakes==2.1.0           # via flake8
 pygments==2.3.1           # via ipython
 pyjwt==1.7.1              # via notifications-python-client
 pyparsing==2.3.1          # via packaging
 pytest-cov==2.6.1
-pytest-django==3.4.5
+pytest-django==3.4.7
 pytest-forked==1.0.1      # via pytest-xdist
 pytest-sugar==0.9.2
-pytest-xdist==1.26.0
-pytest==4.1.1
+pytest-xdist==1.26.1
+pytest==4.2.0
 python-dateutil==2.7.5
 pytz==2018.9              # via celery, django
 pyyaml==3.13
 raven==6.10.0
-redis==3.0.1
+redis==3.1.0
 requests-futures==0.9.9   # via piprot
 requests-mock==1.5.2
 requests==2.21.0
-requests_toolbelt==0.8.0
+requests_toolbelt==0.9.1
 s3transfer==0.1.13        # via boto3
 six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mohawk, more-itertools, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest, pytest-xdist, python-dateutil, requests-mock, traitlets
 snowballstemmer==1.2.1    # via pydocstyle, snowballstemmer


### PR DESCRIPTION
### Description of change

This updates various dependencies. Change logs:

- https://github.com/andymccurdy/redis-py/blob/master/CHANGES
- https://github.com/jazzband/pip-tools/blob/master/CHANGELOG.md
- https://github.com/django-extensions/django-extensions/blob/master/CHANGELOG.md
- https://github.com/boto/boto3/blob/develop/CHANGELOG.rst
- https://docs.pytest.org/en/latest/changelog.html
- https://github.com/pytest-dev/pytest-django/compare/3.4.5...3.4.7
- https://github.com/pytest-dev/pytest-xdist/blob/master/CHANGELOG.rst
- https://flake8.readthedocs.io/en/latest/release-notes/index.html
- https://github.com/requests/toolbelt/blob/master/HISTORY.rst
- https://github.com/PyCQA/pyflakes/blob/master/NEWS.rst (indirect dependency)
- https://github.com/PyCQA/pycodestyle/blob/master/CHANGES.txt (indirect dependency)

We might be able to use the `FileFromURLWrapper` class added in https://github.com/requests/toolbelt/pull/202 for virus-scanning, but I have left investigating that as a separate exercise.

I have left out an update to `pep8-naming` as there are a few linting errors with the new version to look into.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
