### PR TITLE
Add investor company filter to large captial list view

### DIFF
--- a/changelog/investment/large_capital_profile.api.rst
+++ b/changelog/investment/large_capital_profile.api.rst
@@ -1,4 +1,5 @@
 ``GET /v4/large-investor-profile`` returns a list of all the large capital profiles.
+The results can be filtered using a parameter of ``investor_company_id`` given a company id.
 
 ``POST /v4/large-investor-profile`` creates a large capital profile for a given ``investor_company``.
 

--- a/datahub/investment/investor_profile/views.py
+++ b/datahub/investment/investor_profile/views.py
@@ -1,3 +1,5 @@
+from django_filters.rest_framework import DjangoFilterBackend
+
 from datahub.core.viewsets import CoreViewSet
 from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
 from datahub.investment.investor_profile.models import InvestorProfile
@@ -11,6 +13,8 @@ class LargeCapitalInvestorProfileViewSet(CoreViewSet):
     required_scopes = (Scope.internal_front_end,)
     serializer_class = LargeCapitalInvestorProfileSerializer
     profile_type_id = ProfileTypeConstant.large.value.id
+    filter_backends = (DjangoFilterBackend,)
+    filterset_fields = ('investor_company_id',)
 
     def get_queryset(self):
         """Returns only large capital investor profile queryset."""


### PR DESCRIPTION
### Description of change
This adds filtering to the large-capital-profile endpoint. It is required so the FE can find out what profiles a company has whilst navigating the issue of not having any investment related information within the company endpoint.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?

### Jira Ticket
- IPBETA-288