### PR TITLE
Update interaction search CSV export for multiple DIT participants

### DIFF
--- a/changelog/interaction/search-export-adviser.feature.rst
+++ b/changelog/interaction/search-export-adviser.feature.rst
@@ -1,0 +1,3 @@
+The search CSV export was updated to handle interactions with multiple advisers. The previous Adviser and Service provider columns have been merged into a single Advisers column. This column contains the names of all the advisers for each interaction separated by commas. The team of each adviser is in brackets after each name.
+
+For existing interactions, existing teams associated with each interaction have been preserved. For new interactions, the team included is the team each adviser was in when they were added to the interaction.

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -169,21 +169,6 @@ def get_full_name_expression(person_field_name=None, bracketed_field_name=None):
     )
 
 
-def get_front_end_url_expression(model_name, pk_expression, url_suffix=''):
-    """
-    Gets an SQL expression that returns a front-end URL for an object.
-
-    :param model_name:      key in settings.DATAHUB_FRONTEND_URL_PREFIXES
-    :param pk_expression:   expression that resolves to the pk for the model
-    :param url_suffix:      Optional: string appended to the end of the url
-    """
-    return Concat(
-        Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'),
-        pk_expression,
-        Value(url_suffix),
-    )
-
-
 def _full_name_concat(first_name_field, last_name_field, bracketed_field=None):
     parts = [
         NullIf(first_name_field, Value('')),
@@ -199,3 +184,18 @@ def _full_name_concat(first_name_field, last_name_field, bracketed_field=None):
         parts.append(bracketed_expression)
 
     return ConcatWS(Value(' '), *parts)
+
+
+def get_front_end_url_expression(model_name, pk_expression, url_suffix=''):
+    """
+    Gets an SQL expression that returns a front-end URL for an object.
+
+    :param model_name:      key in settings.DATAHUB_FRONTEND_URL_PREFIXES
+    :param pk_expression:   expression that resolves to the pk for the model
+    :param url_suffix:      Optional: string appended to the end of the url
+    """
+    return Concat(
+        Value(f'{settings.DATAHUB_FRONTEND_URL_PREFIXES[model_name]}/'),
+        pk_expression,
+        Value(url_suffix),
+    )

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -1,4 +1,5 @@
 from datahub.core.query_utils import (
+    get_bracketed_concat_expression,
     get_choices_as_case_expression,
     get_front_end_url_expression,
     get_full_name_expression,
@@ -95,7 +96,14 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
                 bracketed_field_name='job_title',
             ),
         ),
-        dit_adviser_name=get_full_name_expression('dit_adviser'),
+        adviser_names=get_string_agg_subquery(
+            DBInteraction,
+            get_bracketed_concat_expression(
+                'dit_participants__adviser__first_name',
+                'dit_participants__adviser__last_name',
+                expression_to_bracket='dit_participants__team__name',
+            ),
+        ),
         link=get_front_end_url_expression('interaction', 'pk'),
         kind_name=get_choices_as_case_expression(DBInteraction, 'kind'),
         policy_issue_type_names=get_string_agg_subquery(
@@ -121,8 +129,7 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
         'company__uk_region__name': 'Company UK region',
         'company_sector_name': 'Company sector',
         'contact_names': 'Contacts',
-        'dit_adviser_name': 'Adviser',
-        'dit_team__name': 'Service provider',
+        'adviser_names': 'Advisers',
         'event__name': 'Event',
         'communication_channel__name': 'Communication channel',
         'service_delivery_status__name': 'Service delivery status',


### PR DESCRIPTION
### Description of change

This restores #1551 (which was previously merged and then reverted to avoid disrupting end of financial year reporting).

The PR updates the interaction search CSV export to incorporate multiple DIT participants.

From the original PR:

The previous Adviser and Service provider columns have been merged into a single Advisers column. This column contains the names of all the advisers for each interaction separated by commas. The team of each adviser is in brackets after each name.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
