### PR TITLE
Remove trading_name from search

### DIFF
--- a/changelog/company/trading-name-removed.api
+++ b/changelog/company/trading-name-removed.api
@@ -1,0 +1,7 @@
+The field ``trading_name`` was removed from the endpoints below, please use the ``trading_names`` field instead:
+
+- ``/v3/search/company``
+- ``/v3/search/company/autocomplete``
+- ``/v3/search/contact``: from the nested company object
+- ``/v3/search/interaction``: from the nested company object
+- ``/v3/search/order``: from the nested company object

--- a/changelog/company/trading-name.removal
+++ b/changelog/company/trading-name.removal
@@ -1,0 +1,7 @@
+The field ``trading_name`` was removed from the endpoints below, please use the ``trading_names`` field instead:
+
+- ``/v3/search/company``
+- ``/v3/search/company/autocomplete``
+- ``/v3/search/contact``: from the nested company object
+- ``/v3/search/interaction``: from the nested company object
+- ``/v3/search/order``: from the nested company object

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -105,7 +105,6 @@ class Company(BaseESModel):
         'trading_address_country',
     )
 
-    trading_name = Keyword(index=False)
     trading_names = Text(
         copy_to=['trading_names_trigram'],
     )
@@ -119,7 +118,6 @@ class Company(BaseESModel):
     suggest = Completion()
 
     COMPUTED_MAPPINGS = {
-        'trading_name': lambda obj: dict_utils.company_dict(obj)['trading_name'],
         'suggest': get_suggestions,
         'address': partial(dict_utils.address_dict, prefix='address'),
         'registered_address': partial(dict_utils.address_dict, prefix='registered_address'),

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -58,7 +58,6 @@ class TestCompanyElasticModel:
             'trading_address_postcode',
             'trading_address_town',
 
-            'trading_name',
             'trading_names',
             'turnover_range',
             'uk_based',

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -118,7 +118,6 @@ class CompanyAutocompleteSearchListAPIView(
     document_fields = [
         'id',
         'name',
-        'trading_name',
         'trading_names',
         'trading_address_1',
         'trading_address_2',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -103,10 +103,6 @@ def test_mapping(setup_es):
                             'analyzer': 'trigram_analyzer',
                             'type': 'text',
                         },
-                        'trading_name': {
-                            'index': False,
-                            'type': 'keyword',
-                        },
                         'trading_names': {
                             'copy_to': ['company.trading_names_trigram'],
                             'type': 'text',

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -81,15 +81,9 @@ def company_dict(obj):
     if obj is None:
         return None
 
-    if not obj.trading_names:
-        trading_name = ''
-    else:
-        trading_name = obj.trading_names[0]
-
     return {
         'id': str(obj.id),
         'name': obj.name,
-        'trading_name': trading_name,
         'trading_names': obj.trading_names,
     }
 

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -117,7 +117,6 @@ def company_field(field):
             'id': Keyword(),
             'name': NormalizedKeyword(copy_to=f'{field}.name_trigram'),
             'name_trigram': TrigramText(),
-            'trading_name': Keyword(index=False),
             'trading_names': Text(
                 copy_to=f'{field}.trading_names_trigram',
             ),

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -37,7 +37,6 @@ def test_interaction_to_dict(setup_es, factory_cls):
         'company': {
             'id': str(interaction.company.pk),
             'name': interaction.company.name,
-            'trading_name': interaction.company.trading_names[0],
             'trading_names': interaction.company.trading_names,
         } if interaction.company else None,
         'company_sector': {
@@ -130,7 +129,6 @@ def test_service_delivery_to_dict(setup_es):
         'company': {
             'id': str(interaction.company.pk),
             'name': interaction.company.name,
-            'trading_name': interaction.company.trading_names[0],
             'trading_names': interaction.company.trading_names,
         },
         'company_sector': {

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -288,7 +288,6 @@ class TestInteractionEntitySearchView(APITestMixin):
             'company': {
                 'id': str(interaction.company.pk),
                 'name': interaction.company.name,
-                'trading_name': interaction.company.trading_names[0],
                 'trading_names': interaction.company.trading_names,
             },
             'company_sector': {

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -157,10 +157,6 @@ def test_mapping(setup_es):
                             'analyzer': 'trigram_analyzer',
                             'type': 'text',
                         },
-                        'trading_name': {
-                            'index': False,
-                            'type': 'keyword',
-                        },
                         'trading_names': {
                             'copy_to': ['company.trading_names_trigram'],
                             'type': 'text',
@@ -496,7 +492,6 @@ def test_indexed_doc(Factory, setup_es):
         'company': {
             'id': str(order.company.pk),
             'name': order.company.name,
-            'trading_name': order.company.trading_names[0],
             'trading_names': order.company.trading_names,
         },
         'contact': {

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -39,7 +39,6 @@ def test_order_to_dict(Factory):
         'company': {
             'id': str(order.company.pk),
             'name': order.company.name,
-            'trading_name': order.company.trading_names[0],
             'trading_names': order.company.trading_names,
         },
         'contact': {

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -83,7 +83,6 @@ def test_id_uri_dict():
             {
                 'id': '123',
                 'name': 'Name',
-                'trading_name': 'Trading 1',
                 'trading_names': ['Trading 1', 'Trading 2'],
             },
         ),
@@ -98,7 +97,6 @@ def test_id_uri_dict():
             {
                 'id': '123',
                 'name': 'Name',
-                'trading_name': '',
                 'trading_names': [],
             },
         ),


### PR DESCRIPTION
### Description of change

This removes the previously deprecated trading_name from the following endpoints:
- /v3/search/company
- /v3/search/company/autocomplete

And from the nested company object in the following endpoints:
- /v3/search/contact
- /v3/search/interaction
- /v3/search/order

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
