### PR TITLE
Remove deprecated interaction contact sorting and filtering options from main API

### DIFF
--- a/changelog/interaction/remove-contact-sorting-main.removal.api.rst
+++ b/changelog/interaction/remove-contact-sorting-main.removal.api.rst
@@ -1,0 +1,1 @@
+``GET /v3/interaction``: The deprecated ``contact__first_name`` and ``contact__last_name`` values for the ``sortby`` query parameter were removed.

--- a/changelog/interaction/remove-single-contact-filtering-main.removal.api.rst
+++ b/changelog/interaction/remove-single-contact-filtering-main.removal.api.rst
@@ -1,0 +1,1 @@
+``GET /v3/interaction``: The deprecated ``contact_id`` query parameter was removed. Please use ``contacts__id`` instead.

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -517,8 +517,6 @@ class TestListInteractions(APITestMixin):
         'field',
         (
             'company.name',
-            'contact.first_name',
-            'contact.last_name',
             'created_on',
             'dit_adviser.first_name',
             'dit_adviser.last_name',
@@ -531,8 +529,6 @@ class TestListInteractions(APITestMixin):
             {
                 'created_on': datetime(2015, 1, 1),
                 'company__name': 'Black Group',
-                'contact__first_name': 'Holly',
-                'contact__last_name': 'Taylor',
                 'dit_adviser__first_name': 'Elaine',
                 'dit_adviser__last_name': 'Johnston',
                 'subject': 'lorem',
@@ -540,8 +536,6 @@ class TestListInteractions(APITestMixin):
             {
                 'created_on': datetime(2005, 4, 1),
                 'company__name': 'Hicks Ltd',
-                'contact__first_name': 'Conor',
-                'contact__last_name': 'Webb',
                 'dit_adviser__first_name': 'Connor',
                 'dit_adviser__last_name': 'Webb',
                 'subject': 'ipsum',
@@ -549,8 +543,6 @@ class TestListInteractions(APITestMixin):
             {
                 'created_on': datetime(2019, 1, 1),
                 'company__name': 'Sheppard LLC',
-                'contact__first_name': 'Suzanne',
-                'contact__last_name': 'Palmer',
                 'dit_adviser__first_name': 'Hayley',
                 'dit_adviser__last_name': 'Hunt',
                 'subject': 'dolor',
@@ -591,25 +583,18 @@ class TestListInteractions(APITestMixin):
         ]
         assert expected == actual
 
-    @pytest.mark.parametrize(
-        'field,factory_class',
-        (
-            ('contact', ContactFactory),
-            ('dit_adviser', AdviserFactory),
-        ),
-    )
-    def test_sort_by_first_and_last_name(self, field, factory_class):
+    def test_sort_by_adviser_first_and_last_name(self):
         """Test sorting interactions by first_name with a secondary last_name sort."""
         people = [
-            factory_class(first_name='Alfred', last_name='Jones'),
-            factory_class(first_name='Alfred', last_name='Terry'),
-            factory_class(first_name='Thomas', last_name='Richards'),
-            factory_class(first_name='Thomas', last_name='West'),
+            AdviserFactory(first_name='Alfred', last_name='Jones'),
+            AdviserFactory(first_name='Alfred', last_name='Terry'),
+            AdviserFactory(first_name='Thomas', last_name='Richards'),
+            AdviserFactory(first_name='Thomas', last_name='West'),
         ]
         interactions = EventServiceDeliveryFactory.create_batch(
             len(people),
             **{
-                field: factory.Iterator(sample(people, k=len(people))),
+                'dit_adviser': factory.Iterator(sample(people, k=len(people))),
             },
         )
 
@@ -617,7 +602,7 @@ class TestListInteractions(APITestMixin):
         response = self.api_client.get(
             url,
             data={
-                'sortby': f'{field}__first_name,{field}__last_name',
+                'sortby': f'dit_adviser__first_name,dit_adviser__last_name',
             },
         )
 
@@ -627,7 +612,7 @@ class TestListInteractions(APITestMixin):
         assert response_data['count'] == len(interactions)
 
         actual_ids = [
-            interaction[field]['id']
+            interaction['dit_adviser']['id']
             for interaction in response_data['results']
         ]
         expected_ids = [str(person.pk) for person in people]

--- a/datahub/interaction/test/views/test_common.py
+++ b/datahub/interaction/test/views/test_common.py
@@ -432,25 +432,6 @@ class TestListInteractions(APITestMixin):
         assert response.data['count'] == 2
         assert {i['id'] for i in response.data['results']} == {str(i.id) for i in interactions}
 
-    def test_filter_by_contact_legacy(self):
-        """
-        Test filtering interactions by contact (using the legacy contact_id field).
-
-        TODO Remove once contact_id filter removed.
-        """
-        contact1 = ContactFactory()
-        contact2 = ContactFactory()
-
-        CompanyInteractionFactory.create_batch(3, contact=contact1)
-        interactions = CompanyInteractionFactory.create_batch(2, contact=contact2)
-
-        url = reverse('api-v3:interaction:collection')
-        response = self.api_client.get(url, data={'contact_id': contact2.id})
-
-        assert response.status_code == status.HTTP_200_OK
-        assert response.data['count'] == 2
-        assert {i['id'] for i in response.data['results']} == {str(i.id) for i in interactions}
-
     def test_filter_by_contact(self):
         """Test filtering interactions by contact (using contacts__id)."""
         contact1 = ContactFactory()

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -39,10 +39,6 @@ class InteractionViewSet(CoreViewSet):
     ]
     ordering_fields = (
         'company__name',
-        # TODO: Remove once contact has been removed (following the deprecation period)
-        'contact__first_name',
-        # TODO: Remove once contact has been removed (following the deprecation period)
-        'contact__last_name',
         'created_on',
         'date',
         'dit_adviser__first_name',

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -31,8 +31,6 @@ class InteractionViewSet(CoreViewSet):
     )
     filterset_fields = [
         'company_id',
-        # TODO: Remove once contact has been removed (following the deprecation period)
-        'contact_id',
         'contacts__id',
         'event_id',
         'investment_project_id',


### PR DESCRIPTION
### Description of change

This removes the deprecated contact sorting options and filter from `/v3/interaction`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
