### PR TITLE
Remove support for AWS authentication with Elasticsearch

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -287,15 +287,8 @@ VCAP_SERVICES = env.json('VCAP_SERVICES', default={})
 # Leeloo stuff
 if 'elasticsearch' in VCAP_SERVICES:
     ES_URL = VCAP_SERVICES['elasticsearch'][0]['credentials']['uri']
-    ES_USE_AWS_AUTH = False
 else:
     ES_URL = env('ES5_URL')
-    ES_USE_AWS_AUTH = env.bool('ES_USE_AWS_AUTH', False)
-
-if ES_USE_AWS_AUTH:
-    AWS_ELASTICSEARCH_REGION = env('AWS_ELASTICSEARCH_REGION')
-    AWS_ELASTICSEARCH_KEY = env('AWS_ELASTICSEARCH_KEY')
-    AWS_ELASTICSEARCH_SECRET = env('AWS_ELASTICSEARCH_SECRET')
 
 ES_VERIFY_CERTS = env.bool('ES_VERIFY_CERTS', True)
 ES_INDEX_PREFIX = env('ES_INDEX_PREFIX')

--- a/datahub/search/elasticsearch.py
+++ b/datahub/search/elasticsearch.py
@@ -1,10 +1,7 @@
 from contextlib import contextmanager
 from logging import getLogger
-from urllib.parse import urlparse
 
-from aws_requests_auth.aws_auth import AWSRequestsAuth
 from django.conf import settings
-from elasticsearch import RequestsHttpConnection
 from elasticsearch.helpers import bulk as es_bulk
 from elasticsearch_dsl import analysis, Index
 from elasticsearch_dsl.connections import connections
@@ -75,38 +72,11 @@ ANALYZERS = (
 
 def configure_connection():
     """Configure Elasticsearch default connection."""
-    if settings.ES_USE_AWS_AUTH:
-        es_protocol = {
-            'http': 80,
-            'https': 443,
-        }
-        es_host = urlparse(settings.ES_URL)
-        es_port = es_host.port if es_host.port else es_protocol.get(es_host.scheme)
-        use_ssl = es_host.scheme == 'https'
-        auth = AWSRequestsAuth(
-            aws_access_key=settings.AWS_ELASTICSEARCH_KEY,
-            aws_secret_access_key=settings.AWS_ELASTICSEARCH_SECRET,
-            aws_host=es_host.netloc,
-            aws_region=settings.AWS_ELASTICSEARCH_REGION,
-            aws_service='es',
-        )
-        connections_default = {
-            'hosts': [es_host.netloc],
-            'port': es_port,
-            'use_ssl': use_ssl,
-            'verify_certs': settings.ES_VERIFY_CERTS,
-            'http_auth': auth,
-            'connection_class': RequestsHttpConnection,
-        }
-    else:
-        connections_default = {
-            'hosts': [settings.ES_URL],
-            'verify_certs': settings.ES_VERIFY_CERTS,
-        }
-
-    connections.configure(
-        default=connections_default,
-    )
+    connections_default = {
+        'hosts': [settings.ES_URL],
+        'verify_certs': settings.ES_VERIFY_CERTS,
+    }
+    connections.configure(default=connections_default)
 
 
 def get_client():

--- a/datahub/search/test/test_elasticsearch.py
+++ b/datahub/search/test/test_elasticsearch.py
@@ -39,7 +39,6 @@ def test_index_exists(mock_es_client, expected):
 def test_configure_connection(connections, settings):
     """Tests if Heroku connection is configured."""
     settings.HEROKU = True
-    settings.ES_USE_AWS_AUTH = False
     settings.ES_URL = 'https://login:password@test:1234'
     connections.configure.return_value = {}
 

--- a/requirements.in
+++ b/requirements.in
@@ -36,7 +36,6 @@ redis==3.1.0
 # ES
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
-aws-requests-auth==0.4.2
 
 # Celery
 celery==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ amqp==2.4.1               # via kombu
 apipkg==1.5               # via execnet
 atomicwrites==1.3.0       # via pytest
 attrs==18.2.0             # via pytest
-aws-requests-auth==0.4.2
 backcall==0.1.0           # via ipython
 billiard==3.5.0.4
 boto3==1.9.105


### PR DESCRIPTION
### Description of change

We are no longer using AWS-provided Elasticsearch with AWS request signing, so this removes support for it.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
