### PR TITLE
Make NestedRelatedField accept model instances

### DIFF
--- a/datahub/core/serializers.py
+++ b/datahub/core/serializers.py
@@ -67,6 +67,7 @@ class NestedRelatedField(serializers.RelatedField):
         'does_not_exist': 'Invalid pk "{pk_value}" - object does not exist.',
         'incorrect_type': 'Incorrect type. Expected object, received {'
                           'data_type}.',
+        'unsaved_object': 'Model instances must be saved.',
     }
 
     def __init__(self, model, extra_fields=('name',), **kwargs):
@@ -98,6 +99,11 @@ class NestedRelatedField(serializers.RelatedField):
 
     def to_internal_value(self, data):
         """Converts a user-provided value to a model instance."""
+        if isinstance(data, self._model):
+            if data._state.adding:
+                self.fail('unsaved_object')
+            return data
+
         try:
             if isinstance(data, str):
                 id_repr = data


### PR DESCRIPTION
### Description of change

This makes NestedRelatedField accept model instances. In general, DRF serialiser fields accept internal values, so this helps maintain consistency with other fields.

The reason for the change is that I may use the serialiser to create interactions as part of the interaction import tool (to avoid duplicating any logic e.g. DIT participant creation and defaults).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
