### PR TITLE
Add Hawk-authenticated get company endpoint

### DIFF
--- a/changelog/company/hawk-get.api.rst
+++ b/changelog/company/hawk-get.api.rst
@@ -1,0 +1,2 @@
+``GET /v4/public/company/<id>`` was added as a Hawk-authenticated endpoint for retrieving a single company. This is similar to
+``GET /v4/company/<id>`` but has a slightly reduced set of fields.

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -4,8 +4,10 @@ from django.urls import include, path
 from rest_framework import routers
 
 from datahub.activity_stream import urls as activity_stream_urls
-from datahub.company import urls as company_urls
 from datahub.company import views as company_views
+from datahub.company.urls import ch_company as ch_company_urls
+from datahub.company.urls import company as company_urls
+from datahub.company.urls import contact as contact_urls
 from datahub.event import urls as event_urls
 from datahub.feature_flag import urls as feature_flag_urls
 from datahub.interaction import urls as interaction_urls
@@ -32,9 +34,9 @@ v3_urls = [
             namespace='activity-stream',
         ),
     ),
-    path('', include((company_urls.contact_urls, 'contact'), namespace='contact')),
-    path('', include((company_urls.company_urls_v3, 'company'), namespace='company')),
-    path('', include((company_urls.ch_company_urls_v3, 'ch-company'), namespace='ch-company')),
+    path('', include((ch_company_urls.urls_v3, 'ch-company'), namespace='ch-company')),
+    path('', include((company_urls.urls_v3, 'company'), namespace='company')),
+    path('', include((contact_urls.urls_v3, 'contact'), namespace='contact')),
     path('', include((event_urls, 'event'), namespace='event')),
     path('', include((feature_flag_urls, 'feature-flag'), namespace='feature-flag')),
     path('', include((interaction_urls, 'interaction'), namespace='interaction')),
@@ -54,7 +56,7 @@ v3_urls = [
 # API V4 - new format for addresses
 
 v4_urls = [
-    path('', include((company_urls.company_urls_v4, 'company'), namespace='company')),
-    path('', include((company_urls.ch_company_urls_v4, 'ch-company'), namespace='ch-company')),
+    path('', include((ch_company_urls.urls_v4, 'ch-company'), namespace='ch-company')),
+    path('', include((company_urls.urls_v4, 'company'), namespace='company')),
     path('', include((search_urls.urls_v4, 'search'), namespace='search')),
 ]

--- a/datahub/activity_stream/views.py
+++ b/datahub/activity_stream/views.py
@@ -1,23 +1,21 @@
-from django.utils.decorators import decorator_from_middleware
 from rest_framework.response import Response
 from rest_framework.viewsets import ViewSet
 
 from config.settings.types import HawkScope
 from datahub.core.hawk_receiver import (
     HawkAuthentication,
-    HawkResponseMiddleware,
+    HawkResponseSigningMixin,
     HawkScopePermission,
 )
 
 
-class ActivityStreamViewSet(ViewSet):
+class ActivityStreamViewSet(HawkResponseSigningMixin, ViewSet):
     """List-only view set for the activity stream."""
 
     authentication_classes = (HawkAuthentication,)
     permission_classes = (HawkScopePermission,)
     required_hawk_scope = HawkScope.activity_stream
 
-    @decorator_from_middleware(HawkResponseMiddleware)
     def list(self, request):
         """A single page of activities"""
         return Response({'secret': 'content-for-pen-test'})

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -766,6 +766,56 @@ class CompanySerializerV4(BaseCompanySerializer):
         )
 
 
