### PR TITLE
Companies House search API v4

### DIFF
--- a/changelog/company/ch-search-api-v3.removal
+++ b/changelog/company/ch-search-api-v3.removal
@@ -1,0 +1,1 @@
+The endpoint ``/v3/search/companieshousecompany`` is deprecated and will be removed on or after the 28th of February, please use v4 instead.

--- a/changelog/company/ch-search-api-v4.api
+++ b/changelog/company/ch-search-api-v4.api
@@ -1,0 +1,3 @@
+API V4 of companieshouse company search was introduced with nested object format for addresses.
+The endpoint ``/v4/search/companieshousecompany`` was added with the ``registered_address_*`` fields
+replaced by the nested object ``registered_address``.

--- a/datahub/search/companieshousecompany/apps.py
+++ b/datahub/search/companieshousecompany/apps.py
@@ -1,7 +1,10 @@
 from datahub.company.models import CompaniesHouseCompany as DBCompaniesHouseCompany
 from datahub.search.apps import SearchApp
 from datahub.search.companieshousecompany.models import CompaniesHouseCompany
-from datahub.search.companieshousecompany.views import SearchCompaniesHouseCompanyAPIViewV3
+from datahub.search.companieshousecompany.views import (
+    SearchCompaniesHouseCompanyAPIViewV3,
+    SearchCompaniesHouseCompanyAPIViewV4,
+)
 
 
 class CompaniesHouseCompanySearchApp(SearchApp):
@@ -10,6 +13,7 @@ class CompaniesHouseCompanySearchApp(SearchApp):
     name = 'companieshousecompany'
     es_model = CompaniesHouseCompany
     view = SearchCompaniesHouseCompanyAPIViewV3
+    view_v4 = SearchCompaniesHouseCompanyAPIViewV4
     view_permissions = ('company.view_companieshousecompany',)
     queryset = DBCompaniesHouseCompany.objects.select_related(
         'registered_address_country',

--- a/datahub/search/companieshousecompany/apps.py
+++ b/datahub/search/companieshousecompany/apps.py
@@ -1,7 +1,7 @@
 from datahub.company.models import CompaniesHouseCompany as DBCompaniesHouseCompany
 from datahub.search.apps import SearchApp
 from datahub.search.companieshousecompany.models import CompaniesHouseCompany
-from datahub.search.companieshousecompany.views import SearchCompaniesHouseCompanyAPIView
+from datahub.search.companieshousecompany.views import SearchCompaniesHouseCompanyAPIViewV3
 
 
 class CompaniesHouseCompanySearchApp(SearchApp):
@@ -9,7 +9,7 @@ class CompaniesHouseCompanySearchApp(SearchApp):
 
     name = 'companieshousecompany'
     es_model = CompaniesHouseCompany
-    view = SearchCompaniesHouseCompanyAPIView
+    view = SearchCompaniesHouseCompanyAPIViewV3
     view_permissions = ('company.view_companieshousecompany',)
     queryset = DBCompaniesHouseCompany.objects.select_related(
         'registered_address_country',

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from elasticsearch_dsl import Date, Keyword, Text
 
 from datahub.search import dict_utils, fields
@@ -21,6 +23,9 @@ class CompaniesHouseCompany(BaseESModel):
             'trigram': fields.TrigramText(),
         },
     )
+    registered_address = fields.address_field(index_country=False)
+
+    # TODO: delete once the migration to nested registered address is complete
     registered_address_1 = Text()
     registered_address_2 = Text()
     registered_address_town = fields.NormalizedKeyword()
@@ -28,22 +33,31 @@ class CompaniesHouseCompany(BaseESModel):
     registered_address_postcode = Text(copy_to='registered_address_postcode_trigram')
     registered_address_postcode_trigram = fields.TrigramText()
     registered_address_country = fields.id_name_field()
+
     sic_code_1 = Text()
     sic_code_2 = Text()
     sic_code_3 = Text()
     sic_code_4 = Text()
     uri = Text()
 
+    COMPUTED_MAPPINGS = {
+        'registered_address': partial(dict_utils.address_dict, prefix='registered_address'),
+    }
+
     MAPPINGS = {
         'id': str,
+
+        # TODO: delete once the migration to nested registered address is complete
         'registered_address_country': dict_utils.id_name_dict,
     }
 
     SEARCH_FIELDS = (
-        # to match names like A & B
-        'name',
+        'name',  # to find 2-letter words
         'name.trigram',
         'company_number',
+
+        # TODO: replace with nested registered address
+        # once the index data has been populated
         'registered_address_postcode_trigram',
     )
 

