### PR TITLE
Add policy feedback fields to interaction CSV export

### DIFF
--- a/changelog/interaction/additional-export-fields.feature
+++ b/changelog/interaction/additional-export-fields.feature
@@ -1,0 +1,1 @@
+Policy issue types, policy areas and policy feedback notes were added to interaction search result CSV exports.

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -22,6 +22,7 @@ from datahub.core.test_utils import (
     create_test_user,
     format_csv_data,
     get_attr_or_none,
+    join_attr_values,
     random_obj_for_queryset,
 )
 from datahub.interaction.models import (
@@ -981,6 +982,14 @@ class TestInteractionExportView(APITestMixin):
                 ContactFactory(company=company, job_title='Sales director'),
             ],
         )
+        CompanyInteractionFactoryWithPolicyFeedback(
+            company=company,
+            contacts=[
+                ContactFactory(company=company, job_title='Business development manager'),
+            ],
+            policy_areas=PolicyArea.objects.order_by('?')[:2],
+            policy_issue_types=PolicyIssueType.objects.order_by('?')[:2],
+        )
 
         setup_es.indices.refresh()
 
@@ -1025,7 +1034,7 @@ class TestInteractionExportView(APITestMixin):
                 ),
                 'Company UK region': get_attr_or_none(interaction, 'company.uk_region.name'),
                 'Company sector': get_attr_or_none(interaction, 'company.sector.name'),
-                'Contacts': _format_interaction_contacts(interaction),
+                'Contacts': _format_expected_contacts(interaction),
                 'Adviser': get_attr_or_none(interaction, 'dit_adviser.name'),
                 'Service provider': get_attr_or_none(interaction, 'dit_team.name'),
                 'Event': get_attr_or_none(interaction, 'event.name'),
@@ -1034,6 +1043,9 @@ class TestInteractionExportView(APITestMixin):
                     'service_delivery_status.name',
                 ),
                 'Net company receipt': interaction.net_company_receipt,
+                'Policy issue types': join_attr_values(interaction.policy_issue_types.all()),
+                'Policy areas': join_attr_values(interaction.policy_areas.all(), separator='; '),
+                'Policy feedback notes': interaction.policy_feedback_notes,
             }
             for interaction in sorted_interactions
         ]
@@ -1042,14 +1054,14 @@ class TestInteractionExportView(APITestMixin):
         assert actual_row_data == format_csv_data(expected_row_data)
 
 
-def _format_interaction_contacts(interaction):
+def _format_expected_contacts(interaction):
     formatted_contact_names = sorted(
-        _format_contact_name_with_job_title(contact) for contact in interaction.contacts.all(),
+        _format_expected_contact_name(contact) for contact in interaction.contacts.all(),
     )
     return ', '.join(formatted_contact_names)
 
 
-def _format_contact_name_with_job_title(contact):
+def _format_expected_contact_name(contact):
     if contact.job_title:
         return f'{contact.name} ({contact.job_title})'
 
@@ -1062,11 +1074,21 @@ def _format_actual_csv_row(row):
 
 def _format_actual_csv_value(key, value):
     """
-    Sorts the value of 'Contacts' for a row alphabetically as they are unordered at present.
+    Sorts the value of multi-value fields for a row alphabetically as they are unordered at
+    present.
 
     TODO Django 2.2 adds ordering support to StringAgg, which will remove the need for this as we
       will be able to perform the sorting in the export query.
     """
-    if key == 'Contacts':
-        return ', '.join(sorted(value.split(', ')))
+    multi_value_fields_and_separators = {
+        'Contacts': ', ',
+        'Policy areas': '; ',
+        'Policy issue types': ', ',
+    }
+
+    if key in multi_value_fields_and_separators:
+        separator = multi_value_fields_and_separators[key]
+        sorted_split_values = sorted(value.split(separator))
+        return separator.join(sorted_split_values)
+
     return value

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -96,6 +96,16 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
         dit_adviser_name=get_full_name_expression('dit_adviser'),
         link=get_front_end_url_expression('interaction', 'pk'),
         kind_name=get_choices_as_case_expression(DBInteraction, 'kind'),
+        policy_issue_type_names=get_string_agg_subquery(
+            DBInteraction,
+            'policy_issue_types__name',
+        ),
+        policy_area_names=get_string_agg_subquery(
+            DBInteraction,
+            'policy_areas__name',
+            # Some policy areas contain commas, so we use a semicolon to delimit multiple values
+            delimiter='; ',
+        ),
     )
     field_titles = {
         'date': 'Date',
@@ -114,4 +124,7 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
         'event__name': 'Event',
         'service_delivery_status__name': 'Service delivery status',
         'net_company_receipt': 'Net company receipt',
+        'policy_issue_type_names': 'Policy issue types',
+        'policy_area_names': 'Policy areas',
+        'policy_feedback_notes': 'Policy feedback notes',
     }


### PR DESCRIPTION
### Description of change

This adds policy issue types, policy areas and policy feedback notes to the interaction CSV export.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
