### PR TITLE
Add DIT participants to interaction admin as a read-only section

### DIFF
--- a/changelog/interaction/dit-participants-admin.feature.rst
+++ b/changelog/interaction/dit-participants-admin.feature.rst
@@ -1,0 +1,1 @@
+A DIT participants section was added to the interaction form in the admin site. This displays all advisers and teams that are associated with an interaction. This section will remain read-only until the old DIT adviser and DIT team fields are removed from the database.

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -7,6 +7,7 @@ from datahub.core.utils import join_truthy_strings
 from datahub.interaction.models import (
     CommunicationChannel,
     Interaction,
+    InteractionDITParticipant,
     InteractionPermission,
     PolicyArea,
     PolicyIssueType,
@@ -18,6 +19,46 @@ admin.site.register(CommunicationChannel, DisableableMetadataAdmin)
 admin.site.register((PolicyArea, PolicyIssueType), OrderedMetadataAdmin)
 
 
+class InteractionDITParticipantInline(admin.TabularInline):
+    """
+    Inline admin for InteractionDITParticipant.
+
+    Currently view-only while the legacy Interaction.dit_adviser and Interaction.dit_team fields
+    still exist (to avoid the need to keep them in sync when edits are made via the admin site).
+    """
+
+    model = InteractionDITParticipant
+    fields = ('adviser', 'team')
+    verbose_name = 'DIT participant'
+    # Note: verbose_name_plural does not get automatically updated here if verbose_name is set,
+    # so we have to set it manually
+    verbose_name_plural = 'DIT participants'
+
+    def has_add_permission(self, request, obj=None):
+        """
+        Gets whether the user can add new objects for this model.
+
+        Always returns False.
+        """
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        """
+        Gets whether the user can change objects for this model.
+
+        Always returns False.
+        """
+        return False
+
+    def has_delete_permission(self, request, obj=None):
+        """
+        Gets whether the user can delete objects for this model.
+
+        Always returns False.
+        """
+        return False
+
+
 @admin.register(Interaction)
 @custom_add_permission(InteractionPermission.add_all)
 @custom_change_permission(InteractionPermission.change_all)
@@ -25,6 +66,9 @@ class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
     """Interaction admin."""
 
     autocomplete_fields = ('contacts',)
+    inlines = (
+        InteractionDITParticipantInline,
+    )
     search_fields = (
         '=pk',
         'subject',
@@ -44,7 +88,6 @@ class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
     raw_id_fields = (
         'company',
         'event',
-        'dit_adviser',
         'investment_project',
     )
     readonly_fields = (

--- a/datahub/interaction/migrations/0043_stricter_dit_adviser_and_dit_team.py
+++ b/datahub/interaction/migrations/0043_stricter_dit_adviser_and_dit_team.py
@@ -15,11 +15,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='interaction',
             name='dit_adviser',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, related_name='interactions', to=settings.AUTH_USER_MODEL),
+            field=models.ForeignKey(help_text='This field is deprecated and has been replaced by DIT participants.', null=True, on_delete=django.db.models.deletion.PROTECT, related_name='interactions', to=settings.AUTH_USER_MODEL),
         ),
         migrations.AlterField(
             model_name='interaction',
             name='dit_team',
-            field=models.ForeignKey(null=True, on_delete=django.db.models.deletion.PROTECT, to='metadata.Team'),
+            field=models.ForeignKey(help_text='This field is deprecated and has been replaced by DIT participants.', null=True, on_delete=django.db.models.deletion.PROTECT, to='metadata.Team'),
         ),
     ]

--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -172,12 +172,16 @@ class Interaction(BaseModel):
         related_name='%(class)ss',
         null=True,
         on_delete=models.PROTECT,
+        help_text='This field is deprecated and has been replaced by DIT participants.',
     )
     notes = models.TextField(max_length=10000, blank=True)
     # TODO: dit_team is being replaced with InteractionDITParticipant, and dit_team will be
     #  removed once the migration is complete
     dit_team = models.ForeignKey(
-        'metadata.Team', null=True, on_delete=models.PROTECT,
+        'metadata.Team',
+        null=True,
+        on_delete=models.PROTECT,
+        help_text='This field is deprecated and has been replaced by DIT participants.',
     )
     communication_channel = models.ForeignKey(
         'CommunicationChannel', blank=True, null=True,

--- a/datahub/interaction/test/test_admin.py
+++ b/datahub/interaction/test/test_admin.py
@@ -43,6 +43,10 @@ class TestInteractionAdminContacts(AdminTestMixin):
             'service': random_obj_for_model(Service).pk,
             'dit_team': random_obj_for_model(Team).pk,
             'was_policy_feedback_provided': False,
+            'dit_participants-TOTAL_FORMS': 0,
+            'dit_participants-INITIAL_FORMS': 0,
+            'dit_participants-MAX_NUM_FORMS': 0,
+            'dit_participants-MIN_NUM_FORMS': 0,
         }
         response = self.client.post(url, data, follow=True)
 
@@ -79,6 +83,12 @@ class TestInteractionAdminContacts(AdminTestMixin):
             'policy_areas': [],
             'policy_issue_types': [],
             'event': '',
+            'dit_participants-TOTAL_FORMS': 0,
+            'dit_participants-INITIAL_FORMS': 0,
+            'dit_participants-MAX_NUM_FORMS': 0,
+            'dit_participants-MIN_NUM_FORMS': 0,
+            'dit_participants-0-id': interaction.dit_participants.first().pk,
+            'dit_participants-0-interaction': interaction.pk,
 
             # Changed values
             'contacts': [contact.pk for contact in new_contacts],
@@ -113,6 +123,12 @@ class TestInteractionAdminContacts(AdminTestMixin):
             'policy_areas': [],
             'policy_issue_types': [],
             'event': '',
+            'dit_participants-TOTAL_FORMS': 0,
+            'dit_participants-INITIAL_FORMS': 0,
+            'dit_participants-MAX_NUM_FORMS': 0,
+            'dit_participants-MIN_NUM_FORMS': 0,
+            'dit_participants-0-id': interaction.dit_participants.first().pk,
+            'dit_participants-0-interaction': interaction.pk,
 
             # Changed values
             'contacts': [],


### PR DESCRIPTION
### Description of change

This adds a DIT participants section to the interaction form in the admin site.

This also adds help text for the deprecated `dit_adviser` and `dit_team` fields to say that they are deprecated. (An existing migration was edited to prevent unnecessary foreign key constraint drop and recreation operations when the schema hasn't been modified.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
