### PR TITLE
Add Gross Value Added to search

### DIFF
--- a/changelog/investment/gross_value_added_search.api.rst
+++ b/changelog/investment/gross_value_added_search.api.rst
@@ -1,0 +1,4 @@
+Investment project search endpoint ``/v3/search/investment_project`` now returns ``gross_value_added`` for each investment project.
+
+Search results can now be filtered by ``gross_value_added`` using the range filters
+``gross_value_added_start`` and ``gross_value_added_end``.

--- a/changelog/investment/gross_value_added_search.feature.rst
+++ b/changelog/investment/gross_value_added_search.feature.rst
@@ -1,0 +1,8 @@
+The following fields have been added to Investment Search:
+
+- gross_value_added
+
+To allow ``gross_value added`` to be filtered by a range the following filters have been added:
+
+- gross_value_added_start
+- gross_value_added_end

--- a/changelog/investment/investment_projects_csv.feature.rst
+++ b/changelog/investment/investment_projects_csv.feature.rst
@@ -1,0 +1,6 @@
+The following fields have been added to the investment csv download:
+
+- FDI type
+- Foreign equity investment
+- GVA multiplier
+- GVA

--- a/datahub/core/csv.py
+++ b/datahub/core/csv.py
@@ -63,5 +63,6 @@ def _transform_csv_value(value):
     if isinstance(value, datetime):
         return value.strftime('%Y-%m-%d %H:%M:%S')
     if isinstance(value, Decimal):
-        return value.normalize()
+        normalized_value = value.normalize()
+        return f'{normalized_value:f}'
     return value

--- a/datahub/core/test/test_csv.py
+++ b/datahub/core/test/test_csv.py
@@ -1,6 +1,13 @@
+import datetime
+from decimal import Decimal
+
 import pytest
 
-from datahub.core.csv import csv_iterator, INCOMPLETE_CSV_MESSAGE
+from datahub.core.csv import (
+    _transform_csv_value,
+    csv_iterator,
+    INCOMPLETE_CSV_MESSAGE,
+)
 
 
 def _rows():
@@ -24,3 +31,45 @@ def test_csv_iterator_with_error():
             pass
 
     assert row == INCOMPLETE_CSV_MESSAGE
+
+
+@pytest.mark.parametrize(
+    'value,expected_value',
+    (
+        (
+            Decimal('2000000000000000000000000000000000000'),
+            '2000000000000000000000000000000000000',
+        ),
+        (
+            Decimal('200.00'),
+            '200',
+        ),
+        (
+            Decimal('200.0'),
+            '200',
+        ),
+        (
+            Decimal('200.8919'),
+            '200.8919',
+        ),
+        (
+            datetime.datetime(2010, 1, 1, 3, 3, 3),
+            '2010-01-01 03:03:03',
+        ),
+        (
+            1000,
+            1000,
+        ),
+        (
+            float(1000),
+            float(1000),
+        ),
+        (
+            'HELLO',
+            'HELLO',
+        ),
+    ),
+)
+def test_transform_csv_value(value, expected_value):
+    """Test transform csv value"""
+    assert _transform_csv_value(value) == expected_value

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -403,7 +403,8 @@ def _format_csv_value(value):
     if value is None:
         return ''
     if isinstance(value, Decimal):
-        return str(value.normalize())
+        normalized_value = value.normalize()
+        return f'{normalized_value:f}'
     if isinstance(value, datetime):
         return value.strftime('%Y-%m-%d %H:%M:%S')
     return str(value)

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -143,6 +143,8 @@ class InvestmentProject(BaseESModel):
     will_new_jobs_last_two_years = Boolean()
     level_of_involvement_simplified = Keyword()
 
+    gross_value_added = Double()
+
     MAPPINGS = {
         'actual_uk_regions': lambda col: [
             dict_utils.id_name_dict(c) for c in col.all()

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -34,6 +34,8 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
         child=serializers.ChoiceField(choices=InvestmentProject.INVOLVEMENT),
         required=False,
     )
+    gross_value_added_start = serializers.IntegerField(required=False, min_value=0)
+    gross_value_added_end = serializers.IntegerField(required=False, min_value=0)
 
     SORT_BY_FIELDS = (
         'actual_land_date',

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -333,6 +333,7 @@ def test_mapping(setup_es):
                 },
                 'foreign_equity_investment': {'type': 'double'},
                 'government_assistance': {'type': 'boolean'},
+                'gross_value_added': {'type': 'double'},
                 'id': {'type': 'keyword'},
                 'intermediate_company': {
                     'properties': {

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -48,6 +48,8 @@ class SearchInvestmentProjectAPIViewMixin:
         'uk_region_location',
         'level_of_involvement_simplified',
         'likelihood_to_land',
+        'gross_value_added_start',
+        'gross_value_added_end',
     )
 
     REMAP_FIELDS = {
@@ -168,4 +170,8 @@ class SearchInvestmentExportAPIView(SearchInvestmentProjectAPIViewMixin, SearchE
         'non_fdi_r_and_d_budget': 'Associated non-FDI R&D project',
         'new_tech_to_uk': 'New to world tech',
         'likelihood_to_land__name': 'Likelihood to land',
+        'fdi_type__name': 'FDI type',
+        'foreign_equity_investment': 'Foreign equity investment',
+        'gva_multiplier__multiplier': 'GVA multiplier',
+        'gross_value_added': 'GVA',
     }


### PR DESCRIPTION
### Description of change
Added `gross_value_added` to investment search as a double. Also added to the csv download.

### Interesting Points
This work highlighted the inaccuracy of large float values. A test has been added to show the inaccuracy. Its deemed that this won't be a problem as this would only occur when none real world data is entered and would only affect a filter at a very high range. 

### How to test
- Update a project so that it has a GVA value (set FDI, sector, foreign equity investment)
- Check CSV download for Gross value added, foreign equity investment and fdi type
- Go to http://localhost:8000/v3/search/investment_project
- Use the `gross value added start` and `gross_value_added_end` range filter. Test your projects appear


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
