### PR TITLE
Update Celery to version 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `REDIS_BASE_URL`  | No | redis base URL without the db |
 | `REDIS_CACHE_DB`  | No | redis db for django cache (default 0) |
 | `REDIS_CELERY_DB`  | No | redis db for celery (default 1) |
-| `REDIS_SSL_CA_CERTS_PATH` | No | Location of SSL CA certs (default /etc/ssl/certs/ca-certificates.crt) |
 | `REPORT_AWS_ACCESS_KEY_ID` | No | Same use as AWS_ACCESS_KEY_ID, but for reports. |
 | `REPORT_AWS_SECRET_ACCESS_KEY` | No | Same use as AWS_SECRET_ACCESS_KEY, but for reports. |
 | `REPORT_AWS_REGION` | No | Same use as AWS_DEFAULT_REGION, but for reports. |

--- a/changelog/update-celery.internal.rst
+++ b/changelog/update-celery.internal.rst
@@ -1,0 +1,1 @@
+Celery was updated to version 4.3.

--- a/datahub/dbmaintenance/test/test_tasks.py
+++ b/datahub/dbmaintenance/test/test_tasks.py
@@ -131,19 +131,19 @@ class TestReplaceNullWithDefault:
                 'non_nullable_with_default is not nullable',
             ),
             (
-                'nullable_without_default',
-                str,
-                'callable defaults for nullable_without_default are not supported',
+                'non_nullable_with_default',
+                True,
+                'non_nullable_with_default is not nullable',
             ),
         ),
     )
     def test_raises_error_on_invalid_field(self, monkeypatch, field, default, expected_error_msg):
         """
-        Test that an error is raised if:
-         - a model field without a default is defined
-         - a model field with a callable default is defined
-         - a model field with a callable default is explicitly specified
-         - a non-nullable model field is defined
+        Test that an error is raised if the task is called with:
+         - a model field without a default
+         - a model field with a callable default
+         - a non-nullable field
+         - a non-nullable field and an explicit default
         """
         res = replace_null_with_default.apply_async(
             args=('support.NullableWithDefaultModel', field),

--- a/requirements.in
+++ b/requirements.in
@@ -31,16 +31,16 @@ notifications-python-client==5.3.0
 
 # REDIS
 django-redis==4.10.0
-redis==3.1.0
+redis==3.2.1
 
 # ES
 elasticsearch==6.3.1
 elasticsearch-dsl==6.3.1
 
 # Celery
-celery[redis]==4.2.1
-billiard==3.5.0.4  # pinned due to https://github.com/celery/billiard/issues/260
-kombu==4.3.0
+celery[redis]==4.3
+billiard==3.6.0.0
+kombu==4.5.0
 
 # Testing and dev
 pytest==4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,10 @@ apipkg==1.5               # via execnet
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via pytest
 backcall==0.1.0           # via ipython
-billiard==3.5.0.4
+billiard==3.6.0.0
 boto3==1.9.125
 botocore==1.12.125        # via boto3, s3transfer
-celery[redis]==4.2.1
+celery[redis]==4.3
 certifi==2019.3.9         # via requests
 chardet==3.0.4
 click==7.0                # via pip-tools, towncrier
@@ -65,7 +65,7 @@ ipython==7.4.0
 jedi==0.13.3              # via ipython
 jinja2==2.10              # via towncrier
 jmespath==0.9.4           # via boto3, botocore
-kombu==4.3.0
+kombu==4.5.0
 lxml==4.3.3
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
@@ -103,7 +103,7 @@ python-dateutil==2.8.0
 pytz==2018.9              # via celery, django
 pyyaml==5.1
 raven==6.10.0
-redis==3.1.0
+redis==3.2.1
 requests-futures==0.9.9   # via piprot
 requests-mock==1.5.2
 requests==2.21.0
@@ -118,7 +118,7 @@ toml==0.10.0              # via towncrier
 towncrier==19.2.0
 traitlets==4.3.2          # via ipython
 urllib3==1.24.1           # via botocore, elasticsearch, requests
-vine==1.2.0               # via amqp
+vine==1.3.0               # via amqp, celery
 wcwidth==0.1.7            # via prompt-toolkit
 werkzeug==0.15.2
 whitenoise==4.1.2


### PR DESCRIPTION
### Description of change

Release notes:

* http://docs.celeryproject.org/en/master/whatsnew-4.3.html

Change log:

* http://docs.celeryproject.org/en/latest/changelog.html

This includes changing a test which was passing a function to a Celery task (which was invalid as a function cannot be serialised as JSON).

The upgrade also allowed us to greatly simplify our `rediss://` handling in our Celery configuration.

Some other change also allowed us to simplify the `rediss://` configuration for caching as well.

The Redis configuration changes have been tested in the UAT environment (and this branch is deployed there at the moment).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
