### PR TITLE
Deprecate global search sortby values

### DIFF
--- a/changelog/search-sortby.removal
+++ b/changelog/search-sortby.removal
@@ -1,0 +1,1 @@
+``GET /v3/search``: all the values for the ``sortby`` query parameter are deprecated and will be removed on or after 28 February 2019.

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -152,11 +152,14 @@ class BasicSearchQuerySerializer(BaseSearchQuerySerializer):
         """
         Logs the sortby search param to see if we can get rid of it from the global search.
 
-        TODO: Remove after figuring out what to do with sortby.
+        TODO: Remove following deprecation period.
         """
         sortby = data.get('sortby')
         if sortby:
-            logger.error(f'Sortby search field "{sortby.field}" used in the global search.')
+            logger.error(
+                'The following deprecated global search sortby field was '
+                f'used: {sortby.field}.',
+            )
         return super().validate(data)
 
 

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -1,4 +1,5 @@
 """Search views."""
+import logging
 from collections import namedtuple
 from itertools import islice
 
@@ -37,6 +38,9 @@ from datahub.user_event_log.utils import record_user_event
 EntitySearch = namedtuple('EntitySearch', ['model', 'name'])
 
 
+logger = logging.getLogger(__name__)
+
+
 class SearchBasicAPIView(APIView):
     """Aggregate all entities search view."""
 
@@ -54,6 +58,13 @@ class SearchBasicAPIView(APIView):
         serializer.is_valid(raise_exception=True)
         validated_params = serializer.validated_data
         ordering = _map_es_ordering(validated_params['sortby'], self.es_sort_by_remappings)
+
+        # TODO Remove following deprecation period.
+        if ordering:
+            logger.error(
+                'The following deprecated global search ordering was '
+                f'used: {ordering.field}.',
+            )
 
         query = get_basic_search_query(
             entity=validated_params['entity'],


### PR DESCRIPTION
### Description of change

This deprecates all the values for the `sortby` query parameter and adds/changes some logging to make sure nobody is using them.

The logging in the `SearchBasicAPIView` is not really necessary but there's no harm in having it just to make sure I don't get rid of logic currently in use.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
