### PR TITLE
Remove contacts field from company search results

### DIFF
--- a/changelog/company/company-search-contacts-removal.removal.rst
+++ b/changelog/company/company-search-contacts-removal.removal.rst
@@ -1,0 +1,7 @@
+The ``contacts`` field in company search results was removed from the following endpoints:
+
+- ``/v3/search``
+- ``/v3/search/company``
+- ``/v4/search/company``
+
+If you require a list of contacts for a company, please use ``/v3/contacts?company_id=<company ID>``

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -42,7 +42,6 @@ class CompanySearchApp(SearchApp):
         'turnover_range',
         'uk_region',
     ).prefetch_related(
-        'contacts',
         'export_to_countries',
         'future_interest_countries',
     )

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -58,7 +58,6 @@ class Company(BaseESModel):
     business_type = fields.id_name_field()
     companies_house_data = fields.ch_company_field()
     company_number = fields.NormalizedKeyword()
-    contacts = fields.contact_or_adviser_field('contacts')
     created_on = Date()
     description = fields.EnglishText()
     employee_range = fields.id_name_field()
@@ -127,7 +126,6 @@ class Company(BaseESModel):
         'archived_by': dict_utils.contact_or_adviser_dict,
         'business_type': dict_utils.id_name_dict,
         'companies_house_data': dict_utils.ch_company_dict,
-        'contacts': lambda col: [dict_utils.contact_or_adviser_dict(c) for c in col.all()],
         'employee_range': dict_utils.id_name_dict,
         'export_experience_category': dict_utils.id_name_dict,
         'export_to_countries': lambda col: [dict_utils.id_name_dict(c) for c in col.all()],

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -73,29 +73,6 @@ def test_mapping(setup_es):
                     'normalizer': 'lowercase_asciifolding_normalizer',
                     'type': 'keyword',
                 },
-                'contacts': {
-                    'properties': {
-                        'first_name': {
-                            'normalizer': 'lowercase_asciifolding_normalizer',
-                            'type': 'keyword',
-                        },
-                        'id': {'type': 'keyword'},
-                        'last_name': {
-                            'normalizer': 'lowercase_asciifolding_normalizer',
-                            'type': 'keyword',
-                        },
-                        'name': {
-                            'normalizer': 'lowercase_asciifolding_normalizer',
-                            'copy_to': ['contacts.name_trigram'],
-                            'type': 'keyword',
-                        },
-                        'name_trigram': {
-                            'analyzer': 'trigram_analyzer',
-                            'type': 'text',
-                        },
-                    },
-                    'type': 'object',
-                },
                 'created_on': {'type': 'date'},
                 'description': {
                     'analyzer': 'english_analyzer',
@@ -603,7 +580,6 @@ def test_indexed_doc(setup_es):
         'business_type',
         'companies_house_data',
         'company_number',
-        'contacts',
         'created_on',
         'description',
         'employee_range',

--- a/datahub/search/company/test/test_entity_search_views_v3.py
+++ b/datahub/search/company/test/test_entity_search_views_v3.py
@@ -158,7 +158,6 @@ class TestSearch(APITestMixin):
                         'id': str(company.business_type.id),
                         'name': company.business_type.name,
                     },
-                    'contacts': [],
                     'description': company.description,
                     'employee_range': {
                         'id': str(company.employee_range.id),

--- a/datahub/search/company/test/test_entity_search_views_v4.py
+++ b/datahub/search/company/test/test_entity_search_views_v4.py
@@ -163,7 +163,6 @@ class TestSearch(APITestMixin):
                         'id': str(company.business_type.id),
                         'name': company.business_type.name,
                     },
-                    'contacts': [],
                     'description': company.description,
                     'employee_range': {
                         'id': str(company.employee_range.id),

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -25,7 +25,6 @@ class TestCompanyElasticModel:
             'business_type',
             'companies_house_data',
             'company_number',
-            'contacts',
             'created_on',
             'description',
             'employee_range',


### PR DESCRIPTION
### Description of change

This is the removal of the ``contacts`` field in company search results (in the ``/v3/search``, ``/v3/search/company`` and ``/v4/search/company`` endpoints) following https://github.com/uktrade/data-hub-leeloo/pull/1465.

This should not be merged until around 27 February 2019.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
