### PR TITLE
Revert redis-py and Kombu updates

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -31,15 +31,16 @@ notifications-python-client==5.3.0
 
 # REDIS
 django-redis==4.10.0
-redis==3.2.1
+redis==3.1.0
 
 # ES
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
 
 # Celery
-celery==4.2.1
+celery[redis]==4.2.1
 billiard==3.5.0.4  # pinned due to https://github.com/celery/billiard/issues/260
+kombu==4.3.0
 
 # Testing and dev
 pytest==4.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ backcall==0.1.0           # via ipython
 billiard==3.5.0.4
 boto3==1.9.119
 botocore==1.12.119        # via boto3, s3transfer
-celery==4.2.1
+celery[redis]==4.2.1
 certifi==2019.3.9         # via requests
 chardet==3.0.4
 click==7.0                # via pip-tools, towncrier
@@ -65,7 +65,7 @@ ipython==7.3.0
 jedi==0.13.3              # via ipython
 jinja2==2.10              # via towncrier
 jmespath==0.9.4           # via boto3, botocore
-kombu==4.4.0              # via celery
+kombu==4.3.0
 lxml==4.3.2
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
@@ -103,7 +103,7 @@ python-dateutil==2.8.0
 pytz==2018.9              # via celery, django
 pyyaml==5.1
 raven==6.10.0
-redis==3.2.1
+redis==3.1.0
 requests-futures==0.9.9   # via piprot
 requests-mock==1.5.2
 requests==2.21.0


### PR DESCRIPTION
### Description of change

Celery 4.2.2 was released but they restricted redis to <3 and Kombu to <4.4 in it (even though Celery 4.2.1 has been out for some time and did not have a redis<3 restriction).

Downgrading redis-py to 2.x now seems risky so this reverts things to how they were in the last release.

When Celery 4.3 is released, we can look at updating these again.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
