### PR TITLE
Remove gross_value_added from search

### DIFF
--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -142,7 +142,6 @@ class InvestmentProject(BaseESModel):
     uk_region_locations = fields.id_name_field()
     will_new_jobs_last_two_years = Boolean()
     level_of_involvement_simplified = Keyword()
-    gross_value_added = Integer()
 
     MAPPINGS = {
         'actual_uk_regions': lambda col: [

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -34,8 +34,6 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
         child=serializers.ChoiceField(choices=InvestmentProject.INVOLVEMENT),
         required=False,
     )
-    gross_value_added_start = serializers.IntegerField(required=False, min_value=0)
-    gross_value_added_end = serializers.IntegerField(required=False, min_value=0)
 
     SORT_BY_FIELDS = (
         'actual_land_date',

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -333,7 +333,6 @@ def test_mapping(setup_es):
                 },
                 'foreign_equity_investment': {'type': 'double'},
                 'government_assistance': {'type': 'boolean'},
-                'gross_value_added': {'type': 'integer'},
                 'id': {'type': 'keyword'},
                 'intermediate_company': {
                     'properties': {

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -57,7 +57,6 @@ def test_investment_project_to_dict(setup_es):
         'total_investment',
         'client_cannot_provide_foreign_investment',
         'foreign_equity_investment',
-        'gross_value_added',
         'government_assistance',
         'some_new_jobs',
         'specific_programme',

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -155,57 +155,6 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['name'] == 'abc defg'
 
-    @pytest.mark.parametrize(
-        'search,expected_gross_value_added,expected_project_name',
-        (
-            (
-                {
-                    'gross_value_added_start': 0,
-                    'gross_value_added_end': 6000,
-                },
-                [5810],
-                ['abc defg'],
-            ),
-            (
-                {
-                    'gross_value_added_start': 20000,
-                },
-                [],
-                [],
-            ),
-            (
-                {
-                    'gross_value_added_end': 100000,
-                },
-                [5810, 11620],
-                ['abc defg', 'won project'],
-            ),
-        ),
-    )
-    def test_gross_value_added_filters(
-        self, setup_data, search, expected_gross_value_added, expected_project_name,
-    ):
-        """Test Gross Value Added (GVA) filters."""
-        url = reverse('api-v3:search:investment_project')
-
-        response = self.api_client.post(
-            url,
-            data=search,
-        )
-
-        assert response.status_code == status.HTTP_200_OK
-        expected_number_of_results = len(expected_gross_value_added)
-        assert response.data['count'] == expected_number_of_results, response.data['results']
-        assert len(response.data['results']) == expected_number_of_results
-        assert (
-            Counter(result['gross_value_added'] for result in response.data['results'])
-            == Counter(expected_gross_value_added)
-        ), expected_gross_value_added
-        assert (
-            Counter(result['name'] for result in response.data['results'])
-            == Counter(expected_project_name)
-        ), expected_project_name
-
     def test_search_adviser_filter(self, setup_es):
         """Tests the adviser filter."""
         adviser = AdviserFactory()
@@ -1136,7 +1085,6 @@ class TestInvestmentProjectExportView(APITestMixin):
                 'R&D budget': project.r_and_d_budget,
                 'Associated non-FDI R&D project': project.non_fdi_r_and_d_budget,
                 'New to world tech': project.new_tech_to_uk,
-                'Gross Value Added': project.gross_value_added,
             }
             for project in sorted_projects
         ]

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -48,8 +48,6 @@ class SearchInvestmentProjectAPIViewMixin:
         'uk_region_location',
         'level_of_involvement_simplified',
         'likelihood_to_land',
-        'gross_value_added_start',
-        'gross_value_added_end',
     )
 
     REMAP_FIELDS = {
@@ -170,5 +168,4 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectAPIViewMixin, SearchE
         'non_fdi_r_and_d_budget': 'Associated non-FDI R&D project',
         'new_tech_to_uk': 'New to world tech',
         'likelihood_to_land__name': 'Likelihood to land',
-        'gross_value_added': 'Gross Value Added',
     }


### PR DESCRIPTION
### Description of change
This removes as yet released functionality. Spotted an issue with the wrong field type for Gross Value Added in search that could have potentially lead to issues on release.

Going to revert the work for adding gross_value_added to search and look into using a double field.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
