### PR TITLE
Add dit_participants to responses in interaction API

### DIFF
--- a/changelog/interaction/adviser-sorting.removal.rst
+++ b/changelog/interaction/adviser-sorting.removal.rst
@@ -1,0 +1,2 @@
+``GET /v3/interaction``: The ``dit_adviser__first_name`` and ``dit_adviser__last_name`` values for the
+``sortby`` query parameter are deprecated and will be removed on or after 28 March 2019.

--- a/changelog/interaction/adviser-team-read-only-admin.removal.rst
+++ b/changelog/interaction/adviser-team-read-only-admin.removal.rst
@@ -1,0 +1,1 @@
+The DIT adviser and DIT team fields were temporarily made read-only in the admin site until the transition to allowing multiple advisers in an interaction is complete.

--- a/changelog/interaction/dit-participants-read.api.rst
+++ b/changelog/interaction/dit-participants-read.api.rst
@@ -1,0 +1,33 @@
+``GET /v3/interaction, GET /v3/interaction/<id>, POST /v3/interaction, PATCH /v3/interaction/<id>``:
+
+``dit_participants`` was added to responses. This is an array in the following format::
+
+    [
+        {
+           "adviser": {
+               "id": ...,
+               "first_name": ...,
+               "last_name": ...,
+               "name": ...
+           },
+           "team": {
+               "id": ...,
+               "name": ...
+           }
+        },
+        {
+           "adviser": {
+               "id": ...,
+               "first_name": ...,
+               "last_name": ...,
+               "name": ...
+           },
+           "team": {
+               "id": ...,
+               "name": ...
+           }
+        },
+        ...
+    ]
+
+This field is intended to replace the ``dit_adviser`` and ``dit_team`` fields.

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -7,7 +7,6 @@ from datahub.core.utils import join_truthy_strings
 from datahub.interaction.models import (
     CommunicationChannel,
     Interaction,
-    InteractionDITParticipant,
     InteractionPermission,
     PolicyArea,
     PolicyIssueType,
@@ -52,6 +51,8 @@ class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
         'archived_documents_url_path',
         'created',
         'modified',
+        'dit_adviser',
+        'dit_team',
     )
     list_select_related = (
         'company',
@@ -95,13 +96,3 @@ class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
             obj.contact = contacts[0] if contacts else None
 
         super().save_model(request, obj, form, change)
-
-        # TODO: Remove once the migration from dit_adviser and dit_team to dit_participants is
-        #  complete.
-        InteractionDITParticipant.objects.update_or_create(
-            interaction=obj,
-            defaults={
-                'adviser': obj.dit_adviser,
-                'team': obj.dit_team,
-            },
-        )

--- a/datahub/interaction/queryset.py
+++ b/datahub/interaction/queryset.py
@@ -1,7 +1,7 @@
-from django.db.models import OuterRef, Subquery
+from django.db.models import OuterRef, Prefetch, Subquery
 
 from datahub.core.model_helpers import get_m2m_model
-from datahub.interaction.models import Interaction
+from datahub.interaction.models import Interaction, InteractionDITParticipant
 
 
 def get_interaction_queryset():
@@ -36,4 +36,8 @@ def get_interaction_queryset():
         'contacts',
         'policy_areas',
         'policy_issue_types',
+        Prefetch(
+            'dit_participants',
+            queryset=InteractionDITParticipant.objects.select_related('adviser', 'team'),
+        ),
     )

--- a/datahub/interaction/queryset.py
+++ b/datahub/interaction/queryset.py
@@ -25,10 +25,12 @@ def get_interaction_queryset():
         ),
     ).select_related(
         'company',
+        'created_by',
         'dit_adviser',
         'dit_team',
         'communication_channel',
         'investment_project',
+        'modified_by',
         'service',
         'service_delivery_status',
         'event',

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -29,6 +29,21 @@ from datahub.investment.project.serializers import NestedInvestmentProjectField
 from datahub.metadata.models import Service, Team
 
 
+class InteractionDITParticipantSerializer(serializers.ModelSerializer):
+    """
+    Interaction DIT participant serialiser.
+
+    Used within InteractionSerializer.
+    """
+
+    adviser = NestedAdviserField()
+    team = NestedRelatedField(Team)
+
+    class Meta:
+        model = InteractionDITParticipant
+        fields = ('adviser', 'team')
+
+
 class InteractionSerializer(serializers.ModelSerializer):
     """V3 interaction serialiser."""
 
@@ -68,8 +83,9 @@ class InteractionSerializer(serializers.ModelSerializer):
             'job_title',
         ),
     )
