### PR TITLE
Simplify docker working copy startup to one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
 3.  Build and run the necessary containers for the required environment:
 
     ```shell
-    docker-compose up -d
+    docker-compose up
     ```
 
     * It will take time for the leeloo API container to come up - it will run

--- a/README.md
+++ b/README.md
@@ -29,22 +29,16 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
 3.  Build and run the necessary containers for the required environment:
 
     ```shell
-    docker-compose build
+    docker-compose up -d
     ```
 
-4.  Populate the database and initialise Elasticsearch:
-
-    ```shell
-    docker-compose run leeloo ./manage.py migrate
-    docker-compose run leeloo ./manage.py init_es
-    docker-compose run leeloo ./manage.py loadinitialmetadata
-    docker-compose run leeloo ./manage.py createinitialrevisions
-    ```
-
+    * It will take time for the leeloo API container to come up - it will run
+      migrations on both DBs, load initial data, sync elasticsearch etc. Watch
+      along in the api container's logs.
     * **NOTE:** 
-      If you are using a linux system, these commands may hang on 
-      waiting for the elasticsearch container to come up (`data-hub-leeloo_es_1`) - 
-      it might be perpetually restarting.
+      If you are using a linux system, the  elasticsearch container may not 
+      come up successfully (`data-hub-leeloo_es_1`) - it might be perpetually 
+      restarting.
       If the logs for that container mention something like 
       `max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`,
       you will need to run the following on your host machine:
