### PR TITLE
Add Large investor profile to search pt 2

### DIFF
--- a/changelog/investment/large_investor_profile_in_search.search.rst
+++ b/changelog/investment/large_investor_profile_in_search.search.rst
@@ -1,0 +1,35 @@
+New endpoint added ``POST /v4/search/large-investor-profile`` to search and retrieve large capital investor profiles.
+
+Profiles are filterable as follows. The following filters accept and single or list of ids:
+
+- id
+- asset_classes_of_interest (metadata id)
+- country_of_origin (country id)
+- investor_company (company id)
+- created_by (adviser id)
+- investor_type (metadata id)
+- required_checks_conducted (metadata id)
+- deal_ticket_size (metadata id)
+- investment_type (metadata id)
+- minimum_return_rate (metadata id)
+- time_horizon (metadata id)
+- restriction (metadata id)
+- construction_risk (metadata id)
+- minimum_equity_percentage (metadata id)
+- desired_deal_role (metadata id)
+- uk_region_location (uk region id)
+- other_countries_being_considered (country id)
+
+
+The following range filters have been added:
+
+- created_on_before (date)
+- created_on_after (date)
+- global_assets_under_management_start (int)
+- global_assets_under_management_end (int)
+- investable_capital_start (int)
+- investable_capital_end (int)
+
+The following text search filter has been added:
+
+- investor_company_name (text)

--- a/datahub/investment/investor_profile/test/constants.py
+++ b/datahub/investment/investor_profile/test/constants.py
@@ -72,6 +72,10 @@ class ConstructionRisk(Enum):
         'Brownfield (some construction risk)',
         '884deaf6-cb0c-4036-b78c-efd92cb10098',
     )
+    operational = Constant(
+        'Operational (no construction risk)',
+        '9f554b26-70f2-4cac-89ae-758c2ef71c70',
+    )
 
 
 class DesiredDealRole(Enum):

--- a/datahub/investment/investor_profile/test/factories.py
+++ b/datahub/investment/investor_profile/test/factories.py
@@ -1,6 +1,7 @@
 import factory
 
 from datahub.company.test.factories import CompanyFactory
+from datahub.core.test.factories import to_many_field
 from datahub.investment.investor_profile.constants import ProfileType as ProfileTypeConstant
 
 
@@ -9,6 +10,51 @@ class LargeInvestorProfileFactory(factory.django.DjangoModelFactory):
 
     investor_company = factory.SubFactory(CompanyFactory)
     profile_type_id = ProfileTypeConstant.large.value.id