+class PublicCompanySerializer(CompanySerializerV4):
+    """
+    Read-only serialiser for the Hawk-authenticated company view.
+
+    This is a slightly stripped down read-only version of the v4 company serialiser. Some fields
+    containing personal data are deliberately omitted.
+    """
+
+    class Meta(CompanySerializerV4.Meta):
+        fields = (
+            'address',
+            'archived',
+            'archived_on',
+            'archived_reason',
+            'business_type',
+            'company_number',
+            'created_on',
+            'description',
+            'duns_number',
+            'employee_range',
+            'export_experience_category',
+            'export_to_countries',
+            'future_interest_countries',
+            'global_headquarters',
+            'headquarter_type',
+            'id',
+            'is_number_of_employees_estimated',
+            'is_turnover_estimated',
+            'modified_on',
+            'name',
+            'number_of_employees',
+            'one_list_group_tier',
+            'reference_code',
+            'registered_address',
+            'sector',
+            'trading_names',
+            'transfer_reason',
+            'transferred_on',
+            'transferred_to',
+            'turnover',
+            'turnover_range',
+            'uk_based',
+            'uk_region',
+            'vat_number',
+            'website',
+        )
+        permissions = {}
+        read_only_fields = fields
+
+
 class OneListCoreTeamMemberSerializer(serializers.Serializer):
     """One List Core Team Member Serializer."""
 

