### PR TITLE
Financial year for GVA

### DIFF
--- a/changelog/investment/gva-logic-update.internal.rst
+++ b/changelog/investment/gva-logic-update.internal.rst
@@ -1,0 +1,1 @@
+The logic has been updated for selecting which financial year's data is used to calculate the GVA for an investment project.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -357,6 +357,13 @@ if REDIS_BASE_URL:
                 'age_check': 60  # in minutes
             }
         },
+        'refresh_gross_value_added_values': {
+            'task': (
+                'datahub.investment.project.tasks.'
+                'refresh_gross_value_added_value_for_fdi_investment_projects'
+            ),
+            'schedule': crontab(minute=0, hour=3, day_of_month=21)
+        }
     }
     if env.bool('ENABLE_DAILY_ES_SYNC', False):
         CELERY_BEAT_SCHEDULE['sync_es'] = {

--- a/datahub/core/test/test_utils.py
+++ b/datahub/core/test/test_utils.py
@@ -1,3 +1,4 @@
+from datetime import date
 from enum import Enum
 from uuid import UUID
 
@@ -6,6 +7,7 @@ import pytest
 from datahub.core.constants import Constant
 from datahub.core.test.support.models import MetadataModel
 from datahub.core.utils import (
+    get_financial_year,
     join_truthy_strings,
     load_constants_to_database,
     reverse_with_query_string,
@@ -97,3 +99,21 @@ def test_load_constants_to_database():
 def test_reverse_with_query_string(query_args, expected_url):
     """Test reverse_with_query_string() for various query arguments."""
     assert reverse_with_query_string('test-disableable-collection', query_args) == expected_url
+
+
+@pytest.mark.parametrize(
+    'date_obj,expected_financial_year',
+    (
+        (None, None),
+        (date(1980, 1, 1), 1979),
+        (date(2018, 1, 1), 2017),
+        (date(2019, 3, 1), 2018),
+        (date(2019, 8, 1), 2019),
+        (date(2025, 3, 1), 2024),
+        (date(2025, 4, 1), 2025),
+        (date(2025, 3, 31), 2024),
+    ),
+)
+def test_get_financial_year(date_obj, expected_financial_year):
+    """Test for get financial year"""
+    assert get_financial_year(date_obj) == expected_financial_year

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -112,3 +112,12 @@ def get_front_end_url(obj):
     """Gets the URL for the object in the Data Hub internal front end."""
     url_prefix = settings.DATAHUB_FRONTEND_URL_PREFIXES[obj._meta.model_name]
     return f'{url_prefix}/{obj.pk}'
+
+
+def get_financial_year(date_obj):
+    """Gets the financial year for a given date."""
+    if not date_obj:
+        return None
+    if date_obj.month > 3:
+        return date_obj.year
+    return date_obj.year - 1

--- a/datahub/investment/project/management/commands/refresh_gross_value_added_values.py
+++ b/datahub/investment/project/management/commands/refresh_gross_value_added_values.py
@@ -1,11 +1,8 @@
 from django.core.management.base import BaseCommand
-from django.db.models import Q
 
-from datahub.core.constants import (
-    InvestmentBusinessActivity as InvestmentBusinessActivityConstant,
-    InvestmentType as InvestmentTypeConstant,
+from datahub.investment.project.tasks import (
+    refresh_gross_value_added_value_for_fdi_investment_projects,
 )
-from datahub.investment.project.models import InvestmentProject
 
 
 class Command(BaseCommand):
@@ -22,22 +19,4 @@ class Command(BaseCommand):
         'update_gross_value_added_for_investment_project_pre_save'
         which sets the Gross Value added data for a project.
         """
-        investment_projects = self.get_investment_projects()
-        for project in investment_projects.iterator():
-            project.save(update_fields=['gross_value_added', 'gva_multiplier'])
-
-    def get_investment_projects(self):
-        """Get investment projects. returns: All projects that GVA can be calculated for."""
-        return InvestmentProject.objects.filter(
-            investment_type_id=InvestmentTypeConstant.fdi.value.id,
-            foreign_equity_investment__isnull=False,
-        ).filter(
-            Q(
-                sector__isnull=False,
-            ) | Q(
-                business_activities__in=[
-                    InvestmentBusinessActivityConstant.retail.value.id,
-                    InvestmentBusinessActivityConstant.sales.value.id,
-                ],
-            ),
-        )
+        refresh_gross_value_added_value_for_fdi_investment_projects()


### PR DESCRIPTION
### Description of change
This adds the logic to GVA for selecting the correct financial year for the GVA Multiplier.

The logic uses fallbacks if the Multipliers have not been updated then the most recent years data is used. 

It's important to remember the GVA prior to actually landing is just an estimate and that when a project is updated the GVA calculation is always checked.

### How to test
- Update a project so that it has a GVA value (set FDI, sector, foreign equity investment)
- View http://localhost:8000/v3/investment/ and check gross value added is set
- Go to http://localhost:8000/admin/investment/gvamultiplier/
- Add a new multiplier for the same sector as your project for a year in the future 2030
- Update the projects actual land date to be that year.
- Make sure that multiplier is used
- Create a new project with an actual land date of 2035
- Make sure the multiplier being used is that of the year 2030

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
