### PR TITLE
Update Dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,3 +3,9 @@ update_configs:
   - package_manager: "python"
     directory: "/"
     update_schedule: "weekly"
+    default_reviewers:
+    - "currycoder"
+    - "elcct"
+    - "marcofucci"
+    - "marcuspp"
+    - "reupen"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -3,7 +3,3 @@ update_configs:
   - package_manager: "python"
     directory: "/"
     update_schedule: "weekly"
-    automerged_updates:
-      - match:
-          dependency_name: "boto3"
-          update_type: "semver:patch"


### PR DESCRIPTION
### Description of change

This removes the auto-merge settings as they don't work because of required approvals (also because we have restrictions on who can merge) and there doesn't appear to be a simple solution.

This also adds default reviewers to the configuration (these were lost as the Dependabot UI settings are disabled when you use a config file).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
