### PR TITLE
Add lgtm configuration file

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,7 @@
+extraction:
+  python:
+    python_setup:
+      version: 3
+      requirements_files:
+        - requirements.txt
+      setup_py: false


### PR DESCRIPTION
### Description of change

This should make [lgtm](https://lgtm.com/projects/g/uktrade/data-hub-leeloo/overview/) use Python 3 instead of Python 2.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