@@ -62,26 +56,7 @@ Leeloo uses Docker compose to setup and run all the necessary components. The do
 
       For more information, [see the elasticsearch docs on vm.max_map_count](https://www.elastic.co/guide/en/elasticsearch/reference/6.6/vm-max-map-count.html).
 
-5. Optionally, you can load some test data and update elasticsearch:
-
-    ```shell
-    docker-compose run leeloo ./manage.py loaddata /app/fixtures/test_data.yaml
-    docker-compose run leeloo ./manage.py sync_es
-    ```
-
-6.  Create a superuser:
-
-    ```shell
-    docker-compose run leeloo ./manage.py createsuperuser
-    ```
-
-7.  Run the services:
-
-    ```shell
-    docker-compose up
-    ```
-
-8.  Optionally, you may want to run a local copy of the data hub frontend. 
+4.  Optionally, you may want to run a local copy of the data hub frontend. 
     By default, you can run both leeloo and the frontend under one docker-compose
     project.  [See the instructions in the frontend readme to set it up](https://github.com/uktrade/data-hub-frontend/#setting-up-with-docker-compose).
 

--- a/datahub/core/management/commands/createsuperuserwithpassword.py
+++ b/datahub/core/management/commands/createsuperuserwithpassword.py
@@ -22,12 +22,12 @@ class Command(BaseCommand):
         parser.add_argument(
             'username',
             type=str,
-            help='The superuser\'s username',
+            help="The superuser's username",
         )
         parser.add_argument(
             'password',
             type=str,
-            help='The superuser\'s password',
+            help="The superuser's password",
         )
 
     def handle(self, *args, **options):

--- a/datahub/core/management/commands/createsuperuserwithpassword.py
+++ b/datahub/core/management/commands/createsuperuserwithpassword.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, CommandError
+from django.db import IntegrityError
 
 User = get_user_model()
 
@@ -35,5 +36,8 @@ class Command(BaseCommand):
         """
         username = options['username']
         password = options['password']
-        user = User.objects.create_superuser(username, password)
-        self.stdout.write(self.style.SUCCESS(f'Successfully created user "{user.id}"'))
+        try:
+            user = User.objects.create_superuser(username, password)
+        except IntegrityError:
+            raise CommandError(f'User with username "{username}" already exists')
+        self.stdout.write(self.style.SUCCESS(f'Successfully created user #{user.id}'))

--- a/datahub/core/management/commands/createsuperuserwithpassword.py
+++ b/datahub/core/management/commands/createsuperuserwithpassword.py
@@ -1,0 +1,39 @@
+from django.contrib.auth import get_user_model
+from django.core.management import BaseCommand
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Create a superuser with a password.
+    """
+
+    help = (
+        'Create a superuser with a password - the standard createsuperuser command '
+        'is interactive, so password cannot be supplied on the CLI'
+    )
+
+    def add_arguments(self, parser):
+        """
+        Adds additional command arguments.
+        """
+        parser.add_argument(
+            'username',
+            type=str,
+            help='The superuser\'s username',
+        )
+        parser.add_argument(
+            'password',
+            type=str,
+            help='The superuser\'s password',
+        )
+
+    def handle(self, *args, **options):
+        """
+        Handle invocation of the command.
+        """
+        username = options['username']
+        password = options['password']
+        user = User.objects.create_superuser(username, password)
+        self.stdout.write(self.style.SUCCESS(f'Successfully created user "{user.id}"'))

--- a/datahub/core/test/management/commands/test_createsuperuserwithpassword.py
+++ b/datahub/core/test/management/commands/test_createsuperuserwithpassword.py
@@ -1,0 +1,38 @@
+from io import StringIO
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core.management import call_command
+from django.core.management import CommandError
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestCreatesuperuserwithpassword:
+    """
+    Test createsuperuserwithpassword django management command.
+    """
+
+    def test_command_successful(self):
+        """
+        Test that calling the command gives an expected message when successful.
+        """
+        out = StringIO()
+        username = 'test-user'
+        call_command('createsuperuserwithpassword', username, 'foobar', stdout=out)
+        assert 'Successfully created user' in out.getvalue()
+        user = User.objects.get(email=username)
+        assert user.is_superuser
+
+    def test_command_failure(self):
+        """
+        Test that calling the command gives an expected message when unsuccessful.
+        """
+        username = 'test-user'
+        # Create superuser initially
+        call_command('createsuperuserwithpassword', username, 'foobar')
+        out = StringIO()
+        # Assert that second call fails as expected
+        with pytest.raises(CommandError):
+            call_command('createsuperuserwithpassword', username, 'foobar', stdout=out)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       context: .
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -wait tcp://leeloo:8000 -timeout 120s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -wait tcp://leeloo:8000 -timeout 180s
     env_file: .env
     command: watchmedo auto-restart -d . -R -p '*.py' -- celery worker -A config -l info -Q celery -B
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       context: .
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 120s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -wait tcp://leeloo:8000 -timeout 120s
     env_file: .env
     command: watchmedo auto-restart -d . -R -p '*.py' -- celery worker -A config -l info -Q celery -B
 

--- a/sample.env
+++ b/sample.env
@@ -29,3 +29,6 @@ DIT_EMAIL_DOMAINS=trade.gov.uk,digital.trade.gov.uk
 # Determines the docker-compose project - by default, containers with the same
 # project name share a network and are able to communicate with eachother
 COMPOSE_PROJECT_NAME=data-hub
+# Some extra ENV variables to make superuser creation easier on docker copies
+#SUPERUSER_USERNAME=brendan.smith
+#SUPERUSER_PASSWORD=foobarbaz

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,19 @@
 python /app/manage.py migrate --noinput
 python /app/manage.py migrate --database mi --noinput
 python /app/manage.py init_es
+# Load initial metadata - ignore errors as we may have already loaded it in to
+# this DB
+python /app/manage.py loadinitialmetadata || true
+# Load initial revisions - ignore errors as we may have already loaded it in to
+# this DB
+python /app/manage.py createinitialrevisions || true
+python /app/manage.py loaddata /app/fixtures/test_data.yaml
+python /app/manage.py sync_es
 python /app/manage.py collectstatic --noinput
+# Create superuser - ignore errors as we may have already loaded it in to
+# this DB
+echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('$SUPERUSER_USERNAME', '$SUPERUSER_PASSWORD')" | python manage.py shell || true
+
 # Run runserver in a while loop as the whole docker container will otherwise die
 # when there is bad syntax
 while true; do 

--- a/start.sh
+++ b/start.sh
@@ -7,9 +7,9 @@ python /app/manage.py init_es
 python /app/manage.py loadinitialmetadata || true
 # Load initial revisions - ignore errors as we may have already loaded it in to
 # this DB
-python /app/manage.py createinitialrevisions || true
 python /app/manage.py loaddata /app/fixtures/test_ch_data.yaml || true
 python /app/manage.py loaddata /app/fixtures/test_data.yaml || true
+python /app/manage.py createinitialrevisions
 python /app/manage.py collectstatic --noinput
 # Create superuser - ignore errors as we may have already loaded it in to
 # this DB.

--- a/start.sh
+++ b/start.sh
@@ -8,8 +8,8 @@ python /app/manage.py loadinitialmetadata || true
 # Load initial revisions - ignore errors as we may have already loaded it in to
 # this DB
 python /app/manage.py createinitialrevisions || true
+python /app/manage.py loaddata /app/fixtures/test_ch_data.yaml
 python /app/manage.py loaddata /app/fixtures/test_data.yaml
-python /app/manage.py sync_es
 python /app/manage.py collectstatic --noinput
 # Create superuser - ignore errors as we may have already loaded it in to
 # this DB.
@@ -17,7 +17,9 @@ if [[ -n "${SUPERUSER_USERNAME}" && -n "${SUPERUSER_PASSWORD}" ]]; then
     # Unfortunately, we have to be a bit hacky here as the standard 
     # django createsuperuser command does not allow password to be specified
     # programmatically
-    echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('$SUPERUSER_USERNAME', '$SUPERUSER_PASSWORD')" | python manage.py shell || true
+    echo "from django.contrib.auth import get_user_model 
+User = get_user_model()
+User.objects.create_superuser('$SUPERUSER_USERNAME', '$SUPERUSER_PASSWORD')" | python manage.py shell || true
 fi
 
 # Run runserver in a while loop as the whole docker container will otherwise die

--- a/start.sh
+++ b/start.sh
@@ -14,12 +14,7 @@ python /app/manage.py collectstatic --noinput
 # Create superuser - ignore errors as we may have already loaded it in to
 # this DB.
 if [[ -n "${SUPERUSER_USERNAME}" && -n "${SUPERUSER_PASSWORD}" ]]; then 
-    # Unfortunately, we have to be a bit hacky here as the standard 
-    # django createsuperuser command does not allow password to be specified
-    # programmatically
-    echo "from django.contrib.auth import get_user_model 
-User = get_user_model()
-User.objects.create_superuser('$SUPERUSER_USERNAME', '$SUPERUSER_PASSWORD')" | python manage.py shell || true
+    python manage.py createsuperuserwithpassword $SUPERUSER_USERNAME $SUPERUSER_PASSWORD || true
 fi
 
 # Run runserver in a while loop as the whole docker container will otherwise die

--- a/start.sh
+++ b/start.sh
@@ -8,8 +8,8 @@ python /app/manage.py loadinitialmetadata || true
 # Load initial revisions - ignore errors as we may have already loaded it in to
 # this DB
 python /app/manage.py createinitialrevisions || true
-python /app/manage.py loaddata /app/fixtures/test_ch_data.yaml
-python /app/manage.py loaddata /app/fixtures/test_data.yaml
+python /app/manage.py loaddata /app/fixtures/test_ch_data.yaml || true
+python /app/manage.py loaddata /app/fixtures/test_data.yaml || true
 python /app/manage.py collectstatic --noinput
 # Create superuser - ignore errors as we may have already loaded it in to
 # this DB.

--- a/start.sh
+++ b/start.sh
@@ -12,8 +12,13 @@ python /app/manage.py loaddata /app/fixtures/test_data.yaml
 python /app/manage.py sync_es
 python /app/manage.py collectstatic --noinput
 # Create superuser - ignore errors as we may have already loaded it in to
-# this DB
-echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('$SUPERUSER_USERNAME', '$SUPERUSER_PASSWORD')" | python manage.py shell || true
+# this DB.
+if [[ -n "${SUPERUSER_USERNAME}" && -n "${SUPERUSER_PASSWORD}" ]]; then 
+    # Unfortunately, we have to be a bit hacky here as the standard 
+    # django createsuperuser command does not allow password to be specified
+    # programmatically
+    echo "from django.contrib.auth import get_user_model; User = get_user_model(); User.objects.create_superuser('$SUPERUSER_USERNAME', '$SUPERUSER_PASSWORD')" | python manage.py shell || true
+fi
 
 # Run runserver in a while loop as the whole docker container will otherwise die
 # when there is bad syntax


### PR DESCRIPTION
### Description of change

Running through a stack of commands from the README each time my docker-compose project was brought up was getting tedious.

I've made the `Dockerfile` run these commands instead (and silenced any failures if the DB is already in a loaded state).  The Dockerfile also creates a superuser for you if you have `SUPERUSER_USERNAME` and `SUPERUSER_PASSWORD` environment variables set.  This reduces the docker readme from 8 steps to 4 and gets us to a point where there is only one meaningful command needed to bring up a working docker-compose project for the API.

### Points of note

- Restarts of a running development container are slower - as there are more things to run through to ensure that the working copy has a workable data set.
- The automatic superuser creation is a bit hacky, but I thought that some hardcoded python was preferable to making/adding a dependency for a whole extra django command.  Especially since this is something we only want to run for local docker copies.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
