### PR TITLE
Remove deprecated interaction adviser sorting options from main API

### DIFF
--- a/changelog/interaction/adviser-sorting.removal.rst
+++ b/changelog/interaction/adviser-sorting.removal.rst
@@ -1,0 +1,1 @@
+``GET /v3/interaction``: The deprecated ``dit_adviser__first_name`` and ``dit_adviser__last_name`` values for the ``sortby`` query parameter were removed.

--- a/datahub/interaction/views.py
+++ b/datahub/interaction/views.py
@@ -39,10 +39,6 @@ class InteractionViewSet(CoreViewSet):
         'company__name',
         'created_on',
         'date',
-        # TODO: Remove following deprecation period
-        'dit_adviser__first_name',
-        # TODO: Remove following deprecation period
-        'dit_adviser__last_name',
         'first_name_of_first_contact',
         'last_name_of_first_contact',
         'subject',


### PR DESCRIPTION
### Description of change

This removes the deprecated adviser sorting options from `/v3/interaction`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
