### PR TITLE
Add context filter to service admin

### DIFF
--- a/changelog/service-filter-admin.feautre.rst
+++ b/changelog/service-filter-admin.feautre.rst
@@ -1,0 +1,1 @@
+A context filter was added to the service list in the admin site.

--- a/datahub/core/fields.py
+++ b/datahub/core/fields.py
@@ -24,7 +24,12 @@ class MultipleChoiceField(ArrayField):
     default_widget = forms.CheckboxSelectMultiple
 
     def __init__(self, max_length=None, choices=None, **kwargs):
-        """Initialises the field."""
+        """
+        Initialises the field.
+
+        Note that self.choices is deliberately not set as it triggers a lot of unwanted form
+        field logic.
+        """
         super().__init__(
             **kwargs,
             base_field=models.CharField(max_length=max_length, choices=choices),
@@ -78,6 +83,10 @@ class MultipleChoiceField(ArrayField):
             choices=self.base_field.choices,
             **field_kwargs,
         )
+
+    def get_base_field_choices(self):
+        """Get the choices for this field from the underlying base_field."""
+        return self.base_field.choices
 
     def validate(self, value, model_instance):
         """Performs validation, checking if any choices have been specified more than once."""

--- a/datahub/metadata/test/test_admin.py
+++ b/datahub/metadata/test/test_admin.py
@@ -1,0 +1,55 @@
+from unittest.mock import Mock
+
+import factory
+import pytest
+from django.contrib.admin import site
+from django.test import RequestFactory
+
+from datahub.metadata.admin import ServiceAdmin
+from datahub.metadata.models import Service
+from datahub.metadata.test.factories import ServiceFactory
+
+
+@pytest.mark.django_db
+class TestServiceAdmin:
+    """Tests for ServiceAdmin."""
+
+    @pytest.mark.parametrize('context', (Service.CONTEXTS.interaction, Service.CONTEXTS.event))
+    def test_context_filter(self, context):
+        """Tests filtering by context."""
+        test_data_contexts = (
+            [Service.CONTEXTS.interaction],
+            [Service.CONTEXTS.service_delivery],
+            [Service.CONTEXTS.interaction, Service.CONTEXTS.service_delivery],
+        )
+        ServiceFactory.create_batch(
+            len(test_data_contexts),
+            contexts=factory.Iterator(test_data_contexts),
+        )
+
+        model_admin = ServiceAdmin(Service, site)
+        request_factory = RequestFactory()
+        request = request_factory.get(
+            '/',
+            data={'context': context},
+        )
+        request.user = Mock()
+        change_list = model_admin.get_changelist_instance(request)
+
+        actual_services = list(change_list.get_queryset(request))
+        service_count_for_context = Service.objects.filter(contexts__overlap=[context]).count()
+        assert len(actual_services) == service_count_for_context
+        assert all(context in service.contexts for service in actual_services)
+
+    def test_no_filter(self):
+        """Test that if no filter is selected, all services are returned."""
+        ServiceFactory.create_batch(5)
+
+        model_admin = ServiceAdmin(Service, site)
+        request_factory = RequestFactory()
+        request = request_factory.get('/')
+        request.user = Mock()
+        change_list = model_admin.get_changelist_instance(request)
+
+        actual_services = change_list.get_queryset(request)
+        assert actual_services.count() == Service.objects.count()


### PR DESCRIPTION
### Description of change

This adds a context filter to the service list in the admin site.

### Screenshot

![image](https://user-images.githubusercontent.com/12693549/55322158-73a9f080-5473-11e9-89c3-1c2fe773dc9e.png)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
