### PR TITLE
Add select file page of import interactions admin tool

### DIFF
--- a/changelog/interaction/import-select-file.feature.rst
+++ b/changelog/interaction/import-select-file.feature.rst
@@ -1,0 +1,2 @@
+The first page of admin site tool for importing interactions was added, allowing a CSV file to be selected.
+This feature is currently behind the ``admin-interaction-csv-importer`` feature flag as it is incomplete.

--- a/datahub/core/admin.py
+++ b/datahub/core/admin.py
@@ -171,6 +171,24 @@ class RawIdWidget(forms.TextInput):
         return str(obj), url
 
 
+def custom_view_permission(permission_codename):
+    """
+    Decorator that allows a custom view permission to be used with ModelAdmin subclasses.
+
+    Usage example::
+
+        @admin.register(InvestmentProject)
+        @custom_view_permission('view_all_investmentproject')
+        class InvestmentProjectAdmin(admin.ModelAdmin):
+            pass
+    """
+    def decorator(admin_cls):
+        admin_cls.has_view_permission = _make_admin_permission_getter(permission_codename)
+        return admin_cls
+
+    return decorator
+
+
 def custom_add_permission(permission_codename):
     """
     Decorator that allows a custom add permission to be used with ModelAdmin subclasses.

--- a/datahub/core/test/test_admin.py
+++ b/datahub/core/test/test_admin.py
@@ -8,6 +8,7 @@ from datahub.core.admin import (
     custom_add_permission,
     custom_change_permission,
     custom_delete_permission,
+    custom_view_permission,
     get_change_link,
     get_change_url,
     RawIdWidget,
@@ -97,6 +98,22 @@ class TestRawIdWidget:
                 'value': value,
             },
         }
+
+
+def test_custom_view_permission():
+    """Tests that the decorator correctly overrides has_view_permission()."""
+    @custom_view_permission('custom_permission')
+    class Admin:
+        opts = Mock(app_label='admin')
+
+        def has_view_permission(self, request, obj=None):
+            return False
+
+    request = Mock()
+    admin = Admin()
+    admin.has_view_permission(request)
+
+    request.user.has_perm.assert_called_once_with('admin.custom_permission')
 
 
 def test_add_change_permission():

--- a/datahub/core/test/test_admin_csv_import.py
+++ b/datahub/core/test/test_admin_csv_import.py
@@ -22,13 +22,14 @@ class TestBaseCSVImportForm:
         form = ExampleCSVImportForm()
         assert form.fields['csv_file'].label == form.csv_file_field_label
 
-    def test_valid_file_is_loaded(self):
+    @pytest.mark.parametrize('encoding', ('windows-1252', 'utf-8', 'utf-8-sig'))
+    def test_valid_file_is_loaded(self, encoding):
         """Test that the form validates with a valid file and reads its data."""
         csv_contents = """data\r
