### PR TITLE
Add task to create DIT participants for all existing interactions

### DIFF
--- a/changelog/interaction/participants-task.internal.rst
+++ b/changelog/interaction/participants-task.internal.rst
@@ -1,0 +1,1 @@
+A Celery task was added to create ``InteractionDITParticipant`` objects from the ``dit_adviser`` and ``dit_team`` values for interactions that do not already have a ``InteractionDITParticipant`` object. The task must be run manually.

--- a/datahub/dbmaintenance/tasks.py
+++ b/datahub/dbmaintenance/tasks.py
@@ -2,10 +2,11 @@ from logging import getLogger
 
 from celery import shared_task
 from django.apps import apps
-from django.db.models import Exists, NOT_PROVIDED, OuterRef, Subquery
+from django.db.models import Exists, NOT_PROVIDED, OuterRef, Q, Subquery
 from django.db.transaction import atomic
 from django_pglocks import advisory_lock
 
+from datahub.interaction.models import Interaction, InteractionDITParticipant
 
 logger = getLogger(__name__)
 
@@ -118,6 +119,48 @@ def copy_foreign_key_to_m2m_field(
         )
 
 
+@shared_task(acks_late=True)
+def populate_interaction_dit_participant(batch_size=5000):
+    """
+    Task that creates InteractionDITParticipant instances for interactions that do not already
+    have one.
+
+    Interactions that have neither a dit_adviser nor a dit_team are skipped.
+
+    Usage example:
+
+        populate_interaction_dit_participant.apply_async()
+
+    """
+    lock_name = 'leeloo-populate_interaction_dit_participant'
+
+    with advisory_lock(lock_name, wait=False) as lock_held:
+        if not lock_held:
+            logger.warning(
+                f'Another populate_interaction_dit_participant task is in '
+                f'progress. Aborting...',
+            )
+            return
+
+        num_processed = _populate_interaction_dit_participant(
+            batch_size=batch_size,
+        )
+
+    # If there are definitely no more rows needing processing, return
+    if num_processed < batch_size:
+        return
+
+    # Schedule another task to update another batch of rows.
+    #
+    # This must be outside of the atomic block, otherwise it will probably run before the
+    # current changes have been committed.
+    #
+    # (Similarly, the lock should also be released before the next task is scheduled.)
+    populate_interaction_dit_participant.apply_async(
+        kwargs={'batch_size': batch_size},
+    )
+
+
 @atomic
 def _copy_foreign_key_to_m2m_field(
     model_label,
@@ -169,6 +212,48 @@ def _copy_foreign_key_to_m2m_field(
 
     logger.info(
         f'{num_created} {model_label}.{target_m2m_field_name} many-to-many objects created',
+    )
+
+    return len(objects_to_create)
+
+
+@atomic
+def _populate_interaction_dit_participant(batch_size=5000):
+    """
+    The main logic for the populate_interaction_dit_participant task.
+
+    This processes a single batch of objects in a transaction.
+    """
+    # Select a batch of rows. The rows are locked to avoid race conditions.
+    batch_queryset = Interaction.objects.select_for_update().annotate(
+        has_m2m_values=Exists(
+            InteractionDITParticipant.objects.filter(
+                interaction_id=OuterRef('pk'),
+            ),
+        ),
+    ).filter(
+        Q(dit_adviser__isnull=False) | Q(dit_team__isnull=False),
+        has_m2m_values=False,
+    ).values(
+        'pk',
+        'dit_adviser_id',
+        'dit_team_id',
+    )[:batch_size]
+
+    objects_to_create = [
+        InteractionDITParticipant(
+            interaction_id=row['pk'],
+            adviser_id=row['dit_adviser_id'],
+            team_id=row['dit_team_id'],
+        ) for row in batch_queryset
+    ]
+
+    # Create many-to-many objects for the batch
+    created_objects = InteractionDITParticipant.objects.bulk_create(objects_to_create)
+    num_created = len(created_objects)
+
+    logger.info(
+        f'{num_created} InteractionDITParticipant many-to-many objects created',
     )
 
     return len(objects_to_create)

--- a/datahub/dbmaintenance/test/test_tasks.py
+++ b/datahub/dbmaintenance/test/test_tasks.py
@@ -1,11 +1,21 @@
 from itertools import chain
 from unittest.mock import MagicMock, Mock
 
+import factory
 import pytest
 
 from datahub.core.test.support.factories import ForeignAndM2MModelFactory, MetadataModelFactory
 from datahub.core.test.support.models import NullableWithDefaultModel
-from datahub.dbmaintenance.tasks import copy_foreign_key_to_m2m_field, replace_null_with_default
+from datahub.dbmaintenance.tasks import (
+    copy_foreign_key_to_m2m_field,
+    populate_interaction_dit_participant,
+    replace_null_with_default,
+)
+from datahub.interaction.test.factories import (
+    CompanyInteractionFactory,
+    InteractionDITParticipantFactory,
+)
+from datahub.metadata.test.factories import TeamFactory
 
 
 @pytest.mark.django_db
@@ -260,3 +270,212 @@ class TestCopyForeignKeyToM2MField:
 
         # The task should not have been scheduled again as the task should've exited instead
         copy_foreign_key_to_m2m_field_mock.apply_async.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestCopyInteractionAdviserAndTeamToDITParticipant:
+    """Tests for the populate_interaction_dit_participant task."""
+
+    @pytest.mark.parametrize(
+        'factory_kwargs',
+        (
+            {},
+            {
+                'dit_adviser': None,
+                'dit_team': factory.SubFactory(TeamFactory),
+            },
+            {
+                'dit_team': None,
+            },
+        ),
+    )
+    @pytest.mark.parametrize(
+        'num_objects,batch_size,expected_batches',
+        (
+            (10, 4, 3),
+            (10, 5, 3),
+            (11, 6, 2),
+            (11, 12, 1),
+            (0, 5, 1),
+        ),
+    )
+    def test_copies_data_for_interactions_without_participants(
+        self,
+        monkeypatch,
+        factory_kwargs,
+        num_objects,
+        batch_size,
+        expected_batches,
+    ):
+        """
+        Test that the task copies data for interactions without an existing DIT participant,
+        and with an adviser or a team.
+
+        Various batch sizes are tested.
+        """
+        populate_interaction_dit_participant_mock = Mock(
+            wraps=populate_interaction_dit_participant,
+        )
+        monkeypatch.setattr(
+            'datahub.dbmaintenance.tasks.populate_interaction_dit_participant',
+            populate_interaction_dit_participant_mock,
+        )
+
+        interactions = CompanyInteractionFactory.create_batch(
+            num_objects,
+            dit_participants=[],
+            **factory_kwargs,
+        )
+
+        result = populate_interaction_dit_participant_mock.apply_async(
+            kwargs={'batch_size': batch_size},
+        )
+
+        assert result.successful()
+        assert populate_interaction_dit_participant_mock.apply_async.call_count == expected_batches
+
+        for obj in interactions:
+            obj.refresh_from_db()
+
+        # List comprehensions (rather than generator expressions) used in the all() calls to give
+        # more useful information in assertion failures
+        # These objects should have been updated by the task
+        assert all(
+            [
+                list(obj.dit_participants.values_list('adviser', 'team')) == [
+                    (obj.dit_adviser_id, obj.dit_team_id),
+                ]
+                for obj in interactions
+            ],
+        )
+
+    def test_ignores_interactions_with_existing_participants(self, monkeypatch, caplog):
+        """Test that the task does not modify interactions with an existing DIT participant."""
+        caplog.set_level('INFO', 'datahub')
+
+        populate_interaction_dit_participant_mock = Mock(
+            wraps=populate_interaction_dit_participant,
+        )
+        monkeypatch.setattr(
+            'datahub.dbmaintenance.tasks.populate_interaction_dit_participant',
+            populate_interaction_dit_participant_mock,
+        )
+
+        interactions = CompanyInteractionFactory.create_batch(
+            5,
+            dit_participants=[],
+        )
+        for interaction in interactions:
+            InteractionDITParticipantFactory(interaction=interaction)
+
+        result = populate_interaction_dit_participant_mock.apply_async(
+            kwargs={'batch_size': 100},
+        )
+
+        assert result.successful()
+        assert populate_interaction_dit_participant_mock.apply_async.call_count == 1
+
+        for obj in interactions:
+            obj.refresh_from_db()
+
+        # These objects should not have been modified
+        assert all(
+            [
+                obj.dit_participants.filter(adviser=obj.dit_adviser).count() == 0
+                for obj in interactions
+            ],
+        )
+        assert len(caplog.records) == 1
+        assert f'0 InteractionDITParticipant many-to-many objects created' in caplog.text
+
+    def test_ignores_interactions_without_adviser_and_team(self, monkeypatch, caplog):
+        """Test that the task does not modify interactions without advisers and teams."""
+        caplog.set_level('INFO', 'datahub')
+        populate_interaction_dit_participant_mock = Mock(
+            wraps=populate_interaction_dit_participant,
+        )
+        monkeypatch.setattr(
+            'datahub.dbmaintenance.tasks.populate_interaction_dit_participant',
+            populate_interaction_dit_participant_mock,
+        )
+
+        interactions = CompanyInteractionFactory.create_batch(
+            10,
+            dit_adviser=None,
+            dit_team=None,
+            dit_participants=[],
+        )
+
+        result = populate_interaction_dit_participant_mock.apply_async(
+            kwargs={'batch_size': 100},
+        )
+
+        assert result.successful()
+        assert populate_interaction_dit_participant_mock.apply_async.call_count == 1
+
+        for interaction in interactions:
+            interaction.refresh_from_db()
+
+        # These objects should not have been modified
+        assert all([obj.dit_participants.count() == 0 for obj in interactions])
+        assert len(caplog.records) == 1
+        assert f'0 InteractionDITParticipant many-to-many objects created' in caplog.text
+
+    def test_rolls_back_on_error(self, monkeypatch):
+        """Test that the task rolls back when an error is raised."""
+        populate_interaction_dit_participant_mock = Mock(
+            wraps=populate_interaction_dit_participant,
+        )
+        monkeypatch.setattr(
+            'datahub.dbmaintenance.tasks.populate_interaction_dit_participant',
+            populate_interaction_dit_participant_mock,
+        )
+
+        monkeypatch.setattr(
+            'datahub.dbmaintenance.tasks.logger.info',
+            Mock(side_effect=ValueError),
+        )
+
+        num_objects = 10
+        objects_to_update = CompanyInteractionFactory.create_batch(
+            num_objects,
+            dit_participants=[],
+        )
+
+        result = populate_interaction_dit_participant_mock.apply_async(
+            kwargs={'batch_size': num_objects},
+        )
+
+        with pytest.raises(ValueError):
+            result.get()
+
+        assert populate_interaction_dit_participant_mock.apply_async.call_count == 1
+
+        for obj in objects_to_update:
+            obj.refresh_from_db()
+
+        # List comprehensions (rather than generator expressions) used in the all() calls to give
+        # more useful information in assertion failures
+        # These objects should not have been modified due to the roll back
+        assert all([obj.dit_participants.count() == 0 for obj in objects_to_update])
+
+    def test_aborts_when_already_in_progress(self, monkeypatch):
+        """Test that the task aborts when a task for the same field is already in progress."""
+        populate_interaction_dit_participant_mock = Mock(
+            wraps=populate_interaction_dit_participant,
+        )
+        monkeypatch.setattr(
+            'datahub.dbmaintenance.tasks.populate_interaction_dit_participant',
+            populate_interaction_dit_participant_mock,
+        )
+
+        # Have to mock rather than acquire the lock as locks are per connection (if the lock is
+        # already held by the current connection, the current connection can still acquire it
+        # again).
+        advisory_lock_mock = MagicMock()
+        advisory_lock_mock.return_value.__enter__.return_value = False
+        monkeypatch.setattr('datahub.dbmaintenance.tasks.advisory_lock', advisory_lock_mock)
+        populate_interaction_dit_participant_mock.apply(args=('label', 'old-field', 'new-field'))
+
+        # The task should not have been scheduled again as the task should've exited instead
+        populate_interaction_dit_participant_mock.apply_async.assert_not_called()

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -31,7 +31,7 @@ class InteractionFactoryBase(factory.django.DjangoModelFactory):
     notes = factory.Faker('paragraph', nb_sentences=10)
     dit_adviser = factory.SubFactory(AdviserFactory)
     service_id = constants.Service.trade_enquiry.value.id
-    dit_team_id = constants.Team.healthcare_uk.value.id
+    dit_team = factory.SelfAttribute('dit_adviser.dit_team')
     archived_documents_url_path = factory.Faker('uri_path')
     was_policy_feedback_provided = False
 

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -538,8 +538,8 @@ class TestGetInteraction(APITestMixin):
                 'name': Service.trade_enquiry.value.name,
             },
             'dit_team': {
-                'id': str(Team.healthcare_uk.value.id),
-                'name': Team.healthcare_uk.value.name,
+                'id': str(interaction.dit_team.pk),
+                'name': interaction.dit_team.name,
             },
             'investment_project': {
                 'id': str(interaction.investment_project.pk),
@@ -620,8 +620,8 @@ class TestGetInteraction(APITestMixin):
                 'name': Service.trade_enquiry.value.name,
             },
             'dit_team': {
-                'id': str(Team.healthcare_uk.value.id),
-                'name': Team.healthcare_uk.value.name,
+                'id': str(interaction.dit_team.pk),
+                'name': interaction.dit_team.name,
             },
             'investment_project': {
                 'id': str(interaction.investment_project.pk),


### PR DESCRIPTION
### Description of change

This adds a Celery task that creates `InteractionDITParticipant` objects from the `dit_adviser` and `dit_team` values for interactions that do not already have a `InteractionDITParticipant` object. This is effectively a data migration. The task must be run manually.

The logic for the task was based on the similar `copy_foreign_key_to_m2m_field` task.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
