### PR TITLE
Company addresses in search logic

### DIFF
--- a/changelog/company/company-addresses-search.internal
+++ b/changelog/company/company-addresses-search.internal
@@ -1,0 +1,1 @@
+The search logic is now using company address and registered address instead of trading address behind the scenes.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -274,14 +274,6 @@ class Company(ArchivableModel, BaseModel):
             except CompaniesHouseCompany.DoesNotExist:
                 return None
 
-    def has_valid_trading_address(self):
-        """Tells if Company has all required trading address fields defined."""
-        field_mapping = self.TRADING_ADDRESS_VALIDATION_MAPPING
-
-        return all(
-            getattr(self, field) for field, rules in field_mapping.items() if rules['required']
-        )
-
     def mark_as_transferred(self, to, reason, user):
         """
         Marks a company record as having been transferred to another company record.

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from decimal import Decimal
 from operator import attrgetter
 from secrets import token_hex
+from unittest import mock
 
 import factory
 import pytest
@@ -346,3 +347,13 @@ def _format_csv_value(value):
     if isinstance(value, datetime):
         return value.strftime('%Y-%m-%d %H:%M:%S')
     return str(value)
+
+
+def construct_mock(**props):
+    """
+    Same as mock.Mock() but using configure_mock as
+    name collides with the kwarg in the Mock constructor.
+    """
+    obj = mock.Mock(spec_set=tuple(props))
+    obj.configure_mock(**props)
+    return obj

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -154,12 +154,10 @@ class Company(BaseESModel):
         'trading_names_trigram',
         'reference_code',
 
-        # TODO: replace with nested address and registered address
-        # once the index data has been populated
-        'registered_address_country.name_trigram',
-        'registered_address_postcode_trigram',
-        'trading_address_country.name_trigram',
-        'trading_address_postcode_trigram',
+        'address.country.name.trigram',
+        'address.postcode.trigram',
+        'registered_address.country.name.trigram',
+        'registered_address.postcode.trigram',
     )
 
     class Meta:

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -387,6 +387,8 @@ def test_get_basic_search_query():
                         'multi_match': {
                             'query': 'test',
                             'fields': [
+                                'address.country.name.trigram',
+                                'address.postcode.trigram',
                                 'address_country.name_trigram',
                                 'address_postcode_trigram',
                                 'company.name',
@@ -413,8 +415,8 @@ def test_get_basic_search_query():
                                 'project_code_trigram',
                                 'reference_code',
                                 'reference_trigram',
-                                'registered_address_country.name_trigram',
-                                'registered_address_postcode_trigram',
+                                'registered_address.country.name.trigram',
+                                'registered_address.postcode.trigram',
                                 'related_programmes.name',
                                 'related_programmes.name_trigram',
                                 'subject_english',
@@ -422,8 +424,6 @@ def test_get_basic_search_query():
                                 'teams.name',
                                 'teams.name_trigram',
                                 'total_cost_string',
-                                'trading_address_country.name_trigram',
-                                'trading_address_postcode_trigram',
                                 'trading_names',
                                 'trading_names_trigram',
                                 'uk_company.name',
@@ -468,10 +468,10 @@ def test_limited_get_search_by_entity_query():
     """Tests search by entity."""
     date = '2017-06-13T09:44:31.062870'
     filter_data = {
-        'address_town': ['Woodside'],
-        'trading_address_country.id': ['80756b9a-5d95-e211-a939-e4115bead28a'],
-        'estimated_land_date_before': date,
-        'estimated_land_date_after': date,
+        'name': 'Woodside',
+        'address.country.id': ['80756b9a-5d95-e211-a939-e4115bead28a'],
+        'archived_before': date,
+        'archived_after': date,
     }
     query = get_search_by_entity_query(
         ESCompany,
@@ -513,10 +513,10 @@ def test_limited_get_search_by_entity_query():
                                             'trading_names',
                                             'trading_names_trigram',
                                             'reference_code',
-                                            'registered_address_country.name_trigram',
-                                            'registered_address_postcode_trigram',
-                                            'trading_address_country.name_trigram',
-                                            'trading_address_postcode_trigram',
+                                            'address.country.name.trigram',
+                                            'address.postcode.trigram',
+                                            'registered_address.country.name.trigram',
+                                            'registered_address.postcode.trigram',
                                         ),
                                         'type': 'cross_fields',
                                         'operator': 'and',
@@ -531,25 +531,19 @@ def test_limited_get_search_by_entity_query():
                         'bool': {
                             'must': [
                                 {
-                                    'bool': {
-                                        'should': [
-                                            {
-                                                'match': {
-                                                    'address_town': {
-                                                        'query': 'Woodside',
-                                                        'operator': 'and',
-                                                    },
-                                                },
-                                            },
-                                        ],
-                                        'minimum_should_match': 1,
+                                    'match': {
+                                        'name': {
+                                            'query': 'Woodside',
+                                            'operator': 'and',
+                                        },
                                     },
-                                }, {
+                                },
+                                {
                                     'bool': {
                                         'should': [
                                             {
                                                 'match': {
-                                                    'trading_address_country.id': {
+                                                    'address.country.id': {
                                                         'query':
                                                             '80756b9a-5d95-e211-a939-e4115bead28a',
                                                         'operator': 'and',
@@ -561,7 +555,7 @@ def test_limited_get_search_by_entity_query():
                                     },
                                 }, {
                                     'range': {
-                                        'estimated_land_date': {
+                                        'archived': {
                                             'lte': '2017-06-13T09:44:31.062870',
                                             'gte': '2017-06-13T09:44:31.062870',
                                         },

--- a/datahub/search/company/test/test_entity_search_views_v3.py
+++ b/datahub/search/company/test/test_entity_search_views_v3.py
@@ -45,19 +45,18 @@ def setup_data(setup_es):
     CompanyFactory(
         name='abc defg ltd',
         trading_names=['helm', 'nop'],
-        trading_address_1='1 Fake Lane',
-        trading_address_town='Downtown',
-        trading_address_country_id=country_uk,
+        address_1='1 Fake Lane',
+        address_town='Downtown',
+        address_country_id=country_uk,
         uk_region_id=uk_region,
     )
     CompanyFactory(
         name='abc defg us ltd',
         trading_names=['helm', 'nop', 'qrs'],
-        trading_address_1='1 Fake Lane',
-        trading_address_town='Downtown',
-        trading_address_country_id=country_us,
-        registered_address_country_id=country_us,
+        address_1='1 Fake Lane',
+        address_town='Downtown',
         address_country_id=country_us,
+        registered_address_country_id=country_us,
     )
     setup_es.indices.refresh()
 
@@ -386,7 +385,7 @@ class TestSearch(APITestMixin):
     def test_composite_country_filter(self, setup_es, country, match):
         """Tests composite country filter."""
         company = CompanyFactory(
-            trading_address_country_id=constants.Country.cayman_islands.value.id,
+            address_country_id=constants.Country.cayman_islands.value.id,
             registered_address_country_id=constants.Country.montserrat.value.id,
         )
         setup_es.indices.refresh()

--- a/datahub/search/company/test/test_entity_search_views_v4.py
+++ b/datahub/search/company/test/test_entity_search_views_v4.py
@@ -41,30 +41,27 @@ def setup_data(setup_es):
     CompanyFactory(
         name='abc defg ltd',
         trading_names=['helm', 'nop'],
-        trading_address_1='1 Fake Lane',
-        trading_address_town='Downtown',
-        trading_address_country_id=country_uk,
-        registered_address_country_id=country_uk,
+        address_1='1 Fake Lane',
+        address_town='Downtown',
         address_country_id=country_uk,
+        registered_address_country_id=country_uk,
         uk_region_id=uk_region,
     )
     CompanyFactory(
         name='abc defg us ltd',
         trading_names=['helm', 'nop', 'qrs'],
-        trading_address_1='1 Fake Lane',
-        trading_address_town='Downtown',
-        trading_address_country_id=country_us,
-        registered_address_country_id=country_us,
+        address_1='1 Fake Lane',
+        address_town='Downtown',
         address_country_id=country_us,
+        registered_address_country_id=country_us,
     )
     CompanyFactory(
         name='archived',
         trading_names=[],
-        trading_address_1='Main Lane',
-        trading_address_town='Somewhere',
-        trading_address_country_id=country_anguilla,
-        registered_address_country_id=country_anguilla,
+        address_1='Main Lane',
+        address_town='Somewhere',
         address_country_id=country_anguilla,
+        registered_address_country_id=country_anguilla,
         archived=True,
     )
     setup_es.indices.refresh()
@@ -410,7 +407,7 @@ class TestSearch(APITestMixin):
     def test_composite_country_filter(self, setup_es, country, match):
         """Tests composite country filter."""
         company = CompanyFactory(
-            trading_address_country_id=constants.Country.cayman_islands.value.id,
+            address_country_id=constants.Country.cayman_islands.value.id,
             registered_address_country_id=constants.Country.montserrat.value.id,
         )
         setup_es.indices.refresh()
@@ -673,8 +670,8 @@ class TestAutocompleteSearch(APITestMixin):
                         'county': company.address_county or '',
                         'postcode': company.address_postcode or '',
                         'country': {
-                            'id': str(company.trading_address_country.id),
-                            'name': company.trading_address_country.name,
+                            'id': str(company.address_country.id),
+                            'name': company.address_country.name,
                         },
                     },
                     'registered_address': {

--- a/datahub/search/company/test/test_entity_search_views_v4.py
+++ b/datahub/search/company/test/test_entity_search_views_v4.py
@@ -138,8 +138,8 @@ class TestSearch(APITestMixin):
                         'county': company.address_county or '',
                         'postcode': company.address_postcode or '',
                         'country': {
-                            'id': str(company.trading_address_country.id),
-                            'name': company.trading_address_country.name,
+                            'id': str(company.address_country.id),
+                            'name': company.address_country.name,
                         },
                     },
                     'registered_address': {

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -43,7 +43,7 @@ class SearchCompanyAPIViewMixin:
         'global_headquarters': 'global_headquarters.id',
         'headquarter_type': 'headquarter_type.id',
         'sector': 'sector.id',
-        'trading_address_country': 'trading_address_country.id',
+        'trading_address_country': 'address.country.id',
         'uk_region': 'uk_region.id',
     }
 
@@ -55,8 +55,8 @@ class SearchCompanyAPIViewMixin:
             'trading_names_trigram',
         ],
         'country': [
-            'trading_address_country.id',
-            'registered_address_country.id',
+            'address.country.id',
+            'registered_address.country.id',
         ],
         'sector_descends': [
             'sector.id',

--- a/datahub/search/contact/dict_utils.py
+++ b/datahub/search/contact/dict_utils.py
@@ -4,19 +4,12 @@ from datahub.search import dict_utils
 def computed_address_field(field):
     """Gets Contact address from Company is address_same_as_company."""
     def get_field(contact):
-        if contact.address_same_as_company:
-            company = contact.company
-            if company.has_valid_trading_address():
-                return getattr(company, f'trading_{field}')
+        obj = contact.company if contact.address_same_as_company else contact
+        value = getattr(obj, field)
 
-            return getattr(company, f'registered_{field}')
+        if field == 'address_country':
+            return dict_utils.id_name_dict(value)
 
-        return getattr(contact, field)
-
-    def get_id_name_field(contact):
-        return dict_utils.id_name_dict(get_field(contact))
-
-    if field == 'address_country':
-        return get_id_name_field
+        return value
 
     return get_field

--- a/datahub/search/contact/test/test_dict_utils.py
+++ b/datahub/search/contact/test/test_dict_utils.py
@@ -1,0 +1,87 @@
+from unittest import mock
+
+import pytest
+
+from datahub.search.contact import dict_utils
+
+
+def _construct_mock(**props):
+    """
+    Same as mock.Mock() but using configure_mock as
+    name collides with the kwarg in the Mock constructor.
+    """
+    obj = mock.Mock(spec_set=tuple(props))
+    obj.configure_mock(**props)
+    return obj
+
+
+@pytest.mark.parametrize(
+    'obj,field_name,expected_output',
+    (
+        # address_same_as_company = False and char field
+        (
+            _construct_mock(
+                address_same_as_company=False,
+                address_1='2',
+            ),
+            'address_1',
+            '2',
+        ),
+
+        # address_same_as_company = False and nested field
+        (
+            _construct_mock(
+                address_same_as_company=False,
+                address_country=_construct_mock(
+                    id='80756b9a-5d95-e211-a939-e4115bead28a',
+                    name='United Kingdom',
+                ),
+            ),
+            'address_country',
+            {
+                'id': '80756b9a-5d95-e211-a939-e4115bead28a',
+                'name': 'United Kingdom',
+            },
+        ),
+
+        # address_same_as_company = True and char field
+        (
+            _construct_mock(
+                address_same_as_company=True,
+                address_1='2',
+                company=_construct_mock(
+                    address_1='3',
+                ),
+            ),
+            'address_1',
+            '3',
+        ),
+
+        # address_same_as_company = True and nested field
+        (
+            _construct_mock(
+                address_same_as_company=True,
+                address_country=_construct_mock(
+                    id='80756b9a-5d95-e211-a939-e4115bead28a',
+                    name='United Kingdom',
+                ),
+                company=_construct_mock(
+                    address_country=_construct_mock(
+                        id='81756b9a-5d95-e211-a939-e4115bead28a',
+                        name='United States',
+                    ),
+                ),
+            ),
+            'address_country',
+            {
+                'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                'name': 'United States',
+            },
+        ),
+    ),
+)
+def test_computed_address_field(obj, field_name, expected_output):
+    """Tests for computed_address_field."""
+    actual_output = dict_utils.computed_address_field(field_name)(obj)
+
+    assert actual_output == expected_output

--- a/datahub/search/contact/test/test_dict_utils.py
+++ b/datahub/search/contact/test/test_dict_utils.py
@@ -1,18 +1,7 @@
-from unittest import mock
-
 import pytest
 
+from datahub.core.test_utils import construct_mock
 from datahub.search.contact import dict_utils
-
-
-def _construct_mock(**props):
-    """
-    Same as mock.Mock() but using configure_mock as
-    name collides with the kwarg in the Mock constructor.
-    """
-    obj = mock.Mock(spec_set=tuple(props))
-    obj.configure_mock(**props)
-    return obj
 
 
 @pytest.mark.parametrize(
@@ -20,7 +9,7 @@ def _construct_mock(**props):
     (
         # address_same_as_company = False and char field
         (
-            _construct_mock(
+            construct_mock(
                 address_same_as_company=False,
                 address_1='2',
             ),
@@ -30,9 +19,9 @@ def _construct_mock(**props):
 
         # address_same_as_company = False and nested field
         (
-            _construct_mock(
+            construct_mock(
                 address_same_as_company=False,
-                address_country=_construct_mock(
+                address_country=construct_mock(
                     id='80756b9a-5d95-e211-a939-e4115bead28a',
                     name='United Kingdom',
                 ),
@@ -46,10 +35,10 @@ def _construct_mock(**props):
 
         # address_same_as_company = True and char field
         (
-            _construct_mock(
+            construct_mock(
                 address_same_as_company=True,
                 address_1='2',
-                company=_construct_mock(
+                company=construct_mock(
                     address_1='3',
                 ),
             ),
@@ -59,14 +48,14 @@ def _construct_mock(**props):
 
         # address_same_as_company = True and nested field
         (
-            _construct_mock(
+            construct_mock(
                 address_same_as_company=True,
-                address_country=_construct_mock(
+                address_country=construct_mock(
                     id='80756b9a-5d95-e211-a939-e4115bead28a',
                     name='United Kingdom',
                 ),
-                company=_construct_mock(
-                    address_country=_construct_mock(
+                company=construct_mock(
+                    address_country=construct_mock(
                         id='81756b9a-5d95-e211-a939-e4115bead28a',
                         name='United States',
                     ),

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -339,10 +339,10 @@ def test_get_limited_search_by_entity_query():
     """Tests search by entity."""
     date = '2017-06-13T09:44:31.062870'
     filter_data = {
-        'address_town': ['Woodside'],
-        'trading_address_country.id': ['80756b9a-5d95-e211-a939-e4115bead28a'],
-        'estimated_land_date_after': date,
-        'estimated_land_date_before': date,
+        'name': 'Woodside',
+        'address_country.id': ['80756b9a-5d95-e211-a939-e4115bead28a'],
+        'archived_before': date,
+        'archived_after': date,
     }
     query = get_search_by_entity_query(
         ESContact,
@@ -398,25 +398,19 @@ def test_get_limited_search_by_entity_query():
                         'bool': {
                             'must': [
                                 {
-                                    'bool': {
-                                        'should': [
-                                            {
-                                                'match': {
-                                                    'address_town': {
-                                                        'query': 'Woodside',
-                                                        'operator': 'and',
-                                                    },
-                                                },
-                                            },
-                                        ],
-                                        'minimum_should_match': 1,
+                                    'match': {
+                                        'name': {
+                                            'query': 'Woodside',
+                                            'operator': 'and',
+                                        },
                                     },
-                                }, {
+                                },
+                                {
                                     'bool': {
                                         'should': [
                                             {
                                                 'match': {
-                                                    'trading_address_country.id': {
+                                                    'address_country.id': {
                                                         'query':
                                                             '80756b9a-5d95-e211-a939-e4115bead28a',
                                                         'operator': 'and',
@@ -428,7 +422,7 @@ def test_get_limited_search_by_entity_query():
                                     },
                                 }, {
                                     'range': {
-                                        'estimated_land_date': {
+                                        'archived': {
                                             'gte': '2017-06-13T09:44:31.062870',
                                             'lte': '2017-06-13T09:44:31.062870',
                                         },

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -258,6 +258,8 @@ def test_get_basic_search_query():
                         'multi_match': {
                             'query': 'test',
                             'fields': [
+                                'address.country.name.trigram',
+                                'address.postcode.trigram',
                                 'address_country.name_trigram',
                                 'address_postcode_trigram',
                                 'company.name',
@@ -284,8 +286,8 @@ def test_get_basic_search_query():
                                 'project_code_trigram',
                                 'reference_code',
                                 'reference_trigram',
-                                'registered_address_country.name_trigram',
-                                'registered_address_postcode_trigram',
+                                'registered_address.country.name.trigram',
+                                'registered_address.postcode.trigram',
                                 'related_programmes.name',
                                 'related_programmes.name_trigram',
                                 'subject_english',
@@ -293,8 +295,6 @@ def test_get_basic_search_query():
                                 'teams.name',
                                 'teams.name_trigram',
                                 'total_cost_string',
-                                'trading_address_country.name_trigram',
-                                'trading_address_postcode_trigram',
                                 'trading_names',
                                 'trading_names_trigram',
                                 'uk_company.name',

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -787,8 +787,7 @@ def test_limited_get_search_by_entity_query():
     """Tests search by entity."""
     date = '2017-06-13T09:44:31.062870'
     filter_data = {
-        'address_town': ['Woodside'],
-        'trading_address_country.id': ['80756b9a-5d95-e211-a939-e4115bead28a'],
+        'investor_company_country.id': ['80756b9a-5d95-e211-a939-e4115bead28a'],
         'estimated_land_date_after': date,
         'estimated_land_date_before': date,
     }
@@ -851,21 +850,7 @@ def test_limited_get_search_by_entity_query():
                                         'should': [
                                             {
                                                 'match': {
-                                                    'address_town': {
-                                                        'query': 'Woodside',
-                                                        'operator': 'and',
-                                                    },
-                                                },
-                                            },
-                                        ],
-                                        'minimum_should_match': 1,
-                                    },
-                                }, {
-                                    'bool': {
-                                        'should': [
-                                            {
-                                                'match': {
-                                                    'trading_address_country.id': {
+                                                    'investor_company_country.id': {
                                                         'query':
                                                             '80756b9a-5d95-e211-a939-e4115bead28a',
                                                         'operator': 'and',

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -706,6 +706,8 @@ def test_get_basic_search_query():
                         'multi_match': {
                             'query': 'test',
                             'fields': [
+                                'address.country.name.trigram',
+                                'address.postcode.trigram',
                                 'address_country.name_trigram',
                                 'address_postcode_trigram',
                                 'company.name',
@@ -732,8 +734,8 @@ def test_get_basic_search_query():
                                 'project_code_trigram',
                                 'reference_code',
                                 'reference_trigram',
-                                'registered_address_country.name_trigram',
-                                'registered_address_postcode_trigram',
+                                'registered_address.country.name.trigram',
+                                'registered_address.postcode.trigram',
                                 'related_programmes.name',
                                 'related_programmes.name_trigram',
                                 'subject_english',
@@ -741,8 +743,6 @@ def test_get_basic_search_query():
                                 'teams.name',
                                 'teams.name_trigram',
                                 'total_cost_string',
-                                'trading_address_country.name_trigram',
-                                'trading_address_postcode_trigram',
                                 'trading_names',
                                 'trading_names_trigram',
                                 'uk_company.name',

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -3,22 +3,13 @@ from unittest import mock
 import pytest
 from pytest import raises
 
+from datahub.core.test_utils import construct_mock
 from datahub.search import dict_utils
-
-
-def _construct_mock(**props):
-    """
-    Same as mock.Mock() but using configure_mock as
-    name collides with the kwarg in the Mock constructor.
-    """
-    obj = mock.Mock(spec_set=tuple(props))
-    obj.configure_mock(**props)
-    return obj
 
 
 def test_id_name_dict():
     """Tests _id_name_dict."""
-    obj = _construct_mock(id=123, name='test')
+    obj = construct_mock(id=123, name='test')
 
     res = dict_utils.id_name_dict(obj)
 
@@ -35,7 +26,7 @@ def test_id_name_list_of_dicts():
         {'id': '99', 'name': 'testing B'},
     ]
     objects = [
-        _construct_mock(**mock_data)
+        construct_mock(**mock_data)
         for mock_data in data
     ]
 
@@ -48,7 +39,7 @@ def test_id_name_list_of_dicts():
 
 def test_id_type_dict():
     """Tests _id_type_dict."""
-    obj = _construct_mock(id=123, type='test')
+    obj = construct_mock(id=123, type='test')
 
     res = dict_utils.id_type_dict(obj)
 
@@ -60,7 +51,7 @@ def test_id_type_dict():
 
 def test_id_uri_dict():
     """Tests id_uri_dict."""
-    obj = _construct_mock(id=123, uri='test')
+    obj = construct_mock(id=123, uri='test')
 
     res = dict_utils.id_uri_dict(obj)
 
@@ -75,7 +66,7 @@ def test_id_uri_dict():
     (
         # complete object
         (
-            _construct_mock(
+            construct_mock(
                 id=123,
                 name='Name',
                 trading_names=['Trading 1', 'Trading 2'],
@@ -89,7 +80,7 @@ def test_id_uri_dict():
 
         # minimal object
         (
-            _construct_mock(
+            construct_mock(
                 id=123,
                 name='Name',
                 trading_names=[],
@@ -120,7 +111,7 @@ def test_company_dict(obj, expected_dict):
     (
         # returns None in case of empty address fields values
         (
-            _construct_mock(
+            construct_mock(
                 address_1='',
                 address_2='',
                 address_town='',
@@ -141,13 +132,13 @@ def test_company_dict(obj, expected_dict):
 
         # all fields converted into a dict
         (
-            _construct_mock(
+            construct_mock(
                 primary_address_1='1',
                 primary_address_2='Main Road',
                 primary_address_town='London',
                 primary_address_county='Greenwich',
                 primary_address_postcode='SE10 9NN',
-                primary_address_country=_construct_mock(
+                primary_address_country=construct_mock(
                     id='80756b9a-5d95-e211-a939-e4115bead28a',
                     name='United Kingdom',
                 ),
@@ -169,13 +160,13 @@ def test_company_dict(obj, expected_dict):
 
         # None values converted to ''
         (
-            _construct_mock(
+            construct_mock(
                 primary_address_1=None,
                 primary_address_2=None,
                 primary_address_town=None,
                 primary_address_county=None,
                 primary_address_postcode=None,
-                primary_address_country=_construct_mock(
+                primary_address_country=construct_mock(
                     id='80756b9a-5d95-e211-a939-e4115bead28a',
                     name='United Kingdom',
                 ),
@@ -207,13 +198,13 @@ def test_address_dict_raises_error_with_invalid_prefix():
     Tests that if address_dict is called with a prefix that
     cannot be found on the object, an AttributeError is raised.
     """
