### PR TITLE
Add ability to merge companies having investment projects

### DIFF
--- a/changelog/company/company-merge-investment-projects.feature
+++ b/changelog/company/company-merge-investment-projects.feature
@@ -1,0 +1,1 @@
+Company merge tool now supports merging companies having investment projects.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -280,6 +280,7 @@ class Company(ArchivableModel, BaseModel):
 
         This is used, for example, for marking a company as a duplicate record.
         """
+        self.modified_by = user
         self.transfer_reason = reason
         self.transferred_by = user
         self.transferred_on = now()

--- a/datahub/company/templates/admin/company/company/merge/step_2_primary_selection.html
+++ b/datahub/company/templates/admin/company/company/merge/step_2_primary_selection.html
@@ -38,7 +38,7 @@
       </ul>
     </div>
 
-    <p>{% blocktrans %}All contacts and interactions will be transferred to the selected company. The other company will be archived.{% endblocktrans %}</p>
+    <p>{% blocktrans %}All contacts, interactions and investment projects will be transferred to the selected company. The other company will be archived.{% endblocktrans %}</p>
 
     <div>
       <input type="submit" value="{% trans 'Next' %}">

--- a/datahub/company/templates/admin/company/company/merge/step_2_primary_selection_radio.html
+++ b/datahub/company/templates/admin/company/company/merge/step_2_primary_selection_radio.html
@@ -19,14 +19,14 @@
     <br>
     {% blocktrans with created_on=option.target.created_on %}Created on {{ created_on }}{% endblocktrans %}
     <br>
-    {% with option.target.contacts.count as contact_count %}
-    {{ contact_count }} contact{{ contact_count|pluralize }}
-    {% endwith %}
-    <br>
-    {% with option.target.interactions.count as interaction_count %}
-    {{ interaction_count }} interaction{{ interaction_count|pluralize }}
-    {% endwith %}
-    <br>
+    {% for merge_entry in option.merge_entries %}
+      {% verbose_name_for_count merge_entry.count merge_entry.model_meta as verbose_name %}
+      {% blocktrans with count=merge_entry.count description=merge_entry.description %}
+        {{ count }} {{ verbose_name }}{{ description }}
+      {% endblocktrans %}
+      <br>
+    {% endfor %}
+
     {% blocktrans with obj_change_url=option.target|admin_change_url site_url=option.target.get_absolute_url %}
     <a href="{{ obj_change_url }}" target="_blank">View company on admin site</a> or <a href="{{ site_url }}" target="_blank">view on Data Hub</a>
     {% endblocktrans %}

--- a/datahub/company/templates/admin/company/company/merge/step_3_confirm_selection.html
+++ b/datahub/company/templates/admin/company/company/merge/step_3_confirm_selection.html
@@ -32,14 +32,15 @@
 </p>
 <p>{% trans 'This will make the following changes:' %}</p>
 <ul>
-  {% for move_entry in move_entries %}
+  {% for merge_entry in merge_entries %}
   <li>
-    {% verbose_name_for_count move_entry.count move_entry.model_meta as verbose_name %}
-    {% blocktrans with count=move_entry.count %}
-    {{ count }} {{ verbose_name }} will be moved from {{ source_company_link }} to {{ target_company_link }}.
+    {% verbose_name_for_count merge_entry.count merge_entry.model_meta as verbose_name %}
+    {% blocktrans with count=merge_entry.count description=merge_entry.description %}
+      {{ count }} {{ verbose_name }}{{ description }}  will be moved from {{ source_company_link }} to {{ target_company_link }}.
     {% endblocktrans %}
   </li>
   {% endfor %}
+
   <li>
     {% if should_archive_source %}
       {% blocktrans %}{{ source_company_link }} will be archived and marked as a duplicate record.{% endblocktrans %}

--- a/datahub/company/test/admin/merge/test_step_2.py
+++ b/datahub/company/test/admin/merge/test_step_2.py
@@ -13,7 +13,6 @@ from datahub.company.test.factories import (
 )
 from datahub.core.test_utils import AdminTestMixin
 from datahub.core.utils import reverse_with_query_string
-from datahub.investment.test.factories import InvestmentProjectFactory
 from datahub.omis.order.test.factories import OrderFactory
 
 
@@ -74,10 +73,6 @@ class TestSelectPrimaryCompanyViewGet(AdminTestMixin):
             ),
             (
                 CompanyFactory,
-                lambda: InvestmentProjectFactory().investor_company,
-            ),
-            (
-                CompanyFactory,
                 lambda: OrderFactory().company,
             ),
             (
@@ -91,7 +86,6 @@ class TestSelectPrimaryCompanyViewGet(AdminTestMixin):
         ),
         ids=[
             'archived-company',
-            'company-with-investment-project',
             'company-with-order',
             'subsidiary',
             'global-headquarters',
@@ -105,8 +99,8 @@ class TestSelectPrimaryCompanyViewGet(AdminTestMixin):
     ):
         """
         Tests that the radio button to select a company is disabled if it is archived,
-        or the other company has an investment project, OMIS order or other related object
-        (other than an interaction or contact).
+        or the other company has an OMIS order or other related object
+        (other than an interaction, contact or investment project).
         """
         company_1 = (company_2_factory if swap else company_1_factory)()
         company_2 = (company_1_factory if swap else company_2_factory)()
@@ -186,12 +180,6 @@ class TestSelectPrimaryCompanyViewPost(AdminTestMixin):
             ),
             (
                 CompanyFactory,
-                lambda: InvestmentProjectFactory().investor_company,
-                'The other company has related records which can’t be moved to the selected '
-                'company.',
-            ),
-            (
-                CompanyFactory,
                 lambda: OrderFactory().company,
                 'The other company has related records which can’t be moved to the selected '
                 'company.',
@@ -240,7 +228,6 @@ class TestSelectPrimaryCompanyViewPost(AdminTestMixin):
                 'selected_company': selected_company,
             },
         )
-
         assert response.status_code == status.HTTP_200_OK
         form = response.context['form']
         assert form.errors == {


### PR DESCRIPTION
### Description of change

This enhances the company merge tool with the ability to merge companies having related investment projects.
It replaces `uk_company`, `investor_company` and `intermediate_company` with a target company.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
