### PR TITLE
Exclude matches with already allocated duns_numbers in D&B cleanse command

### DIFF
--- a/changelog/cleanse-cmd-ignore-existing-duns-numbers.internal.rst
+++ b/changelog/cleanse-cmd-ignore-existing-duns-numbers.internal.rst
@@ -1,0 +1,1 @@
+The ``cleanse_companies_using_worldbase_match`` command now ignores matches for duns numbers already used in Data Hub as there can be only one Data Hub company record with a given duns number.

--- a/datahub/dnb_match/test/test_cleanse_companies_using_worldbase_match.py
+++ b/datahub/dnb_match/test/test_cleanse_companies_using_worldbase_match.py
@@ -236,6 +236,41 @@ TEST_DATA = [
             'archived_reason': ARCHIVED_REASON_DISSOLVED,
         },
     },
+
+    # Should be ignored as a Data Hub company with 'duns_number == '000000007'
+    # already exists in the database
+    {
+        'company': {
+            'id': uuid.UUID('00000000-0000-0000-0000-000000000007'),
+            'duns_number': None,
+        },
+        'dnbmatchingresult_data': {
+            'dnb_match': {
+                'duns_number': '000000007',
+            },
+            'wb_record': {
+                'DUNS Number': '000000007',
+                'Business Name': 'WB Corp 3',
+                'Secondary Name': '',
+                'Employees Total': '0',
+                'Employees Total Indicator': EmployeesIndicator.NOT_AVAILABLE.value,
+                'Employees Here': '0',
+                'Employees Here Indicator': EmployeesIndicator.NOT_AVAILABLE.value,
+                'Annual Sales in US dollars': '0',
+                'Annual Sales Indicator': TurnoverIndicator.NOT_AVAILABLE.value,
+                'Street Address': '',
+                'Street Address 2': '',
+                'City Name': '',
+                'State/Province Name': '',
+                'Country Code': '785',
+                'Postal Code for Street Address': '',
+                'National Identification Number': '',
+                'National Identification System Code': '',
+                'Out of Business indicator': OutOfBusinessIndicator.OUT_OF_BUSINESS.value,
+            },
+        },
+        'expected_fields': {},
+    },
 ]
 
 
@@ -265,6 +300,8 @@ def test_run(caplog, monkeypatch, simulate):
         OrderFactory(company=company)
 
         DnBMatchingResultFactory(company=company, data=test_data_item['dnbmatchingresult_data'])
+
+    CompanyFactory(duns_number='000000007')
 
     call_command('cleanse_companies_using_worldbase_match', simulate=simulate)
 


### PR DESCRIPTION
### Description of change

**Before**: the command did not take into account matches that had a duns number which had already been used in another Data Hub record.

**After**: the command is now excluding duns numbers that have already been allocated to Data Hub Company records.

This is because there's a unique constraint on `Company.duns_number`.

It was not a massive problem as the logic would have handled the error but this way is more elegant as those cases are ignored.

Thanks to @marcuspp for spotting this problem.

### How to test

Set up the data
```python
from django.utils.crypto import get_random_string
from datahub.company.test.factories import CompanyFactory
from datahub.dnb_match.utils import (
    EmployeesIndicator,
    NATIONAL_ID_SYSTEM_CODE_UK,
    OutOfBusinessIndicator,
    TurnoverIndicator,
)

duns_number = get_random_string(9, allowed_chars='0123456789')

company = CompanyFactory(duns_number=duns_number)
company = Company.objects.filter(
    duns_number__isnull=True, 
    dnbmatchingresult__isnull=True, 
    archived=False,
).first()

DnBMatchingResult.objects.create(
    company=company,
    data={
        'dnb_match': {
            'name': 'WB Corp',
            'country': 'ENGLAND',
            'duns_number': duns_number,
            'global_ultimate_name': '',
            'global_ultimate_country': '',
            'global_ultimate_duns_number': ''
        },
        'wb_record': {
            'DUNS Number': duns_number,
            'Business Name': 'WB Corp',
            'Secondary Name': 'Known as...',
            'Employees Total': '11',
            'Employees Total Indicator': EmployeesIndicator.ESTIMATED.value,
            'Employees Here': '0',
            'Employees Here Indicator': EmployeesIndicator.ESTIMATED.value,
            'Annual Sales in US dollars': '100',
            'Annual Sales Indicator': TurnoverIndicator.ESTIMATED.value,
            'Street Address': '1',
            'Street Address 2': 'Main Street',
            'City Name': 'London',
            'State/Province Name': 'Camden',
            'Country Code': '785',
            'Postal Code for Street Address': 'SW1A 1AA',
            'National Identification Number': '12345678',
            'National Identification System Code': str(NATIONAL_ID_SYSTEM_CODE_UK),
            'Out of Business indicator': OutOfBusinessIndicator.NOT_OUT_OF_BUSINESS.value,
        },
        'matched_by': 'data-science'
    }
)
```

Run the command
```
./manage.py cleanse_companies_using_worldbase_match
```

You should see 0 failures as this match is ignored



### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
