### PR TITLE
Remove contact field from interaction search model

### DIFF
--- a/changelog/interaction/search-contact-field.removal.rst
+++ b/changelog/interaction/search-contact-field.removal.rst
@@ -1,0 +1,1 @@
+``GET /v3/search``, ``POST /v3/search/interaction``: The deprecated ``contact`` field in interaction search results was removed. Please use ``contacts`` instead.

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -15,7 +15,6 @@ class InteractionSearchApp(SearchApp):
         'company__sector',
         'company__sector__parent',
         'company__sector__parent__parent',
-        'contact',
         'dit_adviser',
         'dit_team',
         'communication_channel',

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -32,7 +32,6 @@ class Interaction(BaseESModel):
     company = fields.company_field('company')
     company_sector = fields.sector_field()
     communication_channel = fields.id_name_field()
-    contact = fields.contact_or_adviser_field('contact')
     contacts = _contact_field()
     created_on = Date()
     date = Date()
@@ -60,7 +59,6 @@ class Interaction(BaseESModel):
     MAPPINGS = {
         'company': dict_utils.company_dict,
         'communication_channel': dict_utils.id_name_dict,
-        'contact': dict_utils.contact_or_adviser_dict,
         'contacts': dict_utils.contact_or_adviser_list_of_dicts,
         'dit_adviser': dict_utils.contact_or_adviser_dict,
         'dit_team': dict_utils.id_name_dict,

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -46,12 +46,6 @@ def test_interaction_to_dict(setup_es, factory_cls):
                 'id': str(ancestor.pk),
             } for ancestor in interaction.company.sector.get_ancestors()],
         } if interaction.company else None,
-        'contact': {
-            'id': str(interaction.contact.pk),
-            'first_name': interaction.contact.first_name,
-            'name': interaction.contact.name,
-            'last_name': interaction.contact.last_name,
-        },
         'contacts': [
             {
                 'id': str(obj.pk),
@@ -137,12 +131,6 @@ def test_service_delivery_to_dict(setup_es):
             'ancestors': [{
                 'id': str(ancestor.pk),
             } for ancestor in interaction.company.sector.get_ancestors()],
-        },
-        'contact': {
-            'id': str(interaction.contact.pk),
-            'first_name': interaction.contact.first_name,
-            'name': interaction.contact.name,
-            'last_name': interaction.contact.last_name,
         },
         'contacts': [
             {

--- a/datahub/search/interaction/tests/test_signals.py
+++ b/datahub/search/interaction/tests/test_signals.py
@@ -85,9 +85,10 @@ def test_updating_contact_name_updates_interaction(setup_es):
     interaction = CompanyInteractionFactory()
     new_first_name = 'Jamie'
     new_last_name = 'Bloggs'
-    interaction.contact.first_name = new_first_name
-    interaction.contact.last_name = new_last_name
-    interaction.contact.save()
+    contact = interaction.contacts.first()
+    contact.first_name = new_first_name
+    contact.last_name = new_last_name
+    contact.save()
     setup_es.indices.refresh()
 
     result = setup_es.get(
@@ -95,7 +96,7 @@ def test_updating_contact_name_updates_interaction(setup_es):
         doc_type=InteractionSearchApp.name,
         id=interaction.pk,
     )
-    assert result['_source']['contact'] == {
+    assert result['_source']['contacts'][0] == {
         'id': str(interaction.contact.id),
         'first_name': new_first_name,
         'last_name': new_last_name,

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -298,12 +298,6 @@ class TestInteractionEntitySearchView(APITestMixin):
                     'id': str(ancestor.pk),
                 } for ancestor in interaction.company.sector.get_ancestors()],
             },
-            'contact': {
-                'id': str(interaction.contact.pk),
-                'first_name': interaction.contact.first_name,
-                'name': interaction.contact.name,
-                'last_name': interaction.contact.last_name,
-            },
             'contacts': [
                 {
                     'id': str(contact.pk),


### PR DESCRIPTION
### Description of change

This removes the deprecated `contact` field from the interaction search model (including API responses).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
