### PR TITLE
 Add is_active filter to adviser endpoint 

### DIFF
--- a/changelog/adviser/is-active-filter.api
+++ b/changelog/adviser/is-active-filter.api
@@ -1,0 +1,1 @@
+``GET /adviser/``: ``is_active`` was added as a query parameter. This is a boolean filter that filters advisers by whether they are active or not.

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -161,11 +161,12 @@ class AdviserFilter(FilterSet):
 
     class Meta:
         model = Advisor
-        fields = dict(
-            first_name=['exact', 'icontains'],
-            last_name=['exact', 'icontains'],
-            email=['exact', 'icontains'],
-        )
+        fields = {
+            'first_name': ('exact', 'icontains'),
+            'last_name': ('exact', 'icontains'),
+            'email': ('exact', 'icontains'),
+            'is_active': ('exact',),
+        }
 
 
 class AdviserReadOnlyViewSetV1(

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -1,7 +1,6 @@
 """Company and related resources view sets."""
 from django.db.models import Prefetch
-from django_filters import FilterSet
-from django_filters.rest_framework import DjangoFilterBackend
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet
 from rest_framework import mixins, viewsets
 from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response

--- a/datahub/investment/views.py
+++ b/datahub/investment/views.py
@@ -2,8 +2,7 @@
 from django.db import transaction
 from django.db.models import Prefetch
 from django.http import Http404
-from django_filters import IsoDateTimeFilter
-from django_filters.rest_framework import DjangoFilterBackend, FilterSet
+from django_filters.rest_framework import DjangoFilterBackend, FilterSet, IsoDateTimeFilter
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework import status
 from rest_framework.filters import OrderingFilter

--- a/datahub/metadata/filters.py
+++ b/datahub/metadata/filters.py
@@ -1,4 +1,4 @@
-from django_filters import CharFilter, FilterSet
+from django_filters.rest_framework import CharFilter, FilterSet
 
 
 from datahub.metadata.models import Service


### PR DESCRIPTION
### Description of change

This adds an is_active filter to the ``/adviser/`` endpoint.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
