### PR TITLE
Update Data Hub Company from D&B Worldbase record

### DIFF
--- a/datahub/dnb_match/exceptions.py
+++ b/datahub/dnb_match/exceptions.py
@@ -1,0 +1,6 @@
+class MismatchedRecordsException(Exception):
+    """
+    To indicate that 2 entities were mistakenly thought to be the same
+    company. E.g. a Data Hub company record and a Worldbase record with
+    different DUNS numbers.
+    """

--- a/datahub/dnb_match/test/test_utils.py
+++ b/datahub/dnb_match/test/test_utils.py
@@ -1,8 +1,10 @@
+import uuid
 from decimal import InvalidOperation
 from unittest import mock
 
 import pytest
 
+from datahub.core.constants import Country as CountryConstant
 from datahub.dnb_match.constants import DNB_COUNTRY_CODE_MAPPING
 from datahub.dnb_match.utils import (
     _extract_address,
@@ -20,22 +22,7 @@ from datahub.dnb_match.utils import (
 from datahub.metadata.models import Country
 
 
-def _resolve_countries(company_fields):
-    """
-    Replaces all the country fields in company_fields (the ones ending in *_country)
-    with an instance of metadata.Country.
-    """
-    fields_to_resolve = [
-        'address_country',
-        'trading_address_country',
-        'registered_address_country',
-    ]
-
-    for country_field in fields_to_resolve:
-        if country_field in company_fields:
-            company_fields[country_field] = Country.objects.get(
-                iso_alpha2_code=company_fields[country_field],
-            )
+UNITED_KINGDOM_COUNTRY_UUID = uuid.UUID(CountryConstant.united_kingdom.value.id)
 
 
 class TestExtractEmployees:
@@ -441,9 +428,7 @@ class TestExtractAddress:
                     'address_2': 'Main Street',
                     'address_town': 'London',
                     'address_county': 'Camden',
-                    # the body of the test replaces the ISO code in 'address_country'
-                    # with an instance of metadata.Country before any comparison
-                    'address_country': 'GB',
+                    'address_country_id': UNITED_KINGDOM_COUNTRY_UUID,
                     'address_postcode': 'SW1A 1AA',
                 },
             ),
@@ -463,9 +448,7 @@ class TestExtractAddress:
                     'address_2': '',
                     'address_town': '',
                     'address_county': '',
-                    # the body of the test replaces the ISO code in 'address_country'
-                    # with an instance of metadata.Country before any comparison
-                    'address_country': 'GB',
+                    'address_country_id': UNITED_KINGDOM_COUNTRY_UUID,
                     'address_postcode': '',
                 },
             ),
@@ -475,8 +458,6 @@ class TestExtractAddress:
         """
         Test successful cases related to _extract_address().
         """
-        _resolve_countries(expected_output)
-
         actual_output = _extract_address(wb_record)
         assert actual_output == expected_output
 
@@ -663,26 +644,19 @@ class TestExtractWbRecordIntoCompanyFields:
                         'address_2': 'Main Street',
                         'address_town': 'London',
                         'address_county': 'Camden',
-                        # the body of the test replaces the ISO code in 'address_country'
-                        # with an instance of metadata.Country before any comparison
-                        'address_country': 'GB',
+                        'address_country_id': UNITED_KINGDOM_COUNTRY_UUID,
                         'address_postcode': 'SW1A 1AA',
                         'registered_address_1': '1',
                         'registered_address_2': 'Main Street',
                         'registered_address_town': 'London',
                         'registered_address_county': 'Camden',
-                        # the body of the test replaces the ISO code in
-                        # 'registered_address_country' with an instance of metadata.Country
-                        # before any comparison
-                        'registered_address_country': 'GB',
+                        'registered_address_country_id': UNITED_KINGDOM_COUNTRY_UUID,
                         'registered_address_postcode': 'SW1A 1AA',
                         'trading_address_1': '1',
                         'trading_address_2': 'Main Street',
                         'trading_address_town': 'London',
                         'trading_address_county': 'Camden',
-                        # the body of the test replaces the ISO code in 'trading_address_country'
-                        # with an instance of metadata.Country before any comparison
-                        'trading_address_country': 'GB',
+                        'trading_address_country_id': UNITED_KINGDOM_COUNTRY_UUID,
                         'trading_address_postcode': 'SW1A 1AA',
                     },
                     False,
@@ -727,26 +701,19 @@ class TestExtractWbRecordIntoCompanyFields:
                         'address_2': '',
                         'address_town': '',
                         'address_county': '',
-                        # the body of the test replaces the ISO code in 'address_country'
-                        # with an instance of metadata.Country before any comparison
-                        'address_country': 'GB',
+                        'address_country_id': UNITED_KINGDOM_COUNTRY_UUID,
                         'address_postcode': '',
                         'registered_address_1': '',
                         'registered_address_2': '',
                         'registered_address_town': '',
                         'registered_address_county': '',
-                        # the body of the test replaces the ISO code in
-                        # 'registered_address_country' with an instance of metadata.Country
-                        # before any comparison
-                        'registered_address_country': 'GB',
+                        'registered_address_country_id': UNITED_KINGDOM_COUNTRY_UUID,
                         'registered_address_postcode': '',
                         'trading_address_1': '',
                         'trading_address_2': '',
                         'trading_address_town': '',
                         'trading_address_county': '',
-                        # the body of the test replaces the ISO code in 'trading_address_country'
-                        # with an instance of metadata.Country before any comparison
-                        'trading_address_country': 'GB',
+                        'trading_address_country_id': UNITED_KINGDOM_COUNTRY_UUID,
                         'trading_address_postcode': '',
                     },
                     True,
@@ -758,7 +725,5 @@ class TestExtractWbRecordIntoCompanyFields:
         """
         Test successful cases related to extract_wb_record_into_company_fields().
         """
-        _resolve_countries(expected_output[0])
-
         actual_output = extract_wb_record_into_company_fields(wb_record)
         assert actual_output == expected_output

--- a/datahub/dnb_match/utils.py
+++ b/datahub/dnb_match/utils.py
@@ -130,7 +130,7 @@ def _extract_address(wb_record):
         'address_2': wb_record['Street Address 2'],
         'address_town': wb_record['City Name'],
         'address_county': wb_record['State/Province Name'],
-        'address_country': country,
+        'address_country_id': country.id,
         'address_postcode': wb_record['Postal Code for Street Address'],
     }
 


### PR DESCRIPTION
### Description of change

This adds the `dnb_match.utils. update_company_from_wb_record` function which overrides a Data Hub company with data from a D&B Worldbase record.
It also archives it if the D&B record indicates that the company is out of business.

The list of `updated_fields` can be used by the caller to check if the company has been archived and notify the user with what happened.

The next PR will use this function to update a list of companies using the data from Worldbase records in `DnBMatchingResult`.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
