### PR TITLE
Add name sub-fields to company_field_with_copy_to_name_trigram

### DIFF
--- a/changelog/company-field-sub-fields.internal.rst
+++ b/changelog/company-field-sub-fields.internal.rst
@@ -1,0 +1,3 @@
+``name.keyword``, ``name.trigram`` and ``trading_names.trigram`` sub-fields were added to the ``company_field_with_copy_to_name_trigram``
+field type in all search models. These will replace the existing ``name_trigram`` and ``trading_names_trigram`` sub-fields and allow the type of the ``name``
+sub-field to be changed from ``keyword`` to ``text``.

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -118,6 +118,16 @@ def test_mapping(setup_es):
                             'copy_to': ['company.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -126,6 +136,12 @@ def test_mapping(setup_es):
                         'trading_names': {
                             'copy_to': ['company.trading_names_trigram'],
                             'type': 'text',
+                            'fields': {
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'trading_names_trigram': {
                             'analyzer': 'trigram_analyzer',

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -170,14 +170,36 @@ def address_field(index_country=True):
 
 
 def company_field_with_copy_to_name_trigram(field):
-    """Company field with copy to, deprecated in favour of company_field"""
+    """
+    Company field with copy to, deprecated in favour of company_field.
+
+    The `name` and `trading_names` fields is being migrated away from using `copy_to` to being a
+    multi-field. The sub-fields and `_trigram`-suffixed fields are both defined while the switch
+    takes place.
+
+    Additionally, the `name` field should have had a data type of text, but it was mistakenly made
+    a keyword field. Hence, a `keyword` sub-field has also been added so type of `name` can be
+    changed to text once sorting operations have been migrated to using the `keyword` sub-field.
+
+    TODO: replace usages of this with company_field once search logic has been updated to use
+     name.keyword, name.trigram and trading_names.trigram where necessary.
+    """
     return Object(
         properties={
             'id': Keyword(),
-            'name': NormalizedKeyword(copy_to=f'{field}.name_trigram'),
+            'name': NormalizedKeyword(
+                copy_to=f'{field}.name_trigram',
+                fields={
+                    'trigram': TrigramText(),
+                    'keyword': NormalizedKeyword(),
+                },
+            ),
             'name_trigram': TrigramText(),
             'trading_names': Text(
                 copy_to=f'{field}.trading_names_trigram',
+                fields={
+                    'trigram': TrigramText(),
+                },
             ),
             'trading_names_trigram': TrigramText(),
         },

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -172,6 +172,16 @@ def test_mapping(setup_es):
                             'copy_to': ['company.name_trigram'],
                             'normalizer': 'lowercase_asciifolding_normalizer',
                             'type': 'keyword',
+                            'fields': {
+                                'keyword': {
+                                    'normalizer': 'lowercase_asciifolding_normalizer',
+                                    'type': 'keyword',
+                                },
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'name_trigram': {
                             'analyzer': 'trigram_analyzer',
@@ -180,6 +190,12 @@ def test_mapping(setup_es):
                         'trading_names': {
                             'copy_to': ['company.trading_names_trigram'],
                             'type': 'text',
+                            'fields': {
+                                'trigram': {
+                                    'analyzer': 'trigram_analyzer',
+                                    'type': 'text',
+                                },
+                            },
                         },
                         'trading_names_trigram': {
                             'analyzer': 'trigram_analyzer',


### PR DESCRIPTION
### Description of change

This add the following sub-fields to `company_field_with_copy_to_name_trigram`:

- `name.trigram`
- `name.keyword`
- `trading_names.trigram`

This is part of migrating away from using `copy_to`. It's also so that we can migrate `name` to being a text field instead of a keyword field.

This is similar to #1589 and #1550.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
