### PR TITLE
Add sub-fields to name in id_name_partial_field

### DIFF
--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -233,6 +233,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['registered_address_country.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -284,6 +294,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['trading_address_country.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',

--- a/datahub/search/event/tests/test_elasticsearch.py
+++ b/datahub/search/event/tests/test_elasticsearch.py
@@ -25,6 +25,16 @@ def test_mapping(setup_es):
                                 'address_country.name_trigram',
                             ],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -137,6 +147,16 @@ def test_mapping(setup_es):
                                 'related_programmes.name_trigram',
                             ],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -165,6 +185,16 @@ def test_mapping(setup_es):
                                 'teams.name_trigram',
                             ],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -182,6 +212,16 @@ def test_mapping(setup_es):
                                 'uk_region.name_trigram',
                             ],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -73,11 +73,31 @@ def id_unindexed_name_field():
 
 
 def id_name_partial_field(field):
-    """Object field with id and name sub-fields, and with partial matching on name."""
+    """
+    Object field with id and name sub-fields, and with partial matching on name.
+
+    The `name` field is being migrated away from using `copy_to` to being a multi-field.
+    `name_trigram` and `name.trigram` are both defined while the switch takes place.
+
+    Additionally, the `name` field should have had a data type of text, but it was mistakenly made
+    a keyword field. Hence, a `keyword` sub-field has also been added so type of `name` can be
+    changed to text once sorting operations have been migrated to using the `keyword` sub-field.
+
+    TODO:
+        - remove name_trigram once related logic has been updated to use name.trigram
+        - change name use Text instead of NormalizedKeyword once sorting options have been
+        updated to use name.keyword
+    """
     return Object(
         properties={
             'id': Keyword(),
-            'name': NormalizedKeyword(copy_to=f'{field}.name_trigram'),
+            'name': NormalizedKeyword(
+                copy_to=f'{field}.name_trigram',
+                fields={
+                    'keyword': NormalizedKeyword(),
+                    'trigram': TrigramText(),
+                },
+            ),
             'name_trigram': TrigramText(),
         },
     )

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -321,6 +321,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['investor_company.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -659,6 +669,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['uk_company.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',


### PR DESCRIPTION
### Description of change

This is part of migrating away from using `copy_to`. It's also so that we can migrate `name` to being a text field instead of a keyword field.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
