### PR TITLE
Add management command to upload company match candidates from CSV file

### DIFF
--- a/changelog/company/update_company_match_candidates.feature
+++ b/changelog/company/update_company_match_candidates.feature
@@ -1,0 +1,1 @@
+Company match candidates can now be updated with a management command using data from CSV file

--- a/datahub/dbmaintenance/management/commands/update_company_match_candidates.py
+++ b/datahub/dbmaintenance/management/commands/update_company_match_candidates.py
@@ -1,0 +1,103 @@
+import json
+from base64 import b64decode
+from functools import lru_cache
+from logging import getLogger
+
+from datahub.company.models import Company
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_uuid
+from datahub.dnb_match.constants import DNB_COUNTRY_CODE_MAPPING
+from datahub.dnb_match.models import DnBMatchingCSVRecord
+from datahub.metadata.models import Country
+
+logger = getLogger(__name__)
+
+DNB_COUNTRY_MAPPING = {
+    entry['name']: entry['iso_alpha2_code']
+    for entry in DNB_COUNTRY_CODE_MAPPING.values()
+}
+
+
+class Command(CSVBaseCommand):
+    """Command to update DnBMatchingCSVRecord."""
+
+    EXPECTED_FIELDS = {
+        'duns_number',
+        'name',
+        'global_ultimate_duns_number',
+        'global_ultimate_name',
+        'global_ultimate_country',
+        'address_1',
+        'address_2',
+        'address_town',
+        'address_postcode',
+        'address_country',
+        'confidence',
+        'source',
+    }
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        super().add_arguments(parser)
+        parser.add_argument(
+            '--batch_number',
+            type=int,
+            help='Batch number - version of the match candidates.',
+        )
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        company = Company.objects.get(pk=parse_uuid(row['id']))
+        batch_number = options['batch_number']
+
+        raw_data = b64decode(row['data'])
+        data = json.loads(raw_data)
+
+        if not self._validate_data(data):
+            logger.warning(
+                'Required fields are missing for given company: %s, %s',
+                company.pk,
+                data,
+            )
+            return
+
+        enriched_data = self._resolve_dnb_address_country(data)
+        if not enriched_data:
+            logger.warning(
+                'Could not resolve country for given company: %s, %s',
+                company.pk,
+                data,
+            )
+            return
+
+        if not simulate:
+            DnBMatchingCSVRecord.objects.update_or_create(
+                company_id=company.id,
+                defaults={
+                    'batch_number': batch_number,
+                    'data': enriched_data,
+                },
+            )
+
+    def _validate_data(self, data):
+        return all(row.keys() == self.EXPECTED_FIELDS for row in data)
+
+    def _resolve_dnb_address_country(self, data):
+        """Resolve DnB address_country with Data Hub country."""
+        for row in data:
+            country_code = DNB_COUNTRY_MAPPING.get(row['address_country'])
+            country = self._get_dh_country_by_country_code(country_code) if country_code else None
+            if not country:
+                return None
+
+            row['address_country'] = {
+                'id': country.id,
+                'name': country.name,
+            }
+        return data
+
+    @lru_cache(maxsize=None)
+    def _get_dh_country_by_country_code(self, country_code):
+        return Country.objects.get(
+            iso_alpha2_code=country_code,
+        )

