### PR TITLE
Index countries in company address and registered address

### DIFF
--- a/changelog/company/index-countries.internal
+++ b/changelog/company/index-countries.internal
@@ -1,0 +1,1 @@
+``company.address_country_id`` and ``company.registered_address_country_id`` are now indexed in ElasticSearch so that they can be used when filtering down results.

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -200,7 +200,7 @@ def test_mapping(setup_es):
                         'country': {
                             'type': 'object',
                             'properties': {
-                                'id': {'index': False, 'type': 'keyword'},
+                                'id': {'type': 'keyword'},
                                 'name': {
                                     'type': 'text',
                                     'fields': {
@@ -233,7 +233,7 @@ def test_mapping(setup_es):
                         'country': {
                             'type': 'object',
                             'properties': {
-                                'id': {'index': False, 'type': 'keyword'},
+                                'id': {'type': 'keyword'},
                                 'name': {
                                     'type': 'text',
                                     'fields': {

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -98,7 +98,7 @@ def address_field():
             ),
             'country': Object(
                 properties={
-                    'id': Keyword(index=False),
+                    'id': Keyword(),
                     'name': Text(
                         fields={
                             'trigram': TrigramText(),


### PR DESCRIPTION
### Description of change

This indexes `company.address_country_id` and `company.registered_address_country_id` so that they can be used when filtering down results.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
