### PR TITLE
Remove execution of manage.py collectstatic from Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: python manage.py collectstatic --noinput && python manage.py distributed_migrate --noinput && python manage.py init_es && gunicorn config.wsgi --config config/gunicorn.py
+web: python manage.py distributed_migrate --noinput && python manage.py init_es && gunicorn config.wsgi --config config/gunicorn.py
 celeryworker: celery worker -A config -l info -Q celery
 celerylongrunning: celery worker -A config -l info -O fair --prefetch-multiplier 1 -Q long-running
 celerybeat: celery beat -A config -l info


### PR DESCRIPTION
### Description of change

We previously used `DISABLE_COLLECTSTATIC` with the build pack because the app used to attempt to connect to Elasticsearch when `collectstatic` was running, which would fail at that stage.

However, we removed the logic that caused the app to connect to Elasticsearch on app ready, so we no longer need to use `DISABLE_COLLECTSTATIC` and can remove the `collectstatic` invocation from the Procfile.

This should cut down the start-up time of each app instance slightly.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
