### PR TITLE
Update various dependencies

### DIFF
--- a/changelog/update-deps.internal.rst
+++ b/changelog/update-deps.internal.rst
@@ -1,0 +1,1 @@
+Various dependencies were updated.

--- a/datahub/activity_stream/test/test_activity_stream_views.py
+++ b/datahub/activity_stream/test/test_activity_stream_views.py
@@ -290,7 +290,7 @@ def test_empty_object_returned_with_authentication(api_client):
     )
     with pytest.raises(mohawk.exc.MacMismatch):
         sender.accept_response(
-            response_header=response['Server-Authorization'] + 'incorrect',
+            response_header='Hawk mac="incorrect", hash="incorrect"',
             content=response.content,
             content_type=response['Content-Type'],
         )

--- a/datahub/omis/quote/test/views/test_quote_details.py
+++ b/datahub/omis/quote/test/views/test_quote_details.py
@@ -134,12 +134,12 @@ class TestCreatePreviewOrder(APITestMixin):
 
     @freeze_time('2017-04-18 13:00:00.000000')
     @pytest.mark.parametrize(
-        'OrderFactoryClass',  # noqa: N803
+        'order_factory',
         (OrderFactory, OrderWithCancelledQuoteFactory),
     )
-    def test_create_success(self, OrderFactoryClass):
+    def test_create_success(self, order_factory):
         """Test a successful call to create a quote."""
