### PR TITLE
Update default MultipleChoiceField widget to CheckboxSelectMultiple

### DIFF
--- a/changelog/multichoice-admin-widget.feature.rst
+++ b/changelog/multichoice-admin-widget.feature.rst
@@ -1,0 +1,1 @@
+The service contexts and team tags fields in the admin site were updated to use tick boxes for better usability.

--- a/datahub/core/fields.py
+++ b/datahub/core/fields.py
@@ -21,6 +21,7 @@ class MultipleChoiceField(ArrayField):
     default_error_messages = {
         'item_duplicated': _('An item was specified more than once.'),
     }
+    default_widget = forms.CheckboxSelectMultiple
 
     def __init__(self, max_length=None, choices=None, **kwargs):
         """Initialises the field."""
@@ -68,9 +69,14 @@ class MultipleChoiceField(ArrayField):
 
     def formfield(self, **kwargs):
         """Returns a MultipleChoiceField instance as the default form field."""
+        field_kwargs = {
+            'widget': self.default_widget,
+            **kwargs,
+        }
         return super(ArrayField, self).formfield(
             form_class=forms.MultipleChoiceField,
             choices=self.base_field.choices,
+            **field_kwargs,
         )
 
     def validate(self, value, model_instance):


### PR DESCRIPTION
### Description of change

This changes the default widget for our array-based MultipleChoiceField to CheckboxSelectMultiple instead of SelectMultiple.

This is for better usability, as the default widget is that horrible thing where you have to hold Ctrl and click to select multiple items.

The field is being used for Service.contexts and Team.tags so this only affects those two form fields in the admin site.

### Screenshots

#### Before

![image](https://user-images.githubusercontent.com/12693549/55227449-6ab8e500-520f-11e9-95fb-0540198e5344.png)


#### After

![image](https://user-images.githubusercontent.com/12693549/55227390-4826cc00-520f-11e9-8c3c-a26cd6f045dc.png)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
