### PR TITLE
Convert None values for address fields to empty strings in company API v3

### DIFF
--- a/changelog/company/convert_None_to_blank.api.rst
+++ b/changelog/company/convert_None_to_blank.api.rst
@@ -1,0 +1,1 @@
+``POST /v3/company`` and ``PATCH /v3/company/<uuid:pk>``: None values for address CharFields are now internally converted to empty strings as Django recommends: https://docs.djangoproject.com/en/2.1/ref/models/fields/#null


### PR DESCRIPTION
### Description of change

**Before**: Using None values in POST/PATCH company v3 API would set the model fields to None.

**After**: None values are now converted to empty strings so that we can make them NOT NULL in the future.

### How to test

`POST /v3/company` using
```json
{
    "business_type": "98d14e94-5d95-e211-a939-e4115bead28a",
    "name": "Acme",
    "registered_address_1": "75 Stramford Road",
    "registered_address_2": null,
    "registered_address_country": "80756b9a-5d95-e211-a939-e4115bead28a",
    "registered_address_county": null,
    "registered_address_postcode": null,
    "registered_address_town": "London",
    "sector": "73535406-6095-e211-a939-e4115bead28a",
    "trading_address_1": null,
    "trading_address_2": null,
    "trading_address_country": null,
    "trading_address_county": null,
    "trading_address_postcode": null,
    "trading_address_town": null,
    "uk_region": "8a4cd12a-6095-e211-a939-e4115bead28a"
}
```

The following response fields should get converted to `''`
```
    'registered_address_2',
    'registered_address_county',
    'registered_address_postcode',
    'trading_address_1',
    'trading_address_2',
    'trading_address_town',
    'trading_address_county',
     'trading_address_postcode',
```


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
