### PR TITLE
 Update interaction search CSV export for multiple DIT participants 

### DIFF
--- a/changelog/interaction/search-export-adviser.feature.rst
+++ b/changelog/interaction/search-export-adviser.feature.rst
@@ -1,0 +1,3 @@
+The search CSV export was updated to handle interactions with multiple advisers. The previous Adviser and Service provider columns have been merged into a single Advisers column. This column contains the names of all the advisers for each interaction separated by commas. The team of each adviser is in brackets after each name.
+
+For existing interactions, existing teams associated with each interaction have been preserved. For new interactions, the team included is the team each adviser was in when they were added to the interaction.

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -180,16 +180,6 @@ def get_full_name_expression(person_field_name=None, bracketed_field_name=None):
     )
 
 
-def get_front_end_url_expression(model_name, pk_expression):
-    """
-    Gets an SQL expression that returns a front-end URL for an object.
-
-    :param model_name:      key in settings.DATAHUB_FRONTEND_URL_PREFIXES
-    :param pk_expression:   expression that resolves to the pk for the model
-    """
-    return Concat(Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'), pk_expression)
-
-
 def get_bracketed_concat_expression(*expressions, expression_to_bracket=None):
     """
     Gets an SQL expression that concatenates a number of expressions and optionally another
@@ -236,3 +226,13 @@ def get_bracketed_concat_expression(*expressions, expression_to_bracket=None):
         parts.append(bracketed_expression)
 
     return ConcatWS(Value(' '), *parts, output_field=CharField())
+
+
+def get_front_end_url_expression(model_name, pk_expression):
+    """
+    Gets an SQL expression that returns a front-end URL for an object.
+
+    :param model_name:      key in settings.DATAHUB_FRONTEND_URL_PREFIXES
+    :param pk_expression:   expression that resolves to the pk for the model
+    """
+    return Concat(Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'), pk_expression)

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.postgres.aggregates import StringAgg
-from django.db.models import Case, F, Func, OuterRef, Subquery, Value, When
+from django.db.models import Case, CharField, F, Func, OuterRef, Subquery, Value, When
 from django.db.models.functions import Concat
 
 
@@ -157,10 +157,10 @@ def get_full_name_expression(person_field_name=None, bracketed_field_name=None):
         )
     """
     if person_field_name is None:
-        return _full_name_concat(
+        return get_bracketed_concat_expression(
             'first_name',
             'last_name',
-            bracketed_field=bracketed_field_name,
+            expression_to_bracket=bracketed_field_name,
         )
 
     evaluated_bracketed_field_name = (
@@ -170,10 +170,10 @@ def get_full_name_expression(person_field_name=None, bracketed_field_name=None):
     return Case(
         When(
             **{f'{person_field_name}__isnull': False},
-            then=_full_name_concat(
+            then=get_bracketed_concat_expression(
                 f'{person_field_name}__first_name',
                 f'{person_field_name}__last_name',
-                bracketed_field=evaluated_bracketed_field_name,
+                expression_to_bracket=evaluated_bracketed_field_name,
             ),
         ),
         default=None,
@@ -190,18 +190,49 @@ def get_front_end_url_expression(model_name, pk_expression):
     return Concat(Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'), pk_expression)
 
 
-def _full_name_concat(first_name_field, last_name_field, bracketed_field=None):
+def get_bracketed_concat_expression(*expressions, expression_to_bracket=None):
+    """
+    Gets an SQL expression that concatenates a number of expressions and optionally another
+    field surrounded by brackets.
+
+    For simple annotation of full names of contacts or advisers, get_full_name_expression() should
+    be preferred. However, this function can handle other or more complex scenarios.
+
+    Usage examples:
+
+        # Effectively '{Contact.first_name} {Contact.last_name}'
+        Contact.objects.annotate(
+            name=get_bracketed_concat_expression('first_name', 'last_name'),
+        )
+
+        # Effectively '{Contact.first_name} {Contact.last_name} ({Contact.job_title})'
+        # (but the job title would be omitted if blank or NULL)
+        Contact.objects.annotate(
+            name=get_bracketed_concat_expression(
+                'first_name',
+                'last_name',
+                expression_to_bracket='job_title',
+            ),
+        )
+
+        # Effectively '{Interaction.dit_adviser.first_name} {Interaction.dit_adviser.last_name}'
+        Interaction.objects.annotate(
+            dit_adviser_name=get_bracketed_concat_expression(
+                'dit_adviser__first_name',
+                'dit_adviser__last_name',
+            ),
+        )
+    """
     parts = [
-        NullIf(first_name_field, Value('')),
-        NullIf(last_name_field, Value('')),
+        NullIf(field, Value('')) for field in expressions
     ]
 
-    if bracketed_field:
+    if expression_to_bracket:
         bracketed_expression = PreferNullConcat(
             Value('('),
-            NullIf(bracketed_field, Value('')),
+            NullIf(expression_to_bracket, Value('')),
             Value(')'),
         )
         parts.append(bracketed_expression)
 
-    return ConcatWS(Value(' '), *parts)
+    return ConcatWS(Value(' '), *parts, output_field=CharField())

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -26,6 +26,7 @@ from datahub.core.test_utils import (
     join_attr_values,
     random_obj_for_queryset,
 )
+from datahub.core.utils import join_truthy_strings
 from datahub.interaction.models import (
     CommunicationChannel,
     Interaction,
@@ -946,13 +947,20 @@ class TestInteractionExportView(APITestMixin):
         # Faker generates job titles containing commas which complicates comparisons,
         # so all contact job titles are explicitly set
         company = CompanyFactory()
-        CompanyInteractionFactory(
+        interaction = CompanyInteractionFactory(
             company=company,
             contacts=[
                 ContactFactory(company=company, job_title='Engineer'),
                 ContactFactory(company=company, job_title=None),
                 ContactFactory(company=company, job_title=''),
             ],
+        )
+        InteractionDITParticipantFactory.create_batch(2, interaction=interaction)
+        InteractionDITParticipantFactory(interaction=interaction, team=None)
+        InteractionDITParticipantFactory(
+            interaction=interaction,
+            adviser=None,
+            team=factory.SubFactory(TeamFactory),
         )
         EventServiceDeliveryFactory(
             company=company,
@@ -1025,8 +1033,7 @@ class TestInteractionExportView(APITestMixin):
                 'Company UK region': get_attr_or_none(interaction, 'company.uk_region.name'),
                 'Company sector': get_attr_or_none(interaction, 'company.sector.name'),
                 'Contacts': _format_expected_contacts(interaction),
-                'Adviser': get_attr_or_none(interaction, 'dit_adviser.name'),
-                'Service provider': get_attr_or_none(interaction, 'dit_team.name'),
+                'Advisers': _format_expected_advisers(interaction),
                 'Event': get_attr_or_none(interaction, 'event.name'),
                 'Service delivery status': get_attr_or_none(
                     interaction,
@@ -1176,6 +1183,20 @@ def _format_expected_contact_name(contact):
     return f'{contact.name}'
 
 
+def _format_expected_advisers(interaction):
+    formatted_contact_names = sorted(
+        _format_expected_adviser_name(dit_participant)
+        for dit_participant in interaction.dit_participants.all(),
+    )
+    return ', '.join(formatted_contact_names)
+
+
+def _format_expected_adviser_name(dit_participant):
+    adviser_name = dit_participant.adviser.name if dit_participant.adviser else ''
+    team_name = f'({dit_participant.team.name})' if dit_participant.team else ''
+    return join_truthy_strings(adviser_name, team_name)
+
+
 def _format_actual_csv_row(row):
     return {key: _format_actual_csv_value(key, value) for key, value in row.items()}
 
@@ -1189,6 +1210,7 @@ def _format_actual_csv_value(key, value):
       will be able to perform the sorting in the export query.
     """
     multi_value_fields_and_separators = {
+        'Advisers': ', ',
         'Contacts': ', ',
         'Policy areas': '; ',
         'Policy issue types': ', ',

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -1,4 +1,5 @@
 from datahub.core.query_utils import (
+    get_bracketed_concat_expression,
     get_choices_as_case_expression,
     get_front_end_url_expression,
     get_full_name_expression,
@@ -92,7 +93,14 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
                 bracketed_field_name='job_title',
             ),
         ),
-        dit_adviser_name=get_full_name_expression('dit_adviser'),
+        adviser_names=get_string_agg_subquery(
+            DBInteraction,
+            get_bracketed_concat_expression(
+                'dit_participants__adviser__first_name',
+                'dit_participants__adviser__last_name',
+                expression_to_bracket='dit_participants__team__name',
+            ),
+        ),
         link=get_front_end_url_expression('interaction', 'pk'),
         kind_name=get_choices_as_case_expression(DBInteraction, 'kind'),
         policy_issue_type_names=get_string_agg_subquery(
@@ -118,8 +126,7 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
         'company__uk_region__name': 'Company UK region',
         'company_sector_name': 'Company sector',
         'contact_names': 'Contacts',
-        'dit_adviser_name': 'Adviser',
-        'dit_team__name': 'Service provider',
+        'adviser_names': 'Advisers',
         'event__name': 'Event',
         'service_delivery_status__name': 'Service delivery status',
         'net_company_receipt': 'Net company receipt',


### PR DESCRIPTION
### Description of change

This updates the interaction search CSV export to incorporate multiple DIT participants.

The previous Adviser and Service provider columns have been merged into a single Advisers column. This column contains the names of all the advisers for each interaction separated by commas. The team of each adviser is in brackets after each name.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