-    dit_adviser = NestedAdviserField()
     created_by = NestedAdviserField(read_only=True)
+    dit_adviser = NestedAdviserField()
+    dit_participants = InteractionDITParticipantSerializer(many=True, read_only=True)
     dit_team = NestedRelatedField(Team)
     communication_channel = NestedRelatedField(
         CommunicationChannel, required=False, allow_null=True,
@@ -178,6 +194,7 @@ class InteractionSerializer(serializers.ModelSerializer):
             'modified_on',
             'date',
             'dit_adviser',
+            'dit_participants',
             'dit_team',
             'communication_channel',
             'grant_amount_offered',

--- a/datahub/interaction/test/test_admin.py
+++ b/datahub/interaction/test/test_admin.py
@@ -6,14 +6,13 @@ from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.urls import reverse
 from rest_framework import status
 
-from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
+from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core.admin import get_change_url
 from datahub.core.test_utils import AdminTestMixin, random_obj_for_model
 from datahub.interaction.admin import InteractionAdmin
 from datahub.interaction.models import CommunicationChannel, Interaction
 from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.metadata.models import Service, Team
-from datahub.metadata.test.factories import TeamFactory
 
 
 class TestInteractionAdminContacts(AdminTestMixin):
@@ -146,136 +145,3 @@ class TestInteractionAdminContacts(AdminTestMixin):
             first_contact_name=first_contact.name if first_contact else '',
         )
         assert interaction_admin.get_contact_names(interaction) == formatted_expected_display_value