-        order = OrderFactoryClass(
+        order = order_factory(
             delivery_date=dateutil_parse('2017-06-18').date(),
         )
         orig_quote = order.quote
@@ -190,15 +190,15 @@ class TestCreatePreviewOrder(APITestMixin):
 
     @freeze_time('2017-04-18 13:00:00.000000')
     @pytest.mark.parametrize(
-        'OrderFactoryClass',  # noqa: N803
+        'order_factory',
         (OrderFactory, OrderWithCancelledQuoteFactory),
     )
-    def test_preview_success(self, OrderFactoryClass):
+    def test_preview_success(self, order_factory):
         """
         Test a successful call to preview a quote.
         Changes are not saved in the db.
         """
-        order = OrderFactoryClass(
+        order = order_factory(
             delivery_date=dateutil_parse('2017-06-18').date(),
         )
         orig_quote = order.quote

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -451,7 +451,7 @@ def test_mapping(setup_es):
 
 
 @pytest.mark.parametrize(
-    'Factory',  # noqa: N803
+    'order_factory',
     (
         OrderFactory,
         OrderWithAcceptedQuoteFactory,
@@ -460,9 +460,9 @@ def test_mapping(setup_es):
         OrderPaidFactory,
     ),
 )
-def test_indexed_doc(Factory, setup_es):
+def test_indexed_doc(order_factory, setup_es):
     """Test the ES data of an indexed order."""
-    order = Factory()
+    order = order_factory()
     invoice = order.invoice
 
     doc = ESOrder.es_document(order)

--- a/datahub/search/omis/test/test_models.py
+++ b/datahub/search/omis/test/test_models.py
@@ -15,7 +15,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(
-    'Factory',  # noqa: N803
+    'order_factory',
     (
         OrderCancelledFactory,
         OrderCompleteFactory,
@@ -24,9 +24,9 @@ pytestmark = pytest.mark.django_db
         OrderWithAcceptedQuoteFactory,
     ),
 )
-def test_order_to_dict(Factory):
+def test_order_to_dict(order_factory):
     """Test converting an order to dict."""
-    order = Factory()
+    order = order_factory()
 
     invoice = order.invoice
     OrderSubscriberFactory.create_batch(2, order=order)

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 # For CH Sync
-lxml==4.3.0
+lxml==4.3.1
 cssselect==1.0.3
 
 # Django and django related
@@ -19,15 +19,15 @@ whitenoise==4.1.2
 
 chardet==3.0.4
 pyyaml==3.13
-python-dateutil==2.7.5
+python-dateutil==2.8.0
 
 # Persistency layer
 psycopg2==2.7.7
 psycogreen==1.0.1
 
-boto3==1.9.86
+boto3==1.9.95
 
-notifications-python-client==5.2.0
+notifications-python-client==5.3.0
 
 # REDIS
 django-redis==4.10.0
@@ -43,7 +43,7 @@ celery==4.2.1
 billiard==3.5.0.4  # pinned due to https://github.com/celery/billiard/issues/260
 
 # Testing and dev
-pytest==4.2.0
+pytest==4.2.1
 pytest-django==3.4.7
 pytest-sugar==0.9.2
 pytest-cov==2.6.1
@@ -57,10 +57,10 @@ django-debug-toolbar==1.11
 werkzeug==0.14.1  # Required by runserver_plus - useful for local dev
 pip-tools==3.3.2
 piprot==0.9.10
-towncrier==18.6.0
+towncrier==19.2.0
 
 # Code static analysis
-flake8==3.7.4
+flake8==3.7.5
 flake8-blind-except==0.1.1
 flake8-commas==2.0.0
 flake8-debugger==3.1.0

--- a/requirements.in
+++ b/requirements.in
@@ -69,7 +69,7 @@ flake8-docstrings==1.3.0
 flake8-print==3.1.0
 flake8-quotes==1.0.0
 flake8-string-format==0.2.3
-pep8-naming==0.7.0
+pep8-naming==0.8.2
 pydocstyle==2.1.1
 
 gunicorn==19.9.0

--- a/requirements.in
+++ b/requirements.in
@@ -74,7 +74,7 @@ pydocstyle==2.1.1
 
 gunicorn==19.9.0
 gevent==1.4.0
-mohawk==0.3.4
+mohawk==1.0.0
 raven==6.10.0
 requests==2.21.0
 requests_toolbelt==0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ attrs==18.2.0             # via pytest
 aws-requests-auth==0.4.2
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4
-boto3==1.9.86
-botocore==1.12.86         # via boto3, s3transfer
+boto3==1.9.95
+botocore==1.12.95         # via boto3, s3transfer
 celery==4.2.1
 certifi==2018.11.29       # via requests
 chardet==3.0.4
@@ -26,7 +26,7 @@ django-environ==0.4.5
 django-extensions==2.1.5
 django-filter==2.1.0
 django-ipware==2.1.0      # via django-admin-ip-restrictor
-django-js-asset==1.1.0    # via django-mptt
+django-js-asset==1.2.1    # via django-mptt
 django-model-utils==3.1.2
 django-mptt==0.9.1
 django-oauth-toolkit==1.2.0
@@ -52,7 +52,7 @@ flake8-polyfill==1.0.2    # via flake8-docstrings, pep8-naming
 flake8-print==3.1.0
 flake8-quotes==1.0.0
 flake8-string-format==0.2.3
-flake8==3.7.4
+flake8==3.7.5
 freezegun==0.3.11
 future==0.17.1            # via notifications-python-client
 gevent==1.4.0
@@ -66,17 +66,17 @@ ipython==7.2.0
 jedi==0.13.2              # via ipython
 jinja2==2.10              # via towncrier
 jmespath==0.9.3           # via boto3, botocore, jmespath
-kombu==4.2.2.post1        # via celery
-lxml==4.3.0
+kombu==4.3.0              # via celery
+lxml==4.3.1
 markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via flake8, mccabe
 mohawk==0.3.4
 monotonic==1.5            # via notifications-python-client
-more-itertools==5.0.0     # via pytest
-notifications-python-client==5.2.0
+more-itertools==6.0.0     # via pytest
+notifications-python-client==5.3.0
 oauthlib==2.1.0
 packaging==19.0           # via pytest-sugar
-parso==0.3.2              # via jedi
+parso==0.3.4              # via jedi
 pep8-naming==0.7.0
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
@@ -96,11 +96,11 @@ pyjwt==1.7.1              # via notifications-python-client
 pyparsing==2.3.1          # via packaging
 pytest-cov==2.6.1
 pytest-django==3.4.7
-pytest-forked==1.0.1      # via pytest-xdist
+pytest-forked==1.0.2      # via pytest-xdist
 pytest-sugar==0.9.2
 pytest-xdist==1.26.1
-pytest==4.2.0
-python-dateutil==2.7.5
+pytest==4.2.1
+python-dateutil==2.8.0
 pytz==2018.9              # via celery, django
 pyyaml==3.13
 raven==6.10.0
@@ -109,14 +109,14 @@ requests-futures==0.9.9   # via piprot
 requests-mock==1.5.2
 requests==2.21.0
 requests_toolbelt==0.9.1
-s3transfer==0.1.13        # via boto3
-six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mohawk, more-itertools, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest, pytest-xdist, python-dateutil, requests-mock, traitlets
+s3transfer==0.2.0         # via boto3
+six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mohawk, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest, pytest-xdist, python-dateutil, requests-mock, traitlets
 snowballstemmer==1.2.1    # via pydocstyle, snowballstemmer
 sqlparse==0.2.4           # via django-debug-toolbar, sqlparse
 termcolor==1.1.0          # via pytest-sugar, termcolor
 text-unidecode==1.2       # via faker
 toml==0.10.0              # via towncrier
-towncrier==18.6.0
+towncrier==19.2.0
 traitlets==4.3.2          # via ipython, traitlets
 urllib3==1.24.1           # via botocore, elasticsearch, requests
 vine==1.2.0               # via amqp

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ kombu==4.3.0              # via celery
 lxml==4.3.1
 markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via flake8, mccabe
-mohawk==0.3.4
+mohawk==1.0.0
 monotonic==1.5            # via notifications-python-client
 more-itertools==6.0.0     # via pytest
 notifications-python-client==5.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ notifications-python-client==5.3.0
 oauthlib==2.1.0
 packaging==19.0           # via pytest-sugar
 parso==0.3.4              # via jedi
-pep8-naming==0.7.0
+pep8-naming==0.8.2
 pexpect==4.6.0            # via ipython
 pickleshare==0.7.5        # via ipython
 pip-tools==3.3.2


### PR DESCRIPTION
### Description of change

This updates various dependencies. Change logs:

- https://github.com/lxml/lxml/blob/master/CHANGES.txt
- https://github.com/dateutil/dateutil/blob/master/NEWS
- https://github.com/boto/boto3/blob/develop/CHANGELOG.rst
- https://github.com/alphagov/notifications-python-client/blob/master/CHANGELOG.md
- https://github.com/hawkowl/towncrier/blob/master/NEWS.rst
- https://flake8.readthedocs.io/en/latest/release-notes/index.html
- https://mohawk.readthedocs.io/en/latest/
- https://github.com/PyCQA/pep8-naming/blob/master/CHANGELOG.rst

pep8-naming was detecting N803 in additional places, so I renamed the function arguments that were causing it.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
