### PR TITLE
Fix GVA Multiplier string and investment admin

### DIFF
--- a/changelog/investment/investment_admin.internal.rst
+++ b/changelog/investment/investment_admin.internal.rst
@@ -1,0 +1,1 @@
+Fix for investment admin updated GVA multiplier string.

--- a/datahub/investment/project/admin.py
+++ b/datahub/investment/project/admin.py
@@ -52,6 +52,7 @@ class InvestmentProjectAdmin(BaseModelAdminMixin, VersionAdmin):
     readonly_fields = (
         'allow_blank_estimated_land_date',
         'allow_blank_possible_uk_regions',
+        'gva_multiplier',
         'archived_documents_url_path',
         'comments',
         'created',

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -691,7 +691,7 @@ class GVAMultiplier(models.Model):
 
     def __str__(self):
         """Human-readable representation"""
-        return f'GVA Multiplier for {self.fdi_sic_grouping} - {self.year}'
+        return f'GVA Multiplier for {self.fdi_sic_grouping} - {self.financial_year}'
 
 
 class SpecificProgramme(BaseConstantModel):

--- a/datahub/investment/project/test/test_admin.py
+++ b/datahub/investment/project/test/test_admin.py
@@ -6,6 +6,7 @@ from django.contrib.admin.sites import site
 from django.urls import reverse
 from django.utils.timezone import now, utc
 from freezegun import freeze_time
+from rest_framework import status
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core import constants
@@ -40,7 +41,7 @@ class TestInvestmentProjectAdmin(AdminTestMixin):
         data['project_manager'] = project_manager.pk
 
         response = self.client.post(url, data, follow=True)
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
 
         investment_project.refresh_from_db()
         assert investment_project.project_manager == project_manager
@@ -74,7 +75,7 @@ class TestInvestmentProjectAdmin(AdminTestMixin):
 
         response = self.client.post(url, data, follow=True)
 
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
 
         investment_project.refresh_from_db()
         assert investment_project.project_manager == project_manager
@@ -102,7 +103,7 @@ class TestInvestmentProjectAdmin(AdminTestMixin):
             'id': investment_project_pk,
         }
         response = self.client.post(url, data, follow=True)
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
 
         investment_project = InvestmentProject.objects.get(pk=investment_project_pk)
         assert investment_project.project_manager == project_manager
@@ -124,10 +125,17 @@ class TestInvestmentProjectAdmin(AdminTestMixin):
             'proposal_deadline': '2017-04-19',
             'id': investment_project_pk,
         }
+
         response = self.client.post(url, data, follow=True)
-        assert response.status_code == 200
+        assert response.status_code == status.HTTP_200_OK
 
         investment_project = InvestmentProject.objects.get(pk=investment_project_pk)
         assert investment_project.project_manager is None
         assert investment_project.project_manager_first_assigned_on is None
         assert investment_project.project_manager_first_assigned_by is None
+
+    def test_add_investment_project_view_returns_200_response(self):
+        """Test that add investment project returns HTTP 200 OK."""
+        url = reverse('admin:investment_investmentproject_add')
+        response = self.client.get(url)
+        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
### Description of change
This fixes the GVA Multiplier string representation.

To test
- Go to http://localhost:8000/admin/investment/investmentproject/add/
- Make sure the page renders okay

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
