### PR TITLE
Add Large investor profile to search pt 2

### DIFF
--- a/changelog/investment/large_investor_profile_in_search.search.rst
+++ b/changelog/investment/large_investor_profile_in_search.search.rst
@@ -1,0 +1,1 @@
+Large Capital investor profile search index added.

--- a/changelog/investment/large_investor_profile_in_search.search.rst
+++ b/changelog/investment/large_investor_profile_in_search.search.rst
@@ -1,1 +1,35 @@
-Large Capital investor profile search index added.
+New endpoint added ``POST /v4/search/large-investor-profile`` to search and retrieve large capital investor profiles.
+
+Profiles are filterable as follows. The following filters accept and single or list of ids:
+
+- id
+- asset_classes_of_interest (metadata id)
+- country_of_origin (country id)
+- investor_company (company id)
+- created_by (adviser id)
+- investor_type (metadata id)
+- required_checks_conducted (metadata id)
+- deal_ticket_sizes (metadata id)
+- investment_types (metadata id)
+- minimum_return_rate (metadata id)
+- time_horizons (metadata id)
+- restrictions (metadata id)
+- construction_risks (metadata id)
+- minimum_equity_percentage (metadata id)
+- desired_deal_roles (metadata id)
+- uk_region_locations (uk region id)
+- other_countries_being_considered (country id)
+
+
+The following range filters have been added:
+
+- created_on_before (date)
+- created_on_after (date)
+- global_assets_under_management_before (int)
+- global_assets_under_management_after (int)
+- investable_capital_before (int)
+- investable_capital_after (int)
+
+The following text search filter has been added:
+
+- investor_company_name (text)

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -281,6 +281,7 @@ SEARCH_APPS = [
     'datahub.search.interaction.InteractionSearchApp',
     'datahub.search.investment.InvestmentSearchApp',
     'datahub.search.omis.OrderSearchApp',
+    'datahub.search.large_investor_profile.LargeInvestorProfileSearchApp',
 ]
 
 VCAP_SERVICES = env.json('VCAP_SERVICES', default={})

--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -38,7 +38,7 @@ from datahub.interaction.test.factories import (
     CompanyInteractionFactory,
     InvestmentProjectInteractionFactory,
 )
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 from datahub.investment.project.evidence.test.factories import EvidenceDocumentFactory
 from datahub.investment.project.proposition.test.factories import PropositionFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
