### PR TITLE
Add communication channel to interaction search result exports

### DIFF
--- a/changelog/interaction/communication-channel-in-export.feature.rst
+++ b/changelog/interaction/communication-channel-in-export.feature.rst
@@ -1,0 +1,1 @@
+Communication channel is now included in CSV exports of search results.

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -1028,6 +1028,8 @@ class TestInteractionExportView(APITestMixin):
                 'Adviser': get_attr_or_none(interaction, 'dit_adviser.name'),
                 'Service provider': get_attr_or_none(interaction, 'dit_team.name'),
                 'Event': get_attr_or_none(interaction, 'event.name'),
+                'Communication channel':
+                    get_attr_or_none(interaction, 'communication_channel.name'),
                 'Service delivery status': get_attr_or_none(
                     interaction,
                     'service_delivery_status.name',

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -121,6 +121,7 @@ class SearchInteractionExportAPIView(SearchInteractionAPIViewMixin, SearchExport
         'dit_adviser_name': 'Adviser',
         'dit_team__name': 'Service provider',
         'event__name': 'Event',
+        'communication_channel__name': 'Communication channel',
         'service_delivery_status__name': 'Service delivery status',
         'net_company_receipt': 'Net company receipt',
         'policy_issue_type_names': 'Policy issue types',


### PR DESCRIPTION
### Description of change

This updates the CSV search results export of interactions to include communication channel as an additional column.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