-    obj = _construct_mock(
+    obj = construct_mock(
         primary_address_1='1',
         primary_address_2='Main Road',
         primary_address_town='London',
         primary_address_county='Greenwich',
         primary_address_postcode='SE10 9NN',
-        primary_address_country=_construct_mock(
+        primary_address_country=construct_mock(
             id='80756b9a-5d95-e211-a939-e4115bead28a',
             name='United Kingdom',
         ),
@@ -224,7 +215,7 @@ def test_address_dict_raises_error_with_invalid_prefix():
 
 def test_contact_or_adviser_dict():
     """Tests contact_or_adviser_dict."""
-    obj = _construct_mock(
+    obj = construct_mock(
         id=123,
         first_name='First',
         last_name='Last',
@@ -246,12 +237,12 @@ def test_contact_or_adviser_dict():
     (
         # with dit_team != None
         (
-            _construct_mock(
+            construct_mock(
                 id=123,
                 first_name='First',
                 last_name='Last',
                 name='First Last',
-                dit_team=_construct_mock(
+                dit_team=construct_mock(
                     id=321,
                     name='team name',
                 ),
@@ -270,7 +261,7 @@ def test_contact_or_adviser_dict():
 
         # with dit_team = None
         (
-            _construct_mock(
+            construct_mock(
                 id=123,
                 first_name='First',
                 last_name='Last',
@@ -301,7 +292,7 @@ def test_contact_or_adviser_list_of_dicts():
         {'id': '99', 'first_name': 'first B', 'last_name': 'last B', 'name': 'testing B'},
     ]
     objects = [
-        _construct_mock(**data_item)
+        construct_mock(**data_item)
         for data_item in data
     ]
 
@@ -314,7 +305,7 @@ def test_contact_or_adviser_list_of_dicts():
 
 def test_ch_company_dict():
     """Tests ch_company_dict."""
-    obj = _construct_mock(id=123, company_number='01234567')
+    obj = construct_mock(id=123, company_number='01234567')
 
     res = dict_utils.ch_company_dict(obj)
 
@@ -329,9 +320,9 @@ def test_ch_company_dict():
     (
         # complete object
         (
-            _construct_mock(
-                company=_construct_mock(
-                    sector=_construct_mock(
+            construct_mock(
+                company=construct_mock(
+                    sector=construct_mock(
                         id=123,
                         name='Cats',
                     ),
@@ -345,7 +336,7 @@ def test_ch_company_dict():
 
         # None first level field
         (
-            _construct_mock(
+            construct_mock(
                 company=None,
             ),
             None,
@@ -353,8 +344,8 @@ def test_ch_company_dict():
 
         # None second level field
         (
-            _construct_mock(
-                company=_construct_mock(
+            construct_mock(
+                company=construct_mock(
                     sector=None,
                 ),
             ),

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -73,16 +73,16 @@ def setup_data():
     CompanyFactory(
         name='abc defg ltd',
         trading_names=['abc defg trading ltd'],
-        trading_address_1='1 Fake Lane',
-        trading_address_town='Downtown',
-        trading_address_country_id=country_uk,
+        address_1='1 Fake Lane',
+        address_town='Downtown',
+        address_country_id=country_uk,
     )
     CompanyFactory(
         name='abc defg us ltd',
         trading_names=['abc defg us trading ltd'],
-        trading_address_1='1 Fake Lane',
-        trading_address_town='Downtown',
-        trading_address_country_id=country_us,
+        address_1='1 Fake Lane',
+        address_town='Downtown',
+        address_country_id=country_us,
         registered_address_country_id=country_us,
     )
 


### PR DESCRIPTION
### Description of change

This uses the new company address and registered address in nested object format for the basic and company entity search.

I suggest you look at the individual commits in this PR.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