--- a/datahub/search/companieshousecompany/tests/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/tests/test_elasticsearch.py
@@ -87,6 +87,31 @@ def test_mapping(setup_es):
                     'normalizer': 'lowercase_asciifolding_normalizer',
                     'type': 'keyword',
                 },
+                'registered_address': {
+                    'type': 'object',
+                    'properties': {
+                        'line_1': {'index': False, 'type': 'text'},
+                        'line_2': {'index': False, 'type': 'text'},
+                        'town': {'index': False, 'type': 'text'},
+                        'county': {'index': False, 'type': 'text'},
+                        'postcode': {
+                            'type': 'text',
+                            'fields': {
+                                'trigram': {
+                                    'type': 'text',
+                                    'analyzer': 'trigram_analyzer',
+                                },
+                            },
+                        },
+                        'country': {
+                            'type': 'object',
+                            'properties': {
+                                'id': {'index': False, 'type': 'keyword'},
+                                'name': {'index': False, 'type': 'text'},
+                            },
+                        },
+                    },
+                },
                 'sic_code_1': {
                     'type': 'text',
                 },
@@ -126,6 +151,17 @@ def test_indexed_doc(setup_es):
     assert indexed_ch_company['_source'] == {
         'id': str(ch_company.pk),
         'name': ch_company.name,
+        'registered_address': {
+            'line_1': ch_company.registered_address_1,
+            'line_2': ch_company.registered_address_2,
+            'town': ch_company.registered_address_town,
+            'county': ch_company.registered_address_county,
+            'postcode': ch_company.registered_address_postcode,
+            'country': {
+                'id': str(ch_company.registered_address_country.pk),
+                'name': ch_company.registered_address_country.name,
+            },
+        },
         'registered_address_1': ch_company.registered_address_1,
         'registered_address_2': ch_company.registered_address_2,
         'registered_address_town': ch_company.registered_address_town,

--- a/datahub/search/companieshousecompany/tests/test_views_v4.py
+++ b/datahub/search/companieshousecompany/tests/test_views_v4.py
@@ -1,0 +1,149 @@
+import pytest
+from dateutil.parser import parse as dateutil_parse
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.test.factories import CompaniesHouseCompanyFactory
+from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.metadata.test.factories import TeamFactory
+from datahub.search.companieshousecompany import CompaniesHouseCompanySearchApp
+from datahub.search.sync_object import sync_object
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def setup_data(setup_es):
+    """Sets up data for the tests."""
+    companies = (
+        CompaniesHouseCompanyFactory(
+            name='Pallas',
+            company_number='111',
+            incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
+            company_status='jumping',
+        ),
+        CompaniesHouseCompanyFactory(
+            name='Jaguarundi',
+            company_number='222',
+            incorporation_date=dateutil_parse('2015-09-12T00:00:00Z'),
+            company_status='sleeping',
+        ),
+        CompaniesHouseCompanyFactory(
+            name='Cheetah',
+            company_number='333',
+            incorporation_date=dateutil_parse('2016-09-12T00:00:00Z'),
+            company_status='purring',
+        ),
+        CompaniesHouseCompanyFactory(
+            name='Pallas Second',
+            company_number='444',
+            incorporation_date=dateutil_parse('2019-09-12T00:00:00Z'),
+            company_status='crying',
+        ),
+    )
+
+    for company in companies:
+        sync_object(CompaniesHouseCompanySearchApp, company.pk)
+
+    setup_es.indices.refresh()
+
+
+class TestSearchCompaniesHouseCompany(APITestMixin):
+    """Test specific search for companies house companies."""
+
+    def test_no_permissions(self):
+        """Should return 403"""
+        user = create_test_user(dit_team=TeamFactory())
+        api_client = self.create_api_client(user=user)
+        url = reverse('api-v4:search:companieshousecompany')
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        'post_data,expected_results',
+        (
+            (  # no filter => return all records
+                {},
+                {'111', '222', '333', '444'},
+            ),
+            (  # pagination
+                {
+                    'limit': 1,
+                    'offset': 1,
+                    'original_query': 'Pallas',
+                },
+                # exact match should come first, and we're offsetting by 1
+                {'444'},
+            ),
+            (  # original query match
+                {
+                    'original_query': '111',
+                },
+                {'111'},
+            ),
+            (  # original query partial match
+                {
+                    'original_query': 'jaguar',
+                },
+                {'222'},
+            ),
+        ),
+    )
+    def test_search(self, setup_data, post_data, expected_results):
+        """Test search results."""
+        url = reverse('api-v4:search:companieshousecompany')
+
+        response = self.api_client.post(url, post_data)
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        actual_results = {
+            item['company_number']
+            for item in response_data['results']
+        }
+        assert len(response_data['results']) == len(expected_results)
+        assert actual_results == expected_results
+
+    def test_response_body(self, setup_es):
+        """Tests the response body of a search query."""
+        company = CompaniesHouseCompanyFactory(
+            name='Pallas',
+            company_number='111',
+            incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
+            company_status='jumping',
+        )
+        sync_object(CompaniesHouseCompanySearchApp, company.pk)
+        setup_es.indices.refresh()
+
+        url = reverse('api-v4:search:companieshousecompany')
+        response = self.api_client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'count': 1,
+            'results': [
+                {
+                    'id': str(company.pk),
+                    'name': company.name,
+                    'company_category': company.company_category,
+                    'incorporation_date': company.incorporation_date.date().isoformat(),
+                    'company_number': company.company_number,
+                    'company_status': company.company_status,
+                    'registered_address': {
+                        'line_1': company.registered_address_1,
+                        'line_2': company.registered_address_2,
+                        'town': company.registered_address_town,
+                        'county': company.registered_address_county,
+                        'postcode': company.registered_address_postcode,
+                        'country': {
+                            'id': str(company.registered_address_country.id),
+                            'name': company.registered_address_country.name,
+                        },
+                    },
+                    'sic_code_1': company.sic_code_1,
+                    'sic_code_2': company.sic_code_2,
+                    'sic_code_3': company.sic_code_3,
+                    'sic_code_4': company.sic_code_4,
+                    'uri': company.uri,
+                },
+            ],
+        }

