### PR TITLE
Make EmployeeRange read-only in the Django admin

### DIFF
--- a/changelog/company/employee_range_readonly.internal.rst
+++ b/changelog/company/employee_range_readonly.internal.rst
@@ -1,0 +1,1 @@
+It's not possible to change ``EmployeeRange`` records from the Django admin anymore.

--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -17,7 +17,6 @@ MODELS_TO_REGISTER_DISABLEABLE = (
 )
 
 MODELS_TO_REGISTER_WITH_ORDER = (
-    models.EmployeeRange,
     models.FDIValue,
     models.TurnoverRange,
     models.SalaryRange,
@@ -25,6 +24,7 @@ MODELS_TO_REGISTER_WITH_ORDER = (
 
 MODELS_TO_REGISTER_READ_ONLY = (
     models.BusinessType,
+    models.EmployeeRange,
     models.InvestmentType,
     models.OverseasRegion,
     models.SectorCluster,

--- a/datahub/metadata/admin.py
+++ b/datahub/metadata/admin.py
@@ -24,13 +24,13 @@ MODELS_TO_REGISTER_WITH_ORDER = (
 
 MODELS_TO_REGISTER_READ_ONLY = (
     models.BusinessType,
-    models.EmployeeRange,
     models.InvestmentType,
     models.OverseasRegion,
     models.SectorCluster,
 )
 
 MODELS_TO_REGISTER_EDITABLE_ORDER_ONLY = (
+    models.EmployeeRange,
     models.HeadquarterType,
 )
 

--- a/datahub/metadata/migrations/0001_initial_employee_ranges.yaml
+++ b/datahub/metadata/migrations/0001_initial_employee_ranges.yaml
@@ -1,0 +1,30 @@
+- model: metadata.employeerange
+  pk: 3dafd8d0-5d95-e211-a939-e4115bead28a
+  fields:
+    name: 1 to 9
+    order: 100.0
+    disabled_on: null
+- model: metadata.employeerange
+  pk: 3eafd8d0-5d95-e211-a939-e4115bead28a
+  fields:
+    name: 10 to 49
+    order: 200.0
+    disabled_on: null
+- model: metadata.employeerange
+  pk: 3fafd8d0-5d95-e211-a939-e4115bead28a
+  fields:
+    name: 50 to 249
+    order: 300.0
+    disabled_on: null
+- model: metadata.employeerange
+  pk: 40afd8d0-5d95-e211-a939-e4115bead28a
+  fields:
+    name: 250 to 499
+    order: 400.0
+    disabled_on: null
+- model: metadata.employeerange
+  pk: 41afd8d0-5d95-e211-a939-e4115bead28a
+  fields:
+    name: 500+
+    order: 500.0
+    disabled_on: null

--- a/datahub/metadata/migrations/0001_squashed_0011_add_default_id_for_metadata.py
+++ b/datahub/metadata/migrations/0001_squashed_0011_add_default_id_for_metadata.py
@@ -13,6 +13,12 @@ def load_initial_countries(apps, schema_editor):
         PurePath(__file__).parent / '0001_initial_countries.yaml',
     )
 
+def load_initial_employee_ranges(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0001_initial_employee_ranges.yaml',
+    )
+
 
 class Migration(migrations.Migration):
 
@@ -312,4 +318,5 @@ class Migration(migrations.Migration):
             },
         ),
         migrations.RunPython(load_initial_countries, migrations.RunPython.noop),
+        migrations.RunPython(load_initial_employee_ranges, migrations.RunPython.noop),
     ]

--- a/fixtures/metadata/companies.yaml
+++ b/fixtures/metadata/companies.yaml
@@ -9,23 +9,6 @@
   pk: 43281c5e-92a4-4794-867b-b4d5f801e6f3
   fields: {name: ghq}
 
-# Employee range
-- model: metadata.employeerange
-  pk: 3dafd8d0-5d95-e211-a939-e4115bead28a
-  fields: {name: 1 to 9, order: 100.0}
-- model: metadata.employeerange
-  pk: 3eafd8d0-5d95-e211-a939-e4115bead28a
-  fields: {name: 10 to 49, order: 200.0}
-- model: metadata.employeerange
-  pk: 3fafd8d0-5d95-e211-a939-e4115bead28a
-  fields: {name: 50 to 249, order: 300.0}
-- model: metadata.employeerange
-  pk: 40afd8d0-5d95-e211-a939-e4115bead28a
-  fields: {name: 250 to 499, order: 400.0}
-- model: metadata.employeerange
-  pk: 41afd8d0-5d95-e211-a939-e4115bead28a
-  fields: {name: 500+, order: 500.0}
-
 # Turnover range
 - model: metadata.turnoverrange
   pk: 774cd12a-6095-e211-a939-e4115bead28a


### PR DESCRIPTION
### Description of change

This makes the `metadata.EmployeeRange` model read-only in the Django admin and makes sure the data is loaded via a data migration.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
