### PR TITLE
Add sub-fields to name in contact_or_adviser_field

### DIFF
--- a/changelog/person-field-sub-fields.internal.rst
+++ b/changelog/person-field-sub-fields.internal.rst
@@ -1,0 +1,1 @@
+``name.keyword`` and ``name.trigram`` sub-fields were added to the ``contact_or_adviser_field`` field type in all search models. This is in preparation of the removal of the ``name_trigram`` sub-field, and also so we can change the type of the ``name`` sub-field from ``keyword`` to ``text``.

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -39,6 +39,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['archived_by.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -57,6 +57,16 @@ def test_mapping(setup_es):
                             'copy_to': ['adviser.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -81,6 +91,16 @@ def test_mapping(setup_es):
                             'copy_to': ['archived_by.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -163,6 +183,16 @@ def test_mapping(setup_es):
                             'copy_to': ['created_by.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',

--- a/datahub/search/event/tests/test_elasticsearch.py
+++ b/datahub/search/event/tests/test_elasticsearch.py
@@ -122,6 +122,16 @@ def test_mapping(setup_es):
                                 'organiser.name_trigram',
                             ],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -37,12 +37,32 @@ class TextWithKeyword(Text):
 
 
 def contact_or_adviser_field(field, include_dit_team=False):
-    """Object field for advisers and contacts."""
+    """
+    Object field for advisers and contacts.
+
+    The `name` field is being migrated away from using `copy_to` to being a multi-field.
+    `name_trigram` and `name.trigram` are both defined while the switch takes place.
+
+    Additionally, the `name` field should have had a data type of text, but it was mistakenly made
+    a keyword field. Hence, a `keyword` sub-field has also been added so type of `name` can be
+    changed to text once sorting operations have been migrated to using the `keyword` sub-field.
+
+    TODO:
+        - remove name_trigram once related logic has been updated to use name.trigram
+        - change name use Text instead of NormalizedKeyword once sorting options have been
+        updated to use name.keyword
+    """
     props = {
         'id': Keyword(),
         'first_name': NormalizedKeyword(),
         'last_name': NormalizedKeyword(),
-        'name': NormalizedKeyword(copy_to=f'{field}.name_trigram'),
+        'name': NormalizedKeyword(
+            copy_to=f'{field}.name_trigram',
+            fields={
+                'keyword': NormalizedKeyword(),
+                'trigram': TrigramText(),
+            },
+        ),
         'name_trigram': TrigramText(),
     }
 

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -71,6 +71,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['archived_by.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -132,6 +142,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['client_contacts.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -165,6 +185,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['client_relationship_manager.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -244,6 +274,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['created_by.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -427,6 +467,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['project_assurance_adviser.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -469,6 +519,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['project_manager.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -647,6 +707,16 @@ def test_mapping(setup_es):
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'copy_to': ['team_members.name_trigram'],
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',

--- a/datahub/search/large_investor_profile/test/test_elasticsearch.py
+++ b/datahub/search/large_investor_profile/test/test_elasticsearch.py
@@ -95,6 +95,16 @@ def test_mapping(setup_es):
                             ],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -52,6 +52,16 @@ def test_mapping(setup_es):
                             'copy_to': ['assignees.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -132,6 +142,16 @@ def test_mapping(setup_es):
                             'copy_to': ['cancelled_by.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -185,6 +205,16 @@ def test_mapping(setup_es):
                             'copy_to': ['completed_by.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -213,6 +243,16 @@ def test_mapping(setup_es):
                             'copy_to': ['contact.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -248,6 +288,16 @@ def test_mapping(setup_es):
                             'copy_to': ['created_by.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -407,6 +457,16 @@ def test_mapping(setup_es):
                             'copy_to': ['subscribers.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',


### PR DESCRIPTION
### Description of change

This adds `trigram` and `keyword` sub-fields to the `name` field in `contact_or_adviser_field`.

It's is part of migrating away from using `copy_to`. It's also so that we can migrate `name` to being a text field instead of a keyword field.

This is similar to #1550 but for contact_or_adviser_field. 

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
