### PR TITLE
Startup docs improvement for linux/docker users

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,22 +35,23 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
     docker-compose run leeloo ./manage.py createinitialrevisions
     ```
 
-    **NOTE:** If you are using a linux system, these commands may hang on 
-    waiting for the elasticsearch container to come up (`data-hub-leeloo_es_1`).
-    If the logs for that container mention something like 
-    `max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`,
-    you will need to run the following on your running host machine:
+    * **NOTE:** 
+      If you are using a linux system, these commands may hang on 
+      waiting for the elasticsearch container to come up (`data-hub-leeloo_es_1`).
+      If the logs for that container mention something like 
+      `max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`,
+      you will need to run the following on your running host machine:
 
-    ```shell
-    sudo sysctl -w vm.max_map_count=262144
-    ```
+      ```shell
+      sudo sysctl -w vm.max_map_count=262144
+      ```
 
-    and append/modify the `vm.max_map_count` setting in `/etc/sysctl.conf` (so 
-    that this setting persists after restart):
+      and append/modify the `vm.max_map_count` setting in `/etc/sysctl.conf` (so 
+      that this setting persists after restart):
 
-    ```shell
-    vm.max_map_count=262144
-    ```
+      ```shell
+      vm.max_map_count=262144
+      ```
 
 4. Optionally, you can load some test data and update elasticsearch:
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
     docker-compose run leeloo ./manage.py loadinitialmetadata
     docker-compose run leeloo ./manage.py createinitialrevisions
     ```
+
+    **NOTE:** If you are using a linux system, these commands may hang on 
+    waiting for the elasticsearch container to come up (`data-hub-leeloo_es_1`).
+    If the logs for that container mention something like 
+    `max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`,
+    you will need to run the following on your running host machine:
+
+    ```shell
+    sudo sysctl -w vm.max_map_count=262144
+    ```
+
+    and append/modify the `vm.max_map_count` setting in `/etc/sysctl.conf` (so 
+    that this setting persists after restart):
+
+    ```shell
+    vm.max_map_count=262144
+    ```
+
 4. Optionally, you can load some test data and update elasticsearch:
 
     ```shell

--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
 
     * **NOTE:** 
       If you are using a linux system, these commands may hang on 
-      waiting for the elasticsearch container to come up (`data-hub-leeloo_es_1`).
+      waiting for the elasticsearch container to come up (`data-hub-leeloo_es_1`) - 
+      it might be perpetually restarting.
       If the logs for that container mention something like 
       `max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`,
-      you will need to run the following on your running host machine:
+      you will need to run the following on your host machine:
 
       ```shell
       sudo sysctl -w vm.max_map_count=262144

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
       vm.max_map_count=262144
       ```
 
+      For more information, [see the elasticsearch docs on vm.max_map_count](https://www.elastic.co/guide/en/elasticsearch/reference/6.6/vm-max-map-count.html).
+
 4. Optionally, you can load some test data and update elasticsearch:
 
     ```shell


### PR DESCRIPTION
### Description of change

Adding a note to the README to help linux users if they run in to a restart problem with the elasticsearch container.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst] (https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions, *I don't think this applies to this..*
* [X] Have any relevant search models been updated?
* [X] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [X] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [X] Has the admin site been updated (for new models, fields etc.)?
* [X] Has the README been updated (if needed)?
