### PR TITLE
Add overseas region to country API endpoint

### DIFF
--- a/changelog/overseas-region-in-country-endpoint.api.rst
+++ b/changelog/overseas-region-in-country-endpoint.api.rst
@@ -1,0 +1,2 @@
+``/metadata/country/``: ``overseas_region`` was added to each country in responses. For non-UK countries, this is an object
+containing the the ID and name of the DIT overseas region the country belongs to.

--- a/datahub/metadata/metadata.py
+++ b/datahub/metadata/metadata.py
@@ -3,6 +3,7 @@ from datahub.metadata.filters import ServiceFilterSet
 from datahub.metadata.registry import registry
 from datahub.metadata.serializers import (
     AdministrativeAreaSerializer,
+    CountrySerializer,
     InvestmentProjectStageSerializer,
     SectorSerializer,
     ServiceSerializer,
@@ -18,7 +19,14 @@ registry.register(
     serializer=AdministrativeAreaSerializer,
 )
 registry.register(metadata_id='business-type', model=models.BusinessType)
-registry.register(metadata_id='country', model=models.Country)
+registry.register(
+    metadata_id='country',
+    model=models.Country,
+    queryset=models.Country.objects.select_related(
+        'overseas_region',
+    ),
+    serializer=CountrySerializer,
+)
 registry.register(metadata_id='employee-range', model=models.EmployeeRange)
 registry.register(metadata_id='overseas-region', model=models.OverseasRegion)
 registry.register(

--- a/datahub/metadata/serializers.py
+++ b/datahub/metadata/serializers.py
@@ -3,8 +3,7 @@ from functools import partial
 from rest_framework import serializers
 
 from datahub.core.serializers import ConstantModelSerializer, NestedRelatedField
-from datahub.metadata.models import Country, Service, TeamRole, UKRegion
-
+from datahub.metadata.models import Country, OverseasRegion, Service, TeamRole, UKRegion
 
 TeamWithGeographyField = partial(
     NestedRelatedField,
@@ -21,6 +20,12 @@ class AdministrativeAreaSerializer(ConstantModelSerializer):
     """Administrative area serializer."""
 
     country = NestedRelatedField(Country, read_only=True)
+
+
+class CountrySerializer(ConstantModelSerializer):
+    """Country serializer."""
+
+    overseas_region = NestedRelatedField(OverseasRegion, read_only=True)
 
 
 class ServiceSerializer(ConstantModelSerializer):

--- a/datahub/metadata/test/test_views.py
+++ b/datahub/metadata/test/test_views.py
@@ -9,7 +9,7 @@ from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import format_date_or_datetime
 from datahub.metadata import urls
-from datahub.metadata.models import AdministrativeArea, Sector, Service
+from datahub.metadata.models import AdministrativeArea, Country, Sector, Service
 from datahub.metadata.registry import registry
 from datahub.metadata.test.factories import ServiceFactory
 
@@ -115,6 +115,33 @@ def test_administrative_area_view(api_client):
             'name': administrative_area.country.name,
         },
         'disabled_on': format_date_or_datetime(administrative_area.disabled_on),
+    }
+
+
+def test_country_view(api_client):
+    """Test that the country view includes the country field."""
+    country = Country.objects.filter(
+        overseas_region__isnull=False,
+    ).order_by(
+        'name',
+    ).first()
+
+    url = reverse(viewname='country')
+    response = api_client.get(url)
+
+    assert response.status_code == status.HTTP_200_OK
+    first_result_with_overseas_region = next(
+        result for result in response.json()
+        if result['overseas_region'] is not None
+    )
+    assert first_result_with_overseas_region == {
+        'id': str(country.pk),
+        'name': country.name,
+        'overseas_region': {
+            'id': str(country.overseas_region.pk),
+            'name': country.overseas_region.name,
+        },
+        'disabled_on': format_date_or_datetime(country.disabled_on),
     }
 
 


### PR DESCRIPTION
### Description of change

This adds ``overseas_region`` to items returned by the ``metadata/country/`` API endpoint.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
