### PR TITLE
Remove deprecated interaction search filters and sorting options

### DIFF
--- a/changelog/interaction/search-filter.removal.rst
+++ b/changelog/interaction/search-filter.removal.rst
@@ -1,0 +1,1 @@
+``POST /v3/search/interaction``: The deprecated ``contact`` and ``contact_name`` filters were removed.

--- a/changelog/interaction/search-sorting.removal.rst
+++ b/changelog/interaction/search-sorting.removal.rst
@@ -1,0 +1,1 @@
+``POST /v3/search/interaction``: The deprecated ``contact.name``, ``dit_adviser.name``, ``dit_team.name`` and ``id`` values for the ``sortby`` query parameter were removed.

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -19,8 +19,6 @@ class SearchInteractionQuerySerializer(EntitySearchQuerySerializer):
     kind = SingleOrListField(child=serializers.CharField(), required=False)
     company = SingleOrListField(child=StringUUIDField(), required=False)
     company_name = serializers.CharField(required=False)
-    contact = SingleOrListField(child=StringUUIDField(), required=False)
-    contact_name = serializers.CharField(required=False)
     date_after = RelaxedDateTimeField(required=False)
     date_before = RelaxedDateTimeField(required=False)
     created_on_exists = serializers.BooleanField(required=False)
@@ -46,10 +44,6 @@ class SearchInteractionQuerySerializer(EntitySearchQuerySerializer):
         'id',
         'subject',
     )
-    deprecated_filters = {
-        'contact',
-        'contact_name',
-    }
     deprecated_sortby_fields = {
         'contact.name',
         'dit_adviser.name',
@@ -63,13 +57,6 @@ class SearchInteractionQuerySerializer(EntitySearchQuerySerializer):
 
         TODO Remove following deprecation period.
         """
-        deprecated_filters_in_data = data.keys() & self.deprecated_filters
-        if deprecated_filters_in_data:
-            logger.error(
-                'The following deprecated interaction search filters were '
-                f'used: {deprecated_filters_in_data}.',
-            )
-
         sortby = data.get('sortby')
         if sortby and sortby.field in self.deprecated_sortby_fields:
             logger.error(

--- a/datahub/search/interaction/serializers.py
+++ b/datahub/search/interaction/serializers.py
@@ -1,5 +1,3 @@
-from logging import getLogger
-
 from rest_framework import serializers
 
 from datahub.core.serializers import RelaxedDateTimeField
@@ -9,8 +7,6 @@ from datahub.search.serializers import (
     StringUUIDField,
 )
 from datahub.search.utils import SearchOrdering, SortDirection
-
-logger = getLogger(__name__)
 
 
 class SearchInteractionQuerySerializer(EntitySearchQuerySerializer):
@@ -37,30 +33,6 @@ class SearchInteractionQuerySerializer(EntitySearchQuerySerializer):
 
     SORT_BY_FIELDS = (
         'company.name',
-        'contact.name',
         'date',
-        'dit_adviser.name',
-        'dit_team.name',
-        'id',
         'subject',
     )
-    deprecated_sortby_fields = {
-        'contact.name',
-        'dit_adviser.name',
-        'dit_team.name',
-        'id',
-    }
-
-    def validate(self, data):
-        """
-        Logs all deprecated params to make sure we don't break things when we get rid of them.
-
-        TODO Remove following deprecation period.
-        """
-        sortby = data.get('sortby')
-        if sortby and sortby.field in self.deprecated_sortby_fields:
-            logger.error(
-                'The following deprecated interaction search sortby field was '
-                f'used: {sortby.field}.',
-            )
-        return super().validate(data)

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -461,57 +461,6 @@ class TestInteractionEntitySearchView(APITestMixin):
             assert response.data['count'] == 0
             assert len(response.data['results']) == 0
 
-    def test_filter_by_contact_id(self, setup_es):
-        """Tests filtering interaction by contact id."""
-        contacts = ContactFactory.create_batch(10)
-        CompanyInteractionFactory.create_batch(
-            len(contacts),
-            contact=factory.Iterator(contacts),
-        )
-
-        setup_es.indices.refresh()
-
-        url = reverse('api-v3:search:interaction')
-        request_data = {
-            'contact': contacts[5].id,
-        }
-        response = self.api_client.post(url, request_data)
-
-        assert response.status_code == status.HTTP_200_OK
-
-        response_data = response.json()
-
-        assert response_data['count'] == 1
-
-        results = response_data['results']
-        assert results[0]['contact']['id'] == str(contacts[5].id)
-
-    def test_filter_by_contact_name(self, setup_es):
-        """Tests filtering interaction by contact name."""
-        contacts = ContactFactory.create_batch(10)
-        CompanyInteractionFactory.create_batch(
-            len(contacts),
-            contact=factory.Iterator(contacts),
-        )
-        setup_es.indices.refresh()
-
-        url = reverse('api-v3:search:interaction')
-        request_data = {
-            'contact_name': contacts[5].name,
-        }
-        response = self.api_client.post(url, request_data)
-
-        assert response.status_code == status.HTTP_200_OK
-
-        response_data = response.json()
-
-        assert response_data['count'] > 0
-
-        results = response_data['results']
-        # multiple records can match our filter, let's make sure at least one is exact match
-        assert any(result['contact']['id'] == str(contacts[5].id) for result in results)
-        assert any(result['contact']['name'] == contacts[5].name for result in results)
-
     @pytest.mark.parametrize(
         'created_on_exists',
         (True, False),

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -23,8 +23,6 @@ class SearchInteractionAPIViewMixin:
         'kind',
         'company',
         'company_name',
-        'contact',
-        'contact_name',
         'created_on_exists',
         'dit_adviser',
         'dit_adviser_name',
@@ -42,7 +40,6 @@ class SearchInteractionAPIViewMixin:
 
     REMAP_FIELDS = {
         'company': 'company.id',
-        'contact': 'contact.id',
         'dit_adviser': 'dit_adviser.id',
         'dit_team': 'dit_team.id',
         'communication_channel': 'communication_channel.id',
@@ -53,10 +50,6 @@ class SearchInteractionAPIViewMixin:
     }
 
     COMPOSITE_FILTERS = {
-        'contact_name': [
-            'contact.name',
-            'contact.name_trigram',
-        ],
         'company_name': [
             'company.name',
             'company.name_trigram',


### PR DESCRIPTION
### Description of change

This removes deprecated contact sorting options and filters from `/v3/search/interaction`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
