### PR TITLE
Add dit_participants to interaction search model

### DIFF
--- a/changelog/interaction/search-participants-field.api.rst
+++ b/changelog/interaction/search-participants-field.api.rst
@@ -1,0 +1,33 @@
+``GET /v3/search``, ``POST /v3/search/interaction``:
+
+``dit_participants`` was added to interaction search results in responses. This is an array in the following format::
+
+    [
+        {
+           "adviser": {
+               "id": ...,
+               "first_name": ...,
+               "last_name": ...,
+               "name": ...
+           },
+           "team": {
+               "id": ...,
+               "name": ...
+           }
+        },
+        {
+           "adviser": {
+               "id": ...,
+               "first_name": ...,
+               "last_name": ...,
+               "name": ...
+           },
+           "team": {
+               "id": ...,
+               "name": ...
+           }
+        },
+        ...
+    ]
+
+This field is intended to replace the ``dit_adviser`` and ``dit_team`` fields.

--- a/datahub/search/inner_docs.py
+++ b/datahub/search/inner_docs.py
@@ -1,0 +1,27 @@
+from elasticsearch_dsl import InnerDoc, Keyword, Text
+
+from datahub.search.fields import TrigramText
+
+
+class Person(InnerDoc):
+    """Inner doc for a person (e.g. a contact or an adviser)."""
+
+    id = Keyword()
+    first_name = Text(index=False)
+    last_name = Text(index=False)
+    name = Text(
+        fields={
+            'trigram': TrigramText(),
+        },
+    )
+
+
+class IDNameTrigram(InnerDoc):
+    """Inner doc for a named object, with a trigram sub-field on name."""
+
+    id = Keyword()
+    name = Text(
+        fields={
+            'trigram': TrigramText(),
+        },
+    )

--- a/datahub/search/interaction/apps.py
+++ b/datahub/search/interaction/apps.py
@@ -1,4 +1,10 @@
-from datahub.interaction.models import Interaction as DBInteraction, InteractionPermission
+from django.db.models import Prefetch
+
+from datahub.interaction.models import (
+    Interaction as DBInteraction,
+    InteractionDITParticipant,
+    InteractionPermission,
+)
 from datahub.search.apps import SearchApp
 from datahub.search.interaction.models import Interaction
 
@@ -29,4 +35,8 @@ class InteractionSearchApp(SearchApp):
         'contacts',
         'policy_areas',
         'policy_issue_types',
+        Prefetch(
+            'dit_participants',
+            queryset=InteractionDITParticipant.objects.select_related('adviser', 'team'),
+        ),
     )

--- a/datahub/search/interaction/tests/test_models.py
+++ b/datahub/search/interaction/tests/test_models.py
@@ -27,6 +27,7 @@ def test_interaction_to_dict(setup_es, factory_cls):
 
     result = Interaction.db_object_to_dict(interaction)
     result['contacts'].sort(key=itemgetter('id'))
+    result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
     result['policy_areas'].sort(key=itemgetter('id'))
     result['policy_issue_types'].sort(key=itemgetter('id'))
 
@@ -68,6 +69,21 @@ def test_interaction_to_dict(setup_es, factory_cls):
             'name': interaction.dit_adviser.name,
             'last_name': interaction.dit_adviser.last_name,
         },
+        'dit_participants': [
+            {
+                'adviser': {
+                    'id': str(dit_participant.adviser.pk),
+                    'first_name': dit_participant.adviser.first_name,
+                    'name': dit_participant.adviser.name,
+                    'last_name': dit_participant.adviser.last_name,
+                },
+                'team': {
+                    'id': str(dit_participant.team.pk),
+                    'name': dit_participant.team.name,
+                },
+            }
+            for dit_participant in interaction.dit_participants.order_by('adviser__pk')
+        ],
         'notes': interaction.notes,
         'dit_team': {
             'id': str(interaction.dit_team.pk),
@@ -115,6 +131,7 @@ def test_service_delivery_to_dict(setup_es):
 
     result = Interaction.db_object_to_dict(interaction)
     result['contacts'].sort(key=itemgetter('id'))
+    result['dit_participants'].sort(key=lambda dit_participant: dit_participant['adviser']['id'])
 
     assert result == {
         'id': interaction.pk,
@@ -154,6 +171,21 @@ def test_service_delivery_to_dict(setup_es):
             'name': interaction.dit_adviser.name,
             'last_name': interaction.dit_adviser.last_name,
         },
+        'dit_participants': [
+            {
+                'adviser': {
+                    'id': str(dit_participant.adviser.pk),
+                    'first_name': dit_participant.adviser.first_name,
+                    'name': dit_participant.adviser.name,
+                    'last_name': dit_participant.adviser.last_name,
+                },
+                'team': {
+                    'id': str(dit_participant.team.pk),
+                    'name': dit_participant.team.name,
+                },
+            }
+            for dit_participant in interaction.dit_participants.order_by('adviser__pk')
+        ],
         'notes': interaction.notes,
         'dit_team': {
             'id': str(interaction.dit_team.pk),

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -281,6 +281,9 @@ class TestInteractionEntitySearchView(APITestMixin):
 
         for result in results:
             result['contacts'].sort(key=itemgetter('id'))
+            result['dit_participants'].sort(
+                key=lambda dit_participant: dit_participant['adviser']['id'],
+            )
 
         assert results == [{
             'id': str(interaction.pk),
@@ -320,6 +323,21 @@ class TestInteractionEntitySearchView(APITestMixin):
                 'name': interaction.dit_adviser.name,
                 'last_name': interaction.dit_adviser.last_name,
             },
+            'dit_participants': [
+                {
+                    'adviser': {
+                        'id': str(dit_participant.adviser.pk),
+                        'first_name': dit_participant.adviser.first_name,
+                        'name': dit_participant.adviser.name,
+                        'last_name': dit_participant.adviser.last_name,
+                    },
+                    'team': {
+                        'id': str(dit_participant.team.pk),
+                        'name': dit_participant.team.name,
+                    },
+                }
+                for dit_participant in interaction.dit_participants.order_by('adviser__pk')
+            ],
             'notes': interaction.notes,
             'dit_team': {
                 'id': str(interaction.dit_team.pk),


### PR DESCRIPTION
### Description of change

This adds `dit_participants` to the interaction search model.

Existing search logic continues to use `dit_adviser` and `dit_team` as we first need to release this and populate the new fields with data in the Elasticsearch database.

I took the opportunity to use InnerDoc and multi-fields. We already started migrating to multi-fields, and InnerDoc is the main suggested way of using Object in the elasticsearch-dsl docs.  (The benefits improve readability, ability to use inheritance etc.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
