### PR TITLE
Use Sales business activity when selecting GVA multiplier

### DIFF
--- a/changelog/investment/gross_value_added_sales.internal.rst
+++ b/changelog/investment/gross_value_added_sales.internal.rst
@@ -1,0 +1,2 @@
+An investment project with a business activity of sales now uses the
+GVA Multiplier for retail to calculate Gross Value Added.

--- a/datahub/core/constants.py
+++ b/datahub/core/constants.py
@@ -298,6 +298,7 @@ class ReferralSourceActivity(Enum):
 class InvestmentBusinessActivity(Enum):
     """Investment business activity constants."""
 
+    sales = Constant('Sales', '71946309-c92c-4c5b-9c42-8502cc74c72e')
     retail = Constant('Retail', 'a2dbd807-ae52-421c-8d1d-88adfc7a506b')
     other = Constant('Other', 'befab707-5abd-4f47-8477-57f091e6dac9')
 

--- a/datahub/investment/project/gva_utils.py
+++ b/datahub/investment/project/gva_utils.py
@@ -54,15 +54,25 @@ class GrossValueAddedCalculator:
         if str(self.investment_project.investment_type_id) != InvestmentTypeConstant.fdi.value.id:
             return None
 
-        if self.investment_project.business_activities.filter(
-            id=InvestmentBusinessActivityConstant.retail.value.id,
-        ).exists():
+        if self._has_business_activity_of_retail_or_sales():
             return self._get_retail_gva_multiplier()
 
         if self.investment_project.sector:
             return self._get_sector_gva_multiplier()
         else:
             return None
+
+    def _has_business_activity_of_retail_or_sales(self):
+        """
+        :returns True or False. Checks if an investment project has either a
+        business activity of retail or sales.
+        """
+        return self.investment_project.business_activities.filter(
+            id__in=[
+                InvestmentBusinessActivityConstant.retail.value.id,
+                InvestmentBusinessActivityConstant.sales.value.id,
+            ],
+        ).exists()
 
     def _get_retail_gva_multiplier(self):
         """:returns the GVA Multiplier for a retail investment project."""

--- a/datahub/investment/project/test/test_gva_utils.py
+++ b/datahub/investment/project/test/test_gva_utils.py
@@ -40,8 +40,21 @@ class TestGrossValueAddedCalculator:
             ),
             (
                 InvestmentTypeConstant.fdi.value.id,
+                None,
+                [
+                    InvestmentBusinessActivityConstant.sales.value.id,
+                ],
+                '0.0581',
+            ),
+            (
+                InvestmentTypeConstant.fdi.value.id,
                 SectorConstant.renewable_energy_wind.value.id,
-                [InvestmentBusinessActivityConstant.retail.value.id],
+                [
+                    InvestmentBusinessActivityConstant.retail.value.id,
+                    InvestmentBusinessActivityConstant.sales.value.id,
+                    InvestmentBusinessActivityConstant.other.value.id,
+
+                ],
                 '0.0581',
             ),
             (

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -1107,6 +1107,7 @@ class TestPartialUpdateView(APITestMixin):
         (
             # GVA Multiplier for Retails & wholesale trade - 2019 - 0.0581
             (constants.InvestmentBusinessActivity.retail.value.id, '5810'),
+            (constants.InvestmentBusinessActivity.sales.value.id, '5810'),
             # No change - GVA Multiplier - Transportation & storage - 2019 - 0.0621
             (constants.InvestmentBusinessActivity.other.value.id, '6210'),
         ),


### PR DESCRIPTION
### Description of change
Like Retail the business activity of Sales has to override the selection of GVA Multiplier and select the Retail sector's value.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
