### PR TITLE
Search company api v4

### DIFF
--- a/changelog/company/company-search-api-v3.removal
+++ b/changelog/company/company-search-api-v3.removal
@@ -1,0 +1,5 @@
+The following endpoints are deprecated and will be removed on or after the 28th of February, please use v4 instead:
+
+- ``/v3/search/company``
+- ``/v3/search/company/autocomplete``
+- ``/v3/search/company/export``

--- a/changelog/company/company-search-api-v4.api
+++ b/changelog/company/company-search-api-v4.api
@@ -1,0 +1,12 @@
+API V4 for company search was introduced with nested object format for addresses.
+The following endpoints were added:
+
+- ``/v4/search/company``: see below
+- ``/v4/search/company/autocomplete``: see below
+- ``/v4/search/company/export``: same response body as v3
+
+``/v4/search/company``, ``/v4/search/company/autocomplete``:
+
+- The ``trading_address_*`` fields were removed from v4
+- The ``registered_address_*`` fields were replaced by the nested object ``registered_address``
+- The nested object ``address`` was added. Its data was populated from trading_address fields or registered_address whichever was defined.

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -39,7 +39,7 @@ v3_urls = [
     path('', include((feature_flag_urls, 'feature-flag'), namespace='feature-flag')),
     path('', include((interaction_urls, 'interaction'), namespace='interaction')),
     path('', include((investment_urls, 'investment'), namespace='investment')),
-    path('', include((search_urls, 'search'), namespace='search')),
+    path('', include((search_urls.urls_v3, 'search'), namespace='search')),
     path('omis/', include((omis_urls.internal_frontend_urls, 'omis'), namespace='omis')),
     path(
         'omis/public/',
@@ -56,4 +56,5 @@ v3_urls = [
 v4_urls = [
     path('', include((company_urls.company_urls_v4, 'company'), namespace='company')),
     path('', include((company_urls.ch_company_urls_v4, 'ch-company'), namespace='ch-company')),
+    path('', include((search_urls.urls_v4, 'search'), namespace='search')),
 ]

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -18,6 +18,12 @@ class SearchApp:
     view = None
     export_view = None
     autocomplete_view = None
+
+    # TODO: replace the base views with these once the migration to v4 is complete
+    view_v4 = None
+    export_view_v4 = None
+    autocomplete_view_v4 = None
+
     queryset = None
     exclude_from_global_search = False
     # A sequence of permissions. The user must have one of these permissions to perform searches.

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -2,8 +2,10 @@ from datahub.company.models import Company as DBCompany, CompanyPermission
 from datahub.search.apps import SearchApp
 from datahub.search.company.models import Company
 from datahub.search.company.views import (
-    CompanyAutocompleteSearchListAPIView,
+    CompanyAutocompleteSearchListAPIViewV3,
+    CompanyAutocompleteSearchListAPIViewV4,
     SearchCompanyAPIViewV3,
+    SearchCompanyAPIViewV4,
     SearchCompanyExportAPIView,
 )
 
@@ -15,7 +17,12 @@ class CompanySearchApp(SearchApp):
     es_model = Company
     view = SearchCompanyAPIViewV3
     export_view = SearchCompanyExportAPIView
-    autocomplete_view = CompanyAutocompleteSearchListAPIView
+    autocomplete_view = CompanyAutocompleteSearchListAPIViewV3
+
+    view_v4 = SearchCompanyAPIViewV4
+    export_view_v4 = SearchCompanyExportAPIView
+    autocomplete_view_v4 = CompanyAutocompleteSearchListAPIViewV4
+
     view_permissions = (f'company.{CompanyPermission.view_company}',)
     export_permission = f'company.{CompanyPermission.export_company}'
     queryset = DBCompany.objects.select_related(

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -3,7 +3,7 @@ from datahub.search.apps import SearchApp
 from datahub.search.company.models import Company
 from datahub.search.company.views import (
     CompanyAutocompleteSearchListAPIView,
-    SearchCompanyAPIView,
+    SearchCompanyAPIViewV3,
     SearchCompanyExportAPIView,
 )
 
@@ -13,7 +13,7 @@ class CompanySearchApp(SearchApp):
 
     name = 'company'
     es_model = Company
-    view = SearchCompanyAPIView
+    view = SearchCompanyAPIViewV3
     export_view = SearchCompanyExportAPIView
     autocomplete_view = CompanyAutocompleteSearchListAPIView
     view_permissions = (f'company.{CompanyPermission.view_company}',)

--- a/datahub/search/company/test/test_basic_search_views.py
+++ b/datahub/search/company/test/test_basic_search_views.py
@@ -1,0 +1,183 @@
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.models import Company
+from datahub.company.test.factories import CompanyFactory
+from datahub.core import constants
+from datahub.core.test_utils import APITestMixin
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def setup_data(setup_es):
+    """Sets up data for the tests."""
+    country_uk = constants.Country.united_kingdom.value.id
+    country_us = constants.Country.united_states.value.id
+    uk_region = constants.UKRegion.south_east.value.id
+    CompanyFactory(
+        name='abc defg ltd',
+        trading_names=['helm', 'nop'],
+        trading_address_1='1 Fake Lane',
+        trading_address_town='Downtown',
+        trading_address_country_id=country_uk,
+        uk_region_id=uk_region,
+    )
+    CompanyFactory(
+        name='abc defg us ltd',
+        trading_names=['helm', 'nop', 'qrs'],
+        trading_address_1='1 Fake Lane',
+        trading_address_town='Downtown',
+        trading_address_country_id=country_us,
+        registered_address_country_id=country_us,
+        address_country_id=country_us,
+    )
+    setup_es.indices.refresh()
+
+
+class TestBasicSearch(APITestMixin):
+    """Tests basic search view."""
+
+    def test_all_companies(self, setup_data):
+        """Tests basic aggregate all companies query."""
+        url = reverse('api-v3:search:basic')
+        response = self.api_client.get(
+            url,
+            data={
+                'term': '',
+                'entity': 'company',
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] > 0
+
+    def test_companies(self, setup_data):
+        """Tests basic aggregate companies query."""
+        term = 'abc defg'
+
+        url = reverse('api-v3:search:basic')
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 2
+        assert response.data['results'][0]['name'].startswith(term)
+        assert [{'count': 2, 'entity': 'company'}] == response.data['aggregations']
+
+    @pytest.mark.parametrize(
+        'name_term,matched_company_name',
+        (
+            # name
+            ('whiskers', 'whiskers and tabby'),
+            ('whi', 'whiskers and tabby'),
+            ('his', 'whiskers and tabby'),
+            ('ers', 'whiskers and tabby'),
+            ('1a', '1a'),
+
+            # trading names
+            ('maine coon egyptian mau', 'whiskers and tabby'),
+            ('maine', 'whiskers and tabby'),
+            ('mau', 'whiskers and tabby'),
+            ('ine oon', 'whiskers and tabby'),
+            ('ine mau', 'whiskers and tabby'),
+            ('3a', '1a'),
+
+            # non-matches
+            ('whi lorem', None),
+            ('wh', None),
+            ('whe', None),
+            ('tiger', None),
+            ('panda', None),
+            ('moine', None),
+        ),
+    )
+    def test_search_in_name(self, setup_es, name_term, matched_company_name):
+        """Tests basic aggregate companies query."""
+        CompanyFactory(
+            name='whiskers and tabby',
+            trading_names=['Maine Coon', 'Egyptian Mau'],
+        )
+        CompanyFactory(
+            name='1a',
+            trading_names=['3a', '4a'],
+        )
+        setup_es.indices.refresh()
+
+        url = reverse('api-v3:search:basic')
+        response = self.api_client.get(
+            url,
+            data={
+                'term': name_term,
+                'entity': 'company',
+            },
+        )
+
+        match = Company.objects.filter(name=matched_company_name).first()
+        if match:
+            assert response.data['count'] == 1
+            assert len(response.data['results']) == 1
+            assert response.data['results'][0]['id'] == str(match.id)
+            assert [{'count': 1, 'entity': 'company'}] == response.data['aggregations']
+        else:
+            assert response.data['count'] == 0
+            assert len(response.data['results']) == 0
+
+    @pytest.mark.parametrize(
+        'field,value,term,match',
+        (
+            ('trading_address_postcode', 'SW1A 1AA', 'SW1A 1AA', True),
+            ('trading_address_postcode', 'SW1A 1AA', 'SW1A 1AB', False),
+            ('registered_address_postcode', 'SW1A 1AA', 'SW1A 1AA', True),
+            ('registered_address_postcode', 'SW1A 1AA', 'SW1A 1AB', False),
+        ),
+    )
+    def test_search_in_field(self, setup_es, field, value, term, match):
+        """Tests basic aggregate companies query."""
+        CompanyFactory()
+        CompanyFactory(**{field: value})
+        setup_es.indices.refresh()
+
+        url = reverse('api-v3:search:basic')
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        if match:
+            assert response.data['count'] == 1
+            assert response.data['results'][0][field] == value
+        else:
+            assert response.data['count'] == 0
+
+    def test_no_results(self, setup_data):
+        """Tests case where there should be no results."""
+        term = 'there-should-be-no-match'
+
+        url = reverse('api-v3:search:basic')
+        response = self.api_client.get(
+            url,
+            data={
+                'term': term,
+                'entity': 'company',
+            },
+        )
+
+        assert response.data['count'] == 0
+
+    def test_companies_no_term(self, setup_data):
+        """Tests case where there is not term provided."""
+        url = reverse('api-v3:search:basic')
+        response = self.api_client.get(url, {})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -369,7 +369,7 @@ def test_mapping(setup_es):
 
 def test_get_basic_search_query():
     """Tests basic search query."""
-    query = get_basic_search_query('test', entities=(ESCompany,), offset=5, limit=5)
+    query = get_basic_search_query(ESCompany, 'test', offset=5, limit=5)
 
     assert query.to_dict() == {
         'query': {

--- a/datahub/search/company/test/test_entity_search_views_v3.py
+++ b/datahub/search/company/test/test_entity_search_views_v3.py
@@ -665,7 +665,7 @@ class TestAutocompleteSearch(APITestMixin):
         """Should return 403"""
         user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
-        url = reverse('api-v3:search:company-autocomplete-search')
+        url = reverse('api-v3:search:company-autocomplete')
 
         response = api_client.get(url)
 
@@ -679,7 +679,7 @@ class TestAutocompleteSearch(APITestMixin):
         )
         setup_es.indices.refresh()
 
-        url = reverse('api-v3:search:company-autocomplete-search')
+        url = reverse('api-v3:search:company-autocomplete')
         response = self.api_client.get(url, data={'term': 'abc'})
 
         assert response.status_code == status.HTTP_200_OK
@@ -731,7 +731,7 @@ class TestAutocompleteSearch(APITestMixin):
     )
     def test_validation_error(self, data, expected_error, setup_data):
         """Tests case where there is not query provided."""
-        url = reverse('api-v3:search:company-autocomplete-search')
+        url = reverse('api-v3:search:company-autocomplete')
 
         response = self.api_client.get(url, data=data)
 
@@ -757,7 +757,7 @@ class TestAutocompleteSearch(APITestMixin):
     )
     def test_searching_with_a_query(self, setup_data, query, expected_companies):
         """Tests case where search queries are provided."""
-        url = reverse('api-v3:search:company-autocomplete-search')
+        url = reverse('api-v3:search:company-autocomplete')
 
         response = self.api_client.get(url, data={'term': query})
 
@@ -778,7 +778,7 @@ class TestAutocompleteSearch(APITestMixin):
     )
     def test_searching_with_limit(self, setup_data, limit, expected_companies):
         """Tests case where search limit is provided."""
-        url = reverse('api-v3:search:company-autocomplete-search')
+        url = reverse('api-v3:search:company-autocomplete')
 
         response = self.api_client.get(
             url,
@@ -807,7 +807,7 @@ class TestAutocompleteSearch(APITestMixin):
         permitted and a datahub exception error is raised.
         """
         mock_get_app_permission_filters.return_value = True
-        url = reverse('api-v3:search:company-autocomplete-search')
+        url = reverse('api-v3:search:company-autocomplete')
         with pytest.raises(DataHubException) as expected_error:
             self.api_client.get(url, data={'term': 'query'})
         assert (

--- a/datahub/search/company/test/test_entity_search_views_v4.py
+++ b/datahub/search/company/test/test_entity_search_views_v4.py
@@ -1,0 +1,797 @@
+import uuid
+from cgi import parse_header
+from csv import DictReader
+from io import StringIO
+from unittest import mock
+from uuid import UUID, uuid4
+
+import factory
+import pytest
+from django.conf import settings
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.models import Company, CompanyPermission
+from datahub.company.test.factories import CompanyFactory
+from datahub.core import constants
+from datahub.core.exceptions import DataHubException
+from datahub.core.test_utils import (
+    APITestMixin,
+    create_test_user,
+    format_csv_data,
+    get_attr_or_none,
+    random_obj_for_queryset,
+)
+from datahub.metadata.models import Sector
+from datahub.metadata.test.factories import TeamFactory
+from datahub.search.company.models import get_suggestions
+from datahub.search.company.views import SearchCompanyExportAPIView
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def setup_data(setup_es):
+    """Sets up data for the tests."""
+    country_uk = constants.Country.united_kingdom.value.id
+    country_us = constants.Country.united_states.value.id
+    country_anguilla = constants.Country.anguilla.value.id
+    uk_region = constants.UKRegion.south_east.value.id
+    CompanyFactory(
+        name='abc defg ltd',
+        trading_names=['helm', 'nop'],
+        trading_address_1='1 Fake Lane',
+        trading_address_town='Downtown',
+        trading_address_country_id=country_uk,
+        registered_address_country_id=country_uk,
+        address_country_id=country_uk,
+        uk_region_id=uk_region,
+    )
+    CompanyFactory(
+        name='abc defg us ltd',
+        trading_names=['helm', 'nop', 'qrs'],
+        trading_address_1='1 Fake Lane',
+        trading_address_town='Downtown',
+        trading_address_country_id=country_us,
+        registered_address_country_id=country_us,
+        address_country_id=country_us,
+    )
+    CompanyFactory(
+        name='archived',
+        trading_names=[],
+        trading_address_1='Main Lane',
+        trading_address_town='Somewhere',
+        trading_address_country_id=country_anguilla,
+        registered_address_country_id=country_anguilla,
+        address_country_id=country_anguilla,
+        archived=True,
+    )
+    setup_es.indices.refresh()
+
+
+@pytest.fixture
+def setup_headquarters_data(setup_es):
+    """Sets up data for headquarter type tests."""
+    CompanyFactory(
+        name='ghq',
+        headquarter_type_id=constants.HeadquarterType.ghq.value.id,
+    )
+    CompanyFactory(
+        name='ehq',
+        headquarter_type_id=constants.HeadquarterType.ehq.value.id,
+    )
+    CompanyFactory(
+        name='ukhq',
+        headquarter_type_id=constants.HeadquarterType.ukhq.value.id,
+    )
+    CompanyFactory(
+        name='none',
+        headquarter_type_id=None,
+    )
+    setup_es.indices.refresh()
+
+
+class TestSearch(APITestMixin):
+    """Tests search views."""
+
+    def test_company_search_no_permissions(self):
+        """Should return 403"""
+        user = create_test_user(dit_team=TeamFactory())
+        api_client = self.create_api_client(user=user)
+        url = reverse('api-v4:search:company')
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_response_body(self, setup_es):
+        """Tests the response body of a search query."""
+        company = CompanyFactory(
+            company_number='123',
+            trading_names=['Xyz trading', 'Abc trading'],
+            global_headquarters=None,
+            one_list_tier=None,
+            one_list_account_owner=None,
+        )
+        setup_es.indices.refresh()
+
+        url = reverse('api-v4:search:company')
+        response = self.api_client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'count': 1,
+            'results': [
+                {
+                    'id': str(company.pk),
+                    'created_on': company.created_on.isoformat(),
+                    'modified_on': company.modified_on.isoformat(),
+                    'name': company.name,
+                    'reference_code': company.reference_code,
+                    'company_number': company.company_number,
+                    'vat_number': company.vat_number,
+                    'duns_number': company.duns_number,
+                    'trading_names': company.trading_names,
+                    'address': {
+                        'line_1': company.address_1,
+                        'line_2': company.address_2 or '',
+                        'town': company.address_town,
+                        'county': company.address_county or '',
+                        'postcode': company.address_postcode or '',
+                        'country': {
+                            'id': str(company.trading_address_country.id),
+                            'name': company.trading_address_country.name,
+                        },
+                    },
+                    'registered_address': {
+                        'line_1': company.registered_address_1,
+                        'line_2': company.registered_address_2 or '',
+                        'town': company.registered_address_town,
+                        'county': company.registered_address_county or '',
+                        'postcode': company.registered_address_postcode or '',
+                        'country': {
+                            'id': str(company.registered_address_country.id),
+                            'name': company.registered_address_country.name,
+                        },
+                    },
+                    'uk_based': (
+                        company.address_country.id == uuid.UUID(
+                            constants.Country.united_kingdom.value.id,
+                        )
+                    ),
+                    'uk_region': {
+                        'id': str(company.uk_region.id),
+                        'name': company.uk_region.name,
+                    },
+                    'business_type': {
+                        'id': str(company.business_type.id),
+                        'name': company.business_type.name,
+                    },
+                    'contacts': [],
+                    'description': company.description,
+                    'employee_range': {
+                        'id': str(company.employee_range.id),
+                        'name': company.employee_range.name,
+                    },
+                    'export_experience_category': {
+                        'id': str(company.export_experience_category.id),
+                        'name': company.export_experience_category.name,
+                    },
+                    'export_to_countries': [],
+                    'future_interest_countries': [],
+                    'headquarter_type': company.headquarter_type,
+                    'sector': {
+                        'id': str(company.sector.id),
+                        'name': company.sector.name,
+                        'ancestors': [
+                            {'id': str(ancestor.id)}
+                            for ancestor in company.sector.get_ancestors()
+                        ],
+                    },
+                    'turnover_range': {
+                        'id': str(company.turnover_range.id),
+                        'name': company.turnover_range.name,
+                    },
+                    'website': company.website,
+                    'global_headquarters': None,
+                    'archived': False,
+                    'archived_by': None,
+                    'archived_on': None,
+                    'archived_reason': None,
+                    'suggest': get_suggestions(company),
+                },
+            ],
+        }
+
+    @pytest.mark.parametrize(
+        'filters,expected_companies',
+        (
+            # no filter
+            (
+                {},
+                ['abc defg ltd', 'abc defg us ltd', 'archived'],
+            ),
+
+            # archived True
+            (
+                {
+                    'archived': True,
+                },
+                ['archived'],
+            ),
+
+            # archived False
+            (
+                {
+                    'archived': False,
+                },
+                ['abc defg ltd', 'abc defg us ltd'],
+            ),
+
+            # trading_address_country
+            (
+                {
+                    'trading_address_country': constants.Country.united_states.value.id,
+                },
+                ['abc defg us ltd'],
+            ),
+
+            # multiple trading_address_country filters
+            (
+                {
+                    'trading_address_country': [
+                        constants.Country.united_states.value.id,
+                        constants.Country.united_kingdom.value.id,
+                    ],
+                },
+                ['abc defg ltd', 'abc defg us ltd'],
+            ),
+
+            # uk_region
+            (
+                {
+                    'uk_region': constants.UKRegion.south_east.value.id,
+                },
+                ['abc defg ltd'],
+            ),
+
+            # uk_region
+            (
+                {
+                    'uk_based': True,
+                },
+                ['abc defg ltd'],
+            ),
+        ),
+    )
+    def test_filters(self, setup_data, filters, expected_companies):
+        """Tests different filters."""
+        url = reverse('api-v4:search:company')
+
+        response = self.api_client.post(
+            url,
+            data={
+                **filters,
+                'sortby': 'name',
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(expected_companies)
+
+        assert [
+            result['name']
+            for result in response_data['results']
+        ] == expected_companies
+
+    @pytest.mark.parametrize(
+        'query,results',
+        (
+            (
+                {
+                    'headquarter_type': None,
+                },
+                {'none'},
+            ),
+            (
+                {
+                    'headquarter_type': constants.HeadquarterType.ghq.value.id,
+                },
+                {'ghq'},
+            ),
+            (
+                {
+                    'headquarter_type': [
+                        constants.HeadquarterType.ghq.value.id,
+                        constants.HeadquarterType.ehq.value.id,
+                    ],
+                },
+                {'ehq', 'ghq'},
+            ),
+            (
+                {
+                    'headquarter_type': [
+                        constants.HeadquarterType.ghq.value.id,
+                        constants.HeadquarterType.ehq.value.id,
+                        None,
+                    ],
+                },
+                {'ehq', 'ghq', 'none'},
+            ),
+        ),
+    )
+    def test_headquarter_type_filter(self, setup_headquarters_data, query, results):
+        """Test headquarter type filter."""
+        url = reverse('api-v4:search:company')
+        response = self.api_client.post(
+            url,
+            query,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        num_results = len(results)
+        assert response.data['count'] == num_results
+        assert len(response.data['results']) == num_results
+
+        search_results = {company['name'] for company in response.data['results']}
+        assert search_results == results
+
+    def test_global_headquarters(self, setup_es):
+        """Test global headquarters filter."""
+        ghq1 = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ghq.value.id)
+        ghq2 = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ghq.value.id)
+        companies = CompanyFactory.create_batch(5, global_headquarters=ghq1)
+        CompanyFactory.create_batch(5, global_headquarters=ghq2)
+        CompanyFactory.create_batch(10)
+
+        setup_es.indices.refresh()
+
+        url = reverse('api-v4:search:company')
+        response = self.api_client.post(
+            url,
+            {
+                'global_headquarters': ghq1.id,
+            },
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        assert response.data['count'] == 5
+        assert len(response.data['results']) == 5
+
+        search_results = {UUID(company['id']) for company in response.data['results']}
+        assert search_results == {company.id for company in companies}
+
+    @pytest.mark.parametrize(
+        'sector_level',
+        (0, 1, 2),
+    )
+    def test_sector_descends_filter(self, hierarchical_sectors, setup_es, sector_level):
+        """Test the sector_descends filter."""
+        num_sectors = len(hierarchical_sectors)
+        sectors_ids = [sector.pk for sector in hierarchical_sectors]
+
+        companies = CompanyFactory.create_batch(
+            num_sectors,
+            sector_id=factory.Iterator(sectors_ids),
+        )
+        CompanyFactory.create_batch(
+            3,
+            sector=factory.LazyFunction(lambda: random_obj_for_queryset(
+                Sector.objects.exclude(pk__in=sectors_ids),
+            )),
+        )
+
+        setup_es.indices.refresh()
+
+        url = reverse('api-v4:search:company')
+        body = {
+            'sector_descends': hierarchical_sectors[sector_level].pk,
+        }
+        response = self.api_client.post(url, body)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        assert response_data['count'] == num_sectors - sector_level
+
+        actual_ids = {UUID(company['id']) for company in response_data['results']}
+        expected_ids = {company.pk for company in companies[sector_level:]}
+        assert actual_ids == expected_ids
+
+    @pytest.mark.parametrize(
+        'country,match',
+        (
+            (constants.Country.cayman_islands.value.id, True),
+            (constants.Country.montserrat.value.id, True),
+            (constants.Country.azerbaijan.value.id, False),
+            (constants.Country.anguilla.value.id, False),
+        ),
+    )
+    def test_composite_country_filter(self, setup_es, country, match):
+        """Tests composite country filter."""
+        company = CompanyFactory(
+            trading_address_country_id=constants.Country.cayman_islands.value.id,
+            registered_address_country_id=constants.Country.montserrat.value.id,
+        )
+        setup_es.indices.refresh()
+
+        url = reverse('api-v4:search:company')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'country': country,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        if match:
+            assert response.data['count'] == 1
+            assert len(response.data['results']) == 1
+            assert response.data['results'][0]['id'] == str(company.id)
+        else:
+            assert response.data['count'] == 0
+            assert len(response.data['results']) == 0
+
+    @pytest.mark.parametrize(
+        'name_term,matched_company_name',
+        (
+            # name
+            ('whiskers', 'whiskers and tabby'),
+            ('whi', 'whiskers and tabby'),
+            ('his', 'whiskers and tabby'),
+            ('ers', 'whiskers and tabby'),
+            ('1a', '1a'),
+
+            # trading names
+            ('maine coon egyptian mau', 'whiskers and tabby'),
+            ('maine', 'whiskers and tabby'),
+            ('mau', 'whiskers and tabby'),
+            ('ine oon', 'whiskers and tabby'),
+            ('ine mau', 'whiskers and tabby'),
+            ('3a', '1a'),
+
+            # non-matches
+            ('whi lorem', None),
+            ('wh', None),
+            ('whe', None),
+            ('tiger', None),
+            ('panda', None),
+            ('moine', None),
+        ),
+    )
+    def test_composite_name_filter(self, setup_es, name_term, matched_company_name):
+        """Tests composite name filter."""
+        CompanyFactory(
+            name='whiskers and tabby',
+            trading_names=['Maine Coon', 'Egyptian Mau'],
+        )
+        CompanyFactory(
+            name='1a',
+            trading_names=['3a', '4a'],
+        )
+        setup_es.indices.refresh()
+
+        url = reverse('api-v4:search:company')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'name': name_term,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        match = Company.objects.filter(name=matched_company_name).first()
+        if match:
+            assert response.data['count'] == 1
+            assert len(response.data['results']) == 1
+            assert response.data['results'][0]['id'] == str(match.id)
+        else:
+            assert response.data['count'] == 0
+            assert len(response.data['results']) == 0
+
+    def test_company_search_paging(self, setup_es):
+        """
+        Tests the pagination.
+
+        The sortby is not passed in so records are ordered by id.
+        """
+        total_records = 9
+        page_size = 2
+
+        ids = sorted((uuid4() for _ in range(total_records)))
+
+        name = 'test record'
+
+        CompanyFactory.create_batch(
+            len(ids),
+            id=factory.Iterator(ids),
+            name=name,
+            trading_names=[],
+        )
+
+        setup_es.indices.refresh()
+
+        url = reverse('api-v4:search:company')
+        for page in range((len(ids) + page_size - 1) // page_size):
+            response = self.api_client.post(
+                url,
+                data={
+                    'original_query': name,
+                    'offset': page * page_size,
+                    'limit': page_size,
+                },
+            )
+
+            assert response.status_code == status.HTTP_200_OK
+
+            start = page * page_size
+            end = start + page_size
+            assert [
+                UUID(company['id']) for company in response.data['results']
+            ] == ids[start:end]
+
+
+class TestCompanyExportView(APITestMixin):
+    """Tests the company export view."""
+
+    @pytest.mark.parametrize(
+        'permissions',
+        (
+            (),
+            (CompanyPermission.view_company,),
+            (CompanyPermission.export_company,),
+        ),
+    )
+    def test_user_without_permission_cannot_export(self, setup_es, permissions):
+        """Test that a user without the correct permissions cannot export data."""
+        user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
+        api_client = self.create_api_client(user=user)
+
+        url = reverse('api-v4:search:company-export')
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        'request_sortby,orm_ordering',
+        (
+            ('name', 'name'),
+            ('modified_on', 'modified_on'),
+            ('modified_on:desc', '-modified_on'),
+        ),
+    )
+    def test_export(
+        self,
+        setup_es,
+        request_sortby,
+        orm_ordering,
+    ):
+        """Test export of company search results."""
+        CompanyFactory.create_batch(
+            3,
+            turnover=None,
+            is_turnover_estimated=None,
+            number_of_employees=None,
+            is_number_of_employees_estimated=None,
+        )
+        CompanyFactory.create_batch(
+            2,
+            hq=True,
+            turnover=100,
+            is_turnover_estimated=True,
+            number_of_employees=95,
+            is_number_of_employees_estimated=True,
+        )
+
+        setup_es.indices.refresh()
+
+        data = {}
+        if request_sortby:
+            data['sortby'] = request_sortby
+
+        url = reverse('api-v4:search:company-export')
+
+        with freeze_time('2018-01-01 11:12:13'):
+            response = self.api_client.post(url, data=data)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert parse_header(response.get('Content-Type')) == ('text/csv', {'charset': 'utf-8'})
+        assert parse_header(response.get('Content-Disposition')) == (
+            'attachment', {'filename': 'Data Hub - Companies - 2018-01-01-11-12-13.csv'},
+        )
+
+        sorted_company = Company.objects.order_by(orm_ordering, 'pk')
+        reader = DictReader(StringIO(response.getvalue().decode('utf-8-sig')))
+
+        assert reader.fieldnames == list(SearchCompanyExportAPIView.field_titles.values())
+
+        expected_row_data = [
+            {
+                'Name': company.name,
+                'Link': f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}/{company.pk}',
+                'Sector': get_attr_or_none(company, 'sector.name'),
+                'Country': get_attr_or_none(company, 'address_country.name'),
+                'UK region': get_attr_or_none(company, 'uk_region.name'),
+                'Archived': company.archived,
+                'Date created': company.created_on,
+                'Number of employees': (
+                    company.number_of_employees
+                    if company.number_of_employees is not None
+                    else get_attr_or_none(company, 'employee_range.name')
+                ),
+                'Annual turnover': (
+                    f'${company.turnover}'
+                    if company.turnover is not None
+                    else get_attr_or_none(company, 'turnover_range.name')
+                ),
+                'Headquarter type':
+                    (get_attr_or_none(company, 'headquarter_type.name') or '').upper(),
+            }
+            for company in sorted_company
+        ]
+
+        assert list(dict(row) for row in reader) == format_csv_data(expected_row_data)
+
+
+class TestAutocompleteSearch(APITestMixin):
+    """Tests for autocomplete search views."""
+
+    def test_no_permissions_returns_403(self):
+        """Should return 403"""
+        user = create_test_user(dit_team=TeamFactory())
+        api_client = self.create_api_client(user=user)
+        url = reverse('api-v4:search:company-autocomplete-search')
+
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_response_body(self, setup_es):
+        """Tests the response body of autocomplete search query."""
+        company = CompanyFactory(
+            name='abc',
+            trading_names=['Xyz trading', 'Abc trading'],
+        )
+        setup_es.indices.refresh()
+
+        url = reverse('api-v4:search:company-autocomplete-search')
+        response = self.api_client.get(url, data={'term': 'abc'})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'count': 1,
+            'results': [
+                {
+                    'id': str(company.id),
+                    'name': company.name,
+                    'address': {
+                        'line_1': company.address_1,
+                        'line_2': company.address_2 or '',
+                        'town': company.address_town,
+                        'county': company.address_county or '',
+                        'postcode': company.address_postcode or '',
+                        'country': {
+                            'id': str(company.trading_address_country.id),
+                            'name': company.trading_address_country.name,
+                        },
+                    },
+                    'registered_address': {
+                        'line_1': company.registered_address_1,
+                        'line_2': company.registered_address_2 or '',
+                        'town': company.registered_address_town,
+                        'county': company.registered_address_county or '',
+                        'postcode': company.registered_address_postcode or '',
+                        'country': {
+                            'id': str(company.registered_address_country.id),
+                            'name': company.registered_address_country.name,
+                        },
+                    },
+                    'trading_names': ['Xyz trading', 'Abc trading'],
+                },
+            ],
+        }
+
+    @pytest.mark.parametrize(
+        'data,expected_error',
+        (
+            (
+                {},
+                {'term': ['This field is required.']},
+            ),
+            (
+                {'term': 'a', 'limit': 0},
+                {'limit': ['Ensure this value is greater than or equal to 1.']},
+            ),
+            (
+                {'term': 'a', 'limit': 'asdf'},
+                {'limit': ['A valid integer is required.']},
+            ),
+        ),
+    )
+    def test_validation_error(self, data, expected_error, setup_data):
+        """Tests case where there is not query provided."""
+        url = reverse('api-v4:search:company-autocomplete-search')
+
+        response = self.api_client.get(url, data=data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_error
+
+    @pytest.mark.parametrize(
+        'query,expected_companies',
+        (
+            ('abc', ['abc defg ltd', 'abc defg us ltd']),
+            ('abv', []),
+            ('ABC', ['abc defg ltd', 'abc defg us ltd']),
+            ('hello', []),
+            ('', []),
+            (1, []),
+            ('abc defg ltd', ['abc defg ltd']),
+            ('defg', ['abc defg ltd', 'abc defg us ltd']),
+            ('us', ['abc defg us ltd']),
+            ('hel', ['abc defg ltd', 'abc defg us ltd']),
+            ('qrs', ['abc defg us ltd']),
+            ('help qrs', []),
+        ),
+    )
+    def test_searching_with_a_query(self, setup_data, query, expected_companies):
+        """Tests case where search queries are provided."""
+        url = reverse('api-v4:search:company-autocomplete-search')
+
+        response = self.api_client.get(url, data={'term': query})
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == len(expected_companies)
+
+        if expected_companies:
+            companies = [result['name'] for result in response.data['results']]
+            assert companies == expected_companies
+
+    @pytest.mark.parametrize(
+        'limit,expected_companies',
+        (
+            (10, ['abc defg ltd', 'abc defg us ltd']),  # only 2 found
+            (2, ['abc defg ltd', 'abc defg us ltd']),
+            (1, ['abc defg ltd']),
+        ),
+    )
+    def test_searching_with_limit(self, setup_data, limit, expected_companies):
+        """Tests case where search limit is provided."""
+        url = reverse('api-v4:search:company-autocomplete-search')
+
+        response = self.api_client.get(
+            url,
+            data={
+                'term': 'abc',
+                'limit': limit,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == len(expected_companies)
+
+        if expected_companies:
+            companies = [result['name'] for result in response.data['results']]
+            assert companies == expected_companies
+
+    @mock.patch(
+        'datahub.search.company.views.'
+        'CompanyAutocompleteSearchListAPIViewV4._get_permission_filters',
+    )
+    def test_raise_datahub_error_when_search_app_has_permission_search_filters(
+        self, mock_get_app_permission_filters,
+    ):
+        """
+        Tests if a search app has permission filters, if so autocomplete is not
+        permitted and a datahub exception error is raised.
+        """
+        mock_get_app_permission_filters.return_value = True
+        url = reverse('api-v4:search:company-autocomplete-search')
+        with pytest.raises(DataHubException) as expected_error:
+            self.api_client.get(url, data={'term': 'query'})
+        assert (
+            str(expected_error.value)
+            == 'Unable to apply filtering for autocomplete search request'
+        )

--- a/datahub/search/company/test/test_entity_search_views_v4.py
+++ b/datahub/search/company/test/test_entity_search_views_v4.py
@@ -642,7 +642,7 @@ class TestAutocompleteSearch(APITestMixin):
         """Should return 403"""
         user = create_test_user(dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
-        url = reverse('api-v4:search:company-autocomplete-search')
+        url = reverse('api-v4:search:company-autocomplete')
 
         response = api_client.get(url)
 
@@ -656,7 +656,7 @@ class TestAutocompleteSearch(APITestMixin):
         )
         setup_es.indices.refresh()
 
-        url = reverse('api-v4:search:company-autocomplete-search')
+        url = reverse('api-v4:search:company-autocomplete')
         response = self.api_client.get(url, data={'term': 'abc'})
 
         assert response.status_code == status.HTTP_200_OK
@@ -712,7 +712,7 @@ class TestAutocompleteSearch(APITestMixin):
     )
     def test_validation_error(self, data, expected_error, setup_data):
         """Tests case where there is not query provided."""
-        url = reverse('api-v4:search:company-autocomplete-search')
+        url = reverse('api-v4:search:company-autocomplete')
 
         response = self.api_client.get(url, data=data)
 
@@ -738,7 +738,7 @@ class TestAutocompleteSearch(APITestMixin):
     )
     def test_searching_with_a_query(self, setup_data, query, expected_companies):
         """Tests case where search queries are provided."""
-        url = reverse('api-v4:search:company-autocomplete-search')
+        url = reverse('api-v4:search:company-autocomplete')
 
         response = self.api_client.get(url, data={'term': query})
 
@@ -759,7 +759,7 @@ class TestAutocompleteSearch(APITestMixin):
     )
     def test_searching_with_limit(self, setup_data, limit, expected_companies):
         """Tests case where search limit is provided."""
-        url = reverse('api-v4:search:company-autocomplete-search')
+        url = reverse('api-v4:search:company-autocomplete')
 
         response = self.api_client.get(
             url,
@@ -788,7 +788,7 @@ class TestAutocompleteSearch(APITestMixin):
         permitted and a datahub exception error is raised.
         """
         mock_get_app_permission_filters.return_value = True
-        url = reverse('api-v4:search:company-autocomplete-search')
+        url = reverse('api-v4:search:company-autocomplete')
         with pytest.raises(DataHubException) as expected_error:
             self.api_client.get(url, data={'term': 'query'})
         assert (

--- a/datahub/search/company/test/test_signals.py
+++ b/datahub/search/company/test/test_signals.py
@@ -15,7 +15,7 @@ def test_company_auto_sync_to_es(setup_es):
     )
     setup_es.indices.refresh()
 
-    result = get_basic_search_query(test_name, entities=(Company,)).execute()
+    result = get_basic_search_query(Company, test_name).execute()
 
     assert result.hits.total == 1
 
@@ -31,7 +31,7 @@ def test_company_auto_updates_to_es(setup_es):
     company.save()
     setup_es.indices.refresh()
 
-    result = get_basic_search_query(new_test_name, entities=(Company,)).execute()
+    result = get_basic_search_query(Company, new_test_name).execute()
 
     assert result.hits.total == 1
     assert result.hits[0].id == str(company.id)

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -65,8 +65,13 @@ class SearchCompanyAPIViewMixin:
     }
 
 
-class SearchCompanyAPIView(SearchCompanyAPIViewMixin, SearchAPIView):
-    """Filtered company search view."""
+class SearchCompanyAPIViewV3(SearchCompanyAPIViewMixin, SearchAPIView):
+    """Filtered company search view V3."""
+
+    fields_to_exclude = (
+        'address',
+        'registered_address',
+    )
 
 
 class SearchCompanyExportAPIView(SearchCompanyAPIViewMixin, SearchExportAPIView):

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -74,6 +74,27 @@ class SearchCompanyAPIViewV3(SearchCompanyAPIViewMixin, SearchAPIView):
     )
 
 
+class SearchCompanyAPIViewV4(SearchCompanyAPIViewMixin, SearchAPIView):
+    """Filtered company search view V4."""
+
+    # TODO: delete once the migration to v4 is complete
+    fields_to_exclude = (
+        'companies_house_data',
+        'trading_address_1',
+        'trading_address_2',
+        'trading_address_town',
+        'trading_address_county',
+        'trading_address_country',
+        'trading_address_postcode',
+        'registered_address_1',
+        'registered_address_2',
+        'registered_address_town',
+        'registered_address_county',
+        'registered_address_country',
+        'registered_address_postcode',
+    )
+
+
 class SearchCompanyExportAPIView(SearchCompanyAPIViewMixin, SearchExportAPIView):
     """Company search export view."""
 
@@ -114,11 +135,11 @@ class SearchCompanyExportAPIView(SearchCompanyAPIViewMixin, SearchExportAPIView)
     }
 
 
-class CompanyAutocompleteSearchListAPIView(
+class CompanyAutocompleteSearchListAPIViewV3(
     SearchCompanyAPIViewMixin,
     AutocompleteSearchListAPIView,
 ):
-    """Company autocomplete search view."""
+    """Company autocomplete search view V3."""
 
     document_fields = [
         'id',
@@ -136,4 +157,19 @@ class CompanyAutocompleteSearchListAPIView(
         'registered_address_county',
         'registered_address_country',
         'registered_address_postcode',
+    ]
+
+
+class CompanyAutocompleteSearchListAPIViewV4(
+    SearchCompanyAPIViewMixin,
+    AutocompleteSearchListAPIView,
+):
+    """Company autocomplete search view V4."""
+
+    document_fields = [
+        'id',
+        'name',
+        'trading_names',
+        'address',
+        'registered_address',
     ]

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -240,7 +240,7 @@ def test_mapping(setup_es):
 
 def test_get_basic_search_query():
     """Tests basic search query."""
-    query = get_basic_search_query('test', entities=(ESContact,), offset=5, limit=5)
+    query = get_basic_search_query(ESContact, 'test', offset=5, limit=5)
 
     assert query.to_dict() == {
         'query': {

--- a/datahub/search/contact/test/test_signals.py
+++ b/datahub/search/contact/test/test_signals.py
@@ -15,7 +15,7 @@ def test_contact_auto_sync_to_es(setup_es):
     )
     setup_es.indices.refresh()
 
-    result = get_basic_search_query(test_name, entities=(Contact,)).execute()
+    result = get_basic_search_query(Contact, test_name).execute()
 
     assert result.hits.total == 1
 
@@ -33,7 +33,7 @@ def test_contact_auto_updates_to_es(setup_es):
     contact.save()
     setup_es.indices.refresh()
 
-    result = get_basic_search_query(new_test_name, entities=(Contact,)).execute()
+    result = get_basic_search_query(Contact, new_test_name).execute()
 
     assert result.hits.total == 1
     assert result.hits[0].id == str(contact.id)

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -687,7 +687,7 @@ def test_mapping(setup_es):
 def test_get_basic_search_query():
     """Tests basic search query."""
     query = get_basic_search_query(
-        'test', entities=(ESInvestmentProject,), offset=5, limit=5,
+        ESInvestmentProject, 'test', offset=5, limit=5,
     )
 
     assert query.to_dict() == {

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -25,18 +25,16 @@ class MatchNone(Query):
 
 
 def get_basic_search_query(
+        entity,
         term,
-        entities=None,
         permission_filters_by_entity=None,
         ordering=None,
         offset=0,
         limit=100,
 ):
-    """Performs basic search looking for name and then SEARCH_FIELDS in entity.
-
-    Also returns number of results in other entities.
-
-    TODO: entities should be a positional argument and a single ES model instead of a sequence
+    """
+    Performs basic search for the given term in the given entity using the SEARCH_FIELDS.
+    It also returns number of results in other entities.
 
     :param permission_filters_by_entity: List of pairs of entities and corresponding permission
                                          filters. Only entities in this list are included in the
@@ -60,10 +58,10 @@ def get_basic_search_query(
     if permission_query:
         search = search.filter(permission_query)
 
-    entity_type_subqueries = [Term(_type=entity._doc_type.name) for entity in entities]
-
     search = search.post_filter(
-        Bool(should=entity_type_subqueries),
+        Bool(
+            should=Term(_type=entity._doc_type.name),
+        ),
     )
     search = _apply_sorting_to_query(search, ordering)
     search.aggs.bucket(
@@ -84,7 +82,7 @@ def get_search_by_entity_query(
         fields_to_exclude=None,
 ):
     """
-    Performs filtered search for given terms in given entity.
+    Performs filtered search for the given term in the given entity.
     """
     filter_data = filter_data or {}
     query = [Term(_type=entity._doc_type.name)]

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -214,7 +214,7 @@ def test_build_term_query(term, expected):
 def test_offset_near_max_results(offset, limit, expected_size):
     """Tests limit clipping when near max_results."""
     query = get_basic_search_query(
-        'test', entities=(mock.Mock(),), offset=offset, limit=limit,
+        mock.Mock(), 'test', offset=offset, limit=limit,
     )
 
     query_dict = query.to_dict()

--- a/datahub/search/urls.py
+++ b/datahub/search/urls.py
@@ -5,29 +5,58 @@ from django.urls import path
 from datahub.search.apps import get_search_apps
 from datahub.search.views import SearchBasicAPIView
 
+# API V3
 
-urlpatterns = [
+urls_v3 = [
     path('search', SearchBasicAPIView.as_view(), name='basic'),
 ]
 
 for search_app in get_search_apps():
     if search_app.view:
-        urlpatterns.append(path(
+        urls_v3.append(path(
             f'search/{search_app.name}',
             search_app.view.as_view(search_app=search_app),
             name=search_app.name,
         ))
 
     if search_app.export_view:
-        urlpatterns.append(path(
+        urls_v3.append(path(
             f'search/{search_app.name}/export',
             search_app.export_view.as_view(search_app=search_app),
             name=f'{search_app.name}-export',
         ))
 
     if search_app.autocomplete_view:
-        urlpatterns.append(path(
+        urls_v3.append(path(
             f'search/{search_app.name}/autocomplete',
             search_app.autocomplete_view.as_view(search_app=search_app),
+            name=f'{search_app.name}-autocomplete-search',
+        ))
+
+
+# API V4 - new format for addresses
+
+# TODO add global search when all search apps are v4 ready
+urls_v4 = []
+
+for search_app in get_search_apps():
+    if search_app.view_v4:
+        urls_v4.append(path(
+            f'search/{search_app.name}',
+            search_app.view_v4.as_view(search_app=search_app),
+            name=search_app.name,
+        ))
+
+    if search_app.export_view_v4:
+        urls_v4.append(path(
+            f'search/{search_app.name}/export',
+            search_app.export_view_v4.as_view(search_app=search_app),
+            name=f'{search_app.name}-export',
+        ))
+
+    if search_app.autocomplete_view_v4:
+        urls_v4.append(path(
+            f'search/{search_app.name}/autocomplete',
+            search_app.autocomplete_view_v4.as_view(search_app=search_app),
             name=f'{search_app.name}-autocomplete-search',
         ))

--- a/datahub/search/urls.py
+++ b/datahub/search/urls.py
@@ -5,6 +5,28 @@ from django.urls import path
 from datahub.search.apps import get_search_apps
 from datahub.search.views import SearchBasicAPIView
 
+
+def _construct_path(search_app, view, suffix=None):
+    if not view:
+        return []
+
+    url = f'search/{search_app.name}'
+    if suffix:
+        url = f'{url}/{suffix}'
+
+    url_name = search_app.name
+    if suffix:
+        url_name = f'{url_name}-{suffix}'
+
+    return [
+        path(
+            url,
+            view.as_view(search_app=search_app),
+            name=url_name,
+        ),
+    ]
+
+
 # API V3
 
 urls_v3 = [
@@ -12,26 +34,21 @@ urls_v3 = [
 ]
 
 for search_app in get_search_apps():
-    if search_app.view:
-        urls_v3.append(path(
-            f'search/{search_app.name}',
-            search_app.view.as_view(search_app=search_app),
-            name=search_app.name,
-        ))
-
-    if search_app.export_view:
-        urls_v3.append(path(
-            f'search/{search_app.name}/export',
-            search_app.export_view.as_view(search_app=search_app),
-            name=f'{search_app.name}-export',
-        ))
-
-    if search_app.autocomplete_view:
-        urls_v3.append(path(
-            f'search/{search_app.name}/autocomplete',
-            search_app.autocomplete_view.as_view(search_app=search_app),
-            name=f'{search_app.name}-autocomplete-search',
-        ))
+    urls_v3.extend(
+        [
+            *_construct_path(search_app, search_app.view),
+            *_construct_path(
+                search_app,
+                search_app.export_view,
+                'export',
+            ),
+            *_construct_path(
+                search_app,
+                search_app.autocomplete_view,
+                'autocomplete',
+            ),
+        ],
+    )
 
 
 # API V4 - new format for addresses
@@ -40,23 +57,18 @@ for search_app in get_search_apps():
 urls_v4 = []
 
 for search_app in get_search_apps():
-    if search_app.view_v4:
-        urls_v4.append(path(
-            f'search/{search_app.name}',
-            search_app.view_v4.as_view(search_app=search_app),
-            name=search_app.name,
-        ))
-
-    if search_app.export_view_v4:
-        urls_v4.append(path(
-            f'search/{search_app.name}/export',
-            search_app.export_view_v4.as_view(search_app=search_app),
-            name=f'{search_app.name}-export',
-        ))
-
-    if search_app.autocomplete_view_v4:
-        urls_v4.append(path(
-            f'search/{search_app.name}/autocomplete',
-            search_app.autocomplete_view_v4.as_view(search_app=search_app),
-            name=f'{search_app.name}-autocomplete-search',
-        ))
+    urls_v4.extend(
+        [
+            *_construct_path(search_app, search_app.view_v4),
+            *_construct_path(
+                search_app,
+                search_app.export_view_v4,
+                'export',
+            ),
+            *_construct_path(
+                search_app,
+                search_app.autocomplete_view_v4,
+                'autocomplete',
+            ),
+        ],
+    )

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -56,8 +56,8 @@ class SearchBasicAPIView(APIView):
         ordering = _map_es_ordering(validated_params['sortby'], self.es_sort_by_remappings)
 
         query = get_basic_search_query(
+            entity=validated_params['entity'],
             term=validated_params['term'],
-            entities=(validated_params['entity'],),
             permission_filters_by_entity=dict(_get_permission_filters(request)),
             ordering=ordering,
             offset=validated_params['offset'],


### PR DESCRIPTION
### Description of change

This adds v4 of the following endpoints:
- `/v4/search/company`
- `/v4/search/company/autocomplete`
- `/v4/search/company/export`

with nested object for addresses.
Also, `the trading_address_*` fields were removed and replaced by the nested object `address`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
