### PR TITLE
Remove sortby values from basic search

### DIFF
--- a/changelog/search-sortby.removal.rst
+++ b/changelog/search-sortby.removal.rst
@@ -1,0 +1,1 @@
+``GET /v3/search``: all the values for the ``sortby`` query parameter were removed.

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -654,7 +654,7 @@ class TestGlobalSearch(APITestMixin):
     """Test global search for orders."""
 
     @pytest.mark.parametrize(
-        'term,results',
+        'term,expected_results',
         (
             (  # no filter => return all records
                 '',
@@ -694,7 +694,7 @@ class TestGlobalSearch(APITestMixin):
             ),
         ),
     )
-    def test_search(self, setup_data, term, results):
+    def test_search(self, setup_data, term, expected_results):
         """Test search results."""
         url = reverse('api-v3:search:basic')
 
@@ -702,13 +702,14 @@ class TestGlobalSearch(APITestMixin):
             url,
             data={
                 'term': term,
-                'sortby': 'created_on:asc',
                 'entity': 'order',
             },
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.json()['results']) == len(results)
-        assert [
-            item['reference'] for item in response.json()['results']
-        ] == results
+        assert len(response.json()['results']) == len(expected_results)
+        actual_results = sorted(
+            item['reference']
+            for item in response.json()['results']
+        )
+        assert actual_results == expected_results

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -28,7 +28,6 @@ def get_basic_search_query(
         entity,
         term,
         permission_filters_by_entity=None,
-        ordering=None,
         offset=0,
         limit=100,
 ):
@@ -63,7 +62,7 @@ def get_basic_search_query(
             should=Term(_type=entity._doc_type.name),
         ),
     )
-    search = _apply_sorting_to_query(search, ordering)
+    search = search.sort('_score', 'id')
     search.aggs.bucket(
         'count_by_type', 'terms', field='_type',
     )

--- a/datahub/search/serializers.py
+++ b/datahub/search/serializers.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 from rest_framework.settings import api_settings
@@ -7,9 +5,6 @@ from rest_framework.settings import api_settings
 from datahub.search.apps import get_global_search_apps_as_mapping
 from datahub.search.query_builder import MAX_RESULTS
 from datahub.search.utils import SearchOrdering, SortDirection
-
-
-logger = logging.getLogger(__name__)
 
 
 class SingleOrListField(serializers.ListField):
@@ -141,26 +136,8 @@ class _ESModelChoiceField(serializers.Field):
 class BasicSearchQuerySerializer(BaseSearchQuerySerializer):
     """Serialiser used to validate basic (global) search query parameters."""
 
-    SORT_BY_FIELDS = (
-        'created_on',
-        'name',
-    )
     entity = _ESModelChoiceField(default='company')
     term = serializers.CharField(required=True, allow_blank=True)
-
-    def validate(self, data):
-        """
-        Logs the sortby search param to see if we can get rid of it from the global search.
-
-        TODO: Remove following deprecation period.
-        """
-        sortby = data.get('sortby')
-        if sortby:
-            logger.error(
-                'The following deprecated global search sortby field was '
-                f'used: {sortby.field}.',
-            )
-        return super().validate(data)
 
 
 class EntitySearchQuerySerializer(BaseSearchQuerySerializer):


### PR DESCRIPTION
### Description of change

This removes all previously deprecated sortby values from the basic search.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