--- a/datahub/search/companieshousecompany/views.py
+++ b/datahub/search/companieshousecompany/views.py
@@ -4,8 +4,8 @@ from datahub.search.serializers import EntitySearchQuerySerializer
 from datahub.search.views import SearchAPIView
 
 
-class SearchCompaniesHouseCompanyAPIView(SearchAPIView):
-    """Filtered company search view."""
+class SearchCompaniesHouseCompanyAPIViewV3(SearchAPIView):
+    """Filtered company search view V3."""
 
     required_scopes = (Scope.internal_front_end,)
     entity = CompaniesHouseCompany

--- a/datahub/search/companieshousecompany/views.py
+++ b/datahub/search/companieshousecompany/views.py
@@ -18,3 +18,16 @@ class SearchCompaniesHouseCompanyAPIViewV3(BaseSearchCompaniesHouseCompanyAPIVie
     fields_to_exclude = (
         'registered_address',
     )
+
+
+class SearchCompaniesHouseCompanyAPIViewV4(BaseSearchCompaniesHouseCompanyAPIView):
+    """Filtered company search view V4."""
+
+    fields_to_exclude = (
+        'registered_address_1',
+        'registered_address_2',
+        'registered_address_town',
+        'registered_address_county',
+        'registered_address_country',
+        'registered_address_postcode',
+    )

--- a/datahub/search/companieshousecompany/views.py
+++ b/datahub/search/companieshousecompany/views.py
@@ -4,9 +4,17 @@ from datahub.search.serializers import EntitySearchQuerySerializer
 from datahub.search.views import SearchAPIView
 
 
-class SearchCompaniesHouseCompanyAPIViewV3(SearchAPIView):
-    """Filtered company search view V3."""
+class BaseSearchCompaniesHouseCompanyAPIView(SearchAPIView):
+    """Base filtered company search view V3."""
 
     required_scopes = (Scope.internal_front_end,)
     entity = CompaniesHouseCompany
     serializer_class = EntitySearchQuerySerializer
+
+
+class SearchCompaniesHouseCompanyAPIViewV3(BaseSearchCompaniesHouseCompanyAPIView):
+    """Filtered company search view V3."""
+
+    fields_to_exclude = (
+        'registered_address',
+    )

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -83,8 +83,27 @@ def id_name_partial_field(field):
     )
 
 
-def address_field():
+def address_field(index_country=True):
     """Address field as nested object."""
+    if index_country:
+        country_field = Object(
+            properties={
+                'id': Keyword(),
+                'name': Text(
+                    fields={
+                        'trigram': TrigramText(),
+                    },
+                ),
+            },
+        )
+    else:
+        country_field = Object(
+            properties={
+                'id': Keyword(index=False),
+                'name': Text(index=False),
+            },
+        )
+
     return Object(
         properties={
             'line_1': Text(index=False),
@@ -96,16 +115,7 @@ def address_field():
                     'trigram': TrigramText(),
                 },
             ),
-            'country': Object(
-                properties={
-                    'id': Keyword(),
-                    'name': Text(
-                        fields={
-                            'trigram': TrigramText(),
-                        },
-                    ),
-                },
-            ),
+            'country': country_field,
         },
     )
 


### PR DESCRIPTION
### Description of change

This adds the endpoint `/v4/search/companieshousecompany` with the the `registered_address_*` fields replaced by the nested object `registered_address`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