+
+    @to_many_field
+    def construction_risks(self):
+        """Construction risks."""
+        return []
+
+    @to_many_field
+    def deal_ticket_sizes(self):
+        """Deal ticket sizes."""
+        return []
+
+    @to_many_field
+    def asset_classes_of_interest(self):
+        """Asset classes of interest."""
+        return []
+
+    @to_many_field
+    def investment_types(self):
+        """Investment types."""
+        return []
+
+    @to_many_field
+    def time_horizons(self):
+        """Time horizons."""
+        return []
+
+    @to_many_field
+    def restrictions(self):
+        """Restrictions."""
+        return []
+
+    @to_many_field
+    def desired_deal_roles(self):
+        """Desired deal roles."""
+        return []
+
+    @to_many_field
+    def uk_region_locations(self):
+        """UK region locations."""
+        return []
+
+    @to_many_field
+    def other_countries_being_considered(self):
+        """Other countries being considered."""
+        return []
 
     class Meta:
         model = 'investor_profile.InvestorProfile'

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -111,6 +111,7 @@ def company_field():
             'name': Text(
                 fields={
                     'trigram': TrigramText(),
+                    'keyword': NormalizedKeyword(),
                 },
             ),
             'trading_names': Text(

--- a/datahub/search/large_investor_profile/serializers.py
+++ b/datahub/search/large_investor_profile/serializers.py
@@ -1,0 +1,106 @@
+from rest_framework.serializers import CharField, IntegerField
+
+from datahub.core.serializers import RelaxedDateTimeField
+from datahub.search.serializers import (
+    EntitySearchQuerySerializer,
+    SingleOrListField,
+    StringUUIDField,
+)
+
+
+class SearchLargeInvestorProfileQuerySerializer(EntitySearchQuerySerializer):
+    """Serializer used to validate investor profile search POST bodies."""
+
+    id = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+
+    # Main filters
+    asset_classes_of_interest = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    country_of_origin = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    investor_company = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    investor_company_name = CharField(required=False)
+    created_by = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+
+    # Detail filters
+    investor_type = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    required_checks_conducted = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    global_assets_under_management_start = IntegerField(required=False)
+    global_assets_under_management_end = IntegerField(required=False)
+    investable_capital_start = IntegerField(required=False)
+    investable_capital_end = IntegerField(required=False)
+
+    # Requirement filters
+    deal_ticket_size = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    investment_type = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    minimum_return_rate = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    time_horizon = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    restriction = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    construction_risk = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    minimum_equity_percentage = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    desired_deal_role = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+
+    # Location filters
+    uk_region_location = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+    other_countries_being_considered = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
+
+    # Extra filters
+    created_on_after = RelaxedDateTimeField(required=False)
+    created_on_before = RelaxedDateTimeField(required=False)
+
+    SORT_BY_FIELDS = (
+        'created_on',
+        'modified_on',
+        'investor_company.name',
+        'global_assets_under_management',
+        'investable_capital',
+    )

--- a/datahub/search/large_investor_profile/test/test_elasticsearch.py
+++ b/datahub/search/large_investor_profile/test/test_elasticsearch.py
@@ -1,0 +1,354 @@
+import freezegun
+import pytest
+from elasticsearch_dsl import Mapping
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.investment.investor_profile.test.factories import LargeInvestorProfileFactory
+from datahub.search import elasticsearch
+from datahub.search.large_investor_profile import LargeInvestorProfileSearchApp
+from datahub.search.large_investor_profile.models import (
+    LargeInvestorProfile as ESLargeInvestorProfile,
+)
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_mapping(setup_es):
+    """Test the ES mapping for a large capital investor profile."""
+    mapping = Mapping.from_es(
+        LargeInvestorProfileSearchApp.es_model.get_write_index(),
+        LargeInvestorProfileSearchApp.name,
+    )
+    assert mapping.to_dict() == {
+        'large-investor-profile': {
+            'properties': {
+                'asset_classes_of_interest': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'construction_risks': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'country_of_origin': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'fields': {
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
+                            'type': 'text',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'created_by': {
+                    'properties': {
+                        'dit_team': {
+                            'properties': {
+                                'id': {
+                                    'type': 'keyword',
+                                },
+                                'name': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                            },
+                            'type': 'object',
+                        },
+                        'first_name': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'last_name': {
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'copy_to': [
+                                'created_by.name_trigram',
+                            ],
+                            'normalizer': 'lowercase_asciifolding_normalizer',
+                            'type': 'keyword',
+                        },
+                        'name_trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'created_on': {
+                    'type': 'date',
+                },
+                'deal_ticket_sizes': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'desired_deal_roles': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'global_assets_under_management': {
+                    'type': 'long',
+                },
+                'id': {
+                    'type': 'keyword',
+                },
+                'investable_capital': {
+                    'type': 'long',
+                },
+                'investment_types': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'investor_company': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'fields': {
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                            },
+                            'type': 'text',
+                        },
+                        'trading_names': {
+                            'fields': {
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
+                            'type': 'text',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'investor_description': {
+                    'analyzer': 'english_analyzer',
+                    'type': 'text',
+                },
+                'investor_type': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'minimum_equity_percentage': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'minimum_return_rate': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'modified_on': {
+                    'type': 'date',
+                },
+                'notes_on_locations': {
+                    'analyzer': 'english_analyzer',
+                    'type': 'text',
+                },
+                'other_countries_being_considered': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'fields': {
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
+                            'type': 'text',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'required_checks_conducted': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'restrictions': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'time_horizons': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+                'uk_region_locations': {
+                    'properties': {
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'keyword',
+                        },
+                    },
+                    'type': 'object',
+                },
+            },
+            'dynamic': 'false',
+        },
+    }
+
+
+@freezegun.freeze_time('2019-01-01')
+def test_indexed_doc(setup_es):
+    """Test the ES data of an Large investor profile."""
+    investor_company = CompanyFactory()
+
+    large_investor_profile = LargeInvestorProfileFactory(
+        investor_company=investor_company,
+    )
+
+    doc = ESLargeInvestorProfile.es_document(large_investor_profile)
+    elasticsearch.bulk(actions=(doc, ), chunk_size=1)
+
+    setup_es.indices.refresh()
+
+    indexed_large_investor_profile = setup_es.get(
+        index=ESLargeInvestorProfile.get_write_index(),
+        doc_type=LargeInvestorProfileSearchApp.name,
+        id=large_investor_profile.pk,
+    )
+
+    assert indexed_large_investor_profile['_id'] == str(large_investor_profile.pk)
+    assert indexed_large_investor_profile['_source'] == {
+        'id': str(large_investor_profile.pk),
+        'asset_classes_of_interest': [],
+        'country_of_origin': {
+            'id': str(large_investor_profile.country_of_origin.pk),
+            'name': str(large_investor_profile.country_of_origin.name),
+        },
+        'investor_company': {
+            'id': str(investor_company.pk),
+            'name': str(investor_company.name),
+            'trading_names': investor_company.trading_names,
+        },
+        'created_by': None,
+        'investor_type': None,
+        'required_checks_conducted': None,
+        'deal_ticket_sizes': [],
+        'investment_types': [],
+        'minimum_return_rate': None,
+        'time_horizons': [],
+        'restrictions': [],
+        'construction_risks': [],
+        'minimum_equity_percentage': None,
+        'desired_deal_roles': [],
+        'uk_region_locations': [],
+        'other_countries_being_considered': [],
+        'investable_capital': None,
+        'investor_description': '',
+        'created_on': '2019-01-01T00:00:00+00:00',
+        'notes_on_locations': '',
+        'global_assets_under_management': None,
+        'modified_on': '2019-01-01T00:00:00+00:00',
+    }

--- a/datahub/search/large_investor_profile/test/test_views.py
+++ b/datahub/search/large_investor_profile/test/test_views.py
@@ -1,0 +1,563 @@
+from collections import Counter
+
+import pytest
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.constants import (
+    Country as CountryConstant,
+    UKRegion as UKRegionConstant,
+)
+from datahub.core.test_utils import APITestMixin
+from datahub.investment.investor_profile.test.constants import (
+    AssetClassInterest as AssetClassInterestConstant,
+    ConstructionRisk as ConstructionRiskConstant,
+    DealTicketSize as DealTicketSizeConstant,
+    DesiredDealRole as DesiredDealRoleConstant,
+    EquityPercentage as EquityPercentageConstant,
+    LargeCapitalInvestmentTypes as InvestmentTypesConstant,
+    Restriction as RestrictionConstant,
+    ReturnRate as ReturnRateConstant,
+    TimeHorizon as TimeHorizonConstant,
+)
+from datahub.investment.investor_profile.test.factories import (
+    LargeInvestorProfileFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def setup_data(setup_es):
+    """Sets up data for the tests."""
+    investor_company = CompanyFactory(name='large abcdef')
+    argentina_investor_company = CompanyFactory(
+        name='argentina plc',
+        address_country_id=CountryConstant.argentina.value.id,
+    )
+    with freeze_time('2010-02-01'):
+        frozen_created_on_profile = LargeInvestorProfileFactory(
+            investor_company=CompanyFactory(
+                name='Frozen limited',
+            ),
+            investor_description='frozen in 2010',
+            construction_risks=[
+                ConstructionRiskConstant.greenfield.value.id,
+            ],
+            desired_deal_roles=[
+                DesiredDealRoleConstant.lead_manager.value.id,
+            ],
+            minimum_equity_percentage_id=EquityPercentageConstant.zero_percent.value.id,
+            investable_capital=0,
+            global_assets_under_management=10,
+            uk_region_locations=[
+                UKRegionConstant.north_west.value.id,
+                UKRegionConstant.east_of_england.value.id,
+            ],
+        )
+    with freeze_time('2018-01-01 10:00:00'):
+        south_project = LargeInvestorProfileFactory(
+            investor_company=CompanyFactory(
+                name='South',
+            ),
+            investor_description='South Project',
+            investment_types=[
+                InvestmentTypesConstant.direct_investment_in_project_equity.value.id,
+            ],
+            global_assets_under_management=60,
+        )
+    with freeze_time('2018-01-01 11:00:00'):
+        north_project = LargeInvestorProfileFactory(
+            investable_capital=20,
+            investor_company=CompanyFactory(
+                name='North',
+            ),
+            investor_description='North Project',
+            uk_region_locations=[
+                UKRegionConstant.north_west.value.id,
+                UKRegionConstant.north_east.value.id,
+            ],
+            other_countries_being_considered=[
+                CountryConstant.ireland.value.id,
+                CountryConstant.canada.value.id,
+            ],
+            global_assets_under_management=70,
+        )
+
+    with freeze_time('2019-01-01'):
+        investor_profiles = [
+            LargeInvestorProfileFactory(
+                investor_description='Operational construction',
+                investor_company=investor_company,
+                investable_capital=950,
+                construction_risks=[
+                    ConstructionRiskConstant.operational.value.id,
+                ],
+                minimum_return_rate_id=ReturnRateConstant.up_to_five_percent.value.id,
+                time_horizons=[
+                    TimeHorizonConstant.up_to_five_years.value.id,
+                    TimeHorizonConstant.five_to_nine_years.value.id,
+                ],
+                global_assets_under_management=20,
+            ),
+            LargeInvestorProfileFactory(
+                investor_description='Argentina project',
+                investor_company=argentina_investor_company,
+                investable_capital=1490,
+                construction_risks=[
+                    ConstructionRiskConstant.brownfield.value.id,
+                ],
+                time_horizons=[
+                    TimeHorizonConstant.up_to_five_years.value.id,
+                ],
+                restrictions=[
+                    RestrictionConstant.inflation_adjustment.value.id,
+                ],
+                global_assets_under_management=30,
+            ),
+            frozen_created_on_profile,
+            LargeInvestorProfileFactory(
+                investor_company=CompanyFactory(
+                    address_country_id=CountryConstant.argentina.value.id,
+                    name='2 constructions ltd',
+                ),
+                investor_description='2 construction risks',
+                construction_risks=[
+                    ConstructionRiskConstant.brownfield.value.id,
+                    ConstructionRiskConstant.greenfield.value.id,
+                ],
+                investable_capital=3000,
+                asset_classes_of_interest=[
+                    AssetClassInterestConstant.biomass.value.id,
+                ],
+                restrictions=[
+                    RestrictionConstant.inflation_adjustment.value.id,
+                ],
+                global_assets_under_management=40,
+            ),
+            LargeInvestorProfileFactory(
+                investor_company=CompanyFactory(
+                    name='Deal up ltd',
+                ),
+                investable_capital=10,
+                investor_description='Deal up',
+                deal_ticket_sizes=[
+                    DealTicketSizeConstant.up_to_forty_nine_million.value.id,
+                ],
+                asset_classes_of_interest=[
+                    AssetClassInterestConstant.biofuel.value.id,
+                ],
+                time_horizons=[
+                    TimeHorizonConstant.five_to_nine_years.value.id,
+                ],
+                restrictions=[
+                    RestrictionConstant.liquidity.value.id,
+                ],
+                minimum_equity_percentage_id=EquityPercentageConstant.zero_percent.value.id,
+                global_assets_under_management=50,
+            ),
+            north_project,
+            south_project,
+        ]
+    setup_es.indices.refresh()
+
+    yield investor_profiles
+
+
+@pytest.mark.usefixtures('setup_data')
+class TestSearch(APITestMixin):
+    """Tests search views."""
+
+    def test_investor_company_name_filter(self):
+        """Test for in investor company name filter."""
+        url = reverse('api-v4:search:large-investor-profile')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'investor_company_name': 'large',
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 1, response.data['results']
+        assert len(response.data['results']) == 1
+        assert response.data['results'][0]['investor_company']['name'] == 'large abcdef'
+
+    @pytest.mark.parametrize(
+        'country,number_of_results',
+        (
+            (CountryConstant.argentina, 2),
+            (CountryConstant.ireland, 0),
+        ),
+    )
+    def test_country_of_origin_filter(self, country, number_of_results):
+        """Test for country of origin filter."""
+        url = reverse('api-v4:search:large-investor-profile')
+
+        response = self.api_client.post(
+            url,
+            data={
+                'country_of_origin': [str(country.value.id)],
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == number_of_results, response.data['results']
+        assert len(response.data['results']) == number_of_results
+        assert Counter(
+            result['country_of_origin']['name'] for result in response.data['results']
+        ) == Counter(
+            [country.value.name] * number_of_results,
+        )
+
+    @pytest.mark.parametrize(
+        'search,check_response_item,expected_results',
+        (
+            (
+                {
+                    'investable_capital_start': 1000,
+                    'investable_capital_end': 2000,
+                },
+                'investable_capital',
+                [1490],
+
+            ),
+            (
+                {
+                    'investable_capital_start': 1000,
+                },
+                'investable_capital',
+                [1490, 3000],
+            ),
+            (
+                {
+                    'investable_capital_start': 10000,
+                },
+                'investable_capital',
+                [],
+            ),
+            (
+                {
+                    'investable_capital_end': 10000,
+                },
+                'investable_capital',
+                [0, 10, 20, 950, 1490, 3000],
+            ),
+            (
+                {
+                    'global_assets_under_management_start': 30,
+                    'global_assets_under_management_end': 50,
+                },
+                'global_assets_under_management',
+                [30, 40, 50],
+            ),
+            (
+                {
+                    'construction_risk': [
+                        str(ConstructionRiskConstant.brownfield.value.id),
+                        str(ConstructionRiskConstant.operational.value.id),
+                    ],
+                },
+                'investor_description',
+                ['2 construction risks', 'Argentina project', 'Operational construction'],
+            ),
+            (
+                {
+                    'minimum_return_rate': [
+                        str(ReturnRateConstant.up_to_five_percent.value.id),
+                    ],
+                },
+                'investor_description',
+                ['Operational construction'],
+            ),
+            (
+                {
+                    'created_on_after': '2010-01-01',
+                    'created_on_before': '2011-01-01',
+                },
+                'created_on',
+                ['2010-02-01T00:00:00+00:00'],
+            ),
+            (
+                {
+                    'created_on_after': '2020-01-01',
+                },
+                'created_on',
+                [],
+            ),
+            (
+                {
+                    'deal_ticket_size': [
+                        str(DealTicketSizeConstant.up_to_forty_nine_million.value.id),
+                    ],
+                },
+                'investor_description',
+                ['Deal up'],
+            ),
+            (
+                {
+                    'asset_classes_of_interest': [
+                        str(AssetClassInterestConstant.biomass.value.id),
+                    ],
+                },
+                'investor_description',
+                ['2 construction risks'],
+            ),
+            (
+                {
+                    'time_horizon': [
+                        str(TimeHorizonConstant.five_to_nine_years.value.id),
+                    ],
+                },
+                'investor_description',
+                ['Operational construction', 'Deal up'],
+            ),
+            (
+                {
+                    'restriction': [
+                        str(RestrictionConstant.inflation_adjustment.value.id),
+                    ],
+                },
+                'investor_description',
+                ['Argentina project', '2 construction risks'],
+            ),
+            (
+                {
+                    'desired_deal_role': [
+                        str(DesiredDealRoleConstant.co_leader_manager.value.id),
+                    ],
+                },
+                'investor_description',
+                [],
+            ),
+            (
+                {
+                    'desired_deal_role': [
+                        str(DesiredDealRoleConstant.lead_manager.value.id),
+                    ],
+                },
+                'investor_description',
+                ['frozen in 2010'],
+            ),
+            (
+                {
+                    'minimum_equity_percentage': [
+                        str(EquityPercentageConstant.zero_percent.value.id),
+                    ],
+                },
+                'investor_description',
+                ['Deal up', 'frozen in 2010'],
+            ),
+            (
+                {
+                    'other_countries_being_considered': [
+                        str(CountryConstant.canada.value.id),
+                        str(CountryConstant.anguilla.value.id),
+                    ],
+                },
+                'investor_description',
+                ['North Project'],
+            ),
+            (
+                {
+                    'uk_region_location': [
+                        str(UKRegionConstant.north_west.value.id),
+                    ],
+                },
+                'investor_description',
+                ['frozen in 2010', 'North Project'],
+            ),
+
+        ),
+    )
+    def test_filters(self, search, check_response_item, expected_results):
+        """Test filters."""
+        url = reverse('api-v4:search:large-investor-profile')
+
+        response = self.api_client.post(
+            url,
+            data=search,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        expected_number_of_results = len(expected_results)
+        assert response.data['count'] == expected_number_of_results, response.data['results']
+        assert len(response.data['results']) == expected_number_of_results
+        assert (
+            Counter(result[check_response_item] for result in response.data['results'])
+            == Counter(expected_results)
+        )
+
+    def test_investable_capital_filter_error(self):
+        """Test investable capital filter error."""
+        url = reverse('api-v4:search:large-investor-profile')
+
+        response = self.api_client.post(
+            url,
+            data={'investable_capital_start': 'hello'},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.data
+        assert response.data == {'investable_capital_start': ['A valid integer is required.']}
+
+    @pytest.mark.parametrize(
+        'sort_by,check_item_key,expected_results',
+        (
+            (
+                'investable_capital:desc',
+                'investable_capital',
+                [
+                    3000,
+                    1490,
+                    950,
+                    20,
+                    10,
+                    0,
+                    None,
+                ],
+            ),
+            (
+                'investable_capital:asc',
+                'investable_capital',
+                [
+                    None,
+                    0,
+                    10,
+                    20,
+                    950,
+                    1490,
+                    3000,
+                ],
+            ),
+            (
+                'global_assets_under_management:asc',
+                'global_assets_under_management',
+                [
+                    10,
+                    20,
+                    30,
+                    40,
+                    50,
+                    60,
+                    70,
+                ],
+            ),
+            (
+                'global_assets_under_management:desc',
+                'global_assets_under_management',
+                [
+                    70,
+                    60,
+                    50,
+                    40,
+                    30,
+                    20,
+                    10,
+                ],
+            ),
+            (
+                'investor_company.name:asc',
+                'investor_company__name',
+                [
+                    '2 constructions ltd',
+                    'argentina plc',
+                    'Deal up ltd',
+                    'Frozen limited',
+                    'large abcdef',
+                    'North',
+                    'South',
+                ],
+            ),
+            (
+                'investor_company.name:desc',
+                'investor_company__name',
+                [
+                    'South',
+                    'North',
+                    'large abcdef',
+                    'Frozen limited',
+                    'Deal up ltd',
+                    'argentina plc',
+                    '2 constructions ltd',
+                ],
+            ),
+            (
+                'modified_on:asc',
+                'modified_on',
+                [
+                    '2010-02-01T00:00:00+00:00',
+                    '2018-01-01T10:00:00+00:00',
+                    '2018-01-01T11:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                ],
+            ),
+            (
+                'modified_on:desc',
+                'modified_on',
+                [
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2018-01-01T11:00:00+00:00',
+                    '2018-01-01T10:00:00+00:00',
+                    '2010-02-01T00:00:00+00:00',
+                ],
+            ),
+            (
+                'created_on:asc',
+                'created_on',
+                [
+                    '2010-02-01T00:00:00+00:00',
+                    '2018-01-01T10:00:00+00:00',
+                    '2018-01-01T11:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                ],
+            ),
+            (
+                'created_on:desc',
+                'created_on',
+                [
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2019-01-01T00:00:00+00:00',
+                    '2018-01-01T11:00:00+00:00',
+                    '2018-01-01T10:00:00+00:00',
+                    '2010-02-01T00:00:00+00:00',
+                ],
+            ),
+
+        ),
+    )
+    def test_sorts(self, sort_by, check_item_key, expected_results):
+        """Test search sorts."""
+        url = reverse('api-v4:search:large-investor-profile')
+
+        response = self.api_client.post(
+            url,
+            data={'sortby': sort_by},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data['count'] == 7, response.data['results']
+        actual_results = [
+            self._get_data_item(result, check_item_key) for result in response.data['results']
+        ]
+        assert expected_results == actual_results
+
+    def _get_data_item(self, result, check_item_key):
+        check_item_key_list = check_item_key.split('__')
+        item = None
+        for key in check_item_key_list:
+            item = item[key] if item else result[key]
+        return item

--- a/datahub/search/large_investor_profile/views.py
+++ b/datahub/search/large_investor_profile/views.py
@@ -1,0 +1,98 @@
+from datahub.oauth.scopes import Scope
+from datahub.search.large_investor_profile import LargeInvestorProfileSearchApp
+from datahub.search.large_investor_profile.serializers import (
+    SearchLargeInvestorProfileQuerySerializer,
+)
+from datahub.search.views import register_v4_view, SearchAPIView
+
+
+class SearchInvestorProfileAPIViewMixin:
+    """Defines common settings."""
+
+    required_scopes = (Scope.internal_front_end,)
+    search_app = LargeInvestorProfileSearchApp
+    serializer_class = SearchLargeInvestorProfileQuerySerializer
+
+    _MAIN_FILTERS = (
+        'asset_classes_of_interest',
+        'country_of_origin',
+        'investor_company',
+        'investor_company_name',
+        'created_by',
+    )
+
+    _DETAIL_FILTERS = (
+        'investor_type',
+        'investable_capital_start',
+        'investable_capital_end',
+        'global_assets_under_management_start',
+        'global_assets_under_management_end',
+        'required_checks_conducted',
+    )
+
+    _REQUIREMENT_FILTERS = (
+        'deal_ticket_size',
+        'investment_type',
+        'minimum_return_rate',
+        'time_horizon',
+        'restriction',
+        'construction_risk',
+        'minimum_equity_percentage',
+        'desired_deal_role',
+    )
+
+    _LOCATION_FILTERS = (
+        'uk_region_location',
+        'other_countries_being_considered',
+    )
+
+    _EXTRA_FILTERS = (
+        'created_on_before',
+        'created_on_after',
+    )
+
+    FILTER_FIELDS = (
+        'id',
+        *_MAIN_FILTERS,
+        *_DETAIL_FILTERS,
+        *_REQUIREMENT_FILTERS,
+        *_LOCATION_FILTERS,
+        *_EXTRA_FILTERS,
+    )
+
+    REMAP_FIELDS = {
+        'investor_company': 'investor_company.id',
+        'country_of_origin': 'country_of_origin.id',
+        'asset_classes_of_interest': 'asset_classes_of_interest.id',
+        'investor_type': 'investor_type.id',
+        'required_checks_conducted': 'required_checks_conducted.id',
+        'deal_ticket_size': 'deal_ticket_sizes.id',
+        'investment_type': 'investment_types.id',
+        'minimum_return_rate': 'minimum_return_rate.id',
+        'time_horizon': 'time_horizons.id',
+        'restriction': 'restrictions.id',
+        'construction_risk': 'construction_risks.id',
+        'minimum_equity_percentage': 'minimum_equity_percentage.id',
+        'desired_deal_role': 'desired_deal_roles.id',
+        'uk_region_location': 'uk_region_locations.id',
+        'other_countries_being_considered': 'other_countries_being_considered.id',
+        'created_by': 'created_by.id',
+    }
+
+    COMPOSITE_FILTERS = {
+        'investor_company_name': [
+            'investor_company.name',  # to find 2-letter words
+            'investor_company.name.trigram',
+            'investor_company.trading_names',  # to find 2-letter words
+            'investor_company.trading_names.trigram',
+        ],
+    }
+
+
+@register_v4_view()
+class SearchLargeInvestorProfileAPIView(SearchInvestorProfileAPIViewMixin, SearchAPIView):
+    """Filtered large capital investor profile search view."""
+
+    es_sort_by_remappings = {
+        'investor_company.name': 'investor_company.name.keyword',
+    }

--- a/datahub/search/test/test_query_builder.py
+++ b/datahub/search/test/test_query_builder.py
@@ -8,7 +8,7 @@ from datahub.search.query_builder import (
     _build_entity_permission_query,
     _build_field_query,
     _build_term_query,
-    _split_date_range_fields,
+    _split_range_fields,
     build_autocomplete_query,
     get_basic_search_query,
     get_search_by_entity_query,
@@ -231,7 +231,7 @@ def test_date_range_fields():
         'adviser.id': 1234,
     }
 
-    filters, ranges = _split_date_range_fields(fields)
+    filters, ranges = _split_range_fields(fields)
 
     assert filters == {
         'adviser.id': 1234,


### PR DESCRIPTION
### Description of change
This adds the large investor profile search views. It allows most fields to be filtered.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
