### PR TITLE
Fix adviser autocomplete escaping of non-ASCII characters

### DIFF
--- a/changelog/adviser/autocomplete-escaping.bugfix.rst
+++ b/changelog/adviser/autocomplete-escaping.bugfix.rst
@@ -1,0 +1,1 @@
+The adviser autocomplete feature no longer returns an error when certain non-ASCII characters such as é are entered.

--- a/datahub/company/test/test_adviser_views.py
+++ b/datahub/company/test/test_adviser_views.py
@@ -59,6 +59,12 @@ def advisers():
             'dit_team__name': 'New York',
         },
         {
+            # with accent
+            'first_name': 'Éla',
+            'last_name': 'Pien',
+            'dit_team__name': 'Iceland',
+        },
+        {
             # with middle name
             'first_name': 'Amy Sarah',
             'last_name': 'Dacre',
@@ -173,6 +179,7 @@ class TestAdviser(APITestMixin):
                 [
                     ('Amy Sarah', 'Dacre', 'New York'),
                     ('Anna', 'George', 'London'),
+                    ('Éla', 'Pien', 'Iceland'),
                     ('Elisabeth', 'Gravy', 'Johannesburg'),
                     ('Jennifer', 'Cakeman', 'New York'),
                     ('Jessica', 'Samson-James', 'New York'),
@@ -190,7 +197,12 @@ class TestAdviser(APITestMixin):
             ),
             (
                 # nothing odd should happen with special characters
-                r"/\.*+?|'()[]{}",  # noqa: P103
+                r"%_`~:'()[]{}?*+-|^$\\.&~# \t\n\r\v\f",  # noqa: P103
+                [],
+            ),
+            (
+                # non-ASCII characters should not fail
+                r'ẽõḉẹã',
                 [],
             ),
             (
@@ -227,6 +239,18 @@ class TestAdviser(APITestMixin):
             (
                 'conner new york london',
                 [],
+            ),
+            (
+                'É',
+                [
+                    ('Éla', 'Pien', 'Iceland'),
+                ],
+            ),
+            (
+                'Éla',
+                [
+                    ('Éla', 'Pien', 'Iceland'),
+                ],
             ),
             (
                 'Gr',


### PR DESCRIPTION
### Description of change

This restricts escaping of tokens in the adviser autocomplete to special characters.

This is needed as Python 3.6 escapes all non-ASCII characters, which is incompatible with PostgreSQL.

This behaviour has been changed with Python 3.7, so we can revert to re.escape() after updating to Python 3.7.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
