### PR TITLE
Index company addresses

### DIFF
--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -1,4 +1,5 @@
 import itertools
+from functools import partial
 
 from elasticsearch_dsl import Boolean, Completion, Date, Keyword, Text
 
@@ -74,6 +75,11 @@ class Company(BaseESModel):
         },
     )
     reference_code = fields.NormalizedKeyword()
+    sector = fields.sector_field()
+    address = fields.address_field()
+    registered_address = fields.address_field()
+
+    # TODO: delete once the migration to address and registered address is complete
     registered_address_1 = Text()
     registered_address_2 = Text()
     registered_address_town = fields.NormalizedKeyword()
@@ -87,7 +93,6 @@ class Company(BaseESModel):
         ],
     )
     registered_address_postcode_trigram = fields.TrigramText()
-    sector = fields.sector_field()
     trading_address_1 = Text()
     trading_address_2 = Text()
     trading_address_town = fields.NormalizedKeyword()
@@ -99,6 +104,7 @@ class Company(BaseESModel):
     trading_address_country = fields.id_name_partial_field(
         'trading_address_country',
     )
+
     trading_name = Keyword(index=False)
     trading_names = Text(
         copy_to=['trading_names_trigram'],
@@ -115,6 +121,8 @@ class Company(BaseESModel):
     COMPUTED_MAPPINGS = {
         'trading_name': lambda obj: dict_utils.company_dict(obj)['trading_name'],
         'suggest': get_suggestions,
+        'address': partial(dict_utils.address_dict, prefix='address'),
+        'registered_address': partial(dict_utils.address_dict, prefix='registered_address'),
     }
 
     MAPPINGS = {
@@ -128,9 +136,12 @@ class Company(BaseESModel):
         'future_interest_countries': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],
         'global_headquarters': dict_utils.id_name_dict,
         'headquarter_type': dict_utils.id_name_dict,
-        'registered_address_country': dict_utils.id_name_dict,
         'sector': dict_utils.sector_dict,
+
+        # TODO: delete once the migration to address and registered address is complete
+        'registered_address_country': dict_utils.id_name_dict,
         'trading_address_country': dict_utils.id_name_dict,
+
         'turnover_range': dict_utils.id_name_dict,
         'uk_based': bool,
         'uk_region': dict_utils.id_name_dict,
@@ -144,11 +155,14 @@ class Company(BaseESModel):
         'trading_names',  # to find 2-letter words
         'trading_names_trigram',
         'reference_code',
+        'uk_region.name_trigram',
+
+        # TODO: replace with nested address and registered address
+        # once the index data has been populated
         'registered_address_country.name_trigram',
         'registered_address_postcode_trigram',
         'trading_address_country.name_trigram',
         'trading_address_postcode_trigram',
-        'uk_region.name_trigram',
     )
 
     class Meta:

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -181,6 +181,72 @@ def test_mapping(setup_es):
                     'normalizer': 'lowercase_asciifolding_normalizer',
                     'type': 'keyword',
                 },
