### PR TITLE
Add interaction first contact name sorting options

### DIFF
--- a/changelog/interaction/first-contact-sort.api
+++ b/changelog/interaction/first-contact-sort.api
@@ -1,0 +1,6 @@
+``GET /v3/interaction``: ``first_name_of_first_contact`` and ``last_name_of_first_contact`` were added as ``sortby``
+query parameter values for sorting event service deliveries by the first or last name of the contact. These sorting
+options aren't intended to be used for other types of interaction which may have multiple contacts.
+
+The ``contact__first_name`` and ``contact__last_name`` sorting options are deprecated and will be removed on or after
+28 February 2019.

--- a/changelog/interaction/first-contact-sort.removal
+++ b/changelog/interaction/first-contact-sort.removal
@@ -1,0 +1,3 @@
+``GET /v3/interaction``: The ``contact__first_name`` and ``contact__last_name`` values for the ``sortby`` query parameter
+are deprecated and will be removed on or after 28 February 2019. Please use ``first_name_of_first_contact`` and
+``last_name_of_first_contact`` instead for event service deliveries only.

--- a/datahub/core/model_helpers.py
+++ b/datahub/core/model_helpers.py
@@ -6,6 +6,16 @@ rather than model_utils.)
 """
 
 
+def get_m2m_model(model, field_name):
+    """
+    Gets the many-to-many through model for a many-to-many field.
+
+    This is rarely needed, but can be useful in rare cases when a hidden many-to-many
+    through model automatically created by Django needs to be accessed.
+    """
+    return model._meta.get_field(field_name).remote_field.through
+
+
 def get_related_fields(model):
     """
     Returns all the fields of `model` that hold the link between referencing objects

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -31,6 +31,7 @@ class InteractionViewSet(CoreViewSet):
     )
     filterset_fields = [
         'company_id',
+        # TODO: Remove once contact has been removed (following the deprecation period)
         'contact_id',
         'contacts__id',
         'event_id',
@@ -38,12 +39,16 @@ class InteractionViewSet(CoreViewSet):
     ]
     ordering_fields = (
         'company__name',
+        # TODO: Remove once contact has been removed (following the deprecation period)
         'contact__first_name',
+        # TODO: Remove once contact has been removed (following the deprecation period)
         'contact__last_name',
         'created_on',
         'date',
         'dit_adviser__first_name',
         'dit_adviser__last_name',
+        'first_name_of_first_contact',
+        'last_name_of_first_contact',
         'subject',
     )
     ordering = ('-date', '-created_on')


### PR DESCRIPTION
### Description of change

This adds first contact first and last name sorting options to `GET /v3/interaction`.

These are only intended to be used for event service deliveries in the event attendees view in the front end (as event service deliveries are limited to a single contact).

The previous `contact__first_name` and `contact__last_name` sorting options have been deprecated.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
