### PR TITLE
Add file size limit to interaction admin CSV import

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `GUNICORN_WORKER_CLASS`  | No | [Type of Gunicorn worker.](http://docs.gunicorn.org/en/stable/settings.html#worker-class) Uses async workers via gevent by default. |
 | `GUNICORN_WORKER_CONNECTIONS`  | No | Maximum no. of connections for async workers (default=10). |
 | `HAWK_RECEIVER_IP_WHITELIST` | No | IP addresses (comma-separated) that can access the Hawk-authenticated endpoints. |
+| `INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE` | No | Maximum file size in bytes for interaction admin CSV uploads (default=2MB). |
 | `INVESTMENT_DOCUMENT_AWS_ACCESS_KEY_ID` | No | Same use as AWS_ACCESS_KEY_ID, but for investment project documents. |
 | `INVESTMENT_DOCUMENT_AWS_SECRET_ACCESS_KEY` | No | Same use as AWS_SECRET_ACCESS_KEY, but for investment project documents. |
 | `INVESTMENT_DOCUMENT_AWS_REGION` | No | Same use as AWS_DEFAULT_REGION, but for investment project documents. |

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -398,6 +398,13 @@ MI_FDI_DASHBOARD_COUNTRY_URL_PARAMS = (
     ('investor_company_country', ''),
 )
 
+# ADMIN CSV IMPORT
+
+INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE = env.int(
+    'INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE',
+    default=2 * 1024 * 1024,  # 2MB
+)
+
 # FRONTEND
 DATAHUB_FRONTEND_BASE_URL = env('DATAHUB_FRONTEND_BASE_URL', default='http://localhost:3000')
 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -43,6 +43,8 @@ OMIS_NOTIFICATION_API_KEY = ''
 
 GOVUK_PAY_URL = 'https://payments.example.com/'
 
+INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE = 1024
+
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache'

--- a/datahub/core/admin_csv_import.py
+++ b/datahub/core/admin_csv_import.py
@@ -17,6 +17,7 @@ class BaseCSVImportForm(forms.Form):
     )
 
     csv_file_field_label = 'CSV file'
+    csv_file_field_help_text = None
     required_columns = set()
 
     csv_file = forms.FileField(
@@ -27,6 +28,7 @@ class BaseCSVImportForm(forms.Form):
         """Initialises the form, dynamically setting the label of the csv_file field."""
         super().__init__(*args, **kwargs)
         self.fields['csv_file'].label = self.csv_file_field_label
+        self.fields['csv_file'].help_text = self.csv_file_field_help_text
 
     def clean_csv_file(self):
         """Validates the uploaded CSV file and creates a CSV DictReader from it."""

--- a/datahub/core/test/support/urls.py
+++ b/datahub/core/test/support/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from datahub.core.test.support.views import (
     HawkViewWithoutScope,
     HawkViewWithScope,
+    max_upload_size_view,
     MultiAddressModelViewset,
     MyDisableableModelViewset,
 )
@@ -40,5 +41,10 @@ urlpatterns = [
         'test-hawk-with-scope/',
         HawkViewWithScope.as_view(),
         name='test-hawk-with-scope',
+    ),
+    path(
+        'test-max-upload-size/',
+        max_upload_size_view,
+        name='test-max-upload-size',
     ),
 ]

--- a/datahub/core/test/support/views.py
+++ b/datahub/core/test/support/views.py
@@ -1,8 +1,10 @@
+from django.template.response import TemplateResponse
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from config.settings.types import HawkScope
+from datahub.core.admin import max_upload_size
 from datahub.core.hawk_receiver import (
     HawkAuthentication,
     HawkResponseSigningMixin,
@@ -16,6 +18,9 @@ from datahub.core.test.support.serializers import (
 )
 from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.test.scopes import TestScope
+
+
+MAX_UPLOAD_SIZE = 50
 
 
 class MyDisableableModelViewset(CoreViewSet):
@@ -64,3 +69,11 @@ class HawkViewWithScope(HawkResponseSigningMixin, APIView):
     def get(self, request):
         """Simple test view with fixed response."""
         return Response({'content': 'hawk-test-view-with-scope'})
+
+
+@max_upload_size(MAX_UPLOAD_SIZE)
+def max_upload_size_view(request):
+    """View for testing upload file size limiting."""
+    # Force files to be processed
+    request.FILES
+    return TemplateResponse(request, 'empty.html')


### PR DESCRIPTION
### Description of change

This adds a file size limit to the interaction CSV import tool. This is because we only need to process small files and aren't set up to handle large files.

The check is done in a file upload handler to stop large temp files from being written (which could cause us to run out of disk space – if it is done in the form it is too late).

If the limit is hit, an error message is displayed at the top of the page using the messages framework.

I haven't added a news fragment for this as the feature is still behind a feature flag.

### Screenshots

#### Limit displayed as help text

![image](https://user-images.githubusercontent.com/12693549/56222653-5294f280-6064-11e9-9d8e-312f56e0238a.png)

#### Error message

![image](https://user-images.githubusercontent.com/12693549/56222720-6dfffd80-6064-11e9-905c-c236890f4c0a.png)

### To test

1. Navigate to http://localhost:8000/admin/interaction/interaction/import
2. Try to upload a file bigger than 2 MB. You should see an error message
3. Try to upload a file smaller than 2 MB. There should be no error message

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
