### PR TITLE
Use nested registered address in ES CH company search

### DIFF
--- a/changelog/company/ch-search-nested-address-in-logic.internal
+++ b/changelog/company/ch-search-nested-address-in-logic.internal
@@ -1,0 +1,1 @@
+The companieshouse company search endpoints now use the nested registered address object when searching by term.

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -55,10 +55,7 @@ class CompaniesHouseCompany(BaseESModel):
         'name',  # to find 2-letter words
         'name.trigram',
         'company_number',
-
-        # TODO: replace with nested registered address
-        # once the index data has been populated
-        'registered_address_postcode_trigram',
+        'registered_address.postcode.trigram',
     )
 
     class Meta:

--- a/datahub/search/companieshousecompany/tests/test_views_v3.py
+++ b/datahub/search/companieshousecompany/tests/test_views_v3.py
@@ -20,24 +20,28 @@ def setup_data(setup_es):
             name='Pallas',
             company_number='111',
             incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
+            registered_address_postcode='SW1A 1AA',
             company_status='jumping',
         ),
         CompaniesHouseCompanyFactory(
             name='Jaguarundi',
             company_number='222',
             incorporation_date=dateutil_parse('2015-09-12T00:00:00Z'),
+            registered_address_postcode='E1 6JE',
             company_status='sleeping',
         ),
         CompaniesHouseCompanyFactory(
             name='Cheetah',
             company_number='333',
             incorporation_date=dateutil_parse('2016-09-12T00:00:00Z'),
+            registered_address_postcode='SW1A 0PW',
             company_status='purring',
         ),
         CompaniesHouseCompanyFactory(
             name='Pallas Second',
             company_number='444',
             incorporation_date=dateutil_parse('2019-09-12T00:00:00Z'),
+            registered_address_postcode='WC1B 3DG',
             company_status='crying',
         ),
     )
@@ -86,6 +90,12 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
                     'original_query': 'jaguar',
                 },
                 {'222'},
+            ),
+            (  # original query partial postcode
+                {
+                    'original_query': 'SW1',
+                },
+                {'111', '333'},
             ),
         ),
     )

--- a/datahub/search/companieshousecompany/tests/test_views_v4.py
+++ b/datahub/search/companieshousecompany/tests/test_views_v4.py
@@ -20,24 +20,28 @@ def setup_data(setup_es):
             name='Pallas',
             company_number='111',
             incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
+            registered_address_postcode='SW1A 1AA',
             company_status='jumping',
         ),
         CompaniesHouseCompanyFactory(
             name='Jaguarundi',
             company_number='222',
             incorporation_date=dateutil_parse('2015-09-12T00:00:00Z'),
+            registered_address_postcode='E1 6JE',
             company_status='sleeping',
         ),
         CompaniesHouseCompanyFactory(
             name='Cheetah',
             company_number='333',
             incorporation_date=dateutil_parse('2016-09-12T00:00:00Z'),
+            registered_address_postcode='SW1A 0PW',
             company_status='purring',
         ),
         CompaniesHouseCompanyFactory(
             name='Pallas Second',
             company_number='444',
             incorporation_date=dateutil_parse('2019-09-12T00:00:00Z'),
+            registered_address_postcode='WC1B 3DG',
             company_status='crying',
         ),
     )
@@ -86,6 +90,12 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
                     'original_query': 'jaguar',
                 },
                 {'222'},
+            ),
+            (  # original query partial postcode
+                {
+                    'original_query': 'SW1',
+                },
+                {'111', '333'},
             ),
         ),
     )


### PR DESCRIPTION
### Description of change

Before, the search logic used the flat registered address postcode field when searching.
Now, the search logic uses the nested registered address postcode field instead.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
