### PR TITLE
Make admin site CSV validation logic reusable

### DIFF
--- a/datahub/company/admin/contact.py
+++ b/datahub/company/admin/contact.py
@@ -13,7 +13,7 @@ from django.core.validators import FileExtensionValidator
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
-from django.utils.translation import gettext
+from django.utils.translation import gettext_lazy
 from reversion.admin import VersionAdmin
 
 from datahub.company.models import Contact
@@ -27,12 +27,12 @@ logger = getLogger(__name__)
 class LoadEmailMarketingOptOutsForm(forms.Form):
     """Form used for loading a CSV file to opt out contacts from email marketing."""
 
-    HEADER_DECODE_ERROR_MESSAGE = gettext('There was an error decoding the file contents.')
-    BODY_DECODE_ERROR_MESSAGE = gettext(
+    HEADER_DECODE_ERROR_MESSAGE = gettext_lazy('There was an error decoding the file contents.')
+    BODY_DECODE_ERROR_MESSAGE = gettext_lazy(
         'There was an error decoding the text in the file provided. No records have been '
         'modified.',
     )
-    NO_EMAIL_COLUMN_MESSAGE = gettext('This file does not contain an email column.')
+    NO_EMAIL_COLUMN_MESSAGE = gettext_lazy('This file does not contain an email column.')
 
     email_list = forms.FileField(
         label='Email list (CSV file)',

--- a/datahub/core/admin_csv_import.py
+++ b/datahub/core/admin_csv_import.py
@@ -1,0 +1,84 @@
+import csv
+import io
+
+from chardet import UniversalDetector
+from django import forms
+from django.core.exceptions import ValidationError
+from django.core.validators import FileExtensionValidator
+from django.utils.translation import gettext_lazy
+
+
+class BaseCSVImportForm(forms.Form):
+    """Form used for loading a CSV file in the admin site."""
+
+    UNICODE_DECODE_ERROR_MESSAGE = gettext_lazy('There was an error decoding the file contents.')
+    MISSING_COLUMNS_MESSAGE = gettext_lazy(
+        'This file is missing the following required columns: {missing_columns}.',
+    )
+
+    csv_file_field_label = 'CSV file'
+    required_columns = set()
+
+    csv_file = forms.FileField(
+        validators=[FileExtensionValidator(allowed_extensions=('csv',))],
+    )
+
+    def __init__(self, *args, **kwargs):
+        """Initialises the form, dynamically setting the label of the csv_file field."""
+        super().__init__(*args, **kwargs)
+        self.fields['csv_file'].label = self.csv_file_field_label
+
+    def clean_csv_file(self):
+        """Validates the uploaded CSV file and creates a CSV DictReader from it."""
+        # This could be an instance of InMemoryUploadedFile or TemporaryUploadedFile
+        # (depending on the file size)
+        file_field = self.cleaned_data['csv_file']
+
+        # Guess the file encoding (primarily to check for a UTF-8 BOM)
+        encoding_detector = UniversalDetector()
+        for chunk in file_field.chunks():
+            encoding_detector.feed(chunk)
+            if encoding_detector.done:
+                break
+
+        detection_result = encoding_detector.close()
+        encoding = detection_result['encoding']
+
+        # Check that the file can actually be decoded using the detected encoding so that
+        # we don't need to worry about encoding errors when reading the CSV
+        file_field.seek(0)
+        self._validate_encoding(file_field, encoding)
+
+        file_field.seek(0)
+        csv_reader = csv.DictReader(io.TextIOWrapper(file_field, encoding=encoding))
+
+        # Check that the CSV file has the required column
+        self._validate_columns(csv_reader)
+
+        return csv_reader
+
+    @classmethod
+    def _validate_encoding(cls, file_field, encoding):
+        try:
+            stream = io.TextIOWrapper(file_field, encoding=encoding)
+            for _ in stream:
+                pass
+
+            # Detach the file from TextIOWrapper; this stops it being automatically closed
+            stream.detach()
+        except UnicodeError as exc:
+            raise ValidationError(
+                cls.UNICODE_DECODE_ERROR_MESSAGE,
+                code='unicode-decode-error',
+            ) from exc
+
+    @classmethod
+    def _validate_columns(cls, csv_reader):
+        missing_columns = sorted(cls.required_columns - set(csv_reader.fieldnames))
+
+        if missing_columns:
+            msg = cls.MISSING_COLUMNS_MESSAGE.format(
+                missing_columns=', '.join(missing_columns),
+            )
+
+            raise ValidationError(msg, code='missing-columns')

--- a/datahub/core/test/test_admin_csv_import.py
+++ b/datahub/core/test/test_admin_csv_import.py
@@ -1,0 +1,91 @@
+from codecs import BOM_UTF8
+from os.path import splitext
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from datahub.core.admin_csv_import import BaseCSVImportForm
+
+
+class ExampleCSVImportForm(BaseCSVImportForm):
+    """Subclass of BaseCSVImportForm to use in tests."""
+
+    required_columns = {'data'}
+    csv_file_field_label = 'Data'
+
+
+class TestBaseCSVImportForm:
+    """Tests BaseCSVImportForm."""
+
+    def test_csv_file_field_label_is_set(self):
+        """Test that the label of the csv_file field is correctly set."""
+        form = ExampleCSVImportForm()
+        assert form.fields['csv_file'].label == form.csv_file_field_label
+
+    def test_valid_file_is_loaded(self):
+        """Test that the form validates with a valid file and reads its data."""
+        csv_contents = """data\r
+row1\r
+row2\r
+"""
+        file = SimpleUploadedFile('test.csv', csv_contents.encode('utf-8'))
+        form = ExampleCSVImportForm(
+            {},
+            {'csv_file': file},
+        )
+
+        assert form.is_valid()
+        assert list(form.cleaned_data['csv_file']) == [
+            {'data': 'row1'},
+            {'data': 'row2'},
+        ]
+
+    @pytest.mark.parametrize('filename', ('noext', 'file.blah', 'test.test', 'test.csv.docx'))
+    def test_does_not_allow_invalid_file_extensions(self, filename):
+        """Test that the form rejects various invalid file extensions."""
+        file = SimpleUploadedFile(filename, b'test')
+        form = ExampleCSVImportForm(
+            {},
+            {'csv_file': file},
+        )
+
+        _, ext = splitext(filename)
+
+        assert 'csv_file' in form.errors
+        assert form.errors['csv_file'] == [
+            f"File extension '{ext[1:]}' is not allowed. Allowed extensions are: 'csv'.",
+        ]
+
+    def test_does_not_allow_file_without_required_column(self):
+        """Test that the form rejects a CSV file that doesn't contain a 'data' column."""
+        file = SimpleUploadedFile('test.csv', b'test\r\nrow')
+        form = ExampleCSVImportForm(
+            {},
+            {'csv_file': file},
+        )
+
+        assert 'csv_file' in form.errors
+        assert form.errors['csv_file'] == [
+            'This file is missing the following required columns: data.',
+        ]
+
+    @pytest.mark.parametrize(
+        'file_contents',
+        (
+            b'test\xc3\x28\r\nrow',
+            b"""email\r
+test1@datahub\r
+\xc3\x28
+""",
+        ),
+    )
+    def test_does_not_allow_files_with_invalid_utf8(self, file_contents):
+        """Test that the form rejects a CSV file with invalid UTF-8."""
+        file = SimpleUploadedFile('test.csv', BOM_UTF8 + file_contents)
+        form = ExampleCSVImportForm(
+            {},
+            {'csv_file': file},
+        )
+
+        assert 'csv_file' in form.errors
+        assert form.errors['csv_file'] == ['There was an error decoding the file contents.']


### PR DESCRIPTION
### Description of change

This moves the CSV validation logic that was being used in the admin site for loading marketing opt-outs into a separate class so that it can be reused for similar functionality elsewhere in the admin site.

This is being done in advance of another tool being added into the admin site for loading interactions from a CSV file.

This is just a refactor, so I haven't added a news fragment.

I would suggest looking at each commit individually.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