-row1\r
-row2\r
+row1à\r
+row2é\r
 """
-        file = SimpleUploadedFile('test.csv', csv_contents.encode('utf-8'))
+        file = SimpleUploadedFile('test.csv', csv_contents.encode(encoding))
         form = ExampleCSVImportForm(
             {},
             {'csv_file': file},
@@ -36,8 +37,8 @@ row2\r
 
         assert form.is_valid()
         assert list(form.cleaned_data['csv_file']) == [
-            {'data': 'row1'},
-            {'data': 'row2'},
+            {'data': 'row1à'},
+            {'data': 'row2é'},
         ]
 
     @pytest.mark.parametrize('filename', ('noext', 'file.blah', 'test.test', 'test.csv.docx'))

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -2,7 +2,12 @@ from django.contrib import admin
 from django.db.transaction import atomic
 from reversion.admin import VersionAdmin
 
-from datahub.core.admin import BaseModelAdminMixin, custom_add_permission, custom_change_permission
+from datahub.core.admin import (
+    BaseModelAdminMixin,
+    custom_add_permission,
+    custom_change_permission,
+    custom_view_permission,
+)
 from datahub.core.utils import join_truthy_strings
 from datahub.interaction.models import (
     CommunicationChannel,
@@ -62,6 +67,7 @@ class InteractionDITParticipantInline(admin.TabularInline):
 @admin.register(Interaction)
 @custom_add_permission(InteractionPermission.add_all)
 @custom_change_permission(InteractionPermission.change_all)
+@custom_view_permission(InteractionPermission.view_all)
 class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
     """Interaction admin."""
 

--- a/datahub/interaction/admin_csv_import.py
+++ b/datahub/interaction/admin_csv_import.py
@@ -1,0 +1,79 @@
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import path, reverse
+
+from datahub.core.admin_csv_import import BaseCSVImportForm
+from datahub.feature_flag.utils import feature_flagged_view
+
+
+INTERACTION_IMPORTER_FEATURE_FLAG_NAME = 'admin-interaction-csv-importer'
+
+
+class InteractionCSVForm(BaseCSVImportForm):
+    """Form used for loading a CSV file to import interactions."""
+
+    csv_file_field_label = 'Interaction list (CSV file)'
+    required_columns = {
+        'kind',
+        'date',
+        'service',
+        'contact_email',
+        'adviser_1',
+    }
+
+
+class InteractionCSVImportAdmin:
+    """
+    Views related to importing interactions from a CSV file.
+
+    The implementation is not yet complete; hence, views are behind a feature flag.
+    """
+
+    def __init__(self, model_admin):
+        """Initialises the instance with a reference to an InteractionAdmin instance."""
+        self.model_admin = model_admin
+
+    def get_urls(self):
+        """Gets a list of routes that should be registered."""
+        model_meta = self.model_admin.model._meta
+        admin_site = self.model_admin.admin_site
+
+        return [
+            path(
+                'import',
+                admin_site.admin_view(self.select_file),
+                name=f'{model_meta.app_label}_{model_meta.model_name}_import',
+            ),
+        ]
+
+    @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
+    def select_file(self, request, *args, **kwargs):
+        """View containing a form to select a CSV file to import."""
+        if not self.model_admin.has_change_permission(request):
+            raise PermissionDenied
+
+        if request.method != 'POST':
+            return self._select_file_form_response(request, InteractionCSVForm())
+
+        form = InteractionCSVForm(request.POST, request.FILES)
+        if not form.is_valid():
+            return self._select_file_form_response(request, form)
+
+        # Next page not yet implemented; redirect to the change list for now
+        changelist_route_name = admin_urlname(self.model_admin.model._meta, 'changelist')
+        changelist_url = reverse(changelist_route_name)
+        return HttpResponseRedirect(changelist_url)
+
+    def _select_file_form_response(self, request, form):
+        template_name = 'admin/interaction/interaction/import_select_file.html'
+        title = 'Import interactions'
+
+        context = {
+            **self.model_admin.admin_site.each_context(request),
+            'opts': self.model_admin.model._meta,
+            'title': title,
+            'form': form,
+        }
+        return TemplateResponse(request, template_name, context)

--- a/datahub/interaction/templates/admin/interaction/interaction/change_list_object_tools.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/change_list_object_tools.html
@@ -1,0 +1,12 @@
+{% extends "admin/change_list_object_tools.html" %}
+
+{% block object-tools-items %}
+  {% if has_change_permission and csv_import_feature_flag %}
+    <li>
+      <a href="{% url 'admin:interaction_interaction_import' %}">
+        Import interactions
+      </a>
+    </li>
+  {% endif %}
+  {{block.super}}
+{% endblock %}

--- a/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
@@ -1,0 +1,131 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media }}
+{% endblock %}
+
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+  <p>{% trans 'Select a CSV file to import interactions into Data Hub. The CSV file should contain the following columns (in any order):' %}</p>
+
+  {% trans "Yes" as yes %}
+  {% trans "No" as no %}
+
+  <table>
+    <tr>
+      <th>{% trans 'Column name' %}</th>
+      <th>{% trans 'Required' %}</th>
+      <th>{% trans 'Description' %}</th>
+    </tr>
+    <tr>
+      <td><code>{% trans 'kind' %}</code></td>
+      <td>{{ yes }}</td>
+      <td>{% trans '<code>interaction</code> or <code>service_delivery</code>' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'date' %}</code></td>
+      <td>{{ yes }}</td>
+      <td>{% trans 'The date of the interaction in DD/MM/YYYY or YYYY-MM-DD format' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'service' %}</code></td>
+      <td>{{ yes }}</td>
+      <td>{% trans 'The name of the service of the interaction e.g. <code>Account Management</code>' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'contact_email' %}</code></td>
+      <td>{{ yes }}</td>
+      <td>{% trans 'The email address of the contact the interaction was with' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'adviser_1' %}</code></td>
+      <td>{{ yes }}</td>
+      <td>{% trans 'The full name of a DIT adviser' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'team_1' %}</code></td>
+      <td>{{ no }}</td>
+      <td>{% trans 'The team that <code>adviser_1</code> belongs to' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'adviser_2' %}</code></td>
+      <td>{{ no }}</td>
+      <td>{% trans 'The full name of an additional DIT adviser' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'team_2' %}</code></td>
+      <td>{{ no }}</td>
+      <td>{% trans 'The team that <code>adviser_2</code> belongs to' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'communication_channel' %}</code></td>
+      <td>{% trans 'For interactions only' %}</td>
+      <td>{% trans 'The name of the communication channel e.g. <code>Email/Website</code>. Ignored for service deliveries' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'event_id' %}</code></td>
+      <td>{{ no }}</td>
+      <td>{% trans 'The ID of an event associated with a service delivery e.g. <code>aa819ab9-9f4e-4c99-8a30-d89a32957951</code>. Invalid for interactions' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'subject' %}</code></td>
+      <td>{{ no }}</td>
+      <td>{% trans 'The subject of the interaction. Defaults to the service name if not provided' %}</td>
+    </tr>
+    <tr>
+      <td><code>{% trans 'notes' %}</code></td>
+      <td>{{ no }}</td>
+      <td>{% trans 'Notes about the interaction' %}</td>
+    </tr>
+  </table>
+
+  <br>
+
+  <p>
+    {% blocktrans %}
+      Interactions are matched to a contact by looking for a unique match on all contacts' primary email addresses.
+      If no match is found, alternative email addresses are then checked.
+    {% endblocktrans %}
+  </p>
+  <p>
+    {% trans 'The interaction will not be loaded if multiple matches are found at either stage of matching.' %}
+  </p>
+  <p>
+    {% trans 'You will have a chance to review the records that will be loaded on the next page.' %}
+  </p>
+
+  <form action="" method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+
+    {% for field in form %}
+      <div class="fieldWrapper">
+        {{ field.errors }}
+        {{ field.label_tag }} {{ field }}
+        {% if field.help_text %}
+        <p class="help">{{ field.help_text|safe }}</p>
+        {% endif %}
+      </div>
+    {% endfor %}
+
+    <div>
+      <input type="submit" value="{% trans 'Submit' %}">
+    </div>
+  </form>
+{% endblock %}

--- a/datahub/interaction/test/views/test_admin_csv_import.py
+++ b/datahub/interaction/test/views/test_admin_csv_import.py
@@ -1,0 +1,181 @@
+import io
+
+import pytest
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.test import Client
+from django.urls import reverse
+from rest_framework import status
+
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.interaction.admin_csv_import import INTERACTION_IMPORTER_FEATURE_FLAG_NAME
+from datahub.interaction.models import Interaction, InteractionPermission
+
+
+@pytest.fixture()
+def interaction_importer_feature_flag():
+    """Creates the import interactions tool feature flag."""
+    yield FeatureFlagFactory(code=INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
+
+
+import_interactions_url = reverse(
+    admin_urlname(Interaction._meta, 'import'),
+)
+interaction_change_list_url = reverse(
+    admin_urlname(Interaction._meta, 'changelist'),
+)
+
+
+class TestInteractionAdminChangeList(AdminTestMixin):
+    """Tests for the contact admin change list."""
+
+    def test_load_import_link_exists(self, interaction_importer_feature_flag):
+        """
+        Test that there is a link to import interactions on the interaction change list page.
+        """
+        response = self.client.get(interaction_change_list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        assert import_interactions_url in response.rendered_content
+
+    def test_import_link_does_not_exist_if_only_has_view_permission(self):
+        """
+        Test that there is not a link to import interactions if the user only has the delete
+        (but not change) permission for interactions.
+        """
+        user = create_test_user(
+            permission_codenames=(InteractionPermission.view_all,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+
+        client = self.create_client(user=user)
+        response = client.get(interaction_change_list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        assert f'Select {Interaction._meta.verbose_name} to view' in response.rendered_content
+        assert import_interactions_url not in response.rendered_content
+
+    def test_import_link_does_not_exist_if_feature_flag_inactive(self):
+        """
+        Test that there is not a link to import interactions if the feature flag is inactive.
+        """
+        response = self.client.get(interaction_change_list_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        assert import_interactions_url not in response.rendered_content
+
+
+class TestImportInteractionsSelectFileView(AdminTestMixin):
+    """Tests for the import interaction select file form."""
+
+    def test_redirects_to_login_page_if_not_logged_in(self, interaction_importer_feature_flag):
+        """Test that the view redirects to the login page if the user isn't authenticated."""
+        client = Client()
+        response = client.get(import_interactions_url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(
+            import_interactions_url,
+        )
+
+    def test_redirects_to_login_page_if_not_staff(self, interaction_importer_feature_flag):
+        """Test that the view redirects to the login page if the user isn't a member of staff."""
+        user = create_test_user(is_staff=False, password=self.PASSWORD)
+
+        client = self.create_client(user=user)
+        response = client.get(import_interactions_url, follow=True)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == self.login_url_with_redirect(
+            import_interactions_url,
+        )
+
+    def test_permission_denied_if_staff_and_without_change_permission(
+        self,
+        interaction_importer_feature_flag,
+    ):
+        """
+        Test that the view returns a 403 response if the staff user does not have the
+        change interaction permission.
+        """
+        user = create_test_user(
+            permission_codenames=(InteractionPermission.view_all,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+
+        client = self.create_client(user=user)
+        response = client.get(import_interactions_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_displays_page_if_with_correct_permissions(self, interaction_importer_feature_flag):
+        """
+        Test that the view returns displays the form if the feature flag is active
+        and the user has the correct permissions.
+        """
+        response = self.client.get(import_interactions_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert 'form' in response.context
+
+    def test_does_not_allow_file_without_correct_columns(
+        self,
+        interaction_importer_feature_flag,
+    ):
+        """Test that the form rejects a CSV file that doesn't have the required columns."""
+        file = io.BytesIO(b'test\r\nrow')
+        file.name = 'test.csv'
+
+        response = self.client.post(
+            import_interactions_url,
+            data={
+                'csv_file': file,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        form = response.context['form']
+
+        assert 'csv_file' in form.errors
+        assert form.errors['csv_file'] == [
+            'This file is missing the following required columns: '
+            'adviser_1, contact_email, date, kind, service.',
+        ]
+
+    def test_redirects_on_valid_file(self, interaction_importer_feature_flag):
+        """
+        Test that accepts_dit_email_marketing is updated for the contacts specified in the CSV
+        file.
+        """
+        filename = 'filea.csv'
+        file = io.BytesIO("""kind,date,adviser_1,contact_email,service\r
+interaction,01/01/2018,John Dreary,person@company,Account Management
+""".encode(encoding='utf-8'))
+        file.name = filename
+
+        response = self.client.post(
+            import_interactions_url,
+            follow=True,
+            data={
+                'csv_file': file,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.redirect_chain) == 1
+        assert response.redirect_chain[0][0] == interaction_change_list_url
+
+    @pytest.mark.parametrize('http_method', ('get', 'post'))
+    def test_returns_404_if_feature_flag_inactive(self, http_method):
+        """Test that the a 404 is returned if the feature flag is inactive."""
+        response = self.client.generic(
+            http_method,
+            import_interactions_url,
+            data={},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
### Description of change

This adds the first page of the import interactions admin tool (with preliminary content). As the feature is incomplete, the feature is behind a feature flag.

A link to the new page is displayed on the interaction change list in the admin site if the feature flag is active.

For now, submitting a valid file simply redirects back to the change list page.

When complete, the feature will also:

- validate the rows in the CSV file, displaying errors back to the user
- display a preview of what will be imported if the file validates
- match interactions to contacts using email addresses
- return unmatched interactions to the user (either displayed or a download)

The reason for this feature is so that we can load interactions to Data Hub from partners that do not have direct access to Data Hub. Each file will be fairly small (a few hundred interactions).

I would recommend looking at each commit separately (note: I reordered the commits, but GitHub is still displaying them in the original order).

### Screenshots

#### Import interactions link

![image](https://user-images.githubusercontent.com/12693549/56048631-d20e8300-5d3f-11e9-8b65-e0dc84229cff.png)

#### Select file page

![image](https://user-images.githubusercontent.com/12693549/56048682-ec486100-5d3f-11e9-9819-41eb7cc92678.png)

#### Form error

![image](https://user-images.githubusercontent.com/12693549/56048753-0bdf8980-5d40-11e9-8b25-0972e2f9789d.png)

### To test

#### Importing a file

1. Create the `admin-interaction-csv-importer` feature flag and set it as active
2. Create a CSV file with the following columns: `kind`, `date`, `service`, `contact_email`, `adviser_1` (for a valid file, use different columns for an invalid file)
3. Navigate to the interaction change list page in the admin site
4. Click on the 'Import interaction' link
5. Select your CSV file
6. Submit the form
7. If the file is valid, you should be redirected to the change list page. Otherwise, an error should be displayed above the form field.

#### Feature hidden if feature flag not active

1. Delete or deactivate the `admin-interaction-csv-importer` feature flag if it exists
2. Navigate to the interaction change list page in the admin site
3. The 'Import interactions' link should not be present

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
