### PR TITLE
Use autocomplete widget for interaction contacts field in admin site

### DIFF
--- a/changelog/contact/name-sortable.feature
+++ b/changelog/contact/name-sortable.feature
@@ -1,0 +1,1 @@
+Contacts can now be sorted by name in the admin site.

--- a/changelog/interaction/contacts-admin-autocomplete.feature
+++ b/changelog/interaction/contacts-admin-autocomplete.feature
@@ -1,0 +1,1 @@
+The admin site now uses an autocomplete widget for the contacts field when editing or adding an interaction.

--- a/datahub/company/admin/contact.py
+++ b/datahub/company/admin/contact.py
@@ -18,6 +18,7 @@ from reversion.admin import VersionAdmin
 
 from datahub.company.models import Contact
 from datahub.core.admin import BaseModelAdminMixin
+from datahub.core.query_utils import get_full_name_expression
 from datahub.search.signals import disable_search_signal_receivers
 
 
@@ -161,7 +162,7 @@ class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
         'archived_documents_url_path',
     )
     list_display = (
-        '__str__',
+        'get_name',
         'company',
     )
     exclude = (
@@ -170,6 +171,22 @@ class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
         'modified_on',
         'modified_by',
     )
+
+    def get_queryset(self, request):
+        """
+        Annotates the query set with full names.
+
+        Note: name_ is used to avoid a conflict with the Contact.name property.
+        """
+        queryset = super().get_queryset(request)
+        return queryset.annotate(name_=get_full_name_expression())
+
+    def get_name(self, obj):
+        """Returns the full name for a contact using the name annotation."""
+        return obj.name_
+
+    get_name.short_description = 'name'
+    get_name.admin_order_field = 'name_'
 
     def get_urls(self):
         """Gets the URLs for this model."""

--- a/datahub/company/models/contact.py
+++ b/datahub/company/models/contact.py
@@ -91,4 +91,5 @@ class Contact(ArchivableModel, BaseModel):
 
     def __str__(self):
         """Admin displayed human readable name."""
-        return self.name
+        company_desc = f'({self.company})' if self.company and self.company.name else ''
+        return join_truthy_strings(self.name or '(no name)', company_desc)

--- a/datahub/company/test/test_models.py
+++ b/datahub/company/test/test_models.py
@@ -211,3 +211,24 @@ class TestContact:
         assert contact.get_absolute_url() == (
             f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["contact"]}/{contact.pk}'
         )
+
+    @pytest.mark.parametrize(
+        'first_name,last_name,company_factory,expected_output',
+        (
+            ('First', 'Last', lambda: CompanyFactory(name='Company'), 'First Last (Company)'),
+            ('', 'Last', lambda: CompanyFactory(name='Company'), 'Last (Company)'),
+            ('First', '', lambda: CompanyFactory(name='Company'), 'First (Company)'),
+            ('First', 'Last', lambda: None, 'First Last'),
+            ('First', 'Last', lambda: CompanyFactory(name=''), 'First Last'),
+            ('', '', lambda: CompanyFactory(name='Company'), '(no name) (Company)'),
+            ('', '', lambda: None, '(no name)'),
+        ),
+    )
+    def test_str(self, first_name, last_name, company_factory, expected_output):
+        """Test the human-friendly string representation of a Contact object."""
+        contact = ContactFactory.build(
+            first_name=first_name,
+            last_name=last_name,
+            company=company_factory(),
+        )
+        assert str(contact) == expected_output

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -23,6 +23,7 @@ admin.site.register((PolicyArea, PolicyIssueType), OrderedMetadataAdmin)
 class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
     """Interaction admin."""
 
+    autocomplete_fields = ('contacts',)
     search_fields = (
         '=pk',
         'subject',
@@ -44,7 +45,6 @@ class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
         'event',
         'dit_adviser',
         'investment_project',
-        'contacts',
     )
     readonly_fields = (
         'archived_documents_url_path',

--- a/datahub/interaction/test/test_admin.py
+++ b/datahub/interaction/test/test_admin.py
@@ -35,7 +35,7 @@ class TestInteractionAdmin(AdminTestMixin):
             'date_1': '00:00:00',
             'dit_adviser': self.user.pk,
             'company': company.pk,
-            'contacts': ','.join(str(contact.pk) for contact in contacts),
+            'contacts': [contact.pk for contact in contacts],
             'service': random_obj_for_model(Service).pk,
             'dit_team': random_obj_for_model(Team).pk,
             'was_policy_feedback_provided': False,
@@ -77,7 +77,7 @@ class TestInteractionAdmin(AdminTestMixin):
             'event': '',
 
             # Changed values
-            'contacts': ','.join(str(contact.pk) for contact in new_contacts),
+            'contacts': [contact.pk for contact in new_contacts],
         }
         response = self.client.post(url, data, follow=True)
 
@@ -111,7 +111,7 @@ class TestInteractionAdmin(AdminTestMixin):
             'event': '',
 
             # Changed values
-            'contacts': '',
+            'contacts': [],
         }
         response = self.client.post(url, data=data, follow=True)
 


### PR DESCRIPTION
### Description of change

This changes the contacts field in the change form for interactions in the admin site from using a many-to-many raw ID widget to using an autocomplete field. This seems like a simple way to improve usability of the field (without resulting to complex workarounds).

`Contact.__str__()` now also includes the company name, as this is often useful in the admin site for disambiguation.

A related change was also made to contact admin, which now uses a query set annotation for contact names which also means that that column can be used for sorting.

We have some general problems with some admin fields not being wide enough, but I have left that as a separate task.

### Screenshots

With fake data:

![image](https://user-images.githubusercontent.com/12693549/52204029-e2e7d780-286a-11e9-98c8-fd4bf32a7530.png)

(Real data will have better company names...)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
