### PR TITLE
Fix celery beat schedule for generate_spi_report

### DIFF
--- a/changelog/investment/generate_spi_report.internal.rst
+++ b/changelog/investment/generate_spi_report.internal.rst
@@ -1,0 +1,1 @@
+Fix for ``generate_spi_report`` celery task having the incorrect path.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -374,7 +374,7 @@ if REDIS_BASE_URL:
 
     if env.bool('ENABLE_SPI_REPORT_GENERATION', False):
         CELERY_BEAT_SCHEDULE['spi_report'] = {
-            'task': 'datahub.investment.report.tasks.generate_spi_report',
+            'task': 'datahub.investment.project.report.tasks.generate_spi_report',
             'schedule': crontab(minute=0, hour=8),
         }
 


### PR DESCRIPTION
### Description of change
This fixes the issue with the celery beat schedule being incorrect due to the investment project code being moved into a sub directory


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
