### PR TITLE
Deprecate company search params

### DIFF
--- a/changelog/company/company-search-filters.removal
+++ b/changelog/company/company-search-filters.removal
@@ -1,0 +1,8 @@
+``POST /v3/search/company``, ``POST /v3/search/company/export`` the following filters are deprecated and will be removed on or after the 21st of February:
+
+- ``description``
+- ``export_to_country``
+- ``future_interest_country``
+- ``global_headquarters``
+- ``sector``
+- ``trading_address_country``

--- a/changelog/company/company-search-sortby.removal
+++ b/changelog/company/company-search-sortby.removal
@@ -1,0 +1,17 @@
+``POST /v3/search/company``, ``POST /v3/search/company/export`` the following sortby values are deprecated and will be removed on or after the 21st of February:
+
+- ``archived``
+- ``archived_by``
+- ``business_type.name``
+- ``companies_house_data.company_number``
+- ``company_number``
+- ``created_on``
+- ``employee_range.name``
+- ``headquarter_type.name``
+- ``id``
+- ``registered_address_town``
+- ``sector.name``
+- ``trading_address_town``
+- ``turnover_range.name``
+- ``uk_based``
+- ``uk_region.name``

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -1,3 +1,5 @@
+import logging
+
 from rest_framework import serializers
 
 from datahub.search.serializers import (
@@ -5,6 +7,9 @@ from datahub.search.serializers import (
     SingleOrListField,
     StringUUIDField,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
@@ -47,3 +52,51 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
         'uk_based',
         'uk_region.name',
     )
+
+    # TODO remove following deprecation period.
+    deprecated_filters = {
+        'description',
+        'export_to_country',
+        'future_interest_country',
+        'global_headquarters',
+        'sector',
+        'trading_address_country',
+    }
+    deprecated_sortby_fields = {
+        'archived',
+        'archived_by',
+        'business_type.name',
+        'companies_house_data.company_number',
+        'company_number',
+        'created_on',
+        'employee_range.name',
+        'headquarter_type.name',
+        'id',
+        'registered_address_town',
+        'sector.name',
+        'trading_address_town',
+        'turnover_range.name',
+        'uk_based',
+        'uk_region.name',
+    }
+
+    def validate(self, data):
+        """
+        Logs all deprecated params to make sure we don't break things when we get rid of them.
+
+        TODO Remove following deprecation period.
+        """
+        deprecated_filters_in_data = data.keys() & self.deprecated_filters
+        if deprecated_filters_in_data:
+            logger.error(
+                'The following deprecated company search filters were '
+                f'used: {deprecated_filters_in_data}.',
+            )
+
+        sortby = data.get('sortby')
+        if sortby and sortby.field in self.deprecated_sortby_fields:
+            logger.error(
+                'The following deprecated company search sortby field was '
+                f'used: {sortby.field}.',
+            )
+        return super().validate(data)

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 from rest_framework.settings import api_settings
@@ -5,6 +7,9 @@ from rest_framework.settings import api_settings
 from datahub.search.apps import get_global_search_apps_as_mapping
 from datahub.search.query_builder import MAX_RESULTS
 from datahub.search.utils import SearchOrdering, SortDirection
+
+
+logger = logging.getLogger(__name__)
 
 
 class SingleOrListField(serializers.ListField):
@@ -142,6 +147,17 @@ class BasicSearchQuerySerializer(BaseSearchQuerySerializer):
     )
     entity = _ESModelChoiceField(default='company')
     term = serializers.CharField(required=True, allow_blank=True)
+
+    def validate(self, data):
+        """
+        Logs the sortby search param to see if we can get rid of it from the global search.
+
+        TODO: Remove after figuring out what to do with sortby.
+        """
+        sortby = data.get('sortby')
+        if sortby:
+            logger.error(f'Sortby search field "{sortby.field}" used in the global search.')
+        return super().validate(data)
 
 
 class EntitySearchQuerySerializer(BaseSearchQuerySerializer):


### PR DESCRIPTION
### Description of change

This deprecates many company search fields/sortby fields so that we can simplify the codebase and make future refactoring easier.

Logging has been added to make sure we don't break things inadvertently.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
