### PR TITLE
Update interaction global search fields to use contacts

### DIFF
--- a/changelog/interaction/multiple-contacts-global-search.feature
+++ b/changelog/interaction/multiple-contacts-global-search.feature
@@ -1,0 +1,1 @@
+Global search was updated to handle multiple interaction contacts correctly when matching search terms with interactions.

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -155,7 +155,6 @@ class Company(BaseESModel):
         'trading_names',  # to find 2-letter words
         'trading_names_trigram',
         'reference_code',
-        'uk_region.name_trigram',
 
         # TODO: replace with nested address and registered address
         # once the index data has been populated

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -517,7 +517,6 @@ def test_limited_get_search_by_entity_query():
                                             'trading_names',
                                             'trading_names_trigram',
                                             'reference_code',
-                                            'uk_region.name_trigram',
                                             'registered_address_country.name_trigram',
                                             'registered_address_postcode_trigram',
                                             'trading_address_country.name_trigram',

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -398,6 +398,8 @@ def test_get_basic_search_query():
                                 'company_number',
                                 'contact.name',
                                 'contact.name_trigram',
+                                'contacts.name',
+                                'contacts.name.trigram',
                                 'dit_adviser.name',
                                 'dit_adviser.name_trigram',
                                 'dit_team.name',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -269,6 +269,8 @@ def test_get_basic_search_query():
                                 'company_number',
                                 'contact.name',
                                 'contact.name_trigram',
+                                'contacts.name',
+                                'contacts.name.trigram',
                                 'dit_adviser.name',
                                 'dit_adviser.name_trigram',
                                 'dit_team.name',

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -84,8 +84,8 @@ class Interaction(BaseESModel):
         'id',
         'company.name',
         'company.name_trigram',
-        'contact.name',
-        'contact.name_trigram',
+        'contacts.name',  # to find 2-letter words
+        'contacts.name.trigram',
         'event.name',
         'event.name_trigram',
         'subject_english',

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -51,26 +51,60 @@ def interactions(setup_es):
     """Sets up data for the tests."""
     data = []
     with freeze_time('2017-01-01 13:00:00'):
+        company_1 = CompanyFactory(name='ABC Trading Ltd')
+        company_2 = CompanyFactory(name='Little Puddle Ltd')
         data.extend([
             CompanyInteractionFactory(
                 subject='Exports meeting',
                 date=dateutil_parse('2017-10-30T00:00:00Z'),
+                company=company_1,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Lee', last_name='Danger'),
+                    ContactFactory(company=company_1, first_name='Francis', last_name='Brady'),
+                    ContactFactory(company=company_1, first_name='Zanger Za', last_name='Qa'),
+                ],
+                dit_adviser__first_name='Angela',
+                dit_adviser__last_name='Lawson',
             ),
             CompanyInteractionFactory(
                 subject='a coffee',
                 date=dateutil_parse('2017-04-05T00:00:00Z'),
+                company=company_2,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Try', last_name='Slanger'),
+                ],
+                dit_adviser__first_name='Zed',
+                dit_adviser__last_name='Zeddy',
             ),
             CompanyInteractionFactory(
                 subject='Email about exhibition',
                 date=dateutil_parse('2016-09-02T00:00:00Z'),
+                company=company_2,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Caroline', last_name='Green'),
+                ],
+                dit_adviser__first_name='Prime',
+                dit_adviser__last_name='Zeddy',
             ),
             CompanyInteractionFactory(
                 subject='talking about cats',
                 date=dateutil_parse('2018-02-01T00:00:00Z'),
+                company=company_2,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Full', last_name='Bridge'),
+                ],
+                dit_adviser__first_name='Low',
+                dit_adviser__last_name='Tremon',
             ),
             CompanyInteractionFactory(
                 subject='Event at HQ',
                 date=dateutil_parse('2018-01-01T00:00:00Z'),
+                company=company_2,
+                contacts=[
+                    ContactFactory(company=company_1, first_name='Diane', last_name='Pree'),
+                ],
+                dit_adviser__first_name='Trevor',
+                dit_adviser__last_name='Saleman',
             ),
         ])
 
@@ -211,7 +245,24 @@ class TestInteractionEntitySearchView(APITestMixin):
             'sortby': [error],
         }
 
-    @pytest.mark.parametrize('term', ('exports', 'meeting', 'exports meeting'))
+    @pytest.mark.parametrize(
+        'term',
+        (
+            'exports',
+            'meeting',
+            'exports meeting',
+            'danger',
+            'dan',
+            'dang',
+            'FRANCIS',
+            'angela',
+            'angel',
+            'ngel',
+            'ela',
+            'za',
+            'QA',
+        ),
+    )
     def test_search_original_query(self, interactions, term):
         """Tests searching across fields for a particular interaction."""
         url = reverse('api-v3:search:interaction')

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -713,6 +713,8 @@ def test_get_basic_search_query():
                                 'company_number',
                                 'contact.name',
                                 'contact.name_trigram',
+                                'contacts.name',
+                                'contacts.name.trigram',
                                 'dit_adviser.name',
                                 'dit_adviser.name_trigram',
                                 'dit_team.name',

--- a/datahub/search/test/test_models.py
+++ b/datahub/search/test/test_models.py
@@ -82,6 +82,20 @@ def test_validate_model_no_mapping_and_computed_intersection(search_app):
     assert not intersection
 
 
+def test_validate_model_search_fields(search_app):
+    """Test that all field paths in SEARCH_FIELDS exist on the ES model."""
+    es_model = search_app.es_model
+    mapping = es_model._doc_type.mapping
+    invalid_fields = {
+        field for field in es_model.SEARCH_FIELDS
+        if not mapping.resolve_field(field)
+    }
+
+    assert not invalid_fields, (
+        f'Invalid search fields {invalid_fields} detected on {es_model.__name__} search model'
+    )
+
+
 def _get_db_model_fields(db_model):
     return {field.name for field in db_model._meta.get_fields()}
 


### PR DESCRIPTION
### Description of change

This updates the interaction global search fields to use `contacts` instead of `contact`. The relevant test was also updated to be a bit more comprehensive.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
