### PR TITLE
Add Large investor profile to search pt 1

### DIFF
--- a/changelog/investment/large_investor_profile_in_search.search.rst
+++ b/changelog/investment/large_investor_profile_in_search.search.rst
@@ -1,0 +1,1 @@
+Large Capital investor profile search index added.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -281,6 +281,7 @@ SEARCH_APPS = [
     'datahub.search.interaction.InteractionSearchApp',
     'datahub.search.investment.InvestmentSearchApp',
     'datahub.search.omis.OrderSearchApp',
+    'datahub.search.large_investor_profile.LargeInvestorProfileSearchApp',
 ]
 
 VCAP_SERVICES = env.json('VCAP_SERVICES', default={})

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -38,7 +38,7 @@ from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
     InvestmentProjectInteractionFactory,
 )
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 from datahub.investment.project.evidence.test.factories import EvidenceDocumentFactory
 from datahub.investment.project.proposition.test.factories import PropositionFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
@@ -188,7 +188,7 @@ MAPPING = {
                 ],
             },
             {
-                'factory': InvestorProfileFactory,
+                'factory': LargeInvestorProfileFactory,
                 'field': 'investor_company',
                 'expired_objects_kwargs': [
                     {

--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -12,7 +12,7 @@ from datahub.cleanup.management.commands import delete_orphaned_versions
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 from datahub.investment.project.test.factories import (
     InvestmentActivityFactory, InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
 )
@@ -27,7 +27,7 @@ MAPPINGS = {
     'investment.InvestmentProject': InvestmentProjectFactory,
     'investment.InvestmentProjectTeamMember': InvestmentProjectTeamMemberFactory,
     'investment.InvestmentActivity': InvestmentActivityFactory,
-    'investor_profile.InvestorProfile': InvestorProfileFactory,
+    'investor_profile.InvestorProfile': LargeInvestorProfileFactory,
 }
 
 

--- a/datahub/cleanup/test/commands/test_delete_orphans.py
+++ b/datahub/cleanup/test/commands/test_delete_orphans.py
@@ -24,7 +24,7 @@ from datahub.core.exceptions import DataHubException
 from datahub.core.model_helpers import get_related_fields
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 from datahub.omis.order.test.factories import (
     OrderFactory,
@@ -68,7 +68,7 @@ MAPPINGS = {
             (CompanyFactory, 'transferred_to'),
             (CompanyFactory, 'global_headquarters'),
             (OneListCoreTeamMemberFactory, 'company'),
-            (InvestorProfileFactory, 'investor_company'),
+            (LargeInvestorProfileFactory, 'investor_company'),
         ),
         'implicit_related_models': (),
         'ignored_models': (),

--- a/datahub/investment/investor_profile/models.py
+++ b/datahub/investment/investor_profile/models.py
@@ -151,6 +151,12 @@ class InvestorProfile(BaseModel):
         """Human-readable representation"""
         return f'{self.investor_company}, {self.profile_type} capital profile'
 
+    @property
+    def country_of_origin(self):
+        """Returns the country of which the investment would originate from."""
+        if self.investor_company:
+            return self.investor_company.address_country
+
 
 class ProfileType(BaseOrderedConstantModel):
     """Investor profile type metadata."""

--- a/datahub/investment/investor_profile/permissions.py
+++ b/datahub/investment/investor_profile/permissions.py
@@ -1,0 +1,7 @@
+from datahub.core.utils import StrEnum
+
+
+class InvestorProfilePermission(StrEnum):
+    """Permission codename constants."""
+
+    view_investor_profile = 'view_investorprofile'

--- a/datahub/investment/investor_profile/test/factories.py
+++ b/datahub/investment/investor_profile/test/factories.py
@@ -4,11 +4,17 @@ from datahub.company.test.factories import CompanyFactory
 from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
 
 
-class InvestorProfileFactory(factory.django.DjangoModelFactory):
-    """Investor profile factory."""
+class LargeInvestorProfileFactory(factory.django.DjangoModelFactory):
+    """Large Capital Investor profile factory."""
 
     investor_company = factory.SubFactory(CompanyFactory)
     profile_type_id = ProfileTypeConstant.large.value.id
 
     class Meta:
         model = 'investor_profile.InvestorProfile'
+
+
+class GrowthInvestorProfileFactory(LargeInvestorProfileFactory):
+    """Growth Capital Investor profile factory."""
+
+    profile_type_id = ProfileTypeConstant.growth.value.id

--- a/datahub/investment/investor_profile/test/test_models.py
+++ b/datahub/investment/investor_profile/test/test_models.py
@@ -2,8 +2,7 @@ import pytest
 from django.db.utils import IntegrityError
 
 from datahub.company.test.factories import CompanyFactory
-from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 
 
 pytestmark = pytest.mark.django_db
@@ -17,14 +16,12 @@ class TestInvestorProfileModel:
         Tests an integrity error is raised when a company already has a profile of the same type.
         """
         investor_company = CompanyFactory()
-        InvestorProfileFactory(
+        LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
         )
         with pytest.raises(IntegrityError):
-            InvestorProfileFactory(
+            LargeInvestorProfileFactory(
                 investor_company=investor_company,
-                profile_type_id=ProfileTypeConstant.large.value.id,
             )
 
     @pytest.mark.parametrize(
@@ -37,4 +34,4 @@ class TestInvestorProfileModel:
     def test_raises_error_when_required_fields_not_provided(self, parameters):
         """Tests an integrity error is raised when any of the required fields are missing."""
         with pytest.raises(IntegrityError):
-            InvestorProfileFactory(**parameters)
+            LargeInvestorProfileFactory(**parameters)

--- a/datahub/investment/investor_profile/test/test_validate.py
+++ b/datahub/investment/investor_profile/test/test_validate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 from datahub.investment.investor_profile.validate import get_incomplete_fields
 
 pytestmark = pytest.mark.django_db
@@ -8,6 +8,6 @@ pytestmark = pytest.mark.django_db
 
 def test_incomplete_fields():
     """Tests incomplete fields on an investor profile are returned."""
-    instance = InvestorProfileFactory.build()
+    instance = LargeInvestorProfileFactory.build()
     result = get_incomplete_fields(instance, ['investor_company', 'investor_description'])
     assert result == ['investor_description']

--- a/datahub/investment/investor_profile/test/test_views.py
+++ b/datahub/investment/investor_profile/test/test_views.py
@@ -13,7 +13,6 @@ from datahub.core.constants import (
     UKRegion as UKRegionConstant,
 )
 from datahub.core.test_utils import APITestMixin, create_test_user
-from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
 from datahub.investment.investor_profile.test.constants import (
     AssetClassInterest as AssetClassInterestConstant,
     ConstructionRisk as ConstructionRiskConstant,
@@ -27,7 +26,10 @@ from datahub.investment.investor_profile.test.constants import (
     ReturnRate as ReturnRateConstant,
     TimeHorizon as TimeHorizonConstant,
 )
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import (
+    GrowthInvestorProfileFactory,
+    LargeInvestorProfileFactory,
+)
 
 
 INVALID_CHOICE_ERROR_MESSAGE = (
@@ -38,18 +40,13 @@ INVALID_CHOICE_ERROR_MESSAGE = (
 @pytest.fixture
 def get_large_capital_profile_for_search():
     """Sets up search list test by adding many profiles and returning a large capital profile."""
-    InvestorProfileFactory.create_batch(
-        5,
-        profile_type_id=ProfileTypeConstant.large.value.id,
-    )
+    LargeInvestorProfileFactory.create_batch(5)
     investor_company = CompanyFactory()
-    large_capital_profile = InvestorProfileFactory(
+    large_capital_profile = LargeInvestorProfileFactory(
         investor_company=investor_company,
-        profile_type_id=ProfileTypeConstant.large.value.id,
     )
-    InvestorProfileFactory(
+    GrowthInvestorProfileFactory(
         investor_company=investor_company,
-        profile_type_id=ProfileTypeConstant.growth.value.id,
     )
     yield large_capital_profile
 
@@ -127,9 +124,8 @@ class TestCreateLargeCapitalProfileView(APITestMixin):
         """Test creating a large investor profile with minimum required fields."""
         url = reverse('api-v4:large-investor-profile:collection')
         investor_company = CompanyFactory()
-        InvestorProfileFactory(
+        LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
         )
 
         request_data = {
@@ -217,9 +213,8 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
         """Test updating a large capital profile."""
         new_description = 'Description 2'
         investor_company = CompanyFactory()
-        investor_profile = InvestorProfileFactory(
+        investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
             investor_description='Description 1',
         )
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
@@ -244,9 +239,8 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
         """
         investor_company = CompanyFactory()
         new_investor_company = CompanyFactory()
-        investor_profile = InvestorProfileFactory(
+        investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
         )
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
         request_data = {
@@ -265,9 +259,8 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
     def test_patch_large_capital_profile_all_details_fields(self):
         """Test updating the details fields for a large capital profile"""
         investor_company = CompanyFactory()
-        investor_profile = InvestorProfileFactory(
+        investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
         )
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
 
@@ -302,9 +295,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
             LargeCapitalInvestmentTypesConstant.direct_investment_in_project_equity.value.id
         )
 
-        investor_profile = InvestorProfileFactory(
-            profile_type_id=ProfileTypeConstant.large.value.id,
-        )
+        investor_profile = LargeInvestorProfileFactory()
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
         request_data = {
             'deal_ticket_sizes': [
@@ -396,9 +387,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
 
     def test_patch_large_capital_profile_all_location_fields(self):
         """Test updating the location fields for a large capital profile."""
-        investor_profile = InvestorProfileFactory(
-            profile_type_id=ProfileTypeConstant.large.value.id,
-        )
+        investor_profile = LargeInvestorProfileFactory()
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
         request_data = {
             'uk_region_locations': [

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -26,7 +26,7 @@ class Contact(BaseESModel):
     archived_by = fields.contact_or_adviser_field('archived_by')
     archived_on = Date()
     archived_reason = Text()
-    company = fields.company_field('company')
+    company = fields.company_field_with_copy_to_name_trigram('company')
     company_sector = fields.sector_field()
     company_uk_region = fields.id_name_field()
     created_by = fields.contact_or_adviser_field('created_by', include_dit_team=True)

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -83,21 +83,45 @@ def id_name_partial_field(field):
     )
 
 
+def company_field():
+    """Company field with id, name, trading_names and trigrams."""
+    return Object(
+        properties={
+            'id': Keyword(),
+            'name': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+            'trading_names': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+        },
+    )
+
+
+def country_field():
+    """Country field with id, name and trigram."""
+    return Object(
+        properties={
+            'id': Keyword(),
+            'name': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+        },
+    )
+
+
 def address_field(index_country=True):
     """Address field as nested object."""
     if index_country:
-        country_field = Object(
-            properties={
-                'id': Keyword(),
-                'name': Text(
-                    fields={
-                        'trigram': TrigramText(),
-                    },
-                ),
-            },
-        )
+        nested_country_field = country_field()
     else:
-        country_field = Object(
+        nested_country_field = Object(
             properties={
                 'id': Keyword(index=False),
                 'name': Text(index=False),
@@ -115,13 +139,13 @@ def address_field(index_country=True):
                     'trigram': TrigramText(),
                 },
             ),
-            'country': country_field,
+            'country': nested_country_field,
         },
     )
 
 
-def company_field(field):
-    """Company field."""
+def company_field_with_copy_to_name_trigram(field):
+    """Company field with copy to, deprecated in favour of company_field"""
     return Object(
         properties={
             'id': Keyword(),

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -45,7 +45,7 @@ class Interaction(BaseESModel):
     """Elasticsearch representation of Interaction model."""
 
     id = Keyword()
-    company = fields.company_field('company')
+    company = fields.company_field_with_copy_to_name_trigram('company')
     company_sector = fields.sector_field()
     communication_channel = fields.id_name_field()
     contacts = _contact_field()

--- a/datahub/search/large_investor_profile/__init__.py
+++ b/datahub/search/large_investor_profile/__init__.py
@@ -1,0 +1,3 @@
+from datahub.search.large_investor_profile.apps import LargeInvestorProfileSearchApp
+
+__all__ = ('LargeInvestorProfileSearchApp',)

--- a/datahub/search/large_investor_profile/apps.py
+++ b/datahub/search/large_investor_profile/apps.py
@@ -1,0 +1,36 @@
+from datahub.investment.investor_profile.constants import ProfileType
+from datahub.investment.investor_profile.models import InvestorProfile as DBInvestorProfile
+from datahub.investment.investor_profile.permissions import InvestorProfilePermission
+from datahub.search.apps import SearchApp
+from datahub.search.large_investor_profile.models import (
+    DOC_TYPE as LARGE_INVESTOR_PROFILE_DOC_TYPE,
+    LargeInvestorProfile,
+)
+
+
+class LargeInvestorProfileSearchApp(SearchApp):
+    """SearchApp for investor profile."""
+
+    name = LARGE_INVESTOR_PROFILE_DOC_TYPE
+    es_model = LargeInvestorProfile
+    view_permissions = (f'investor_profile.{InvestorProfilePermission.view_investor_profile}',)
+    exclude_from_global_search = True
+    queryset = DBInvestorProfile.objects.filter(
+        profile_type_id=ProfileType.large.value.id,
+    ).select_related(
+        'investor_company',
+        'investor_type',
+        'required_checks_conducted',
+        'minimum_return_rate',
+        'minimum_equity_percentage',
+    ).prefetch_related(
+        'deal_ticket_sizes',
+        'asset_classes_of_interest',
+        'investment_types',
+        'time_horizons',
+        'restrictions',
+        'construction_risks',
+        'desired_deal_roles',
+        'uk_region_locations',
+        'other_countries_being_considered',
+    )

--- a/datahub/search/large_investor_profile/models.py
+++ b/datahub/search/large_investor_profile/models.py
@@ -1,0 +1,95 @@
+from elasticsearch_dsl import Date, Keyword, Long
+
+from datahub.search import dict_utils
+from datahub.search import fields
+from datahub.search.models import BaseESModel
+
+
+DOC_TYPE = 'large-investor-profile'
+
+
+def _get_adviser_list(col):
+    return [dict_utils.contact_or_adviser_dict(c['adviser']) for c in col]
+
+
+def _get_many_to_many_list(col):
+    return [dict_utils.id_name_dict(c) for c in col.all()]
+
+
+class LargeInvestorProfile(BaseESModel):
+    """Elasticsearch representation of LargeInvestorProfile."""
+
+    id = Keyword()
+
+    investor_company = fields.company_field()
+    country_of_origin = fields.country_field()
+    asset_classes_of_interest = fields.id_unindexed_name_field()
+    created_by = fields.contact_or_adviser_field(
+        'created_by', include_dit_team=True,
+    )
+
+    investor_type = fields.id_unindexed_name_field()
+    global_assets_under_management = Long()
+    investable_capital = Long()
+    required_checks_conducted = fields.id_unindexed_name_field()
+
+    deal_ticket_sizes = fields.id_unindexed_name_field()
+    investment_types = fields.id_unindexed_name_field()
+    minimum_return_rate = fields.id_unindexed_name_field()
+    time_horizons = fields.id_unindexed_name_field()
+    restrictions = fields.id_unindexed_name_field()
+    construction_risks = fields.id_unindexed_name_field()
+    minimum_equity_percentage = fields.id_unindexed_name_field()
+    desired_deal_roles = fields.id_unindexed_name_field()
+
+    uk_region_locations = fields.id_unindexed_name_field()
+    other_countries_being_considered = fields.country_field()
+
+    investor_description = fields.EnglishText()
+    notes_on_locations = fields.EnglishText()
+
+    created_on = Date()
+    modified_on = Date()
+
+    _MAIN_FIELD_MAPPINGS = {
+        'asset_classes_of_interest': _get_many_to_many_list,
+        'country_of_origin': dict_utils.id_name_dict,
+        'investor_company': dict_utils.company_dict,
+        'created_by': dict_utils.adviser_dict_with_team,
+    }
+
+    _DETAIL_FIELD_MAPPINGS = {
+        'investor_type': dict_utils.id_name_dict,
+        'required_checks_conducted': dict_utils.id_name_dict,
+    }
+
+    _REQUIREMENT_FIELD_MAPPINGS = {
+        'deal_ticket_sizes': _get_many_to_many_list,
+        'investment_types': _get_many_to_many_list,
+        'minimum_return_rate': dict_utils.id_name_dict,
+        'time_horizons': _get_many_to_many_list,
+        'restrictions': _get_many_to_many_list,
+        'construction_risks': _get_many_to_many_list,
+        'minimum_equity_percentage': dict_utils.id_name_dict,
+        'desired_deal_roles': _get_many_to_many_list,
+    }
+
+    _LOCATION_FIELD_MAPPINGS = {
+        'uk_region_locations': _get_many_to_many_list,
+        'other_countries_being_considered': _get_many_to_many_list,
+    }
+
+    MAPPINGS = {
+        **_MAIN_FIELD_MAPPINGS,
+        **_DETAIL_FIELD_MAPPINGS,
+        **_REQUIREMENT_FIELD_MAPPINGS,
+        **_LOCATION_FIELD_MAPPINGS,
+    }
+
+    class Meta:
+        """Default document meta data."""
+
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/large_investor_profile/signals.py
+++ b/datahub/search/large_investor_profile/signals.py
@@ -1,0 +1,47 @@
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save
+
+from datahub.company.models import Company as DBCompany
+from datahub.investment.investor_profile.constants import ProfileType
+from datahub.investment.investor_profile.models import InvestorProfile as DBInvestorProfile
+from datahub.search.deletion import delete_document
+from datahub.search.large_investor_profile import LargeInvestorProfileSearchApp
+from datahub.search.large_investor_profile.models import (
+    LargeInvestorProfile as ESLargeInvestorProfile,
+)
+from datahub.search.signals import SignalReceiver
+from datahub.search.sync_object import sync_object_async, sync_related_objects_async
+
+
+def investor_profile_sync_es(instance):
+    """Sync investor profile to Elasticsearch."""
+    if str(instance.profile_type_id) == ProfileType.large.value.id:
+        transaction.on_commit(
+            lambda: sync_object_async(LargeInvestorProfileSearchApp, instance.pk),
+        )
+
+
+def related_investor_profiles_sync_es(instance):
+    """Sync related Company investor profiles to Elasticsearch."""
+    transaction.on_commit(
+        lambda: sync_related_objects_async(
+            instance,
+            'investor_profiles',
+            related_obj_filter={'profile_type_id': ProfileType.large.value.id},
+        ),
+    )
+
+
+def remove_investor_profile_from_es(instance):
+    """Remove investor profile from es."""
+    if instance.profile_type_id == ProfileType.large.value.id:
+        transaction.on_commit(
+            lambda pk=instance.pk: delete_document(ESLargeInvestorProfile, pk),
+        )
+
+
+receivers = (
+    SignalReceiver(post_save, DBInvestorProfile, investor_profile_sync_es),
+    SignalReceiver(post_save, DBCompany, related_investor_profiles_sync_es),
+    SignalReceiver(post_delete, DBInvestorProfile, remove_investor_profile_from_es),
+)

--- a/datahub/search/large_investor_profile/test/test_models.py
+++ b/datahub/search/large_investor_profile/test/test_models.py
@@ -1,0 +1,52 @@
+import pytest
+
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
+from datahub.search.large_investor_profile.models import (
+    LargeInvestorProfile as ESLargeInvestorProfile,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+class TestLargeInvestorProfileElasticModel:
+    """Test for the large investor profile elasticsearch model"""
+
+    def test_large_investor_profile_dbmodel_to_dict(self, setup_es):
+        """Tests conversion of db model to dict."""
+        large_investor_profile = LargeInvestorProfileFactory()
+
+        result = ESLargeInvestorProfile.db_object_to_dict(large_investor_profile)
+        keys = {
+            'asset_classes_of_interest',
+            'construction_risks',
+            'country_of_origin',
+            'created_by',
+            'created_on',
+            'deal_ticket_sizes',
+            'desired_deal_roles',
+            'global_assets_under_management',
+            'id',
+            'investable_capital',
+            'investment_types',
+            'investor_company',
+            'investor_description',
+            'investor_type',
+            'minimum_equity_percentage',
+            'minimum_return_rate',
+            'modified_on',
+            'notes_on_locations',
+            'other_countries_being_considered',
+            'required_checks_conducted',
+            'restrictions',
+            'time_horizons',
+            'uk_region_locations',
+        }
+        assert set(result.keys()) == keys
+
+    def test_investment_project_dbmodels_to_es_documents(self, setup_es):
+        """Tests conversion of db models to Elasticsearch documents."""
+        large_profiles = LargeInvestorProfileFactory.create_batch(2)
+
+        result = ESLargeInvestorProfile.db_objects_to_es_documents(large_profiles)
+
+        assert len(list(result)) == len(large_profiles)

--- a/datahub/search/large_investor_profile/test/test_signals.py
+++ b/datahub/search/large_investor_profile/test/test_signals.py
@@ -1,0 +1,111 @@
+from unittest import mock
+
+import pytest
+from elasticsearch.exceptions import NotFoundError
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.investment.investor_profile.test.factories import (
+    GrowthInvestorProfileFactory,
+    LargeInvestorProfileFactory,
+)
+from datahub.search.large_investor_profile.apps import LargeInvestorProfileSearchApp
+
+pytestmark = pytest.mark.django_db
+
+
+def _get_es_document(setup_es, pk):
+    return setup_es.get(
+        index=LargeInvestorProfileSearchApp.es_model.get_read_alias(),
+        doc_type=LargeInvestorProfileSearchApp.name,
+        id=pk,
+    )
+
+
+def test_new_large_investor_profile_synced(setup_es):
+    """Test that new large capital profiles are synced to ES."""
+    investor_profile = LargeInvestorProfileFactory()
+    setup_es.indices.refresh()
+    assert _get_es_document(setup_es, investor_profile.pk)
+
+
+def test_updated_large_investor_profile_synced(setup_es):
+    """Test that when an large investor profile is updated it is synced to ES."""
+    large_investor_profile = LargeInvestorProfileFactory()
+    large_investor_profile.investable_capital = 12345
+    large_investor_profile.save()
+    setup_es.indices.refresh()
+
+
+@pytest.mark.parametrize(
+    'investor_profile_factory,expected_in_index,expected_to_call_delete',
+    (
+        (LargeInvestorProfileFactory, True, True),
+        (GrowthInvestorProfileFactory, False, False),
+    ),
+)
+def test_delete_from_es(
+    investor_profile_factory, expected_in_index, expected_to_call_delete, setup_es,
+):
+    """
+    Test that when an large investor profile is deleted from db it is also
+    calls delete document to delete from ES.
+    """
+    investor_profile = investor_profile_factory()
+    setup_es.indices.refresh()
+
+    if expected_in_index:
+        assert _get_es_document(setup_es, investor_profile.pk)
+    else:
+        with pytest.raises(NotFoundError):
+            assert _get_es_document(setup_es, investor_profile.pk) is None
+
+    with mock.patch(
+        'datahub.search.large_investor_profile.signals.delete_document',
+    ) as mock_delete_document:
+        investor_profile.delete()
+        setup_es.indices.refresh()
+        assert mock_delete_document.called == expected_in_index
+
+
+def test_edit_company_syncs_large_investor_profile_in_es(setup_es):
+    """Tests that updating company details also updated the relevant investor profiles."""
+    new_company_name = 'SYNC TEST'
+    investor_company = CompanyFactory()
+    GrowthInvestorProfileFactory(investor_company=investor_company)
+    investor_profile = LargeInvestorProfileFactory(investor_company=investor_company)
+    setup_es.indices.refresh()
+    investor_company.name = new_company_name
+    investor_company.save()
+
+    result = _get_es_document(setup_es, investor_profile.pk)
+    assert result['_source']['investor_company']['name'] == new_company_name
+
+
+def test_growth_investor_profile_does_not_sync_to_es(setup_es):
+    """Tests that a growth investor profile is not synced to elasticsearch."""
+    investor_company = CompanyFactory()
+    setup_es.indices.refresh()
+    with mock.patch('datahub.search.tasks.sync_object_task.apply_async') as mock_sync_object:
+        growth_profile = GrowthInvestorProfileFactory(investor_company=investor_company)
+        with pytest.raises(NotFoundError):
+            assert _get_es_document(setup_es, growth_profile.id) is None
+        assert not mock_sync_object.called
+
+
+def test_edit_company_does_not_sync_growth_investor_profile(setup_es):
+    """
+    Tests that updating company details of a company with a growth investor profile,
+    the profile is not synced to elasticsearch.
+    """
+    investor_company = CompanyFactory()
+    setup_es.indices.refresh()
+
+    with mock.patch('datahub.search.tasks.sync_object_task.apply_async') as mock_sync_object:
+        growth_profile = GrowthInvestorProfileFactory(investor_company=investor_company)
+        investor_company.name = 'SYNC TEST'
+        investor_company.save()
+        assert mock_sync_object.call_args[1]['args'][0] != 'large-investor-profile'
+        assert mock_sync_object.call_count == 1  # Updating the company instance
+
+    with pytest.raises(NotFoundError):
+        assert _get_es_document(setup_es, growth_profile.id) is None

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -15,7 +15,7 @@ class Order(BaseESModel):
     reference = fields.NormalizedKeyword(copy_to=['reference_trigram'])
     reference_trigram = fields.TrigramText()
     status = fields.NormalizedKeyword()
-    company = fields.company_field('company')
+    company = fields.company_field_with_copy_to_name_trigram('company')
     contact = fields.contact_or_adviser_field('contact')
     created_by = fields.contact_or_adviser_field('created_by', include_dit_team=True)
     created_on = Date()

--- a/datahub/search/sync_object.py
+++ b/datahub/search/sync_object.py
@@ -44,7 +44,7 @@ def sync_object_async(search_app, pk):
     )
 
 
-def sync_related_objects_async(related_obj, related_obj_field_name):
+def sync_related_objects_async(related_obj, related_obj_field_name, related_obj_filter=None):
     """
     Syncs objects related to another object via a specified field.
 
@@ -56,13 +56,17 @@ def sync_related_objects_async(related_obj, related_obj_field_name):
     This function is normally used by signal receivers to copy new or updated related objects to
     Elasticsearch.
     """
+    kwargs = {'related_obj_filter': related_obj_filter} if related_obj_filter else {}
+
     result = sync_related_objects_task.apply_async(
         args=(
             related_obj._meta.label,
             str(related_obj.pk),
             related_obj_field_name,
         ),
+        kwargs=kwargs,
     )
+
     logger.info(
         f'Task {result.id} scheduled to synchronise {related_obj_field_name} for object'
         f' {related_obj.pk}',

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -69,6 +69,7 @@ def sync_related_objects_task(
     related_model_label,
     related_obj_pk,
     related_obj_field_name,
+    related_obj_filter=None,
 ):
     """
     Syncs objects related to another object via a specified field.
@@ -89,6 +90,8 @@ def sync_related_objects_task(
     related_model = apps.get_model(related_model_label)
     related_obj = related_model.objects.get(pk=related_obj_pk)
     manager = getattr(related_obj, related_obj_field_name)
+    if related_obj_filter:
+        manager = manager.filter(**related_obj_filter)
     queryset = manager.values_list('pk', flat=True)
     search_app = get_search_app_by_model(manager.model)
 


### PR DESCRIPTION
### Description of change
First part of the large investor profile search. I have tried to split everything up into easily reviewable chunks. So this is just the initial search app and the signals to update and delete.
Was unsure what to put in the changelog for this PR as this can't really be used till part 2 is released.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
