### PR TITLE
Remove uses of # noqa: Q000

### DIFF
--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -94,7 +94,7 @@ class Interaction(BaseModel):
     date = models.DateTimeField()
     company = models.ForeignKey(
         'company.Company',
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         blank=True,
         null=True,
         on_delete=models.CASCADE,
@@ -116,7 +116,7 @@ class Interaction(BaseModel):
     )
     event = models.ForeignKey(
         'event.Event',
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
@@ -128,7 +128,7 @@ class Interaction(BaseModel):
     subject = models.TextField()
     dit_adviser = models.ForeignKey(
         'company.Advisor',
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         blank=True,
         null=True,
         on_delete=models.SET_NULL,
@@ -144,7 +144,7 @@ class Interaction(BaseModel):
     )
     investment_project = models.ForeignKey(
         'investment.InvestmentProject',
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         null=True,
         blank=True,
         on_delete=models.CASCADE,

--- a/datahub/metadata/models.py
+++ b/datahub/metadata/models.py
@@ -33,7 +33,7 @@ class Sector(MPTTModel, DisableableModel):
     sector_cluster = models.ForeignKey(
         SectorCluster,
         null=True, blank=True,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         on_delete=models.PROTECT,
     )
     parent = TreeForeignKey(
@@ -145,19 +145,19 @@ class Team(BaseConstantModel):
     role = models.ForeignKey(
         TeamRole,
         null=True, blank=True,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         on_delete=models.PROTECT,
     )
     uk_region = models.ForeignKey(
         UKRegion,
         null=True, blank=True,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         on_delete=models.PROTECT,
     )
     country = models.ForeignKey(
         Country,
         null=True, blank=True,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         on_delete=models.PROTECT,
     )
     tags = MultipleChoiceField(

--- a/datahub/omis/order/models.py
+++ b/datahub/omis/order/models.py
@@ -129,18 +129,18 @@ class Order(BaseModel):
 
     company = models.ForeignKey(
         Company,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         on_delete=models.PROTECT,
     )
     contact = models.ForeignKey(
         Contact,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         on_delete=models.PROTECT,
     )
 
     primary_market = models.ForeignKey(
         Country,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         null=True,
         on_delete=models.SET_NULL,
     )
@@ -152,14 +152,14 @@ class Order(BaseModel):
     )
     uk_region = models.ForeignKey(
         UKRegion,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         null=True, blank=True,
         on_delete=models.SET_NULL,
     )
 
     service_types = models.ManyToManyField(
         ServiceType,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         blank=True,
     )
     description = models.TextField(
@@ -197,7 +197,7 @@ class Order(BaseModel):
 
     hourly_rate = models.ForeignKey(
         HourlyRate,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
         on_delete=models.PROTECT,
         default=DEFAULT_HOURLY_RATE,
     )

--- a/datahub/omis/payment/models.py
+++ b/datahub/omis/payment/models.py
@@ -124,7 +124,7 @@ class Payment(BaseModel):
     order = models.ForeignKey(
         'order.Order',
         on_delete=models.CASCADE,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
     )
     reference = models.CharField(
         max_length=100,
@@ -189,7 +189,7 @@ class Refund(BaseModel):
     order = models.ForeignKey(
         'order.Order',
         on_delete=models.CASCADE,
-        related_name="%(class)ss",  # noqa: Q000
+        related_name='%(class)ss',
     )
     reference = models.CharField(max_length=100)
     status = models.CharField(max_length=100, choices=RefundStatus)


### PR DESCRIPTION
### Description of change

Not sure how these usages of `# noqa: Q000` slipped in. We can use single quotes in all of these cases, so this does that and removes the `# noqa: Q000` usages.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