@@ -188,7 +188,7 @@ MAPPING = {
                 ],
             },
             {
-                'factory': InvestorProfileFactory,
+                'factory': LargeInvestorProfileFactory,
                 'field': 'investor_company',
                 'expired_objects_kwargs': [
                     {

--- a/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
+++ b/datahub/cleanup/test/commands/test_delete_orphaned_versions.py
@@ -12,7 +12,7 @@ from datahub.cleanup.management.commands import delete_orphaned_versions
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 from datahub.investment.project.test.factories import (
     InvestmentActivityFactory, InvestmentProjectFactory, InvestmentProjectTeamMemberFactory,
 )
@@ -27,7 +27,7 @@ MAPPINGS = {
     'investment.InvestmentProject': InvestmentProjectFactory,
     'investment.InvestmentProjectTeamMember': InvestmentProjectTeamMemberFactory,
     'investment.InvestmentActivity': InvestmentActivityFactory,
-    'investor_profile.InvestorProfile': InvestorProfileFactory,
+    'investor_profile.InvestorProfile': LargeInvestorProfileFactory,
 }
 
 

--- a/datahub/cleanup/test/commands/test_delete_orphans.py
+++ b/datahub/cleanup/test/commands/test_delete_orphans.py
@@ -24,7 +24,7 @@ from datahub.core.exceptions import DataHubException
 from datahub.core.model_helpers import get_related_fields
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 from datahub.omis.order.test.factories import (
     OrderFactory,
@@ -68,7 +68,7 @@ MAPPINGS = {
             (CompanyFactory, 'transferred_to'),
             (CompanyFactory, 'global_headquarters'),
             (OneListCoreTeamMemberFactory, 'company'),
-            (InvestorProfileFactory, 'investor_company'),
+            (LargeInvestorProfileFactory, 'investor_company'),
         ),
         'implicit_related_models': (),
         'ignored_models': (),

--- a/datahub/investment/investor_profile/models.py
+++ b/datahub/investment/investor_profile/models.py
@@ -151,6 +151,12 @@ class InvestorProfile(BaseModel):
         """Human-readable representation"""
         return f'{self.investor_company}, {self.profile_type} capital profile'
 
+    @property
+    def country_of_origin(self):
+        """Returns the country of which the investment would originate from."""
+        if self.investor_company:
+            return self.investor_company.address_country
+
 
 class ProfileType(BaseOrderedConstantModel):
     """Investor profile type metadata."""

--- a/datahub/investment/investor_profile/permissions.py
+++ b/datahub/investment/investor_profile/permissions.py
@@ -1,0 +1,7 @@
+from datahub.core.utils import StrEnum
+
+
+class InvestorProfilePermission(StrEnum):
+    """Permission codename constants."""
+
+    view_investor_profile = 'view_investorprofile'

--- a/datahub/investment/investor_profile/test/factories.py
+++ b/datahub/investment/investor_profile/test/factories.py
@@ -5,7 +5,7 @@ from datahub.investment.investor_profile.constants import ProfileType as Profile
 
 
 class LargeInvestorProfileFactory(factory.django.DjangoModelFactory):
-    """Investor profile factory."""
+    """Large Capital Investor profile factory."""
 
     investor_company = factory.SubFactory(CompanyFactory)
     profile_type_id = ProfileTypeConstant.large.value.id
@@ -15,4 +15,6 @@ class LargeInvestorProfileFactory(factory.django.DjangoModelFactory):
 
 
 class GrowthInvestorProfileFactory(LargeInvestorProfileFactory):
+    """Growth Capital Investor profile factory."""
+
     profile_type_id = ProfileTypeConstant.growth.value.id

--- a/datahub/investment/investor_profile/test/factories.py
+++ b/datahub/investment/investor_profile/test/factories.py
@@ -4,7 +4,7 @@ from datahub.company.test.factories import CompanyFactory
 from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
 
 
-class InvestorProfileFactory(factory.django.DjangoModelFactory):
+class LargeInvestorProfileFactory(factory.django.DjangoModelFactory):
     """Investor profile factory."""
 
     investor_company = factory.SubFactory(CompanyFactory)
@@ -12,3 +12,7 @@ class InvestorProfileFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'investor_profile.InvestorProfile'
+
+
+class GrowthInvestorProfileFactory(LargeInvestorProfileFactory):
+    profile_type_id = ProfileTypeConstant.growth.value.id

--- a/datahub/investment/investor_profile/test/test_models.py
+++ b/datahub/investment/investor_profile/test/test_models.py
@@ -2,7 +2,6 @@ import pytest
 from django.db.utils import IntegrityError
 
 from datahub.company.test.factories import CompanyFactory
-from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
 from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 
 
@@ -19,12 +18,10 @@ class TestInvestorProfileModel:
         investor_company = CompanyFactory()
         LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
         )
         with pytest.raises(IntegrityError):
             LargeInvestorProfileFactory(
                 investor_company=investor_company,
-                profile_type_id=ProfileTypeConstant.large.value.id,
             )
 
     @pytest.mark.parametrize(

--- a/datahub/investment/investor_profile/test/test_models.py
+++ b/datahub/investment/investor_profile/test/test_models.py
@@ -3,7 +3,7 @@ from django.db.utils import IntegrityError
 
 from datahub.company.test.factories import CompanyFactory
 from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 
 
 pytestmark = pytest.mark.django_db
@@ -17,12 +17,12 @@ class TestInvestorProfileModel:
         Tests an integrity error is raised when a company already has a profile of the same type.
         """
         investor_company = CompanyFactory()
-        InvestorProfileFactory(
+        LargeInvestorProfileFactory(
             investor_company=investor_company,
             profile_type_id=ProfileTypeConstant.large.value.id,
         )
         with pytest.raises(IntegrityError):
-            InvestorProfileFactory(
+            LargeInvestorProfileFactory(
                 investor_company=investor_company,
                 profile_type_id=ProfileTypeConstant.large.value.id,
             )
@@ -37,4 +37,4 @@ class TestInvestorProfileModel:
     def test_raises_error_when_required_fields_not_provided(self, parameters):
         """Tests an integrity error is raised when any of the required fields are missing."""
         with pytest.raises(IntegrityError):
-            InvestorProfileFactory(**parameters)
+            LargeInvestorProfileFactory(**parameters)

--- a/datahub/investment/investor_profile/test/test_validate.py
+++ b/datahub/investment/investor_profile/test/test_validate.py
@@ -1,6 +1,6 @@
 import pytest
 
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 from datahub.investment.investor_profile.validate import get_incomplete_fields
 
 pytestmark = pytest.mark.django_db
@@ -8,6 +8,6 @@ pytestmark = pytest.mark.django_db
 
 def test_incomplete_fields():
     """Tests incomplete fields on an investor profile are returned."""
-    instance = InvestorProfileFactory.build()
+    instance = LargeInvestorProfileFactory.build()
     result = get_incomplete_fields(instance, ['investor_company', 'investor_description'])
     assert result == ['investor_description']

--- a/datahub/investment/investor_profile/test/test_views.py
+++ b/datahub/investment/investor_profile/test/test_views.py
@@ -13,7 +13,6 @@ from datahub.core.constants import (
     UKRegion as UKRegionConstant,
 )
 from datahub.core.test_utils import APITestMixin, create_test_user
-from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
 from datahub.investment.investor_profile.test.constants import (
     AssetClassInterest as AssetClassInterestConstant,
     ConstructionRisk as ConstructionRiskConstant,
@@ -27,7 +26,10 @@ from datahub.investment.investor_profile.test.constants import (
     ReturnRate as ReturnRateConstant,
     TimeHorizon as TimeHorizonConstant,
 )
-from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import (
+    GrowthInvestorProfileFactory,
+    LargeInvestorProfileFactory,
+)
 
 
 INVALID_CHOICE_ERROR_MESSAGE = (
@@ -38,18 +40,13 @@ INVALID_CHOICE_ERROR_MESSAGE = (
 @pytest.fixture
 def get_large_capital_profile_for_search():
     """Sets up search list test by adding many profiles and returning a large capital profile."""
-    LargeInvestorProfileFactory.create_batch(
-        5,
-        profile_type_id=ProfileTypeConstant.large.value.id,
-    )
+    LargeInvestorProfileFactory.create_batch(5)
     investor_company = CompanyFactory()
     large_capital_profile = LargeInvestorProfileFactory(
         investor_company=investor_company,
-        profile_type_id=ProfileTypeConstant.large.value.id,
     )
-    LargeInvestorProfileFactory(
+    GrowthInvestorProfileFactory(
         investor_company=investor_company,
-        profile_type_id=ProfileTypeConstant.growth.value.id,
     )
     yield large_capital_profile
 
@@ -129,7 +126,6 @@ class TestCreateLargeCapitalProfileView(APITestMixin):
         investor_company = CompanyFactory()
         LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
         )
 
         request_data = {
@@ -219,7 +215,6 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
         investor_company = CompanyFactory()
         investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
             investor_description='Description 1',
         )
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
@@ -246,7 +241,6 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
         new_investor_company = CompanyFactory()
         investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
         )
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
         request_data = {
@@ -267,7 +261,6 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
         investor_company = CompanyFactory()
         investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
-            profile_type_id=ProfileTypeConstant.large.value.id,
         )
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
 
@@ -302,9 +295,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
             LargeCapitalInvestmentTypesConstant.direct_investment_in_project_equity.value.id
         )
 
-        investor_profile = LargeInvestorProfileFactory(
-            profile_type_id=ProfileTypeConstant.large.value.id,
-        )
+        investor_profile = LargeInvestorProfileFactory()
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
         request_data = {
             'deal_ticket_sizes': [
@@ -396,9 +387,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
 
     def test_patch_large_capital_profile_all_location_fields(self):
         """Test updating the location fields for a large capital profile."""
-        investor_profile = LargeInvestorProfileFactory(
-            profile_type_id=ProfileTypeConstant.large.value.id,
-        )
+        investor_profile = LargeInvestorProfileFactory()
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
         request_data = {
             'uk_region_locations': [

--- a/datahub/investment/investor_profile/test/test_views.py
+++ b/datahub/investment/investor_profile/test/test_views.py
@@ -27,7 +27,7 @@ from datahub.investment.investor_profile.test.constants import (
     ReturnRate as ReturnRateConstant,
     TimeHorizon as TimeHorizonConstant,
 )
-from datahub.investment.investor_profile.test.factories import InvestorProfileFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
 
 
 INVALID_CHOICE_ERROR_MESSAGE = (
@@ -38,16 +38,16 @@ INVALID_CHOICE_ERROR_MESSAGE = (
 @pytest.fixture
 def get_large_capital_profile_for_search():
     """Sets up search list test by adding many profiles and returning a large capital profile."""
-    InvestorProfileFactory.create_batch(
+    LargeInvestorProfileFactory.create_batch(
         5,
         profile_type_id=ProfileTypeConstant.large.value.id,
     )
     investor_company = CompanyFactory()
-    large_capital_profile = InvestorProfileFactory(
+    large_capital_profile = LargeInvestorProfileFactory(
         investor_company=investor_company,
         profile_type_id=ProfileTypeConstant.large.value.id,
     )
-    InvestorProfileFactory(
+    LargeInvestorProfileFactory(
         investor_company=investor_company,
         profile_type_id=ProfileTypeConstant.growth.value.id,
     )
@@ -127,7 +127,7 @@ class TestCreateLargeCapitalProfileView(APITestMixin):
         """Test creating a large investor profile with minimum required fields."""
         url = reverse('api-v4:large-investor-profile:collection')
         investor_company = CompanyFactory()
-        InvestorProfileFactory(
+        LargeInvestorProfileFactory(
             investor_company=investor_company,
             profile_type_id=ProfileTypeConstant.large.value.id,
         )
@@ -217,7 +217,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
         """Test updating a large capital profile."""
         new_description = 'Description 2'
         investor_company = CompanyFactory()
-        investor_profile = InvestorProfileFactory(
+        investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
             profile_type_id=ProfileTypeConstant.large.value.id,
             investor_description='Description 1',
@@ -244,7 +244,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
         """
         investor_company = CompanyFactory()
         new_investor_company = CompanyFactory()
-        investor_profile = InvestorProfileFactory(
+        investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
             profile_type_id=ProfileTypeConstant.large.value.id,
         )
@@ -265,7 +265,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
     def test_patch_large_capital_profile_all_details_fields(self):
         """Test updating the details fields for a large capital profile"""
         investor_company = CompanyFactory()
-        investor_profile = InvestorProfileFactory(
+        investor_profile = LargeInvestorProfileFactory(
             investor_company=investor_company,
             profile_type_id=ProfileTypeConstant.large.value.id,
         )
@@ -302,7 +302,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
             LargeCapitalInvestmentTypesConstant.direct_investment_in_project_equity.value.id
         )
 
-        investor_profile = InvestorProfileFactory(
+        investor_profile = LargeInvestorProfileFactory(
             profile_type_id=ProfileTypeConstant.large.value.id,
         )
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})
@@ -396,7 +396,7 @@ class TestUpdateLargeCapitalProfileView(APITestMixin):
 
     def test_patch_large_capital_profile_all_location_fields(self):
         """Test updating the location fields for a large capital profile."""
-        investor_profile = InvestorProfileFactory(
+        investor_profile = LargeInvestorProfileFactory(
             profile_type_id=ProfileTypeConstant.large.value.id,
         )
         url = reverse('api-v4:large-investor-profile:item', kwargs={'pk': investor_profile.pk})

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -26,7 +26,7 @@ class Contact(BaseESModel):
     archived_by = fields.contact_or_adviser_field('archived_by')
     archived_on = Date()
     archived_reason = Text()
-    company = fields.company_field('company')
+    company = fields.company_field_with_copy_to_name_trigram('company')
     company_sector = fields.sector_field()
     company_uk_region = fields.id_name_field()
     created_by = fields.contact_or_adviser_field('created_by', include_dit_team=True)

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -84,6 +84,7 @@ def id_name_partial_field(field):
 
 
 def company_field():
+    """Company field with id, name, trading_names and trigrams."""
     return Object(
         properties={
             'id': Keyword(),
@@ -102,6 +103,7 @@ def company_field():
 
 
 def country_field():
+    """Country field with id, name and trigram."""
     return Object(
         properties={
             'id': Keyword(),
@@ -143,7 +145,7 @@ def address_field(index_country=True):
 
 
 def company_field_with_copy_to_name_trigram(field):
-    """Company field."""
+    """Company field with copy to, deprecated in favour of company_field"""
     return Object(
         properties={
             'id': Keyword(),

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -83,21 +83,43 @@ def id_name_partial_field(field):
     )
 
 
+def company_field():
+    return Object(
+        properties={
+            'id': Keyword(),
+            'name': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+            'trading_names': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+        },
+    )
+
+
+def country_field():
+    return Object(
+        properties={
+            'id': Keyword(),
+            'name': Text(
+                fields={
+                    'trigram': TrigramText(),
+                },
+            ),
+        },
+    )
+
+
 def address_field(index_country=True):
     """Address field as nested object."""
     if index_country:
-        country_field = Object(
-            properties={
-                'id': Keyword(),
-                'name': Text(
-                    fields={
-                        'trigram': TrigramText(),
-                    },
-                ),
-            },
-        )
+        nested_country_field = country_field()
     else:
-        country_field = Object(
+        nested_country_field = Object(
             properties={
                 'id': Keyword(index=False),
                 'name': Text(index=False),
@@ -115,12 +137,12 @@ def address_field(index_country=True):
                     'trigram': TrigramText(),
                 },
             ),
-            'country': country_field,
+            'country': nested_country_field,
         },
     )
 
 
-def company_field(field):
+def company_field_with_copy_to_name_trigram(field):
     """Company field."""
     return Object(
         properties={

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -29,7 +29,7 @@ class Interaction(BaseESModel):
     """Elasticsearch representation of Interaction model."""
 
     id = Keyword()
-    company = fields.company_field('company')
+    company = fields.company_field_with_copy_to_name_trigram('company')
     company_sector = fields.sector_field()
     communication_channel = fields.id_name_field()
     contacts = _contact_field()

--- a/datahub/search/large_investor_profile/__init__.py
+++ b/datahub/search/large_investor_profile/__init__.py
@@ -1,0 +1,3 @@
+from datahub.search.large_investor_profile.apps import LargeInvestorProfileSearchApp
+
+__all__ = ('LargeInvestorProfileSearchApp',)

--- a/datahub/search/large_investor_profile/apps.py
+++ b/datahub/search/large_investor_profile/apps.py
@@ -18,4 +18,18 @@ class LargeInvestorProfileSearchApp(SearchApp):
         profile_type_id=ProfileType.large.value.id,
     ).select_related(
         'investor_company',
+        'investor_type',
+        'required_checks_conducted',
+        'minimum_return_rate',
+        'minimum_equity_percentage',
+    ).prefetch_related(
+        'deal_ticket_sizes',
+        'asset_classes_of_interest',
+        'investment_types',
+        'time_horizons',
+        'restrictions',
+        'construction_risks',
+        'desired_deal_roles',
+        'uk_region_locations',
+        'other_countries_being_considered',
     )

--- a/datahub/search/large_investor_profile/apps.py
+++ b/datahub/search/large_investor_profile/apps.py
@@ -1,0 +1,21 @@
+from datahub.investment.investor_profile.constants import ProfileType
+from datahub.investment.investor_profile.models import InvestorProfile as DBInvestorProfile
+from datahub.investment.investor_profile.permissions import InvestorProfilePermission
+from datahub.search.apps import SearchApp
+from datahub.search.large_investor_profile.models import (
+    DOC_TYPE as LARGE_INVESTOR_PROFILE_DOC_TYPE,
+    LargeInvestorProfile,
+)
+
+
+class LargeInvestorProfileSearchApp(SearchApp):
+    """SearchApp for investor profile."""
+
+    name = LARGE_INVESTOR_PROFILE_DOC_TYPE
+    es_model = LargeInvestorProfile
+    view_permissions = (f'investor_profile.{InvestorProfilePermission.view_investor_profile}',)
+    queryset = DBInvestorProfile.objects.filter(
+        profile_type_id=ProfileType.large.value.id,
+    ).select_related(
+        'investor_company',
+    )

--- a/datahub/search/large_investor_profile/models.py
+++ b/datahub/search/large_investor_profile/models.py
@@ -83,12 +83,6 @@ class LargeInvestorProfile(BaseESModel):
         **_LOCATION_FIELD_MAPPINGS,
     }
 
-    SEARCH_FIELDS = (
-        'id',
-        'investor_company.name',
-        'investor_company.name.trigram',
-    )
-
     class Meta:
         """Default document meta data."""
 

--- a/datahub/search/large_investor_profile/models.py
+++ b/datahub/search/large_investor_profile/models.py
@@ -23,26 +23,26 @@ class LargeInvestorProfile(BaseESModel):
 
     investor_company = fields.company_field('investor_company')
     country_of_origin = fields.id_name_partial_field('country_of_origin')
-    asset_classes_of_interest = fields.id_name_field()
+    asset_classes_of_interest = fields.id_unindexed_name_field()
     created_by = fields.contact_or_adviser_field(
         'created_by', include_dit_team=True,
     )
 
-    investor_type = fields.id_name_field()
+    investor_type = fields.id_unindexed_name_field()
     global_assets_under_management = Long()
     investable_capital = Long()
-    required_checks_conducted = fields.id_name_field()
+    required_checks_conducted = fields.id_unindexed_name_field()
 
-    deal_ticket_sizes = fields.id_name_field()
-    investment_types = fields.id_name_field()
-    minimum_return_rate = fields.id_name_field()
-    time_horizons = fields.id_name_field()
-    restrictions = fields.id_name_field()
-    construction_risks = fields.id_name_field()
-    minimum_equity_percentage = fields.id_name_field()
-    desired_deal_roles = fields.id_name_field()
+    deal_ticket_sizes = fields.id_unindexed_name_field()
+    investment_types = fields.id_unindexed_name_field()
+    minimum_return_rate = fields.id_unindexed_name_field()
+    time_horizons = fields.id_unindexed_name_field()
+    restrictions = fields.id_unindexed_name_field()
+    construction_risks = fields.id_unindexed_name_field()
+    minimum_equity_percentage = fields.id_unindexed_name_field()
+    desired_deal_roles = fields.id_unindexed_name_field()
 
-    uk_region_locations = fields.id_name_field()
+    uk_region_locations = fields.id_unindexed_name_field()
     other_countries_being_considered = fields.id_name_partial_field(
         'other_countries_being_considered',
     )

--- a/datahub/search/large_investor_profile/models.py
+++ b/datahub/search/large_investor_profile/models.py
@@ -21,8 +21,8 @@ class LargeInvestorProfile(BaseESModel):
 
     id = Keyword()
 
-    investor_company = fields.company_field('investor_company')
-    country_of_origin = fields.id_name_partial_field('country_of_origin')
+    investor_company = fields.company_field()
+    country_of_origin = fields.country_field()
     asset_classes_of_interest = fields.id_unindexed_name_field()
     created_by = fields.contact_or_adviser_field(
         'created_by', include_dit_team=True,
@@ -43,9 +43,7 @@ class LargeInvestorProfile(BaseESModel):
     desired_deal_roles = fields.id_unindexed_name_field()
 
     uk_region_locations = fields.id_unindexed_name_field()
-    other_countries_being_considered = fields.id_name_partial_field(
-        'other_countries_being_considered',
-    )
+    other_countries_being_considered = fields.country_field()
 
     created_on = Date()
     modified_on = Date()

--- a/datahub/search/large_investor_profile/models.py
+++ b/datahub/search/large_investor_profile/models.py
@@ -1,0 +1,100 @@
+from elasticsearch_dsl import Date, Keyword, Long
+
+from datahub.search import dict_utils
+from datahub.search import fields
+from datahub.search.models import BaseESModel
+
+
+DOC_TYPE = 'large-investor-profile'
+
+
+def _get_adviser_list(col):
+    return [dict_utils.contact_or_adviser_dict(c['adviser']) for c in col]
+
+
+def _get_many_to_many_list(col):
+    return [dict_utils.id_name_dict(c) for c in col.all()]
+
+
+class LargeInvestorProfile(BaseESModel):
+    """Elasticsearch representation of LargeInvestorProfile."""
+
+    id = Keyword()
+
+    investor_company = fields.company_field('investor_company')
+    country_of_origin = fields.id_name_partial_field('country_of_origin')
+    asset_classes_of_interest = fields.id_name_field()
+    created_by = fields.contact_or_adviser_field(
+        'created_by', include_dit_team=True,
+    )
+
+    investor_type = fields.id_name_field()
+    global_assets_under_management = Long()
+    investable_capital = Long()
+    required_checks_conducted = fields.id_name_field()
+
+    deal_ticket_sizes = fields.id_name_field()
+    investment_types = fields.id_name_field()
+    minimum_return_rate = fields.id_name_field()
+    time_horizons = fields.id_name_field()
+    restrictions = fields.id_name_field()
+    construction_risks = fields.id_name_field()
+    minimum_equity_percentage = fields.id_name_field()
+    desired_deal_roles = fields.id_name_field()
+
+    uk_region_locations = fields.id_name_field()
+    other_countries_being_considered = fields.id_name_partial_field(
+        'other_countries_being_considered',
+    )
+
+    created_on = Date()
+    modified_on = Date()
+
+    _MAIN_FIELD_MAPPINGS = {
+        'asset_classes_of_interest': _get_many_to_many_list,
+        'country_of_origin': dict_utils.id_name_dict,
+        'investor_company': dict_utils.company_dict,
+        'created_by': dict_utils.adviser_dict_with_team,
+    }
+
+    _DETAIL_FIELD_MAPPINGS = {
+        'investor_type': dict_utils.id_name_dict,
+        'required_checks_conducted': dict_utils.id_name_dict,
+    }
+
+    _REQUIREMENT_FIELD_MAPPINGS = {
+        'deal_ticket_sizes': _get_many_to_many_list,
+        'investment_types': _get_many_to_many_list,
+        'minimum_return_rate': dict_utils.id_name_dict,
+        'time_horizons': _get_many_to_many_list,
+        'restrictions': _get_many_to_many_list,
+        'construction_risks': _get_many_to_many_list,
+        'minimum_equity_percentage': dict_utils.id_name_dict,
+        'desired_deal_roles': _get_many_to_many_list,
+    }
+
+    _LOCATION_FIELD_MAPPINGS = {
+        'uk_region_locations': _get_many_to_many_list,
+        'other_countries_being_considered': _get_many_to_many_list,
+    }
+
+    MAPPINGS = {
+        **_MAIN_FIELD_MAPPINGS,
+        **_DETAIL_FIELD_MAPPINGS,
+        **_REQUIREMENT_FIELD_MAPPINGS,
+        **_LOCATION_FIELD_MAPPINGS,
+    }
+
+    SEARCH_FIELDS = (
+        'id',
+        'investor_company.name',
+        'investor_company.name_trigram',
+    )
+
+    class Meta:
+        """Default document meta data."""
+
+        doc_type = DOC_TYPE
+
+    class Index:
+        doc_type = DOC_TYPE

--- a/datahub/search/large_investor_profile/models.py
+++ b/datahub/search/large_investor_profile/models.py
@@ -86,7 +86,7 @@ class LargeInvestorProfile(BaseESModel):
     SEARCH_FIELDS = (
         'id',
         'investor_company.name',
-        'investor_company.name_trigram',
+        'investor_company.name.trigram',
     )
 
     class Meta:

--- a/datahub/search/large_investor_profile/serializers.py
+++ b/datahub/search/large_investor_profile/serializers.py
@@ -1,0 +1,55 @@
+from rest_framework.serializers import CharField, IntegerField
+
+from datahub.core.serializers import RelaxedDateTimeField
+from datahub.search.serializers import (
+    EntitySearchQuerySerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
+
+
+class SearchLargeInvestorProfileQuerySerializer(EntitySearchQuerySerializer):
+    """Serialiser used to validate investor profile search POST bodies."""
+
+    id = SingleOrListField(child=StringUUIDField(), required=False)
+
+    """Main filters"""
+    asset_classes_of_interest = SingleOrListField(child=StringUUIDField(), required=False)
+    country_of_origin = SingleOrListField(child=StringUUIDField(), required=False)
+    investor_company = SingleOrListField(child=StringUUIDField(), required=False)
+    investor_company_name = CharField(required=False)
+    created_by = SingleOrListField(child=StringUUIDField(), required=False)
+
+    """Detail filters"""
+    investor_type = SingleOrListField(child=StringUUIDField(), required=False)
+    required_checks_conducted = SingleOrListField(child=StringUUIDField(), required=False)
+    global_assets_under_management_before = IntegerField(required=False)
+    global_assets_under_management_after = IntegerField(required=False)
+    investable_capital_before = IntegerField(required=False)
+    investable_capital_after = IntegerField(required=False)
+
+    """Requirement filters"""
+    deal_ticket_sizes = SingleOrListField(child=StringUUIDField(), required=False)
+    investment_types = SingleOrListField(child=StringUUIDField(), required=False)
+    minimum_return_rate = SingleOrListField(child=StringUUIDField(), required=False)
+    time_horizons = SingleOrListField(child=StringUUIDField(), required=False)
+    restrictions = SingleOrListField(child=StringUUIDField(), required=False)
+    construction_risks = SingleOrListField(child=StringUUIDField(), required=False)
+    minimum_equity_percentage = SingleOrListField(child=StringUUIDField(), required=False)
+    desired_deal_roles = SingleOrListField(child=StringUUIDField(), required=False)
+
+    """Location filters"""
+    uk_region_locations = SingleOrListField(child=StringUUIDField(), required=False)
+    other_countries_being_considered = SingleOrListField(child=StringUUIDField(), required=False)
+
+    """Extra filters"""
+    created_on_after = RelaxedDateTimeField(required=False)
+    created_on_before = RelaxedDateTimeField(required=False)
+
+    SORT_BY_FIELDS = (
+        'created_on',
+        'modified_on',
+        'investor_company.name',
+        'global_assets_under_management',
+        'investable_capital',
+    )

--- a/datahub/search/large_investor_profile/signals.py
+++ b/datahub/search/large_investor_profile/signals.py
@@ -15,7 +15,7 @@ from datahub.search.sync_object import sync_object_async, sync_related_objects_a
 
 def investor_profile_sync_es(instance):
     """Sync investor profile to Elasticsearch."""
-    if instance.profile_type_id == ProfileType.large.value.id:
+    if str(instance.profile_type_id) == str(ProfileType.large.value.id):
         transaction.on_commit(
             lambda: sync_object_async(LargeInvestorProfileSearchApp, instance.pk),
         )

--- a/datahub/search/large_investor_profile/signals.py
+++ b/datahub/search/large_investor_profile/signals.py
@@ -1,0 +1,47 @@
+from django.db import transaction
+from django.db.models.signals import post_delete, post_save
+
+from datahub.company.models import Company as DBCompany
+from datahub.investment.investor_profile.constants import ProfileType
+from datahub.investment.investor_profile.models import InvestorProfile as DBInvestorProfile
+from datahub.search.deletion import delete_document
+from datahub.search.large_investor_profile import LargeInvestorProfileSearchApp
+from datahub.search.large_investor_profile.models import (
+    LargeInvestorProfile as ESLargeInvestorProfile,
+)
+from datahub.search.signals import SignalReceiver
+from datahub.search.sync_object import sync_object_async, sync_related_objects_async
+
+
+def investor_profile_sync_es(instance):
+    """Sync investor profile to Elasticsearch."""
+    if instance.profile_type_id == ProfileType.large.value.id:
+        transaction.on_commit(
+            lambda: sync_object_async(LargeInvestorProfileSearchApp, instance.pk),
+        )
+
+
+def related_investor_profiles_sync_es(instance):
+    """Sync related Company investor profiles to Elasticsearch."""
+    transaction.on_commit(
+        lambda: sync_related_objects_async(
+            instance,
+            'investor_profiles',
+            related_obj_filter={'profile_type_id': ProfileType.large.value.id},
+        ),
+    )
+
+
+def remove_investor_profile_from_es(instance):
+    """Remove investor profile from es."""
+    if instance.profile_type_id == ProfileType.large.value.id:
+        transaction.on_commit(
+            lambda pk=instance.pk: delete_document(ESLargeInvestorProfile, pk),
+        )
+
+
+receivers = (
+    SignalReceiver(post_save, DBInvestorProfile, investor_profile_sync_es),
+    SignalReceiver(post_save, DBCompany, related_investor_profiles_sync_es),
+    SignalReceiver(post_delete, DBInvestorProfile, remove_investor_profile_from_es),
+)

--- a/datahub/search/large_investor_profile/test/test_models.py
+++ b/datahub/search/large_investor_profile/test/test_models.py
@@ -1,0 +1,50 @@
+import pytest
+
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
+from datahub.search.large_investor_profile.models import (
+    LargeInvestorProfile as ESLargeInvestorProfile,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+class TestLargeInvestorProfileElasticModel:
+    """Test for the large investor profile elasticsearch model"""
+
+    def test_large_investor_profile_dbmodel_to_dict(self, setup_es):
+        """Tests conversion of db model to dict."""
+        large_investor_profile = LargeInvestorProfileFactory()
+
+        result = ESLargeInvestorProfile.db_object_to_dict(large_investor_profile)
+        keys = {
+            'asset_classes_of_interest',
+            'construction_risks',
+            'country_of_origin',
+            'created_by',
+            'created_on',
+            'deal_ticket_sizes',
+            'desired_deal_roles',
+            'global_assets_under_management',
+            'id',
+            'investable_capital',
+            'investment_types',
+            'investor_company',
+            'investor_type',
+            'minimum_equity_percentage',
+            'minimum_return_rate',
+            'modified_on',
+            'other_countries_being_considered',
+            'required_checks_conducted',
+            'restrictions',
+            'time_horizons',
+            'uk_region_locations',
+        }
+        assert set(result.keys()) == keys
+
+    def test_investment_project_dbmodels_to_es_documents(self, setup_es):
+        """Tests conversion of db models to Elasticsearch documents."""
+        large_profiles = LargeInvestorProfileFactory.create_batch(2)
+
+        result = ESLargeInvestorProfile.db_objects_to_es_documents(large_profiles)
+
+        assert len(list(result)) == len(large_profiles)

--- a/datahub/search/large_investor_profile/test/test_signals.py
+++ b/datahub/search/large_investor_profile/test/test_signals.py
@@ -1,0 +1,98 @@
+from unittest import mock
+
+import pytest
+from elasticsearch.exceptions import NotFoundError
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.investment.investor_profile.test.factories import (
+    GrowthInvestorProfileFactory,
+    LargeInvestorProfileFactory,
+)
+from datahub.search.large_investor_profile.apps import LargeInvestorProfileSearchApp
+
+pytestmark = pytest.mark.django_db
+
+
+def _get_es_document(setup_es, pk):
+    return setup_es.get(
+        index=LargeInvestorProfileSearchApp.es_model.get_read_alias(),
+        doc_type=LargeInvestorProfileSearchApp.name,
+        id=pk,
+    )
+
+
+def test_new_large_investor_profile_synced(setup_es):
+    """Test that new large capital profiles are synced to ES."""
+    investor_profile = LargeInvestorProfileFactory()
+    setup_es.indices.refresh()
+    assert _get_es_document(setup_es, investor_profile.pk)
+
+
+def test_updated_large_investor_profile_synced(setup_es):
+    """Test that when an large investor profile is updated it is synced to ES."""
+    large_investor_profile = LargeInvestorProfileFactory()
+    large_investor_profile.investable_capital = 12345
+    large_investor_profile.save()
+    setup_es.indices.refresh()
+
+
+def test_deleted_large_investor_profile_deleted_from_es(setup_es):
+    """
+    Test that when an large investor profile is deleted from db it is also
+    deleted from ES.
+    """
+    large_investor_profile = LargeInvestorProfileFactory()
+    setup_es.indices.refresh()
+
+    assert _get_es_document(setup_es, large_investor_profile.pk)
+
+    large_investor_profile_id = large_investor_profile.pk
+    large_investor_profile.delete()
+    setup_es.indices.refresh()
+
+    with pytest.raises(NotFoundError):
+        assert _get_es_document(setup_es, large_investor_profile_id) is None
+
+
+def test_edit_company_syncs_large_investor_profile_in_es(setup_es):
+    """Tests that updating company details also updated the relevant investor profiles."""
+    new_company_name = 'SYNC TEST'
+    investor_company = CompanyFactory()
+    GrowthInvestorProfileFactory(investor_company=investor_company)
+    investor_profile = LargeInvestorProfileFactory(investor_company=investor_company)
+    setup_es.indices.refresh()
+    investor_company.name = new_company_name
+    investor_company.save()
+
+    result = _get_es_document(setup_es, investor_profile.pk)
+    assert result['_source']['investor_company']['name'] == new_company_name
+
+
+def test_growth_investor_profile_does_not_sync_to_es(setup_es):
+    """Tests that a growth investor profile is not synced to elasticsearch."""
+    investor_company = CompanyFactory()
+    setup_es.indices.refresh()
+    with mock.patch('datahub.search.tasks.sync_object_task.apply_async') as mock_sync_object:
+        growth_profile = GrowthInvestorProfileFactory(investor_company=investor_company)
+        with pytest.raises(NotFoundError):
+            assert _get_es_document(setup_es, growth_profile.id) is None
+        assert not mock_sync_object.called
+
+
+def test_edit_company_does_not_sync_growth_investor_profile(setup_es):
+    """
+    Tests that updating company details of a company with a growth investor profile,
+    the profile is not synced to elasticsearch.
+    """
+    investor_company = CompanyFactory()
+    setup_es.indices.refresh()
+
+    with mock.patch('datahub.search.tasks.sync_object_task.apply_async') as mock_sync_object:
+        growth_profile = GrowthInvestorProfileFactory(investor_company=investor_company)
+        investor_company.name = 'SYNC TEST'
+        investor_company.save()
+        assert mock_sync_object.call_args[1]['args'][0] != 'large-investor-profile'
+        assert mock_sync_object.call_count == 1  # Updating the company instance
+
+    with pytest.raises(NotFoundError):
+        assert _get_es_document(setup_es, growth_profile.id) is None

--- a/datahub/search/large_investor_profile/test/test_signals.py
+++ b/datahub/search/large_investor_profile/test/test_signals.py
@@ -44,7 +44,7 @@ def test_updated_large_investor_profile_synced(setup_es):
     ),
 )
 def test_delete_from_es(
-    investor_profile_factory, expected_in_index, expected_to_call_delete, setup_es
+    investor_profile_factory, expected_in_index, expected_to_call_delete, setup_es,
 ):
     """
     Test that when an large investor profile is deleted from db it is also
@@ -60,7 +60,7 @@ def test_delete_from_es(
             assert _get_es_document(setup_es, investor_profile.pk) is None
 
     with mock.patch(
-        'datahub.search.large_investor_profile.signals.delete_document'
+        'datahub.search.large_investor_profile.signals.delete_document',
     ) as mock_delete_document:
         investor_profile.delete()
         setup_es.indices.refresh()

--- a/datahub/search/large_investor_profile/views.py
+++ b/datahub/search/large_investor_profile/views.py
@@ -1,0 +1,94 @@
+from datahub.oauth.scopes import Scope
+from datahub.search.large_investor_profile import LargeInvestorProfileSearchApp
+from datahub.search.large_investor_profile.serializers import (
+    SearchLargeInvestorProfileQuerySerializer,
+)
+from datahub.search.views import register_v4_view, SearchAPIView
+
+
+class SearchInvestorProfileAPIViewMixin:
+    """Defines common settings."""
+
+    required_scopes = (Scope.internal_front_end,)
+    search_app = LargeInvestorProfileSearchApp
+    serializer_class = SearchLargeInvestorProfileQuerySerializer
+
+    _MAIN_FILTERS = (
+        'asset_classes_of_interest',
+        'country_of_origin',
+        'investor_company',
+        'investor_company_name',
+        'created_by',
+    )
+
+    _DETAIL_FILTERS = (
+        'investor_type',
+        'investable_capital_before',
+        'investable_capital_after',
+        'global_assets_under_management_before',
+        'global_assets_under_management_after',
+        'required_checks_conducted',
+    )
+
+    _REQUIREMENT_FILTERS = (
+        'deal_ticket_sizes',
+        'investment_types',
+        'minimum_return_rate',
+        'time_horizons',
+        'restrictions',
+        'construction_risks',
+        'minimum_equity_percentage',
+        'desired_deal_roles',
+    )
+
+    _LOCATION_FIELDS = (
+        'uk_region_locations',
+        'other_countries_being_considered',
+    )
+
+    _EXTRA_FIELDS = (
+        'created_on_before',
+        'created_on_after',
+    )
+
+    FILTER_FIELDS = (
+        'id',
+        *_MAIN_FILTERS,
+        *_DETAIL_FILTERS,
+        *_REQUIREMENT_FILTERS,
+        *_LOCATION_FIELDS,
+        *_EXTRA_FIELDS,
+    )
+
+    REMAP_FIELDS = {
+        'investor_company': 'investor_company.id',
+        'country_of_origin': 'country_of_origin.id',
+        'asset_classes_of_interest': 'asset_classes_of_interest.id',
+        'investor_type': 'investor_type.id',
+        'required_checks_conducted': 'required_checks_conducted.id',
+        'deal_ticket_sizes': 'deal_ticket_sizes.id',
+        'investment_types': 'investment_types.id',
+        'minimum_return_rate': 'minimum_return_rate.id',
+        'time_horizons': 'time_horizons.id',
+        'restrictions': 'restrictions.id',
+        'construction_risks': 'construction_risks.id',
+        'minimum_equity_percentage': 'minimum_equity_percentage.id',
+        'desired_deal_roles': 'desired_deal_roles.id',
+        'uk_region_locations': 'uk_region_locations.id',
+        'other_countries_being_considered': 'other_countries_being_considered.id',
+        'created_by': 'created_by.id',
+    }
+
+    COMPOSITE_FILTERS = {
+        'investor_company_name': [
+            'investor_company.name',
+            'investor_company.name.trigram',
+            'investor_company.trading_names',  # to find 2-letter words
+            'investor_company.trading_names.trigram',
+        ],
+    }
+
+
+@register_v4_view()
+class SearchLargeInvestorProfileAPIView(SearchInvestorProfileAPIViewMixin, SearchAPIView):
+    """Filtered large capital investor profile search view."""

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -15,7 +15,7 @@ class Order(BaseESModel):
     reference = fields.NormalizedKeyword(copy_to=['reference_trigram'])
     reference_trigram = fields.TrigramText()
     status = fields.NormalizedKeyword()
-    company = fields.company_field('company')
+    company = fields.company_field_with_copy_to_name_trigram('company')
     contact = fields.contact_or_adviser_field('contact')
     created_by = fields.contact_or_adviser_field('created_by', include_dit_team=True)
     created_on = Date()

--- a/datahub/search/sync_object.py
+++ b/datahub/search/sync_object.py
@@ -44,7 +44,7 @@ def sync_object_async(search_app, pk):
     )
 
 
-def sync_related_objects_async(related_obj, related_obj_field_name):
+def sync_related_objects_async(related_obj, related_obj_field_name, related_obj_filter=None):
     """
     Syncs objects related to another object via a specified field.
 
@@ -61,6 +61,7 @@ def sync_related_objects_async(related_obj, related_obj_field_name):
             related_obj._meta.label,
             str(related_obj.pk),
             related_obj_field_name,
+            related_obj_filter,
         ),
     )
     logger.info(

--- a/datahub/search/sync_object.py
+++ b/datahub/search/sync_object.py
@@ -56,14 +56,17 @@ def sync_related_objects_async(related_obj, related_obj_field_name, related_obj_
     This function is normally used by signal receivers to copy new or updated related objects to
     Elasticsearch.
     """
+    kwargs = {'related_obj_filter': related_obj_filter} if related_obj_filter else {}
+
     result = sync_related_objects_task.apply_async(
         args=(
             related_obj._meta.label,
             str(related_obj.pk),
             related_obj_field_name,
-            related_obj_filter,
         ),
+        kwargs=kwargs,
     )
+
     logger.info(
         f'Task {result.id} scheduled to synchronise {related_obj_field_name} for object'
         f' {related_obj.pk}',

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -69,6 +69,7 @@ def sync_related_objects_task(
     related_model_label,
     related_obj_pk,
     related_obj_field_name,
+    related_obj_filter,
 ):
     """
     Syncs objects related to another object via a specified field.
@@ -89,6 +90,8 @@ def sync_related_objects_task(
     related_model = apps.get_model(related_model_label)
     related_obj = related_model.objects.get(pk=related_obj_pk)
     manager = getattr(related_obj, related_obj_field_name)
+    if related_obj_filter:
+        manager = manager.filter(**related_obj_filter)
     queryset = manager.values_list('pk', flat=True)
     search_app = get_search_app_by_model(manager.model)
 

--- a/datahub/search/tasks.py
+++ b/datahub/search/tasks.py
@@ -69,7 +69,7 @@ def sync_related_objects_task(
     related_model_label,
     related_obj_pk,
     related_obj_field_name,
-    related_obj_filter,
+    related_obj_filter=None,
 ):
     """
     Syncs objects related to another object via a specified field.

--- a/datahub/search/test/test_tasks.py
+++ b/datahub/search/test/test_tasks.py
@@ -78,6 +78,7 @@ def test_sync_related_objects_task_syncs(monkeypatch):
             SimpleModel._meta.label,
             str(simpleton.pk),
             'relatedmodel_set',
+            None,
         ),
     )
 


### PR DESCRIPTION
### Description of change
This adds the large investor profile search views. It allows most fields to be filtered.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