--- a/datahub/dbmaintenance/test/commands/test_update_company_match_candidates.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_match_candidates.py
@@ -1,0 +1,245 @@
+import json
+from base64 import b64encode
+from io import BytesIO
+
+import pytest
+from django.core.management import call_command
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.dnb_match.models import DnBMatchingCSVRecord
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('WARNING')
+
+    companies, data = _get_test_companies_and_data()
+
+    wrong_json = b64encode('{"what": }'.encode('utf-8')).decode('utf-8')
+
+    # to check that existing match will be overwritten
+    company_2_match = DnBMatchingCSVRecord.objects.create(
+        company_id=companies[2].id,
+        batch_number=1,
+        data=[],
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,data
+00000000-0000-0000-0000-000000000000,NULL
+{companies[0].id},{data[0]}
+{companies[1].id},{wrong_json}
+{companies[2].id},{data[0]}
+{companies[3].id},invalidbase64
+{companies[4].id},{data[1]}
+{companies[5].id},{data[2]}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_company_match_candidates', bucket, object_key, batch_number=1)
+
+    assert 'Company matching query does not exist' in caplog.text
+    assert 'json.decoder.JSONDecodeError' in caplog.text
+    assert 'binascii.Error: Invalid base64-encoded string' in caplog.text
+    assert 'Required fields are missing for given company' in caplog.text
+    assert 'Could not resolve country for given company' in caplog.text
+    assert len(caplog.records) == 5
+
+    matches = DnBMatchingCSVRecord.objects.filter(
+        company_id__in=(company.id for company in companies),
+    )
+    assert matches.count() == 2
+
+    for match in matches:
+        assert match.data == [
+            {
+                'duns_number': 12345,
+                'name': 'test name',
+                'global_ultimate_duns_number': 12345,
+                'global_ultimate_name': 'test name global',
+                'global_ultimate_country': 'USA',
+                'address_1': '1st LTD street',
+                'address_2': '',
+                'address_town': 'London',
+                'address_postcode': 'SW1A 1AA',
+                'address_country': {
+                    'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                    'name': 'United States',
+                },
+                'confidence': 10,
+                'source': 'cats',
+            },
+            {
+                'duns_number': 12345,
+                'name': 'test name',
+                'global_ultimate_duns_number': 12345,
+                'global_ultimate_name': 'test name global',
+                'global_ultimate_country': 'USA',
+                'address_1': '1st LTD street',
+                'address_2': '',
+                'address_town': 'London',
+                'address_postcode': 'SW1A 1AA',
+                'address_country': {
+                    'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                    'name': 'United States',
+                },
+                'confidence': 10,
+                'source': 'cats',
+            },
+        ]
+
+    company_2_match.refresh_from_db()
+    assert company_2_match.data == [
+        {
+            'duns_number': 12345,
+            'name': 'test name',
+            'global_ultimate_duns_number': 12345,
+            'global_ultimate_name': 'test name global',
+            'global_ultimate_country': 'USA',
+            'address_1': '1st LTD street',
+            'address_2': '',
+            'address_town': 'London',
+            'address_postcode': 'SW1A 1AA',
+            'address_country': {
+                'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                'name': 'United States',
+            },
+            'confidence': 10,
+            'source': 'cats',
+        },
+        {
+            'duns_number': 12345,
+            'name': 'test name',
+            'global_ultimate_duns_number': 12345,
+            'global_ultimate_name': 'test name global',
+            'global_ultimate_country': 'USA',
+            'address_1': '1st LTD street',
+            'address_2': '',
+            'address_town': 'London',
+            'address_postcode': 'SW1A 1AA',
+            'address_country': {
+                'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                'name': 'United States',
+            },
+            'confidence': 10,
+            'source': 'cats',
+        },
+    ]
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('WARNING')
+
+    companies, data = _get_test_companies_and_data()
+
+    # to check that existing match will not be overwritten
+    company_2_match = DnBMatchingCSVRecord.objects.create(
+        company_id=companies[2].id,
+        batch_number=1,
+        data=[],
+    )
+
+    wrong_json = b64encode('{"what": }'.encode('utf-8')).decode('utf-8')
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""id,data
+00000000-0000-0000-0000-000000000000,NULL
+{companies[0].id},{data[0]}
+{companies[1].id},{wrong_json}
+{companies[2].id},{data[0]}
+{companies[3].id},invalidbase64
+{companies[4].id},{data[1]}
+{companies[5].id},{data[2]}
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command(
+        'update_company_match_candidates',
+        bucket,
+        object_key,
+        batch_number=1,
+        simulate=True,
+    )
+
+    assert 'Company matching query does not exist' in caplog.text
+    assert 'json.decoder.JSONDecodeError' in caplog.text
+    assert 'binascii.Error: Invalid base64-encoded string' in caplog.text
+    assert 'Required fields are missing for given company' in caplog.text
+    assert 'Could not resolve country for given company' in caplog.text
+    assert len(caplog.records) == 5
+
+    num_matches = DnBMatchingCSVRecord.objects.filter(
+        company_id__in=(company.id for company in companies),
+    ).count()
+    assert num_matches == 1
+
+    company_2_match.refresh_from_db()
+    assert company_2_match.data == []
+
+
+def _get_data_for_company(country_name='USA'):
+    return {
+        'duns_number': 12345,
+        'name': 'test name',
+        'global_ultimate_duns_number': 12345,
+        'global_ultimate_name': 'test name global',
+        'global_ultimate_country': 'USA',
+        'address_1': '1st LTD street',
+        'address_2': '',
+        'address_town': 'London',
+        'address_postcode': 'SW1A 1AA',
+        'address_country': country_name,
+        'confidence': 10,
+        'source': 'cats',
+    }
+
+
+def _encode_data(data):
+    raw_data = json.dumps(data)
+    base64_data = b64encode(raw_data.encode('utf-8')).decode('utf-8')
+    return base64_data
+
+
+def _get_test_companies_and_data():
+    companies = CompanyFactory.create_batch(6)
+
+    records = [_get_data_for_company(), _get_data_for_company()]
+    base64_record = _encode_data(records)
+    data = [base64_record]
+
+    # missing fields record
+    missing_fields_record = [{'name': 'missing company'}]
+    missing_fields_base64_record = _encode_data(missing_fields_record)
+    data.append(missing_fields_base64_record)
+
+    # unknown country
+    unknown_country_record = [_get_data_for_company('UNKNOWN COUNTRY')]
+    unknown_country_base64_record = _encode_data(unknown_country_record)
+    data.append(unknown_country_base64_record)
+
+    return companies, data


### PR DESCRIPTION
### Description of change

This adds a management command that enables upload of CSV file with company match candidates.

It it possible to upload different sets of match candidates for a company by using different `batch_number`.

This code is temporary and the consumed CSV file is machine generated so basic validation should be enough.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
