### PR TITLE
Remove unused company filters and sortby params

### DIFF
--- a/changelog/company/company-search-filters.removal
+++ b/changelog/company/company-search-filters.removal
@@ -1,0 +1,8 @@
+``POST /v3/search/company``, ``POST /v3/search/company/export`` the following filters were deleted:
+
+- ``description``
+- ``export_to_country``
+- ``future_interest_country``
+- ``global_headquarters``
+- ``sector``
+- ``trading_address_country``

--- a/changelog/company/company-search-sortby.removal
+++ b/changelog/company/company-search-sortby.removal
@@ -1,0 +1,17 @@
+``POST /v3/search/company``, ``POST /v3/search/company/export`` the following sortby values were deleted:
+
+- ``archived``
+- ``archived_by``
+- ``business_type.name``
+- ``companies_house_data.company_number``
+- ``company_number``
+- ``created_on``
+- ``employee_range.name``
+- ``headquarter_type.name``
+- ``id``
+- ``registered_address_town``
+- ``sector.name``
+- ``trading_address_town``
+- ``turnover_range.name``
+- ``uk_based``
+- ``uk_region.name``

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -1,5 +1,3 @@
-import logging
-
 from rest_framework import serializers
 
 from datahub.search.serializers import (
@@ -9,94 +7,22 @@ from datahub.search.serializers import (
 )
 
 
-logger = logging.getLogger(__name__)
-
-
 class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
     """Serialiser used to validate company search POST bodies."""
 
     archived = serializers.BooleanField(required=False)
-    description = serializers.CharField(required=False)
-    export_to_country = SingleOrListField(child=StringUUIDField(), required=False)
-    future_interest_country = SingleOrListField(child=StringUUIDField(), required=False)
-    global_headquarters = SingleOrListField(child=StringUUIDField(), required=False)
     headquarter_type = SingleOrListField(
         child=StringUUIDField(allow_null=True),
         required=False,
         allow_null=True,
     )
     name = serializers.CharField(required=False)
-    sector = SingleOrListField(child=StringUUIDField(), required=False)
     sector_descends = SingleOrListField(child=StringUUIDField(), required=False)
-    trading_address_country = SingleOrListField(child=StringUUIDField(), required=False)
     country = SingleOrListField(child=StringUUIDField(), required=False)
     uk_based = serializers.BooleanField(required=False)
     uk_region = SingleOrListField(child=StringUUIDField(), required=False)
 
     SORT_BY_FIELDS = (
-        'archived',
-        'archived_by',
-        'business_type.name',
-        'companies_house_data.company_number',
-        'company_number',
-        'created_on',
-        'employee_range.name',
-        'headquarter_type.name',
-        'id',
         'modified_on',
         'name',
-        'registered_address_town',
-        'sector.name',
-        'trading_address_town',
-        'turnover_range.name',
-        'uk_based',
-        'uk_region.name',
     )
-
-    # TODO remove following deprecation period.
-    deprecated_filters = {
-        'description',
-        'export_to_country',
-        'future_interest_country',
-        'global_headquarters',
-        'sector',
-        'trading_address_country',
-    }
-    deprecated_sortby_fields = {
-        'archived',
-        'archived_by',
-        'business_type.name',
-        'companies_house_data.company_number',
-        'company_number',
-        'created_on',
-        'employee_range.name',
-        'headquarter_type.name',
-        'id',
-        'registered_address_town',
-        'sector.name',
-        'trading_address_town',
-        'turnover_range.name',
-        'uk_based',
-        'uk_region.name',
-    }
-
-    def validate(self, data):
-        """
-        Logs all deprecated params to make sure we don't break things when we get rid of them.
-
-        TODO Remove following deprecation period.
-        """
-        deprecated_filters_in_data = data.keys() & self.deprecated_filters
-        if deprecated_filters_in_data:
-            logger.error(
-                'The following deprecated company search filters were '
-                f'used: {deprecated_filters_in_data}.',
-            )
-
-        sortby = data.get('sortby')
-        if sortby and sortby.field in self.deprecated_sortby_fields:
-            logger.error(
-                'The following deprecated company search sortby field was '
-                f'used: {sortby.field}.',
-            )
-        return super().validate(data)

--- a/datahub/search/company/test/test_entity_search_views_v3.py
+++ b/datahub/search/company/test/test_entity_search_views_v3.py
@@ -225,23 +225,6 @@ class TestSearch(APITestMixin):
         actual_ids = Counter(result['id'] for result in response_data['results'])
         assert expected_ids == actual_ids
 
-    def test_trading_address_country_filter(self, setup_data):
-        """Tests trading address country filter."""
-        url = reverse('api-v3:search:company')
-        united_states_id = constants.Country.united_states.value.id
-
-        response = self.api_client.post(
-            url,
-            data={
-                'trading_address_country': united_states_id,
-            },
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 1
-        assert len(response.data['results']) == 1
-        assert response.data['results'][0]['trading_address_country']['id'] == united_states_id
-
     def test_uk_region_filter(self, setup_data):
         """Tests uk region filter."""
         url = reverse('api-v3:search:company')
@@ -311,31 +294,6 @@ class TestSearch(APITestMixin):
 
         search_results = {company['name'] for company in response.data['results']}
         assert search_results == results
-
-    def test_global_headquarters(self, setup_es):
-        """Test global headquarters filter."""
-        ghq1 = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ghq.value.id)
-        ghq2 = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ghq.value.id)
-        companies = CompanyFactory.create_batch(5, global_headquarters=ghq1)
-        CompanyFactory.create_batch(5, global_headquarters=ghq2)
-        CompanyFactory.create_batch(10)
-
-        setup_es.indices.refresh()
-
-        url = reverse('api-v3:search:company')
-        response = self.api_client.post(
-            url,
-            {
-                'global_headquarters': ghq1.id,
-            },
-        )
-        assert response.status_code == status.HTTP_200_OK
-
-        assert response.data['count'] == 5
-        assert len(response.data['results']) == 5
-
-        search_results = {UUID(company['id']) for company in response.data['results']}
-        assert search_results == {company.id for company in companies}
 
     @pytest.mark.parametrize(
         'sector_level',

--- a/datahub/search/company/test/test_entity_search_views_v4.py
+++ b/datahub/search/company/test/test_entity_search_views_v4.py
@@ -224,25 +224,6 @@ class TestSearch(APITestMixin):
                 ['abc defg ltd', 'abc defg us ltd'],
             ),
 