-
-
-class TestInteractionAdminParticipants(AdminTestMixin):
-    """
-    Tests for the dit_adviser, dit_team and dit_participants logic in interaction admin.
-
-    TODO: These tests will be removed once the migration from dit_adviser and dit_team to
-     dit_participants is complete.
-    """
-
-    def test_add(self):
-        """Test that adding an interaction also creates a DIT participant."""
-        company = CompanyFactory()
-        contacts = ContactFactory.create_batch(2, company=company)
-        communication_channel = random_obj_for_model(CommunicationChannel)
-
-        url = reverse(admin_urlname(Interaction._meta, 'add'))
-        dit_adviser = AdviserFactory()
-        dit_team = TeamFactory()
-
-        data = {
-            'id': uuid4(),
-            'kind': Interaction.KINDS.interaction,
-            'communication_channel': communication_channel.pk,
-            'subject': 'whatever',
-            'date_0': '2018-01-01',
-            'date_1': '00:00:00',
-            'dit_adviser': dit_adviser.pk,
-            'company': company.pk,
-            'contacts': [contact.pk for contact in contacts],
-            'service': random_obj_for_model(Service).pk,
-            'dit_team': dit_team.pk,
-            'was_policy_feedback_provided': False,
-        }
-        response = self.client.post(url, data, follow=True)
-
-        assert response.status_code == status.HTTP_200_OK
-
-        assert Interaction.objects.count() == 1
-        interaction = Interaction.objects.first()
-
-        assert interaction.dit_participants.count() == 1
-
-        dit_participant = interaction.dit_participants.first()
-
-        assert dit_participant.adviser == dit_adviser
-        assert dit_participant.team == dit_team
-
-    def test_update_without_existing_participant(self):
-        """
-        Test that if an interaction without an existing DIT participant is updated, a
-        DIT participant is created.
-        """
-        interaction = CompanyInteractionFactory(dit_participants=[])
-        new_dit_adviser = AdviserFactory()
-        new_dit_team = TeamFactory()
-
-        url = get_change_url(interaction)
-        data = {
-            # Unchanged values
-            'id': interaction.pk,
-            'kind': Interaction.KINDS.interaction,
-            'communication_channel': interaction.communication_channel.pk,
-            'subject': interaction.subject,
-            'date_0': interaction.date.date().isoformat(),
-            'date_1': interaction.date.time().isoformat(),
-            'company': interaction.company.pk,
-            'service': interaction.service.pk,
-            'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
-            'policy_feedback_notes': interaction.policy_feedback_notes,
-            'policy_areas': [],
-            'policy_issue_types': [],
-            'event': '',
-
-            # Changed values
-            'dit_adviser': new_dit_adviser.pk,
-            'dit_team': new_dit_team.pk,
-        }
-        response = self.client.post(url, data, follow=True)
-
-        assert response.status_code == status.HTTP_200_OK
-
-        interaction.refresh_from_db()
-        assert interaction.dit_participants.count() == 1
-
-        dit_participant = interaction.dit_participants.first()
-        assert dit_participant.adviser == new_dit_adviser
-        assert dit_participant.team == new_dit_team
-
-    @pytest.mark.parametrize('update_dit_adviser', (True, False))
-    @pytest.mark.parametrize('update_dit_team', (True, False))
-    def test_update_with_existing_participant(self, update_dit_adviser, update_dit_team):
-        """
-        Test that if an interaction with an existing DIT participant is updated the participant
-        is updated as well.
-        """
-        interaction = CompanyInteractionFactory()
-
-        new_dit_adviser = AdviserFactory() if update_dit_adviser else interaction.dit_adviser
-        new_dit_team = TeamFactory() if update_dit_team else interaction.dit_team
-
-        url = get_change_url(interaction)
-        data = {
-            # Unchanged values
-            'id': interaction.pk,
-            'kind': Interaction.KINDS.interaction,
-            'communication_channel': interaction.communication_channel.pk,
-            'subject': interaction.subject,
-            'date_0': interaction.date.date().isoformat(),
-            'date_1': interaction.date.time().isoformat(),
-            'company': interaction.company.pk,
-            'service': interaction.service.pk,
-            'was_policy_feedback_provided': interaction.was_policy_feedback_provided,
-            'policy_feedback_notes': interaction.policy_feedback_notes,
-            'policy_areas': [],
-            'policy_issue_types': [],
-            'event': '',
-
-            # Possibly changed values
-            'dit_adviser': new_dit_adviser.pk,
-            'dit_team': new_dit_team.pk,
-        }
-        response = self.client.post(url, data, follow=True)
-
-        assert response.status_code == status.HTTP_200_OK
-
-        interaction.refresh_from_db()
-        assert interaction.dit_participants.count() == 1
-
-        dit_participant = interaction.dit_participants.first()
-
-        assert dit_participant.adviser == new_dit_adviser
-        assert dit_participant.team == new_dit_team

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -150,6 +150,24 @@ class TestAddInteraction(APITestMixin):
                 'last_name': adviser.last_name,
                 'name': adviser.name,
             },
+            'dit_participants': [
+                {
+                    'adviser': {
+                        'id': str(adviser.pk),
+                        'first_name': adviser.first_name,
+                        'last_name': adviser.last_name,
+                        'name': adviser.name,
+                    },
+                    'team': {
+                        'id': str(Team.healthcare_uk.value.id),
+                        'name': Team.healthcare_uk.value.name,
+                    },
+                },
+            ],
+            'dit_team': {
+                'id': str(Team.healthcare_uk.value.id),
+                'name': Team.healthcare_uk.value.name,
+            },
             'notes': request_data.get('notes', ''),
             'company': {
                 'id': str(company.pk),
@@ -166,10 +184,6 @@ class TestAddInteraction(APITestMixin):
             'service': {
                 'id': str(Service.trade_enquiry.value.id),
                 'name': Service.trade_enquiry.value.name,
-            },
-            'dit_team': {
-                'id': str(Team.healthcare_uk.value.id),
-                'name': Team.healthcare_uk.value.name,
             },
             'investment_project': request_data.get('investment_project'),
             'archived_documents_url_path': '',
@@ -520,6 +534,24 @@ class TestGetInteraction(APITestMixin):
                 'last_name': interaction.dit_adviser.last_name,
                 'name': interaction.dit_adviser.name,
             },
