### PR TITLE
Search includes excludes fields

### DIFF
--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -474,9 +474,9 @@ def test_limited_get_search_by_entity_query():
         'estimated_land_date_after': date,
     }
     query = get_search_by_entity_query(
+        ESCompany,
         term='test',
         filter_data=filter_data,
-        entity=ESCompany,
     )
     query = limit_search_query(
         query,

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -345,9 +345,9 @@ def test_get_limited_search_by_entity_query():
         'estimated_land_date_before': date,
     }
     query = get_search_by_entity_query(
+        ESContact,
         term='test',
         filter_data=filter_data,
-        entity=ESContact,
     )
     query = limit_search_query(
         query,

--- a/datahub/search/dashboard/views.py
+++ b/datahub/search/dashboard/views.py
@@ -42,8 +42,8 @@ def _get_objects(request, limit, search_app, adviser_field):
         return []
 
     query = get_search_by_entity_query(
+        search_app.es_model,
         term='',
-        entity=search_app.es_model,
         filter_data={
             adviser_field: request.user.id,
             'created_on_exists': True,

--- a/datahub/search/execute_query.py
+++ b/datahub/search/execute_query.py
@@ -9,10 +9,13 @@ from datahub.search.query_builder import build_autocomplete_query
 logger = getLogger(__name__)
 
 
-def execute_autocomplete_query(es_model, keyword_search, limit, only_return_fields=None):
+def execute_autocomplete_query(es_model, keyword_search, limit, fields_to_include=None):
     """Executes the query for autocomplete search returning all suggested documents."""
     autocomplete_search = build_autocomplete_query(
-        es_model, keyword_search, limit, only_return_fields,
+        es_model,
+        keyword_search,
+        limit,
+        fields_to_include,
     )
 
     results = autocomplete_search.execute()

--- a/datahub/search/execute_query.py
+++ b/datahub/search/execute_query.py
@@ -9,7 +9,7 @@ from datahub.search.query_builder import build_autocomplete_query
 logger = getLogger(__name__)
 
 
-def execute_autocomplete_query(es_model, keyword_search, limit, fields_to_include=None):
+def execute_autocomplete_query(es_model, keyword_search, limit, fields_to_include):
     """Executes the query for autocomplete search returning all suggested documents."""
     autocomplete_search = build_autocomplete_query(
         es_model,

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -793,9 +793,9 @@ def test_limited_get_search_by_entity_query():
         'estimated_land_date_before': date,
     }
     query = get_search_by_entity_query(
+        ESInvestmentProject,
         term='test',
         filter_data=filter_data,
-        entity=ESInvestmentProject,
     )
     query = limit_search_query(
         query,

--- a/datahub/search/investment/test/test_signals.py
+++ b/datahub/search/investment/test/test_signals.py
@@ -23,9 +23,9 @@ def test_investment_project_auto_sync_to_es(setup_es):
     setup_es.indices.refresh()
 
     result = get_search_by_entity_query(
+        InvestmentProject,
         term='',
         filter_data={'name': test_name},
-        entity=InvestmentProject,
     ).execute()
 
     assert result.hits.total == 1
@@ -40,9 +40,9 @@ def test_investment_project_auto_updates_to_es(setup_es):
     setup_es.indices.refresh()
 
     result = get_search_by_entity_query(
+        InvestmentProject,
         term='',
         filter_data={'name': new_test_name},
-        entity=InvestmentProject,
     ).execute()
 
     assert result.hits.total == 1
@@ -59,9 +59,9 @@ def test_investment_project_team_member_added_sync_to_es(setup_es, team_member):
     setup_es.indices.refresh()
 
     results = get_search_by_entity_query(
+        InvestmentProject,
         term='',
         filter_data={},
-        entity=InvestmentProject,
     ).execute()
 
     assert len(results) == 1
@@ -79,9 +79,9 @@ def test_investment_project_team_member_updated_sync_to_es(setup_es, team_member
     setup_es.indices.refresh()
 
     results = get_search_by_entity_query(
+        InvestmentProject,
         term='',
         filter_data={},
-        entity=InvestmentProject,
     ).execute()
 
     assert len(results) == 1
@@ -97,9 +97,9 @@ def test_investment_project_team_member_deleted_sync_to_es(setup_es, team_member
     setup_es.indices.refresh()
 
     results = get_search_by_entity_query(
+        InvestmentProject,
         term='',
         filter_data={},
-        entity=InvestmentProject,
     ).execute()
 
     assert len(results) == 1
@@ -131,9 +131,9 @@ def test_investment_project_syncs_when_adviser_changes(setup_es, field):
     setup_es.indices.refresh()
 
     result = get_search_by_entity_query(
+        InvestmentProject,
         term='',
         filter_data={'id': project.pk},
-        entity=InvestmentProject,
     ).execute()
 
     assert result.hits.total == 1
@@ -154,9 +154,9 @@ def test_investment_project_syncs_when_team_member_adviser_changes(setup_es, tea
     setup_es.indices.refresh()
 
     result = get_search_by_entity_query(
+        InvestmentProject,
         term='',
         filter_data={'id': team_member.investment_project.pk},
-        entity=InvestmentProject,
     ).execute()
 
     assert result.hits.total == 1

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -74,11 +74,11 @@ def get_basic_search_query(
 
 
 def get_search_by_entity_query(
+        entity,
         term=None,
         filter_data=None,
         composite_field_mapping=None,
         permission_filters=None,
-        entity=None,
         ordering=None,
         fields_to_include=None,
         fields_to_exclude=None,

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -86,6 +86,7 @@ def get_search_by_entity_query(
     """
     Performs filtered search for given terms in given entity.
     """
+    filter_data = filter_data or {}
     query = [Term(_type=entity._doc_type.name)]
     if term != '':
         query.append(_build_term_query(term, fields=entity.SEARCH_FIELDS))

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -80,12 +80,11 @@ def get_search_by_entity_query(
         permission_filters=None,
         entity=None,
         ordering=None,
+        fields_to_include=None,
+        fields_to_exclude=None,
 ):
     """
     Performs filtered search for given terms in given entity.
-
-    :param permission_filters: dict of field names and values. These represent rules that records
-                               must match one of to be included in the results.
     """
     query = [Term(_type=entity._doc_type.name)]
     if term != '':
@@ -107,16 +106,22 @@ def get_search_by_entity_query(
         s = s.filter(permission_query)
 
     s = s.filter(Bool(must=must_filter))
+    s = _apply_sorting_to_query(s, ordering)
+    return _apply_source_filtering_to_query(
+        s,
+        fields_to_include=fields_to_include,
+        fields_to_exclude=fields_to_exclude,
+    )
 
-    return _apply_sorting_to_query(s, ordering)
 
-
-def build_autocomplete_query(es_model, keyword_search, limit, only_return_fields):
+def build_autocomplete_query(es_model, keyword_search, limit, fields_to_include):
     """Builds the query for autocomplete search and applies source filtering."""
     index = es_model.get_read_alias()
     autocomplete_search = es_model.search(index=index)
-    if only_return_fields:
-        autocomplete_search = autocomplete_search.extra(_source={'include': only_return_fields})
+    autocomplete_search = _apply_source_filtering_to_query(
+        autocomplete_search,
+        fields_to_include=fields_to_include,
+    )
     return autocomplete_search.suggest(
         'autocomplete',
         keyword_search,
@@ -355,3 +360,7 @@ def _apply_sorting_to_query(query, ordering):
         {ordering.field: sort_params},
         'id',
     )
+
+
+def _apply_source_filtering_to_query(query, fields_to_include=None, fields_to_exclude=None):
+    return query.source(includes=fields_to_include, excludes=fields_to_exclude)

--- a/datahub/search/test/test_execute_query.py
+++ b/datahub/search/test/test_execute_query.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
-from datahub.search.company.apps import CompanySearchApp
 from datahub.search.execute_query import execute_autocomplete_query
+from datahub.search.test.search_support.simplemodel.apps import SimpleModelSearchApp
 
 
 class TestExecuteQueryBuilder:
@@ -14,6 +14,11 @@ class TestExecuteQueryBuilder:
         mocked_es_response = mock.MagicMock(suggest=suggest)
         with mock.patch('elasticsearch_dsl.Search.execute') as mock_es_execute:
             mock_es_execute.return_value = mocked_es_response
-            result = execute_autocomplete_query(CompanySearchApp.es_model, 'hello', 10)
+            result = execute_autocomplete_query(
+                SimpleModelSearchApp.es_model,
+                'hello',
+                10,
+                ['id', 'name'],
+            )
         assert result == fake_result
         assert mock_es_execute.called

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -350,7 +350,7 @@ def test_build_autocomplete_search_query(keyword, size, only_fields, expected):
         # minimal
         (
             None,
-            {},
+            None,
             None,
             None,
             None,

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -1,9 +1,9 @@
 import datetime
 from unittest import mock
+from uuid import UUID
 
 import pytest
 
-from datahub.search.company.apps import CompanySearchApp
 from datahub.search.query_builder import (
     _build_entity_permission_query,
     _build_field_query,
@@ -11,320 +11,516 @@ from datahub.search.query_builder import (
     _split_date_range_fields,
     build_autocomplete_query,
     get_basic_search_query,
+    get_search_by_entity_query,
 )
+from datahub.search.test.search_support.simplemodel.apps import SimpleModelSearchApp
+from datahub.search.utils import SearchOrdering, SortDirection
 
 
-class TestQueryBuilder:
-    """Tests for query building and executing functions."""
-
-    @pytest.mark.parametrize(
-        'field,value,expected',
+@pytest.mark.parametrize(
+    'field,value,expected',
+    (
         (
-            (
-                'field_name',
-                'field value',
-                {
-                    'match': {
-                        'field_name': {
-                            'query': 'field value',
-                            'operator': 'and',
-                        },
+            'field_name',
+            'field value',
+            {
+                'match': {
+                    'field_name': {
+                        'query': 'field value',
+                        'operator': 'and',
                     },
                 },
-            ),
-            (
-                'field_name.id',
-                'field value',
-                {
-                    'match': {
-                        'field_name.id': {
-                            'query': 'field value',
-                            'operator': 'and',
-                        },
-                    },
-                },
-            ),
-            (
-                'field_name.name.keyword',
-                'field value',
-                {
-                    'match': {
-                        'field_name.name.keyword': {
-                            'query': 'field value',
-                            'operator': 'and',
-                        },
-                    },
-                },
-            ),
-            (
-                'field_name.prop',
-                'field value',
-                {
-                    'match': {
-                        'field_name.prop': {
-                            'query': 'field value',
-                            'operator': 'and',
-                        },
-                    },
-                },
-            ),
-            (
-                'field_name_exists',
-                True,
-                {
-                    'bool': {
-                        'must': [
-                            {
-                                'exists': {
-                                    'field': 'field_name',
-                                },
-                            },
-                        ],
-                    },
-                },
-            ),
-            (
-                'field_name_exists',
-                False,
-                {
-                    'bool': {
-                        'must_not': [
-                            {
-                                'exists': {
-                                    'field': 'field_name',
-                                },
-                            },
-                        ],
-                    },
-                },
-            ),
-            (
-                'field_name',
-                None,
-                {
-                    'bool': {
-                        'must_not': [
-                            {
-                                'exists': {
-                                    'field': 'field_name',
-                                },
-                            },
-                        ],
-                    },
-                },
-            ),
-            (
-                'field_name_exists',
-                None,
-                {
-                    'bool': {
-                        'must_not': [
-                            {
-                                'exists': {
-                                    'field': 'field_name',
-                                },
-                            },
-                        ],
-                    },
-                },
-            ),
-            (
-                'field_name',
-                ['field value 1', 'field value 2'],
-                {
-                    'bool': {
-                        'minimum_should_match': 1,
-                        'should': [
-                            {
-                                'match': {
-                                    'field_name': {
-                                        'query': 'field value 1',
-                                        'operator': 'and',
-                                    },
-                                },
-                            },
-                            {
-                                'match': {
-                                    'field_name': {
-                                        'query': 'field value 2',
-                                        'operator': 'and',
-                                    },
-                                },
-                            },
-                        ],
-                    },
-                },
-            ),
+            },
         ),
-    )
-    def test_build_field_query(self, field, value, expected):
-        """Test for the _build_field_query function."""
-        assert _build_field_query(field, value).to_dict() == expected
-
-    @pytest.mark.parametrize(
-        'term,expected',
         (
-            (
-                'hello',
-                {
-                    'bool': {
-                        'should': [
-                            {
-                                'match': {
-                                    'name.keyword': {
-                                        'query': 'hello',
-                                        'boost': 2,
-                                    },
-                                },
+            'field_name.id',
+            'field value',
+            {
+                'match': {
+                    'field_name.id': {
+                        'query': 'field value',
+                        'operator': 'and',
+                    },
+                },
+            },
+        ),
+        (
+            'field_name.name.keyword',
+            'field value',
+            {
+                'match': {
+                    'field_name.name.keyword': {
+                        'query': 'field value',
+                        'operator': 'and',
+                    },
+                },
+            },
+        ),
+        (
+            'field_name.prop',
+            'field value',
+            {
+                'match': {
+                    'field_name.prop': {
+                        'query': 'field value',
+                        'operator': 'and',
+                    },
+                },
+            },
+        ),
+        (
+            'field_name_exists',
+            True,
+            {
+                'bool': {
+                    'must': [
+                        {
+                            'exists': {
+                                'field': 'field_name',
                             },
-                            {
-                                'multi_match': {
-                                    'query': 'hello',
-                                    'fields': ('country.id', 'sector'),
-                                    'type': 'cross_fields',
+                        },
+                    ],
+                },
+            },
+        ),
+        (
+            'field_name_exists',
+            False,
+            {
+                'bool': {
+                    'must_not': [
+                        {
+                            'exists': {
+                                'field': 'field_name',
+                            },
+                        },
+                    ],
+                },
+            },
+        ),
+        (
+            'field_name',
+            None,
+            {
+                'bool': {
+                    'must_not': [
+                        {
+                            'exists': {
+                                'field': 'field_name',
+                            },
+                        },
+                    ],
+                },
+            },
+        ),
+        (
+            'field_name_exists',
+            None,
+            {
+                'bool': {
+                    'must_not': [
+                        {
+                            'exists': {
+                                'field': 'field_name',
+                            },
+                        },
+                    ],
+                },
+            },
+        ),
+        (
+            'field_name',
+            ['field value 1', 'field value 2'],
+            {
+                'bool': {
+                    'minimum_should_match': 1,
+                    'should': [
+                        {
+                            'match': {
+                                'field_name': {
+                                    'query': 'field value 1',
                                     'operator': 'and',
                                 },
                             },
-                        ],
-                    },
+                        },
+                        {
+                            'match': {
+                                'field_name': {
+                                    'query': 'field value 2',
+                                    'operator': 'and',
+                                },
+                            },
+                        },
+                    ],
                 },
-            ),
-            (
-                '',
-                {
-                    'match_all': {},
-                },
-            ),
-        ),
-    )
-    def test_build_term_query(self, term, expected):
-        """Tests search term query."""
-        query = _build_term_query(term, fields=('country.id', 'sector'))
-        assert query.to_dict() == expected
-
-    @pytest.mark.parametrize(
-        'offset,limit,expected_size', (
-            (8950, 1000, 1000),
-            (9950, 1000, 50),
-            (10000, 1000, 0),
-        ),
-    )
-    def test_offset_near_max_results(self, offset, limit, expected_size):
-        """Tests limit clipping when near max_results."""
-        query = get_basic_search_query(
-            'test', entities=(mock.Mock(),), offset=offset, limit=limit,
-        )
-
-        query_dict = query.to_dict()
-        assert query_dict['from'] == offset
-        assert query_dict['size'] == expected_size
-
-    def test_date_range_fields(self):
-        """Tests date range fields."""
-        now = datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)
-        fields = {
-            'estimated_land_date_after': now,
-            'estimated_land_date_before': now,
-            'adviser.id': 1234,
-        }
-
-        filters, ranges = _split_date_range_fields(fields)
-
-        assert filters == {
-            'adviser.id': 1234,
-        }
-        assert ranges == {
-            'estimated_land_date': {
-                'gte': now,
-                'lte': now,
             },
-        }
-
-    @pytest.mark.parametrize(
-        'filters,expected',
-        (
-            # An empty list of conditions should mean that there are no conditions
-            # that would permit access.
-            (
-                [],
-                {
-                    'match_none': {},
-                },
-            ),
-            (
-                None,
-                None,
-            ),
-            (
-                [
-                    ('field_name', 'field value'),
-                ],
-                {
-                    'bool': {
-                        'should': [
-                            {'term': {'field_name': 'field value'}},
-                        ],
-                    },
-                },
-            ),
-            (
-                [
-                    ('field_name1', 'field value 1'),
-                    ('field_name2', 'field value 2'),
-                ],
-                {
-                    'bool': {
-                        'should': [
-                            {'term': {'field_name1': 'field value 1'}},
-                            {'term': {'field_name2': 'field value 2'}},
-                        ],
-                    },
-                },
-            ),
         ),
-    )
-    def test_build_entity_permission_query_no_conditions(self, filters, expected):
-        """Test for the _build_entity_permission_query function."""
-        query = _build_entity_permission_query(permission_filters=filters)
-        if expected is None:
-            assert query is None
-        else:
-            assert query.to_dict() == expected
+    ),
+)
+def test_build_field_query(field, value, expected):
+    """Test for the _build_field_query function."""
+    assert _build_field_query(field, value).to_dict() == expected
 
-    @pytest.mark.parametrize(
-        'keyword,size,only_fields,expected',
+
+@pytest.mark.parametrize(
+    'term,expected',
+    (
         (
-            (
-                'hello',
-                20,
-                None,
-                {
-                    'suggest': {
-                        'autocomplete': {
-                            'completion': {'field': 'suggest', 'size': 20},
-                            'text': 'hello',
+            'hello',
+            {
+                'bool': {
+                    'should': [
+                        {
+                            'match': {
+                                'name.keyword': {
+                                    'query': 'hello',
+                                    'boost': 2,
+                                },
+                            },
                         },
-                    },
-                },
-            ),
-            (
-                'goodbye',
-                1,
-                ['id', 'name'],
-                {
-                    '_source': {'include': ['id', 'name']},
-                    'suggest': {
-                        'autocomplete': {
-                            'completion': {'field': 'suggest', 'size': 1},
-                            'text': 'goodbye',
+                        {
+                            'multi_match': {
+                                'query': 'hello',
+                                'fields': ('country.id', 'sector'),
+                                'type': 'cross_fields',
+                                'operator': 'and',
+                            },
                         },
-                    },
+                    ],
                 },
-            ),
+            },
         ),
+        (
+            '',
+            {
+                'match_all': {},
+            },
+        ),
+    ),
+)
+def test_build_term_query(term, expected):
+    """Tests search term query."""
+    query = _build_term_query(term, fields=('country.id', 'sector'))
+    assert query.to_dict() == expected
+
+
+@pytest.mark.parametrize(
+    'offset,limit,expected_size', (
+        (8950, 1000, 1000),
+        (9950, 1000, 50),
+        (10000, 1000, 0),
+    ),
+)
+def test_offset_near_max_results(offset, limit, expected_size):
+    """Tests limit clipping when near max_results."""
+    query = get_basic_search_query(
+        'test', entities=(mock.Mock(),), offset=offset, limit=limit,
     )
-    def test_build_autocomplete_search_query(self, keyword, size, only_fields, expected):
-        """Test for building an autocomplete search query."""
-        query = build_autocomplete_query(CompanySearchApp.es_model, keyword, size, only_fields)
+
+    query_dict = query.to_dict()
+    assert query_dict['from'] == offset
+    assert query_dict['size'] == expected_size
+
+
+def test_date_range_fields():
+    """Tests date range fields."""
+    now = datetime.datetime(2017, 6, 13, 9, 44, 31, 62870)
+    fields = {
+        'estimated_land_date_after': now,
+        'estimated_land_date_before': now,
+        'adviser.id': 1234,
+    }
+
+    filters, ranges = _split_date_range_fields(fields)
+
+    assert filters == {
+        'adviser.id': 1234,
+    }
+    assert ranges == {
+        'estimated_land_date': {
+            'gte': now,
+            'lte': now,
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    'filters,expected',
+    (
+        # An empty list of conditions should mean that there are no conditions
+        # that would permit access.
+        (
+            [],
+            {
+                'match_none': {},
+            },
+        ),
+        (
+            None,
+            None,
+        ),
+        (
+            [
+                ('field_name', 'field value'),
+            ],
+            {
+                'bool': {
+                    'should': [
+                        {'term': {'field_name': 'field value'}},
+                    ],
+                },
+            },
+        ),
+        (
+            [
+                ('field_name1', 'field value 1'),
+                ('field_name2', 'field value 2'),
+            ],
+            {
+                'bool': {
+                    'should': [
+                        {'term': {'field_name1': 'field value 1'}},
+                        {'term': {'field_name2': 'field value 2'}},
+                    ],
+                },
+            },
+        ),
+    ),
+)
+def test_build_entity_permission_query_no_conditions(filters, expected):
+    """Test for the _build_entity_permission_query function."""
+    query = _build_entity_permission_query(permission_filters=filters)
+    if expected is None:
+        assert query is None
+    else:
         assert query.to_dict() == expected
-        assert query._index == [CompanySearchApp.es_model.get_read_alias()]
+
+
+@pytest.mark.parametrize(
+    'keyword,size,only_fields,expected',
+    (
+        (
+            'hello',
+            20,
+            None,
+            {
+                'suggest': {
+                    'autocomplete': {
+                        'completion': {'field': 'suggest', 'size': 20},
+                        'text': 'hello',
+                    },
+                },
+            },
+        ),
+        (
+            'goodbye',
+            1,
+            ['id', 'name'],
+            {
+                '_source': {'includes': ['id', 'name']},
+                'suggest': {
+                    'autocomplete': {
+                        'completion': {'field': 'suggest', 'size': 1},
+                        'text': 'goodbye',
+                    },
+                },
+            },
+        ),
+    ),
+)
+def test_build_autocomplete_search_query(keyword, size, only_fields, expected):
+    """Test for building an autocomplete search query."""
+    query = build_autocomplete_query(SimpleModelSearchApp.es_model, keyword, size, only_fields)
+    assert query.to_dict() == expected
+    assert query._index == [SimpleModelSearchApp.es_model.get_read_alias()]
+
+
+@pytest.mark.parametrize(
+    (
+        'term',
+        'filter_data',
+        'composite_field_mapping',
+        'permission_filters',
+        'ordering',
+        'fields_to_include',
+        'fields_to_exclude',
+        'expected_query',
+    ),
+    (
+        # minimal
+        (
+            None,
+            {},
+            None,
+            None,
+            None,
+            None,
+            None,
+            {
+                'query': {
+                    'bool': {
+                        'must': [
+                            {'term': {'_type': 'simplemodel'}},
+                            {
+                                'bool': {
+                                    'should': [
+                                        {
+                                            'match': {
+                                                'name.keyword': {
+                                                    'query': None,
+                                                    'boost': 2,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            'multi_match': {
+                                                'query': None,
+                                                'fields': ('name', 'name.trigram'),
+                                                'type': 'cross_fields',
+                                                'operator': 'and',
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                        'filter': [{'bool': {}}],
+                    },
+                },
+                'sort': ['_score', 'id'],
+            },
+        ),
+
+        # complete
+        (
+            'search term',
+            {
+                'name': ['test'],
+            },
+            {
+                'name': [
+                    'name.trigram',
+                ],
+            },
+            [
+                (
+                    'created_by.dit_team.id',
+                    UUID('00000000-0000-0000-0000-000000000000'),
+                ),
+            ],
+            SearchOrdering('id', SortDirection.desc),
+            ['id'],
+            ['name'],
+            {
+                'query': {
+                    'bool': {
+                        'must': [
+                            {'term': {'_type': 'simplemodel'}},
+                            {
+                                'bool': {
+                                    'should': [
+                                        {
+                                            'match': {
+                                                'name.keyword': {
+                                                    'query': 'search term',
+                                                    'boost': 2,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            'multi_match': {
+                                                'query': 'search term',
+                                                'fields': ('name', 'name.trigram'),
+                                                'type': 'cross_fields',
+                                                'operator': 'and',
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                        'filter': [
+                            {
+                                'bool': {
+                                    'should': [
+                                        {
+                                            'term': {
+                                                'created_by.dit_team.id': UUID(
+                                                    '00000000-0000-0000-0000-000000000000',
+                                                ),
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                            {
+                                'bool': {
+                                    'must': [
+                                        {
+                                            'bool': {
+                                                'should': [
+                                                    {
+                                                        'bool': {
+                                                            'should': [
+                                                                {
+                                                                    'match': {
+                                                                        'name.trigram': {
+                                                                            'query': 'test',
+                                                                            'operator': 'and',
+                                                                        },
+                                                                    },
+                                                                },
+                                                            ],
+                                                            'minimum_should_match': 1,
+                                                        },
+                                                    },
+                                                ],
+                                                'minimum_should_match': 1,
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        ],
+                    },
+                },
+                'sort': [
+                    {
+                        'id': {
+                            'order': SortDirection.desc,
+                            'missing': '_last',
+                        },
+                    },
+                    'id',
+                ],
+                '_source': {
+                    'includes': ['id'],
+                    'excludes': ['name'],
+                },
+            },
+        ),
+    ),
+)
+def test_get_search_by_entity_query(
+    term,
+    filter_data,
+    composite_field_mapping,
+    permission_filters,
+    ordering,
+    fields_to_include,
+    fields_to_exclude,
+    expected_query,
+):
+    """Tests for the get_search_by_entity_query function."""
+    query = get_search_by_entity_query(
+        term=term,
+        filter_data=filter_data,
+        composite_field_mapping=composite_field_mapping,
+        permission_filters=permission_filters,
+        entity=SimpleModelSearchApp.es_model,
+        ordering=ordering,
+        fields_to_include=fields_to_include,
+        fields_to_exclude=fields_to_exclude,
+    )
+    assert query.to_dict() == expected_query
+    assert query._index == [SimpleModelSearchApp.es_model.get_read_alias()]

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -513,11 +513,11 @@ def test_get_search_by_entity_query(
 ):
     """Tests for the get_search_by_entity_query function."""
     query = get_search_by_entity_query(
+        SimpleModelSearchApp.es_model,
         term=term,
         filter_data=filter_data,
         composite_field_mapping=composite_field_mapping,
         permission_filters=permission_filters,
-        entity=SimpleModelSearchApp.es_model,
         ordering=ordering,
         fields_to_include=fields_to_include,
         fields_to_exclude=fields_to_exclude,

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -135,7 +135,7 @@ class SearchAPIView(APIView):
         ordering = _map_es_ordering(validated_data['sortby'], self.es_sort_by_remappings)
 
         return get_search_by_entity_query(
-            entity=self.entity,
+            self.entity,
             term=validated_data['original_query'],
             filter_data=filter_data,
             composite_field_mapping=self.COMPOSITE_FILTERS,

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -108,6 +108,8 @@ class SearchAPIView(APIView):
 
     serializer_class = EntitySearchQuerySerializer
     entity = None
+    fields_to_include = None
+    fields_to_exclude = None
 
     http_method_names = ('post',)
 
@@ -139,6 +141,8 @@ class SearchAPIView(APIView):
             composite_field_mapping=self.COMPOSITE_FILTERS,
             permission_filters=permission_filters,
             ordering=ordering,
+            fields_to_include=self.fields_to_include,
+            fields_to_exclude=self.fields_to_exclude,
         )
 
     def post(self, request, format=None):
@@ -291,7 +295,7 @@ class AutocompleteSearchListAPIView(ListAPIView):
             self.search_app.es_model,
             validated_params['term'],
             validated_params['limit'],
-            only_return_fields=self.document_fields,
+            fields_to_include=self.document_fields,
         )
 
         return Response(data={

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -295,7 +295,7 @@ class AutocompleteSearchListAPIView(ListAPIView):
             self.search_app.es_model,
             validated_params['term'],
             validated_params['limit'],
-            fields_to_include=self.document_fields,
+            self.document_fields,
         )
 
         return Response(data={


### PR DESCRIPTION
### Description of change

This adds the ability to include only specific fields and/or exclude some fields from the ES returned source.

This way, I can create specific views for the v4, exclude the old flat fields for addresses from the v4 views and exclude the nested ones from the v3 views.

I've also refactored `get_search_by_entity_query` slightly so that the arguments are not broken.

It uses https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-source-filtering.html

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