+                'address': {
+                    'type': 'object',
+                    'properties': {
+                        'line_1': {'index': False, 'type': 'text'},
+                        'line_2': {'index': False, 'type': 'text'},
+                        'town': {'index': False, 'type': 'text'},
+                        'county': {'index': False, 'type': 'text'},
+                        'postcode': {
+                            'type': 'text',
+                            'fields': {
+                                'trigram': {
+                                    'type': 'text',
+                                    'analyzer': 'trigram_analyzer',
+                                },
+                            },
+                        },
+                        'country': {
+                            'type': 'object',
+                            'properties': {
+                                'id': {'index': False, 'type': 'keyword'},
+                                'name': {
+                                    'type': 'text',
+                                    'fields': {
+                                        'trigram': {
+                                            'type': 'text',
+                                            'analyzer': 'trigram_analyzer',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                'registered_address': {
+                    'type': 'object',
+                    'properties': {
+                        'line_1': {'index': False, 'type': 'text'},
+                        'line_2': {'index': False, 'type': 'text'},
+                        'town': {'index': False, 'type': 'text'},
+                        'county': {'index': False, 'type': 'text'},
+                        'postcode': {
+                            'type': 'text',
+                            'fields': {
+                                'trigram': {
+                                    'type': 'text',
+                                    'analyzer': 'trigram_analyzer',
+                                },
+                            },
+                        },
+                        'country': {
+                            'type': 'object',
+                            'properties': {
+                                'id': {'index': False, 'type': 'keyword'},
+                                'name': {
+                                    'type': 'text',
+                                    'fields': {
+                                        'trigram': {
+                                            'type': 'text',
+                                            'analyzer': 'trigram_analyzer',
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
                 'registered_address_1': {'type': 'text'},
                 'registered_address_2': {'type': 'text'},
                 'registered_address_country': {
@@ -449,11 +515,11 @@ def test_limited_get_search_by_entity_query():
                                             'trading_names',
                                             'trading_names_trigram',
                                             'reference_code',
+                                            'uk_region.name_trigram',
                                             'registered_address_country.name_trigram',
                                             'registered_address_postcode_trigram',
                                             'trading_address_country.name_trigram',
                                             'trading_address_postcode_trigram',
-                                            'uk_region.name_trigram',
                                         ),
                                         'type': 'cross_fields',
                                         'operator': 'and',
@@ -559,6 +625,8 @@ def test_indexed_doc(setup_es):
         'name',
         'global_headquarters',
         'reference_code',
+        'address',
+        'registered_address',
         'registered_address_1',
         'registered_address_2',
         'registered_address_country',

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -38,20 +38,26 @@ class TestCompanyElasticModel:
             'name',
             'global_headquarters',
             'reference_code',
+            'sector',
+            'suggest',
+
+            'address',
+            'registered_address',
+
+            # TODO: delete once the migration to address and registered address is complete
             'registered_address_1',
             'registered_address_2',
             'registered_address_country',
             'registered_address_county',
             'registered_address_postcode',
             'registered_address_town',
-            'sector',
-            'suggest',
             'trading_address_1',
             'trading_address_2',
             'trading_address_country',
             'trading_address_county',
             'trading_address_postcode',
             'trading_address_town',
+
             'trading_name',
             'trading_names',
             'turnover_range',

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -1,3 +1,14 @@
+def _attrgetter_with_default(attr, default):
+    """
+    It returns a function that can be called with an object to get the value
+    of attr or the default.
+    Useful to convert None values to ''.
+    """
+    def _getter(obj):
+        return getattr(obj, attr) or default
+    return _getter
+
+
 def id_name_dict(obj):
     """Creates dictionary with selected field from supplied object."""
     if obj is None:
@@ -34,6 +45,35 @@ def id_uri_dict(obj):
         'id': str(obj.id),
         'uri': obj.uri,
     }
+
+
+def address_dict(obj, prefix='address'):
+    """
+    Creates a dictionary for the address fields with the given prefix
+    to be used as nested object.
+    """
+    if obj is None:
+        return None
+
+    mapping = {
+        'line_1': _attrgetter_with_default(f'{prefix}_1', ''),
+        'line_2': _attrgetter_with_default(f'{prefix}_2', ''),
+        'town': _attrgetter_with_default(f'{prefix}_town', ''),
+        'county': _attrgetter_with_default(f'{prefix}_county', ''),
+        'postcode': _attrgetter_with_default(f'{prefix}_postcode', ''),
+        'country': lambda obj: id_name_dict(
+            getattr(obj, f'{prefix}_country'),
+        ),
+    }
+
+    address = {
+        target_source_name: value_getter(obj)
+        for target_source_name, value_getter in mapping.items()
+    }
+
+    if any(address.values()):
+        return address
+    return None
 
 
 def company_dict(obj):

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -83,6 +83,33 @@ def id_name_partial_field(field):
     )
 
 
+def address_field():
+    """Address field as nested object."""
+    return Object(
+        properties={
+            'line_1': Text(index=False),
+            'line_2': Text(index=False),
+            'town': Text(index=False),
+            'county': Text(index=False),
+            'postcode': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+            'country': Object(
+                properties={
+                    'id': Keyword(index=False),
+                    'name': Text(
+                        fields={
+                            'trigram': TrigramText(),
+                        },
+                    ),
+                },
+            ),
+        },
+    )
+
+
 def company_field(field):
     """Company field."""
     return Object(


### PR DESCRIPTION
### Description of change

This indexes company address and registered address as nested objects.
The objects are automatically made available in the response body but I'm not announcing it in the CHANGELOG yet because I need to update the autocompletion endpoint and I might add a virtual v4 prefix somehow for these.

Only postcode and countries are indexed as they are the ones currently used by the frontend.

I refactored `test_dict_utils` as well so you might want to check the commits individually.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
