### PR TITLE
Add ability to merge companies having OMIS orders

### DIFF
--- a/changelog/company/company-merge-omis-orders.feature
+++ b/changelog/company/company-merge-omis-orders.feature
@@ -1,0 +1,1 @@
+Company merge tool now supports merging companies having OMIS orders.

--- a/datahub/company/merge.py
+++ b/datahub/company/merge.py
@@ -5,6 +5,8 @@ from datahub.core.exceptions import DataHubException
 from datahub.core.model_helpers import get_related_fields, get_self_referential_relations
 from datahub.interaction.models import Interaction
 from datahub.investment.models import InvestmentProject
+from datahub.omis.order.models import Order
+
 
 ALLOWED_RELATIONS_FOR_MERGING = {
     Company._meta.get_field('dnbmatchingresult').remote_field,
@@ -13,6 +15,7 @@ ALLOWED_RELATIONS_FOR_MERGING = {
     InvestmentProject.investor_company.field,
     InvestmentProject.intermediate_company.field,
     InvestmentProject.uk_company.field,
+    Order.company.field,
 }
 
 
@@ -51,6 +54,7 @@ MERGE_CONFIGURATION = [
     MergeConfiguration(Interaction, ('company',)),
     MergeConfiguration(Contact, ('company',)),
     MergeConfiguration(InvestmentProject, INVESTMENT_PROJECT_COMPANY_FIELDS),
+    MergeConfiguration(Order, ('company',)),
 ]
 
 

--- a/datahub/company/test/admin/merge/test_step_2.py
+++ b/datahub/company/test/admin/merge/test_step_2.py
@@ -13,7 +13,6 @@ from datahub.company.test.factories import (
 )
 from datahub.core.test_utils import AdminTestMixin
 from datahub.core.utils import reverse_with_query_string
-from datahub.omis.order.test.factories import OrderFactory
 
 
 class TestSelectPrimaryCompanyViewGet(AdminTestMixin):
@@ -73,10 +72,6 @@ class TestSelectPrimaryCompanyViewGet(AdminTestMixin):
             ),
             (
                 CompanyFactory,
-                lambda: OrderFactory().company,
-            ),
-            (
-                CompanyFactory,
                 SubsidiaryFactory,
             ),
             (
@@ -86,7 +81,6 @@ class TestSelectPrimaryCompanyViewGet(AdminTestMixin):
         ),
         ids=[
             'archived-company',
-            'company-with-order',
             'subsidiary',
             'global-headquarters',
         ],
@@ -177,12 +171,6 @@ class TestSelectPrimaryCompanyViewPost(AdminTestMixin):
                 ArchivedCompanyFactory,
                 CompanyFactory,
                 'The company selected is archived.',
-            ),
-            (
-                CompanyFactory,
-                lambda: OrderFactory().company,
-                'The other company has related records which can’t be moved to the selected '
-                'company.',
             ),
             (
                 CompanyFactory,


### PR DESCRIPTION
### Description of change

This enhances the merge tool with the ability to merge companies having OMIS orders.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