--- a/datahub/company/test/test_public_company_view.py
+++ b/datahub/company/test/test_public_company_view.py
@@ -1,0 +1,275 @@
+import uuid
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.models import OneListTier
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.core.constants import Country
+from datahub.core.test_utils import format_date_or_datetime, HawkAPITestClient
+
+
+@pytest.fixture
+def hawk_api_client():
+    """Hawk API client fixture."""
+    yield HawkAPITestClient()
+
+
+@pytest.fixture
+def public_company_api_client(hawk_api_client):
+    """Hawk API client fixture configured to use credentials with the public_company scope."""
+    hawk_api_client.set_credentials(
+        'public-company-id',
+        'public-company-key',
+    )
+    yield hawk_api_client
+
+
+@pytest.mark.django_db
+class TestPublicCompanyViewSet:
+    """Tests for the Hawk-authenticated public company view."""
+
+    def test_without_credentials(self, api_client):
+        """Test that making a request without credentials returns an error."""
+        company = CompanyFactory()
+
+        url = reverse('api-v4:company:public-item', kwargs={'pk': company.pk})
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_without_scope(self, hawk_api_client):
+        """Test that making a request without the correct Hawk scope returns an error."""
+        company = CompanyFactory()
+        hawk_api_client.set_credentials(
+            'test-id-without-scope',
+            'test-key-without-scope',
+        )
+        url = reverse('api-v4:company:public-item', kwargs={'pk': company.pk})
+        response = hawk_api_client.get(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize('method', ('delete', 'patch', 'post', 'put'))
+    def test_other_methods_not_allowed(self, method, public_company_api_client):
+        """Test that various HTTP methods are not allowed."""
+        company = CompanyFactory()
+
+        url = reverse('api-v4:company:public-item', kwargs={'pk': company.pk})
+        response = public_company_api_client.request(method, url)
+
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_response_is_signed(self, setup_es, public_company_api_client):
+        """Test that responses are signed."""
+        company = CompanyFactory()
+        url = reverse('api-v4:company:public-item', kwargs={'pk': company.pk})
+        response = public_company_api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert 'Server-Authorization' in response
+
+    def test_get(self, public_company_api_client):
+        """Test getting a single company."""
+        ghq = CompanyFactory(
+            global_headquarters=None,
+            one_list_tier=OneListTier.objects.first(),
+            one_list_account_owner=AdviserFactory(),
+        )
+        company = CompanyFactory(
+            company_number='123',
+            trading_names=['Xyz trading', 'Abc trading'],
+            global_headquarters=ghq,
+            one_list_tier=None,
+            one_list_account_owner=None,
+        )
+
+        url = reverse('api-v4:company:public-item', kwargs={'pk': company.id})
+        response = public_company_api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {
+            'address': {
+                'line_1': company.address_1,
+                'line_2': company.address_2 or '',
+                'town': company.address_town,
+                'county': company.address_county or '',
+                'postcode': company.address_postcode or '',
+                'country': {
+                    'id': str(company.address_country.id),
+                    'name': company.address_country.name,
+                },
+            },
+            'archived': False,
+            'archived_on': None,
+            'archived_reason': None,
+            'business_type': {
+                'id': str(company.business_type.id),
+                'name': company.business_type.name,
+            },
+            'company_number': company.company_number,
+            'created_on': format_date_or_datetime(company.created_on),
+            'description': company.description,
+            'duns_number': company.duns_number,
+            'employee_range': {
+                'id': str(company.employee_range.id),
+                'name': company.employee_range.name,
+            },
+            'export_experience_category': {
+                'id': str(company.export_experience_category.id),
+                'name': company.export_experience_category.name,
+            },
+            'export_to_countries': [],
+            'future_interest_countries': [],
+            'global_headquarters': {
+                'id': str(ghq.id),
+                'name': ghq.name,
+            },
+            'headquarter_type': company.headquarter_type,
+            'id': str(company.pk),
+            'is_number_of_employees_estimated': company.is_number_of_employees_estimated,
+            'is_turnover_estimated': company.is_turnover_estimated,
+            'modified_on': format_date_or_datetime(company.modified_on),
+            'name': company.name,
+            'number_of_employees': company.number_of_employees,
+            'one_list_group_tier': {
+                'id': str(ghq.one_list_tier.id),
+                'name': ghq.one_list_tier.name,
+            },
+            'reference_code': company.reference_code,
+            'registered_address': {
+                'line_1': company.registered_address_1,
+                'line_2': company.registered_address_2 or '',
+                'town': company.registered_address_town,
+                'county': company.registered_address_county or '',
+                'postcode': company.registered_address_postcode or '',
+                'country': {
+                    'id': str(company.registered_address_country.id),
+                    'name': company.registered_address_country.name,
+                },
+            },
+            'sector': {
+                'id': str(company.sector.id),
+                'name': company.sector.name,
+            },
+            'trading_names': company.trading_names,
+            'vat_number': company.vat_number,
+            'uk_based': (
+                company.address_country.id == uuid.UUID(Country.united_kingdom.value.id)
+            ),
+            'uk_region': {
+                'id': str(company.uk_region.id),
+                'name': company.uk_region.name,
+            },
+            'transferred_on': None,
+            'transferred_to': None,
+            'transfer_reason': '',
+            'turnover_range': {
+                'id': str(company.turnover_range.id),
+                'name': company.turnover_range.name,
+            },
+            'turnover': company.turnover,
+            'website': company.website,
+        }
+
+    def test_get_company_without_country(self, public_company_api_client):
+        """
+        Tests the company item view for a company without a country.
+
+        Checks that the endpoint returns 200 and the uk_based attribute is
+        set to None.
+        """
+        company = CompanyFactory(
+            address_country_id=None,
+        )
+
+        url = reverse('api-v4:company:public-item', kwargs={'pk': company.id})
+        response = public_company_api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['uk_based'] is None
+
+    @pytest.mark.parametrize(
+        'input_website,expected_website',
+        (
+            ('www.google.com', 'http://www.google.com'),
+            ('http://www.google.com', 'http://www.google.com'),
+            ('https://www.google.com', 'https://www.google.com'),
+            ('', ''),
+            (None, None),
+        ),
+    )
+    def test_get_company_with_website(
+        self,
+        input_website,
+        expected_website,
+        public_company_api_client,
+    ):
+        """
+        Test that if the website field on a company doesn't have any scheme
+        specified, the endpoint adds it automatically.
+        """
+        company = CompanyFactory(
+            website=input_website,
+        )
+        url = reverse('api-v4:company:public-item', kwargs={'pk': company.pk})
+        response = public_company_api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['website'] == expected_website
+
+    @pytest.mark.parametrize(
+        'build_company',
+        (
+            # subsidiary with Global Headquarters on the One List
+            lambda one_list_tier: CompanyFactory(
+                one_list_tier=None,
+                global_headquarters=CompanyFactory(one_list_tier=one_list_tier),
+            ),
+            # subsidiary with Global Headquarters not on the One List
+            lambda one_list_tier: CompanyFactory(
+                one_list_tier=None,
+                global_headquarters=CompanyFactory(one_list_tier=None),
+            ),
+            # single company on the One List
+            lambda one_list_tier: CompanyFactory(
+                one_list_tier=one_list_tier,
+                global_headquarters=None,
+            ),
+            # single company not on the One List
+            lambda one_list_tier: CompanyFactory(
+                one_list_tier=None,
+                global_headquarters=None,
+            ),
+        ),
+        ids=(
+            'as_subsidiary_of_one_list_company',
+            'as_subsidiary_of_non_one_list_company',
+            'as_one_list_company',
+            'as_non_one_list_company',
+        ),
+    )
+    def test_one_list_group_tier(self, build_company, public_company_api_client):
+        """
+        Test that the endpoint includes the One List Tier
+        of the Global Headquarters in the group.
+        """
+        one_list_tier = OneListTier.objects.first()
+        company = build_company(one_list_tier)
+
+        url = reverse('api-v4:company:public-item', kwargs={'pk': company.pk})
+        response = public_company_api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+
+        group_global_headquarters = company.global_headquarters or company
+
+        actual_one_list_group_tier = response.json()['one_list_group_tier']
+        if not group_global_headquarters.one_list_tier:
+            assert not actual_one_list_group_tier
+        else:
+            assert actual_one_list_group_tier == {
+                'id': str(one_list_tier.id),
+                'name': one_list_tier.name,
+            }

--- a/datahub/company/urls/ch_company.py
+++ b/datahub/company/urls/ch_company.py
@@ -1,0 +1,31 @@
+from django.urls import path
+
+from datahub.company.views import CompaniesHouseCompanyViewSetV3, CompaniesHouseCompanyViewSetV4
+
+# TODO: delete once the migration to v4 is complete
+ch_company_collection_v3 = CompaniesHouseCompanyViewSetV3.as_view({
+    'get': 'list',
+})
+
+# TODO: delete once the migration to v4 is complete
+ch_company_item_v3 = CompaniesHouseCompanyViewSetV3.as_view({
+    'get': 'retrieve',
+})
+
+ch_company_collection_v4 = CompaniesHouseCompanyViewSetV4.as_view({
+    'get': 'list',
+})
+
+ch_company_item_v4 = CompaniesHouseCompanyViewSetV4.as_view({
+    'get': 'retrieve',
+})
+
+urls_v3 = [
+    path('ch-company', ch_company_collection_v3, name='collection'),
+    path('ch-company/<company_number>', ch_company_item_v3, name='item'),
+]
+
+urls_v4 = [
+    path('ch-company', ch_company_collection_v4, name='collection'),
+    path('ch-company/<company_number>', ch_company_item_v4, name='item'),
+]

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -1,52 +1,12 @@
-"""Company views URL config."""
-
 from django.urls import path
 
 from datahub.company.timeline.views import CompanyTimelineViewSet
 from datahub.company.views import (
-    CompaniesHouseCompanyViewSetV3,
-    CompaniesHouseCompanyViewSetV4,
     CompanyAuditViewSet,
     CompanyViewSetV3,
     CompanyViewSetV4,
-    ContactAuditViewSet,
-    ContactViewSet,
     OneListGroupCoreTeamViewSet,
 )
-
-# CONTACT
-
-contact_collection = ContactViewSet.as_view({
-    'get': 'list',
-    'post': 'create',
-})
-
-contact_item = ContactViewSet.as_view({
-    'get': 'retrieve',
-    'patch': 'partial_update',
-})
-
-contact_archive = ContactViewSet.as_view({
-    'post': 'archive',
-})
-
-contact_unarchive = ContactViewSet.as_view({
-    'post': 'unarchive',
-})
-
-contact_audit = ContactAuditViewSet.as_view({
-    'get': 'list',
-})
-
-contact_urls = [
-    path('contact', contact_collection, name='list'),
-    path('contact/<uuid:pk>', contact_item, name='detail'),
-    path('contact/<uuid:pk>/archive', contact_archive, name='archive'),
-    path('contact/<uuid:pk>/unarchive', contact_unarchive, name='unarchive'),
-    path('contact/<uuid:pk>/audit', contact_audit, name='audit-item'),
-]
-
-# COMPANY
 
 # TODO: delete once the migration to address and registered address is complete
 company_collection_v3 = CompanyViewSetV3.as_view({
@@ -100,25 +60,8 @@ one_list_group_core_team = OneListGroupCoreTeamViewSet.as_view({
     'get': 'list',
 })
 
-# TODO: delete once the migration to v4 is complete
-ch_company_collection_v3 = CompaniesHouseCompanyViewSetV3.as_view({
-    'get': 'list',
-})
 
-# TODO: delete once the migration to v4 is complete
-ch_company_item_v3 = CompaniesHouseCompanyViewSetV3.as_view({
-    'get': 'retrieve',
-})
-
-ch_company_collection_v4 = CompaniesHouseCompanyViewSetV4.as_view({
-    'get': 'list',
-})
-
-ch_company_item_v4 = CompaniesHouseCompanyViewSetV4.as_view({
-    'get': 'retrieve',
-})
-
-company_urls_v3 = [
+urls_v3 = [
     path('company', company_collection_v3, name='collection'),
     path('company/<uuid:pk>', company_item_v3, name='item'),
     path('company/<uuid:pk>/archive', company_archive_v3, name='archive'),
@@ -132,7 +75,7 @@ company_urls_v3 = [
     ),
 ]
 
-company_urls_v4 = [
+urls_v4 = [
     path('company', company_collection_v4, name='collection'),
     path('company/<uuid:pk>', company_item_v4, name='item'),
     path('company/<uuid:pk>/archive', company_archive_v4, name='archive'),
@@ -144,14 +87,4 @@ company_urls_v4 = [
         one_list_group_core_team,
         name='one-list-group-core-team',
     ),
-]
-
-ch_company_urls_v3 = [
-    path('ch-company', ch_company_collection_v3, name='collection'),
-    path('ch-company/<company_number>', ch_company_item_v3, name='item'),
-]
-
-ch_company_urls_v4 = [
-    path('ch-company', ch_company_collection_v4, name='collection'),
-    path('ch-company/<company_number>', ch_company_item_v4, name='item'),
 ]

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -6,6 +6,7 @@ from datahub.company.views import (
     CompanyViewSetV3,
     CompanyViewSetV4,
     OneListGroupCoreTeamViewSet,
+    PublicCompanyViewSet,
 )
 
 # TODO: delete once the migration to address and registered address is complete
@@ -60,6 +61,9 @@ one_list_group_core_team = OneListGroupCoreTeamViewSet.as_view({
     'get': 'list',
 })
 
+public_company_item_v4 = PublicCompanyViewSet.as_view({
+    'get': 'retrieve',
+})
 
 urls_v3 = [
     path('company', company_collection_v3, name='collection'),
@@ -87,4 +91,5 @@ urls_v4 = [
         one_list_group_core_team,
         name='one-list-group-core-team',
     ),
+    path('public/company/<uuid:pk>', public_company_item_v4, name='public-item'),
 ]

--- a/datahub/company/urls/contact.py
+++ b/datahub/company/urls/contact.py
@@ -1,0 +1,33 @@
+from django.urls import path
+
+from datahub.company.views import ContactAuditViewSet, ContactViewSet
+
+contact_collection = ContactViewSet.as_view({
+    'get': 'list',
+    'post': 'create',
+})
+
+contact_item = ContactViewSet.as_view({
+    'get': 'retrieve',
+    'patch': 'partial_update',
+})
+
+contact_archive = ContactViewSet.as_view({
+    'post': 'archive',
+})
+
+contact_unarchive = ContactViewSet.as_view({
+    'post': 'unarchive',
+})
+
+contact_audit = ContactAuditViewSet.as_view({
+    'get': 'list',
+})
+
+urls_v3 = [
+    path('contact', contact_collection, name='list'),
+    path('contact/<uuid:pk>', contact_item, name='detail'),
+    path('contact/<uuid:pk>/archive', contact_archive, name='archive'),
+    path('contact/<uuid:pk>/unarchive', contact_unarchive, name='unarchive'),
+    path('contact/<uuid:pk>/audit', contact_audit, name='audit-item'),
+]

--- a/datahub/core/test/support/views.py
+++ b/datahub/core/test/support/views.py
@@ -1,4 +1,3 @@
-from django.utils.decorators import decorator_from_middleware
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -6,7 +5,7 @@ from rest_framework.views import APIView
 from config.settings.types import HawkScope
 from datahub.core.hawk_receiver import (
     HawkAuthentication,
-    HawkResponseMiddleware,
+    HawkResponseSigningMixin,
     HawkScopePermission,
 )
 from datahub.core.test.support.models import MultiAddressModel, MyDisableableModel, PermissionModel
@@ -44,26 +43,24 @@ class MultiAddressModelViewset(CoreViewSet):
     queryset = MultiAddressModel.objects.all()
 
 
-class HawkViewWithoutScope(APIView):
+class HawkViewWithoutScope(HawkResponseSigningMixin, APIView):
     """View using Hawk authentication."""
 
     authentication_classes = (HawkAuthentication,)
     permission_classes = ()
 
-    @decorator_from_middleware(HawkResponseMiddleware)
     def get(self, request):
         """Simple test view with fixed response."""
         return Response({'content': 'hawk-test-view-without-scope'})
 
 
-class HawkViewWithScope(APIView):
+class HawkViewWithScope(HawkResponseSigningMixin, APIView):
     """View using Hawk authentication."""
 
     authentication_classes = (HawkAuthentication,)
     permission_classes = (HawkScopePermission,)
     required_hawk_scope = next(iter(HawkScope.__members__.values()))
 
-    @decorator_from_middleware(HawkResponseMiddleware)
     def get(self, request):
         """Simple test view with fixed response."""
         return Response({'content': 'hawk-test-view-with-scope'})

--- a/datahub/core/test/test_hawk_receiver.py
+++ b/datahub/core/test/test_hawk_receiver.py
@@ -285,7 +285,7 @@ class TestHawkAuthentication:
 
 @pytest.mark.django_db
 @pytest.mark.urls('datahub.core.test.support.urls')
-class TestHawkResponseMiddleware:
+class TestHawkResponseSigningMixin:
     """Tests Hawk response signing when using HawkResponseMiddleware."""
 
     def test_empty_object_returned_with_authentication(self, api_client):

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -1,13 +1,12 @@
 from django.db.models.expressions import Case, Value, When
 from django.db.models.fields import CharField
 from django.db.models.functions import Cast, Concat, Upper
-from django.utils.decorators import decorator_from_middleware
 
 from config.settings.types import HawkScope
 from datahub.company.models import Company as DBCompany
 from datahub.core.hawk_receiver import (
     HawkAuthentication,
-    HawkResponseMiddleware,
+    HawkResponseSigningMixin,
     HawkScopePermission,
 )
 from datahub.core.query_utils import get_front_end_url_expression
@@ -103,7 +102,7 @@ class SearchCompanyAPIViewV4(SearchCompanyAPIViewMixin, SearchAPIView):
 
 
 @register_v4_view(is_public=True)
-class PublicSearchCompanyAPIView(SearchAPIView):
+class PublicSearchCompanyAPIView(HawkResponseSigningMixin, SearchAPIView):
     """
     Company search view using Hawk authentication.
 
@@ -161,15 +160,6 @@ class PublicSearchCompanyAPIView(SearchAPIView):
             'trading_names_trigram',
         ],
     }
-
-    @decorator_from_middleware(HawkResponseMiddleware)
-    def post(self, request, format=None):
-        """
-        Perform search.
-
-        Overridden to add Hawk response signing.
-        """
-        return super().post(request, format=format)
 
 
 @register_v3_view(sub_path='export')


### PR DESCRIPTION
### Description of change

This depends on https://github.com/uktrade/data-hub-leeloo/pull/1491, so at the moment it targets that branch.

There are a few bits of refactoring in this, so would suggest looking at the commits individually.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
