### PR TITLE
Rename populate gross value added command

### DIFF
--- a/changelog/investment/refresh_gross_value_added_cmd.internal.rst
+++ b/changelog/investment/refresh_gross_value_added_cmd.internal.rst
@@ -1,0 +1,2 @@
+Renamed command ``populate_gross_value_addded`` to ``refresh_gross_value_added_values``
+and updated to include projects with a business activity of ``sales`` that do not have a sector.

--- a/datahub/investment/project/management/commands/refresh_gross_value_added_values.py
+++ b/datahub/investment/project/management/commands/refresh_gross_value_added_values.py
@@ -9,9 +9,9 @@ from datahub.investment.project.models import InvestmentProject
 
 
 class Command(BaseCommand):
-    """Command to populate the Gross Value Added for all fdi investment projects."""
+    """Command to refresh the Gross Value Added values for all fdi investment projects."""
 
-    help = 'Updates all FDI investment projects that require a GVA multiplier to be set.'
+    help = 'Refreshes all FDI investment projects that have or require a GVA to be set.'
 
     def handle(self, *args, **options):
         """
@@ -27,7 +27,7 @@ class Command(BaseCommand):
             project.save(update_fields=['gross_value_added', 'gva_multiplier'])
 
     def get_investment_projects(self):
-        """Get investment projects. returns: All projects that GVA could be calculated for."""
+        """Get investment projects. returns: All projects that GVA can be calculated for."""
         return InvestmentProject.objects.filter(
             investment_type_id=InvestmentTypeConstant.fdi.value.id,
             foreign_equity_investment__isnull=False,
@@ -35,6 +35,9 @@ class Command(BaseCommand):
             Q(
                 sector__isnull=False,
             ) | Q(
-                business_activities=InvestmentBusinessActivityConstant.retail.value.id,
+                business_activities__in=[
+                    InvestmentBusinessActivityConstant.retail.value.id,
+                    InvestmentBusinessActivityConstant.sales.value.id,
+                ],
             ),
         )

--- a/datahub/investment/project/test/management/commands/test_refresh_gross_value_added_values.py
+++ b/datahub/investment/project/test/management/commands/test_refresh_gross_value_added_values.py
@@ -8,15 +8,15 @@ from datahub.core.constants import (
     InvestmentType as InvestmentTypeConstant,
     Sector as SectorConstant,
 )
-from datahub.investment.project.management.commands import populate_gross_value_added
+from datahub.investment.project.management.commands import refresh_gross_value_added_values
 from datahub.investment.project.test.factories import InvestmentProjectFactory
 
 
 pytestmark = pytest.mark.django_db
 
 
-class TestPopulateGrossValueAddedCommand:
-    """Test populate gross value added command."""
+class TestRefreshGrossValueAddedCommand:
+    """Test refreshing gross value added values command."""
 
     @pytest.mark.parametrize(
         'investment_type,sector,business_activities,multiplier_value',
@@ -32,6 +32,14 @@ class TestPopulateGrossValueAddedCommand:
                 None,
                 [
                     InvestmentBusinessActivityConstant.retail.value.id,
+                ],
+                '0.0581',
+            ),
+            (
+                InvestmentTypeConstant.fdi.value.id,
+                None,
+                [
+                    InvestmentBusinessActivityConstant.sales.value.id,
                 ],
                 '0.0581',
             ),
@@ -78,7 +86,7 @@ class TestPopulateGrossValueAddedCommand:
             ),
         ),
     )
-    def test_populate_gross_value_added(
+    def test_refresh_gross_value_added(
         self,
         investment_type,
         sector,
@@ -98,13 +106,13 @@ class TestPopulateGrossValueAddedCommand:
             )
 
         assert not project.gva_multiplier
-        self._run_populate_command()
+        self._run_command()
         project.refresh_from_db()
         if not multiplier_value:
             assert not project.gva_multiplier
         else:
             assert project.gva_multiplier.multiplier == Decimal(multiplier_value)
 
-    def _run_populate_command(self):
-        cmd = populate_gross_value_added.Command()
+    def _run_command(self):
+        cmd = refresh_gross_value_added_values.Command()
         cmd.handle()


### PR DESCRIPTION
### Description of change
This renames the command to populate the gross value added data as there could be a use case for it being re-ran at a later date.
Also updated to include projects that have sales set but no sector.

### To test
``./manage.py refresh_gross_value_added_values``
- Check projects have a gross value added populated



### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
