### PR TITLE
Deprecate contacts property in company search results

### DIFF
--- a/changelog/company/company-search-contacts.removal.rst
+++ b/changelog/company/company-search-contacts.removal.rst
@@ -1,0 +1,5 @@
+The ``contacts`` field in company search results is deprecated and will be removed on or after 28 February 2019 from the following endpoints:
+
+- ``/v3/search``
+- ``/v3/search/company``
+- ``/v4/search/company``


### PR DESCRIPTION
### Description of change

This deprecates the ``contacts`` field in company search results (in the ``/v3/search`` and ``/v4/search/company`` endpoints).

(I have left out ``/v3/search/company`` as that is being removed anyway.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
