### PR TITLE
Update investment related URLs in the settings

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -413,11 +413,11 @@ DATAHUB_FRONTEND_URL_PREFIXES = {
     'contact': f'{DATAHUB_FRONTEND_BASE_URL}/contacts',
     'event': f'{DATAHUB_FRONTEND_BASE_URL}/events',
     'interaction': f'{DATAHUB_FRONTEND_BASE_URL}/interactions',
-    'investmentproject': f'{DATAHUB_FRONTEND_BASE_URL}/investment-projects',
+    'investmentproject': f'{DATAHUB_FRONTEND_BASE_URL}/investments/projects',
     'order': f'{DATAHUB_FRONTEND_BASE_URL}/omis',
 
     'mi_fdi_dashboard_country': (
-        f'{DATAHUB_FRONTEND_BASE_URL}/investment-projects?{urlencode(MI_FDI_DASHBOARD_COUNTRY_URL_PARAMS)}'
+        f'{DATAHUB_FRONTEND_BASE_URL}/investments/projects?{urlencode(MI_FDI_DASHBOARD_COUNTRY_URL_PARAMS)}'
     )
 }
 


### PR DESCRIPTION
### Description of change

This updates the URLs pointing at investment projects as the front end paths changed.
Mainly this fixes country URLs in MI dashboards.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