+            'dit_participants': [
+                {
+                    'adviser': {
+                        'id': str(interaction.dit_adviser.pk),
+                        'first_name': interaction.dit_adviser.first_name,
+                        'last_name': interaction.dit_adviser.last_name,
+                        'name': interaction.dit_adviser.name,
+                    },
+                    'team': {
+                        'id': str(interaction.dit_team.pk),
+                        'name': interaction.dit_team.name,
+                    },
+                },
+            ],
+            'dit_team': {
+                'id': str(interaction.dit_team.pk),
+                'name': interaction.dit_team.name,
+            },
             'notes': interaction.notes,
             'company': {
                 'id': str(interaction.company.pk),
@@ -536,10 +568,6 @@ class TestGetInteraction(APITestMixin):
             'service': {
                 'id': str(Service.trade_enquiry.value.id),
                 'name': Service.trade_enquiry.value.name,
-            },
-            'dit_team': {
-                'id': str(interaction.dit_team.pk),
-                'name': interaction.dit_team.name,
             },
             'investment_project': {
                 'id': str(interaction.investment_project.pk),
@@ -602,6 +630,24 @@ class TestGetInteraction(APITestMixin):
                 'last_name': interaction.dit_adviser.last_name,
                 'name': interaction.dit_adviser.name,
             },
+            'dit_participants': [
+                {
+                    'adviser': {
+                        'id': str(interaction.dit_adviser.pk),
+                        'first_name': interaction.dit_adviser.first_name,
+                        'last_name': interaction.dit_adviser.last_name,
+                        'name': interaction.dit_adviser.name,
+                    },
+                    'team': {
+                        'id': str(interaction.dit_team.pk),
+                        'name': interaction.dit_team.name,
+                    },
+                },
+            ],
+            'dit_team': {
+                'id': str(interaction.dit_team.pk),
+                'name': interaction.dit_team.name,
+            },
             'notes': interaction.notes,
             'company': {
                 'id': str(interaction.company.pk),
@@ -618,10 +664,6 @@ class TestGetInteraction(APITestMixin):
             'service': {
                 'id': str(Service.trade_enquiry.value.id),
                 'name': Service.trade_enquiry.value.name,
-            },
-            'dit_team': {
-                'id': str(interaction.dit_team.pk),
-                'name': interaction.dit_team.name,
             },
             'investment_project': {
                 'id': str(interaction.investment_project.pk),

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -111,6 +111,24 @@ class TestAddServiceDelivery(APITestMixin):
                 'last_name': adviser.last_name,
                 'name': adviser.name,
             },
+            'dit_participants': [
+                {
+                    'adviser': {
+                        'id': str(adviser.pk),
+                        'first_name': adviser.first_name,
+                        'last_name': adviser.last_name,
+                        'name': adviser.name,
+                    },
+                    'team': {
+                        'id': str(Team.healthcare_uk.value.id),
+                        'name': Team.healthcare_uk.value.name,
+                    },
+                },
+            ],
+            'dit_team': {
+                'id': str(Team.healthcare_uk.value.id),
+                'name': Team.healthcare_uk.value.name,
+            },
             'notes': request_data.get('notes', ''),
             'company': {
                 'id': str(company.pk),
@@ -127,10 +145,6 @@ class TestAddServiceDelivery(APITestMixin):
             'service': {
                 'id': str(Service.trade_enquiry.value.id),
                 'name': Service.trade_enquiry.value.name,
-            },
-            'dit_team': {
-                'id': str(Team.healthcare_uk.value.id),
-                'name': Team.healthcare_uk.value.name,
             },
             'investment_project': None,
             'archived_documents_url_path': '',

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -39,7 +39,9 @@ class InteractionViewSet(CoreViewSet):
         'company__name',
         'created_on',
         'date',
+        # TODO: Remove following deprecation period
         'dit_adviser__first_name',
+        # TODO: Remove following deprecation period
         'dit_adviser__last_name',
         'first_name_of_first_contact',
         'last_name_of_first_contact',


### PR DESCRIPTION
### Description of change

This contains some preparatory work for making dit_participants writable in interaction endpoints.

This:

- adds `dit_participants` to `/v3/interaction` and `/v3/interaction/<id>` as a read-only field
- makes `dit_adviser` and `dit_team` read-only in interaction admin to avoid complexity there while `dit_participants` co-exists with `dit_adviser` and `dit_team`
- deprecates `dit_adviser`-related sorting options in `/v3/interaction` (as these are being removed without a replacement)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
