### PR TITLE
Gross value added string in API Response

### DIFF
--- a/changelog/investment/gross_value_added_string.api.rst
+++ b/changelog/investment/gross_value_added_string.api.rst
@@ -1,0 +1,3 @@
+The following read only field  on``/v3/investment/`` endpoint has been updated.
+
+- ``gross_value_added`` now returns a string not a decimal

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -338,7 +338,6 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
     associated_non_fdi_r_and_d_project = NestedRelatedField(
         InvestmentProject, required=False, allow_null=True, extra_fields=('name', 'project_code'),
     )
-    gross_value_added = serializers.ReadOnlyField()
 
     # Requirements fields
     competitor_countries = NestedRelatedField(meta_models.Country, many=True, required=False)
@@ -516,6 +515,7 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
             'archived_documents_url_path',
             'comments',
             'project_manager_requested_on',
+            'gross_value_added',
         )
 
 

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -473,7 +473,7 @@ class TestCreateView(APITestMixin):
             == str(project_manager_request_status_id)
         )
         # GVA Multiplier - Transportation & storage - 2019 - 0.0621 * 1000
-        assert response_data['gross_value_added'] == 62
+        assert response_data['gross_value_added'] == '62'
 
     def test_create_project_fail(self):
         """Test creating a project with missing required values."""
@@ -765,7 +765,7 @@ class TestRetrieveView(APITestMixin):
         assert response_data['export_revenue'] is True
         assert response_data['value_complete'] is True
         # GVA Multiplier - Transportation & storage - 2019 - 0.0621
-        assert response_data['gross_value_added'] == 6
+        assert response_data['gross_value_added'] == '6'
 
     def test_get_requirements_success(self):
         """Test successfully getting a project requirements object."""
@@ -1061,7 +1061,7 @@ class TestPartialUpdateView(APITestMixin):
     @pytest.mark.parametrize(
         'foreign_equity_investment,expected_gross_value_added,expected_multiplier_value',
         (
-            (20000, 1242, '0.0621'),
+            (20000, '1242', '0.0621'),
             (None, None, '0.0621'),
         ),
     )
@@ -1106,9 +1106,9 @@ class TestPartialUpdateView(APITestMixin):
         'business_activity,expected_gross_value_added',
         (
             # GVA Multiplier for Retails & wholesale trade - 2019 - 0.0581
-            (constants.InvestmentBusinessActivity.retail.value.id, 5810),
+            (constants.InvestmentBusinessActivity.retail.value.id, '5810'),
             # No change - GVA Multiplier - Transportation & storage - 2019 - 0.0621
-            (constants.InvestmentBusinessActivity.other.value.id, 6210),
+            (constants.InvestmentBusinessActivity.other.value.id, '6210'),
         ),
     )
     def test_change_business_activity_to_retail_updated_gross_value_added(


### PR DESCRIPTION
### Description of change
When changing gross_value_added to a decimal this left the field returning `1234.0` rather than `1234` so have changed how the readonly field is declared and updated the tests to expect a string.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