-            # trading_address_country
-            (
-                {
-                    'trading_address_country': constants.Country.united_states.value.id,
-                },
-                ['abc defg us ltd'],
-            ),
-
-            # multiple trading_address_country filters
-            (
-                {
-                    'trading_address_country': [
-                        constants.Country.united_states.value.id,
-                        constants.Country.united_kingdom.value.id,
-                    ],
-                },
-                ['abc defg ltd', 'abc defg us ltd'],
-            ),
-
             # uk_region
             (
                 {
@@ -333,31 +314,6 @@ class TestSearch(APITestMixin):
 
         search_results = {company['name'] for company in response.data['results']}
         assert search_results == results
-
-    def test_global_headquarters(self, setup_es):
-        """Test global headquarters filter."""
-        ghq1 = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ghq.value.id)
-        ghq2 = CompanyFactory(headquarter_type_id=constants.HeadquarterType.ghq.value.id)
-        companies = CompanyFactory.create_batch(5, global_headquarters=ghq1)
-        CompanyFactory.create_batch(5, global_headquarters=ghq2)
-        CompanyFactory.create_batch(10)
-
-        setup_es.indices.refresh()
-
-        url = reverse('api-v4:search:company')
-        response = self.api_client.post(
-            url,
-            {
-                'global_headquarters': ghq1.id,
-            },
-        )
-        assert response.status_code == status.HTTP_200_OK
-
-        assert response.data['count'] == 5
-        assert len(response.data['results']) == 5
-
-        search_results = {UUID(company['id']) for company in response.data['results']}
-        assert search_results == {company.id for company in companies}
 
     @pytest.mark.parametrize(
         'sector_level',

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -23,27 +23,16 @@ class SearchCompanyAPIViewMixin:
 
     FILTER_FIELDS = (
         'archived',
-        'description',
-        'export_to_country',
-        'future_interest_country',
-        'global_headquarters',
         'headquarter_type',
         'name',
-        'sector',
         'sector_descends',
         'country',
-        'trading_address_country',
         'uk_based',
         'uk_region',
     )
 
     REMAP_FIELDS = {
-        'export_to_country': 'export_to_countries.id',
-        'future_interest_country': 'future_interest_countries.id',
-        'global_headquarters': 'global_headquarters.id',
         'headquarter_type': 'headquarter_type.id',
-        'sector': 'sector.id',
-        'trading_address_country': 'address.country.id',
         'uk_region': 'uk_region.id',
     }
 


### PR DESCRIPTION
### Description of change

This gets rid of the previously deprecated and unused company search filters and sortby parameters.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
