### PR TITLE
 Fix performance regression with interaction list in admin site 

### DIFF
--- a/changelog/interaction/interaction-admin-perf.bugfix
+++ b/changelog/interaction/interaction-admin-perf.bugfix
@@ -1,0 +1,1 @@
+A performance problem with the interaction list in the admin site was resolved.

--- a/datahub/company/admin/contact.py
+++ b/datahub/company/admin/contact.py
@@ -18,7 +18,6 @@ from reversion.admin import VersionAdmin
 
 from datahub.company.models import Contact
 from datahub.core.admin import BaseModelAdminMixin
-from datahub.core.query_utils import get_full_name_expression
 from datahub.search.signals import disable_search_signal_receivers
 
 
@@ -162,7 +161,10 @@ class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
         'archived_documents_url_path',
     )
     list_display = (
-        'get_name',
+        'name',
+        'company',
+    )
+    list_select_related = (
         'company',
     )
     exclude = (
@@ -171,22 +173,6 @@ class ContactAdmin(BaseModelAdminMixin, VersionAdmin):
         'modified_on',
         'modified_by',
     )
-
-    def get_queryset(self, request):
-        """
-        Annotates the query set with full names.
-
-        Note: name_ is used to avoid a conflict with the Contact.name property.
-        """
-        queryset = super().get_queryset(request)
-        return queryset.annotate(name_=get_full_name_expression())
-
-    def get_name(self, obj):
-        """Returns the full name for a contact using the name annotation."""
-        return obj.name_
-
-    get_name.short_description = 'name'
-    get_name.admin_order_field = 'name_'
 
     def get_urls(self):
         """Gets the URLs for this model."""


### PR DESCRIPTION
### Description of change

As it turns out, `QuerySet.count()` in Django generates very inefficient queries for annotated query sets. In such cases, it forces the use of a subquery with group bys on every column (in effect, deduplicating the entire table). 

This appears to be documented in the source code:

https://github.com/django/django/blob/master/django/db/models/sql/query.py#L404-L414

There is also a relevant ticket in the Django bug tracker:

https://code.djangoproject.com/ticket/28477

Calling `.values('pk')` before `.count()` helps as it removes most of the columns from the group by, but it still does a group by on the annotations so it doesn't fix it completely. There are also two places where counts are done (the paginator and the view).

As there is no simple fix, this replaces the contact names annotation (in interaction admin) with Python code. There are also related changes to contact admin.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
