### PR TITLE
Add company matching API.

### DIFF
--- a/changelog/company/dnb-matching-api.api.rst
+++ b/changelog/company/dnb-matching-api.api.rst
@@ -1,0 +1,124 @@
+New API endpoints were added to aid matching Data Hub companies with D&B companies:
+
+All endpoints return a response body with the following format::
+
+    {
+        "result": {
+            ...
+        },
+        "candidates": [
+            { ... },
+            { ... }
+        ],
+        "company": {
+            "id": "81756b9a-5d95-e211-a939-e4115bead28a",
+            "name": 'My Corp',
+            "trading_names": ["trading name"]
+        }
+    }
+
+The value of ``result`` depends on the type of match.
+
+If a match was found and recorded::
+
+    {
+        "dnb_match": {
+            "duns_number": "111",
+            'name': 'NAME OF A COMPANY',
+            "country": {
+                "id": "81756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "United States"
+            },
+            "global_ultimate_duns_number": "112",
+            "global_ultimate_name": "NAME OF A GLOBAL COMPANY",
+            "global_ultimate_country": {
+                "id": "81756b9a-5d95-e211-a939-e4115bead28a",
+                "name": "United States"
+            },
+        },
+        "matched_by": "data-science"
+    },
+
+If ``matched_by`` contains ``adviser`` value, then additional ``adviser`` key will be added to the ``result`` response::
+
+    {
+        ...
+        "matched_by": "adviser",
+        "adviser": {
+            "id": "12777b9a-5d95-2241-a939-fa112be2d22a",
+            "first_name": "John",
+            "last_name": "Doe",
+            "name": "John Doe"
+        }
+    },
+
+If a match wasn't found because the company isn't listed or the adviser is not confident to make the match::
+
+    {
+        "no_match": {
+            "reason': "not_listed",  # or "not_confident"
+        },
+        "matched_by": "adviser",
+        "adviser": { ... }
+    },
+
+If a match wasn't found because there were multiple potential matches::
+
+    {
+        "no_match": {
+            "reason": "more_than_one",
+            "candidates": [  # list of duns numbers
+                "123456789",
+                "987654321"
+            ]
+        },
+        "matched_by": "adviser",
+        "adviser": { ... }
+    },
+
+If a match wasn't found because of other reasons::
+
+    {
+        "no_match": {
+            "reason": "other",
+            "description": "explanation..."
+        },
+        "matched_by": "adviser",
+        "adviser": { ... }
+    },
+
+The top level ``candidates`` is a list of objects with this format::
+
+    {
+        "duns_number": 12345,
+        "name": 'test name',
+        "global_ultimate_duns_number": 12345,
+        "global_ultimate_name": "test name global",
+        "global_ultimate_country": {
+            "id": "81756b9a-5d95-e211-a939-e4115bead28a",
+            "name": "United States"
+        },
+        "address_1": "1st LTD street",
+        "address_2": "",
+        "address_town": "London",
+        "address_postcode": "SW1A 1AA",
+        "address_country": {
+            "id": "81756b9a-5d95-e211-a939-e4115bead28a",
+            "name": "United States"
+        },
+        "confidence": 10,
+        "source": "cats"
+    }
+
+Endpoints:
+
+``GET /v4/dnb-match/<company_pk>`` returns the response above
+
+``POST /v4/dnb-match/<company_pk>/select-match`` accepts the ``duns_number`` of the candidate to be selected as a match from the list of candidates
+
+``POST /v4/dnb-match/<company_pk>/select-no-match`` accepts ``reason`` with value:
+
+- ``not_listed``: if none of the candidates is a good match
+- ``not_confident``: if the adviser is not confident to make the match
+- ``more_than_one``: if there are multiple potential matches. In this case an extra ``candidates`` field is required with the list of valid duns numbers.
+- ``other``: for other reasons. In this case an extra free text ``description`` field is required

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -8,6 +8,7 @@ from datahub.company import views as company_views
 from datahub.company.urls import ch_company as ch_company_urls
 from datahub.company.urls import company as company_urls
 from datahub.company.urls import contact as contact_urls
+from datahub.dnb_match import urls as dnb_match_urls
 from datahub.event import urls as event_urls
 from datahub.feature_flag import urls as feature_flag_urls
 from datahub.interaction import urls as interaction_urls
@@ -59,6 +60,7 @@ v3_urls = [
 v4_urls = [
     path('', include((ch_company_urls.urls_v4, 'ch-company'), namespace='ch-company')),
     path('', include((company_urls.urls_v4, 'company'), namespace='company')),
+    path('dnb-match/', include((dnb_match_urls, 'dnb_match'), namespace='dnb-match')),
     path('', include((search_urls.urls_v4, 'search'), namespace='search')),
     path(
         '',

--- a/datahub/dnb_match/constants.py
+++ b/datahub/dnb_match/constants.py
@@ -1,3 +1,5 @@
+from model_utils import Choices
+
 # Countries in the DnB Worldbase record are represented as numbers.
 # The mapping below can be used to determine the related iso_alpha2_code.
 # Not all countries have an iso_alpha2_code but this should not be a problem
@@ -268,3 +270,15 @@ DNB_COUNTRY_CODE_MAPPING = {
     '873': {'iso_alpha2_code': 'ZW', 'name': 'ZIMBABWE'},
     '000': {'iso_alpha2_code': None, 'name': 'Unknown'},
 }
+
+DNB_COUNTRY_MAPPING = {
+    entry['name']: entry['iso_alpha2_code']
+    for entry in DNB_COUNTRY_CODE_MAPPING.values()
+}
+
+NoMatchReason = Choices(
+    ('not_listed', 'The correct company is not listed, it is not possible to make a match'),
+    ('more_than_one', 'There is more than one company in the list that could be a match'),
+    ('not_confident', 'I am not confident to make the match'),
+    ('other', 'Other'),
+)

--- a/datahub/dnb_match/serializers.py
+++ b/datahub/dnb_match/serializers.py
@@ -1,0 +1,168 @@
+from django.utils.translation import gettext_lazy
+from rest_framework import serializers
+from rest_framework.settings import api_settings
+
+from datahub.dnb_match.constants import NoMatchReason
+from datahub.dnb_match.models import DnBMatchingResult
+from datahub.dnb_match.utils import _get_list_of_latest_match_candidates
+
+
+class SelectMatchingCandidateSerializer(serializers.Serializer):
+    """DRF serializer for company match candidate selection."""
+
+    duns_number = serializers.ChoiceField(choices=[])
+
+    def __init__(self, *args, **kwargs):
+        """Initialise the serializer with candidates data."""
+        super().__init__(*args, **kwargs)
+
+        company = self.context['company']
+
+        self.context['candidates'] = _get_list_of_latest_match_candidates(company.pk)
+        self.fields['duns_number'].choices = self._candidates_to_choices()
+
+    def save(self):
+        """Save matched candidate data into DnBMatchingResult."""
+        for candidate in self.context['candidates']:
+            if self.validated_data['duns_number'] == str(candidate.get('duns_number')):
+                data = self._candidate_to_result(
+                    candidate,
+                    self.context['request'].user,
+                )
+
+                DnBMatchingResult.objects.update_or_create(
+                    company=self.context['company'],
+                    defaults={
+                        'data': data,
+                    },
+                )
+
+    def _candidates_to_choices(self):
+        return [
+            (str(candidate['duns_number']), candidate['name'])
+            for candidate in self.context['candidates']
+        ]
+
+    @staticmethod
+    def _candidate_to_result(candidate, adviser):
+        """Transform matching candidate to matching result."""
+        fields = (
+            'duns_number',
+            'name',
+            'address_country',
+            'global_ultimate_duns_number',
+            'global_ultimate_name',
+            'global_ultimate_country',
+        )
+        remap_key = {
+            'address_country': 'country',
+        }
+        dnb_match = {
+            remap_key.get(key, key): value for key, value in candidate.items() if key in fields
+        }
+
+        return {
+            'dnb_match': dnb_match,
+            'matched_by': 'adviser',
+            'adviser': {
+                'id': adviser.id,
+                'first_name': adviser.first_name,
+                'last_name': adviser.last_name,
+                'name': adviser.name,
+            },
+        }
+
+
+class SelectNoMatchSerializer(serializers.Serializer):
+    """DRF serializer for no match candidate selection."""
+
+    default_error_messages = {
+        'list_of_candidates_required': gettext_lazy(
+            'List of candidates is required if the reason is "more_than_one".',
+        ),
+        'description_required': gettext_lazy(
+            'The "description" is required if the reason is "other".',
+        ),
+        'too_many_fields': gettext_lazy(
+            'If the reason is "not_listed" or "not_confident", other fields '
+            'should not need to be filled.',
+        ),
+    }
+
+    reason = serializers.ChoiceField(choices=NoMatchReason)
+
+    description = serializers.CharField(required=False)
+    candidates = serializers.ListField(child=serializers.CharField(), required=False)
+
+    def save(self):
+        """Save no match information to DnBMatchingResult."""
+        data = self._get_request_data_to_result(self.context['request'].user)
+
+        DnBMatchingResult.objects.update_or_create(
+            company=self.context['company'],
+            defaults={
+                'data': data,
+            },
+        )
+
+    def validate(self, data):
+        """Check if correct fields are filled in."""
+        self._check_reason_more_than_one(data)
+        self._check_reason_other(data)
+        self._check_reason_not_listed_or_not_confident(data)
+        return data
+
+    def _check_reason_more_than_one(self, data):
+        """Check if the reason "more_than_one" has a list of candidates."""
+        if data['reason'] == NoMatchReason.more_than_one and not data.get('candidates'):
+            error = {
+                'candidates': [
+                    self.error_messages['list_of_candidates_required'],
+                ],
+            }
+            raise serializers.ValidationError(error, code='list_of_candidates_required')
+
+    def _check_reason_other(self, data):
+        """Check if the reason "other" has a description."""
+        if data['reason'] == NoMatchReason.other and not data.get('description'):
+            error = {
+                'description': [
+                    self.error_messages['description_required'],
+                ],
+            }
+            raise serializers.ValidationError(error, code='description_required')
+
+    def _check_reason_not_listed_or_not_confident(self, data):
+        """Check if the reason "not_listed" or "not_confident" does not have other fields."""
+        reason_not_listed_or_not_confident = data['reason'] in (
+            NoMatchReason.not_listed, NoMatchReason.not_confident,
+        )
+        other_fields_than_reason = data.keys() != {'reason'}
+
+        if reason_not_listed_or_not_confident and other_fields_than_reason:
+            error = {
+                api_settings.NON_FIELD_ERRORS_KEY: [
+                    self.error_messages['too_many_fields'],
+                ],
+            }
+            raise serializers.ValidationError(error, code='too_many_fields')
+
+    def _get_request_data_to_result(self, adviser):
+        no_match = {
+            'reason': self.validated_data['reason'],
+        }
+        if self.validated_data['reason'] == NoMatchReason.more_than_one:
+            no_match['candidates'] = self.validated_data['candidates']
+        if self.validated_data['reason'] == NoMatchReason.other:
+            no_match['description'] = self.validated_data['description']
+
+        return {
+            'no_match': no_match,
+            'matched_by': 'adviser',
+            'adviser': {
+                'id': adviser.id,
+                'first_name': adviser.first_name,
+                'last_name': adviser.last_name,
+                'name': adviser.name,
+            },
+        }

--- a/datahub/dnb_match/test/factories.py
+++ b/datahub/dnb_match/test/factories.py
@@ -11,3 +11,16 @@ class DnBMatchingResultFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = 'dnb_match.DnBMatchingResult'
+
+
+class DnBMatchingCSVRecord(factory.django.DjangoModelFactory):
+    """DnBMatchingCSVRecord factory."""
+
+    company_id = factory.SelfAttribute('company.id')
+    company = factory.SubFactory(CompanyFactory)
+    batch_number = 1
+    data = {}
+
+    class Meta:
+        exclude = ('company',)
+        model = 'dnb_match.DnBMatchingCSVRecord'

--- a/datahub/dnb_match/test/test_views.py
+++ b/datahub/dnb_match/test/test_views.py
@@ -1,0 +1,458 @@
+"""Tests for matching information views."""
+
+from uuid import uuid4
+
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.test_utils import APITestMixin
+from datahub.core.test_utils import create_test_user
+from datahub.dnb_match.test.factories import DnBMatchingCSVRecord, DnBMatchingResultFactory
+from datahub.dnb_match.views import _replace_dnb_country_fields
+
+
+def _create_match_result_selected():
+    """Create match result test dictionary."""
+    return {
+        'dnb_match': {
+            'duns_number': '111',
+            'name': 'NAME OF A COMPANY',
+            'country': 'United Kingdom',
+            'global_ultimate_duns_number': '112',
+            'global_ultimate_name': 'NAME OF A GLOBAL COMPANY',
+            'global_ultimate_country': 'United Kingdom',
+        },
+        'matched_by': 'data-science',
+    }
+
+
+def _create_match_result_no_match(reason, description=None, candidates=None):
+    """Create no match result test dictionary."""
+    no_match = {
+        'reason': reason,
+    }
+    if description:
+        no_match['description'] = description
+    if candidates:
+        no_match['candidates'] = candidates
+
+    return {
+        'no_match': no_match,
+        'matched_by': 'adviser',
+    }
+
+
+class TestMatchingInformationView(APITestMixin):
+    """Tests for the matching information view."""
+
+    def test_access_is_denied_if_without_permissions(self):
+        """Test that a 403 is returned if the user has no permissions."""
+        company = CompanyFactory()
+        user = create_test_user(permission_codenames=[])
+        api_client = self.create_api_client(user=user)
+
+        url = reverse(
+            'api-v4:dnb-match:item',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+
+        response = api_client.get(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_cannot_get_match_information_of_company_that_doesnt_exist(self):
+        """Test that a 404 is returned if company doesn't exist."""
+        url = reverse(
+            'api-v4:dnb-match:item',
+            kwargs={
+                'company_pk': uuid4(),
+            },
+        )
+
+        response = self.api_client.get(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('result', (
+        _create_match_result_selected(),
+        _create_match_result_no_match('not_listed'),
+        _create_match_result_no_match('more_than_one', candidates=['111', '222', '333']),
+        _create_match_result_no_match('not_confident'),
+        _create_match_result_no_match('other', description='These candidates are out of place.'),
+    ))
+    def test_matching_information(self, result):
+        """Tests matching information endpoint."""
+        company = _create_company_with_matching_result_and_candidates(
+            result=result,
+            candidates=_get_match_candidates(),
+        )
+
+        url = reverse(
+            'api-v4:dnb-match:item',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert 'result' in response_data
+
+        expected_result = _replace_dnb_country_fields({'result': result})
+
+        assert response_data['result'] == expected_result['result']
+        assert 'candidates' in response_data
+        assert response_data['candidates'] == [
+            {
+                'duns_number': 12345,
+                'name': 'test name',
+                'global_ultimate_duns_number': 12345,
+                'global_ultimate_name': 'test name global',
+                'global_ultimate_country': {
+                    'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                    'name': 'United States',
+                },
+                'address_1': '1st LTD street',
+                'address_2': '',
+                'address_town': 'London',
+                'address_postcode': 'SW1A 1AA',
+                'address_country': {
+                    'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                    'name': 'United States',
+                },
+                'confidence': 10,
+                'source': 'cats',
+            },
+            {
+                'duns_number': 12346,
+                'name': 'test name',
+                'global_ultimate_duns_number': 12345,
+                'global_ultimate_name': 'test name global',
+                'global_ultimate_country': {
+                    'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                    'name': 'United States',
+                },
+                'address_1': '1st LTD street',
+                'address_2': '',
+                'address_town': 'London',
+                'address_postcode': 'SW1A 1AA',
+                'address_country': {
+                    'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                    'name': 'United States',
+                },
+                'confidence': 10,
+                'source': 'cats',
+            },
+        ]
+
+    def test_can_get_information_if_matching_records_dont_exist(self):
+        """
+        Tests that matching information endpoint returns information if corresponding matching
+        records don't exist.
+        """
+        company = CompanyFactory()
+        url = reverse(
+            'api-v4:dnb-match:item',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert 'result' in response_data
+        assert response_data['result'] == {}
+        assert 'candidates' in response_data
+        assert response_data['candidates'] == []
+
+
+class TestSelectMatchView(APITestMixin):
+    """Tests for the select a match view."""
+
+    def test_access_is_denied_if_without_permissions(self):
+        """Test that a 403 is returned if the user has no permissions."""
+        company = CompanyFactory()
+        user = create_test_user(permission_codenames=[])
+        api_client = self.create_api_client(user=user)
+
+        url = reverse(
+            'api-v4:dnb-match:select-match',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_cannot_match_company_that_doesnt_exist(self):
+        """Test that a 404 is returned if company doesn't exist."""
+        url = reverse(
+            'api-v4:dnb-match:select-match',
+            kwargs={
+                'company_pk': uuid4(),
+            },
+        )
+
+        response = self.api_client.post(url, {'duns_number': '12345'})
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_select_match(self):
+        """Tests if candidate can be selected."""
+        company = _create_company_with_matching_result_and_candidates(
+            candidates=_get_match_candidates(),
+        )
+
+        url = reverse(
+            'api-v4:dnb-match:select-match',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+
+        data = {
+            'duns_number': 12345,
+        }
+        response = self.api_client.post(url, data)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert 'result' in response_data
+        assert response_data['result'] == {
+            'dnb_match': {
+                'name': 'test name',
+                'duns_number': 12345,
+                'country': {
+                    'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                    'name': 'United States',
+                },
+                'global_ultimate_name': 'test name global',
+                'global_ultimate_country': {
+                    'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                    'name': 'United States',
+                },
+                'global_ultimate_duns_number': 12345,
+            },
+            'matched_by': 'adviser',
+            'adviser': {
+                'id': str(self.user.pk),
+                'first_name': self.user.first_name,
+                'last_name': self.user.last_name,
+                'name': self.user.name,
+            },
+        }
+
+    @pytest.mark.parametrize('body,expected', (
+        (
+            {},
+            {'duns_number': ['This field is required.']},
+        ),
+        (
+            {'nothing_to_declare': 'cats'},
+            {'duns_number': ['This field is required.']},
+        ),
+        (
+            {'duns_numbers': ['cats', 'tigers', 'manuls']},
+            {'duns_number': ['This field is required.']},
+        ),
+    ))
+    def test_cant_select_match_using_invalid_request(self, body, expected):
+        """Tests if candidate cannot be selected when sending invalid request."""
+        company = _create_company_with_matching_result_and_candidates(
+            candidates=_get_match_candidates(),
+        )
+
+        url = reverse(
+            'api-v4:dnb-match:select-match',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+        response = self.api_client.post(url, body)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected
+
+
+class TestSelectNoMatch(APITestMixin):
+    """Tests for select no match view."""
+
+    def test_access_is_denied_if_without_permissions(self):
+        """Test that a 403 is returned if the user has no permissions."""
+        company = CompanyFactory()
+        user = create_test_user(permission_codenames=[])
+        api_client = self.create_api_client(user=user)
+
+        url = reverse(
+            'api-v4:dnb-match:select-no-match',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_cannot_select_no_match_for_company_that_doesnt_exist(self):
+        """Test that a 404 is returned if company doesn't exist."""
+        url = reverse(
+            'api-v4:dnb-match:select-no-match',
+            kwargs={
+                'company_pk': uuid4(),
+            },
+        )
+
+        response = self.api_client.post(url, {'reason': 'not_listed'})
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.parametrize('body', (
+        _create_match_result_no_match('not_listed'),
+        _create_match_result_no_match('more_than_one', candidates=['111', '222', '333']),
+        _create_match_result_no_match('not_confident'),
+        _create_match_result_no_match('other', description='These candidates are out of place.'),
+    ))
+    def test_select_no_match(self, body):
+        """Tests if no match can be selected."""
+        company = _create_company_with_matching_result_and_candidates(
+            candidates=_get_match_candidates(),
+        )
+
+        url = reverse(
+            'api-v4:dnb-match:select-no-match',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+        response = self.api_client.post(url, body['no_match'])
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert 'result' in response_data
+        assert response_data['result'] == {
+            'no_match': body['no_match'],
+            'matched_by': 'adviser',
+            'adviser': {
+                'id': str(self.user.pk),
+                'first_name': self.user.first_name,
+                'last_name': self.user.last_name,
+                'name': self.user.name,
+            },
+        }
+
+    @pytest.mark.parametrize('body,expected', (
+        (
+            _create_match_result_no_match('what'), {'reason': ['"what" is not a valid choice.']},
+        ),
+        (
+            _create_match_result_no_match('No reason at all!'),
+            {'reason': ['"No reason at all!" is not a valid choice.']},
+        ),
+        (
+            {},
+            {'reason': ['This field is required.']},
+        ),
+        (
+            {'nothing_to_declare': 'cats'},
+            {'reason': ['This field is required.']},
+        ),
+        (
+            _create_match_result_no_match('more_than_one', candidates='123'),
+            {'candidates': ['Expected a list of items but got type "str".']},
+        ),
+        (
+            {'reason': 'other'},
+            {'description': ['The "description" is required if the reason is "other".']},
+        ),
+        (
+            {'reason': 'more_than_one'},
+            {'candidates': [
+                'List of candidates is required if the reason is "more_than_one".',
+            ]},
+        ),
+        (
+            {'reason': 'not_listed', 'candidates': ['111', '333']},
+            {'non_field_errors': [
+                'If the reason is "not_listed" or "not_confident", other fields should not '
+                'need to be filled.',
+            ]},
+        ),
+        (
+            {'reason': 'not_confident', 'description': 'is not confident?'},
+            {
+                'non_field_errors': [
+                    'If the reason is "not_listed" or "not_confident", other fields should not '
+                    'need to be filled.',
+                ],
+            },
+        ),
+    ))
+    def test_cant_select_no_match_with_invalid_request(self, body, expected):
+        """Tests if no match can be selected."""
+        company = _create_company_with_matching_result_and_candidates(
+            candidates=_get_match_candidates(),
+        )
+
+        url = reverse(
+            'api-v4:dnb-match:select-no-match',
+            kwargs={
+                'company_pk': company.pk,
+            },
+        )
+
+        response = self.api_client.post(url, body['no_match'] if 'no_match' in body else body)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected
+
+
+def _create_company_with_matching_result_and_candidates(result=None, candidates=None):
+    """Creates company with matching result and matching candidates."""
+    if not result:
+        result = {}
+    if not candidates:
+        candidates = {}
+
+    company = CompanyFactory()
+
+    DnBMatchingResultFactory(company=company, data=result)
+    DnBMatchingCSVRecord(company_id=company.pk, data=candidates)
+
+    return company
+
+
+def _get_match_candidates():
+    return [
+        {
+            'duns_number': 12345,
+            'name': 'test name',
+            'global_ultimate_duns_number': 12345,
+            'global_ultimate_name': 'test name global',
+            'global_ultimate_country': 'USA',
+            'address_1': '1st LTD street',
+            'address_2': '',
+            'address_town': 'London',
+            'address_postcode': 'SW1A 1AA',
+            'address_country': 'USA',
+            'confidence': 10,
+            'source': 'cats',
+        },
+        {
+            'duns_number': 12346,
+            'name': 'test name',
+            'global_ultimate_duns_number': 12345,
+            'global_ultimate_name': 'test name global',
+            'global_ultimate_country': 'USA',
+            'address_1': '1st LTD street',
+            'address_2': '',
+            'address_town': 'London',
+            'address_postcode': 'SW1A 1AA',
+            'address_country': {
+                'id': '81756b9a-5d95-e211-a939-e4115bead28a',
+                'name': 'United States',
+            },
+            'confidence': 10,
+            'source': 'cats',
+        },
+    ]

--- a/datahub/dnb_match/urls.py
+++ b/datahub/dnb_match/urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+
+from datahub.dnb_match.views import (
+    MatchingInformationAPIView,
+    SelectMatchAPIView,
+    SelectNoMatchAPIView,
+)
+
+urlpatterns = [
+    path('<uuid:company_pk>', MatchingInformationAPIView.as_view(), name='item'),
+    path('<uuid:company_pk>/select-match', SelectMatchAPIView.as_view(), name='select-match'),
+    path(
+        '<uuid:company_pk>/select-no-match',
+        SelectNoMatchAPIView.as_view(),
+        name='select-no-match',
+    ),
+]

--- a/datahub/dnb_match/views.py
+++ b/datahub/dnb_match/views.py
@@ -1,0 +1,121 @@
+from django.core.exceptions import ObjectDoesNotExist
+from django.forms.models import model_to_dict
+from rest_framework.generics import GenericAPIView
+from rest_framework.response import Response
+
+from datahub.company.models import Company
+from datahub.dnb_match.serializers import (
+    SelectMatchingCandidateSerializer,
+    SelectNoMatchSerializer,
+)
+from datahub.dnb_match.utils import (
+    _get_list_of_latest_match_candidates,
+    resolve_dnb_country_to_dh_country_dict,
+)
+from datahub.oauth.scopes import Scope
+
+
+class BaseMatchingInformationAPIView(GenericAPIView):
+    """Base matching information APIView."""
+
+    required_scopes = (Scope.internal_front_end,)
+
+    queryset = Company.objects.select_related('dnbmatchingresult')
+
+    lookup_url_kwarg = 'company_pk'
+
+    def _get_matching_information(self):
+        """Get matching candidates and current selection."""
+        company = self.get_object()
+        try:
+            matching_result = company.dnbmatchingresult.data
+        except ObjectDoesNotExist:
+            matching_result = {}
+
+        response = {
+            'result': self._get_dnb_match_result(matching_result),
+            'candidates': _get_list_of_latest_match_candidates(company.pk),
+            'company': model_to_dict(company, fields=('id', 'name', 'trading_names')),
+        }
+
+        normalised_response = _replace_dnb_country_fields(response)
+
+        return Response(data=normalised_response)
+
+    @staticmethod
+    def _get_dnb_match_result(data):
+        """Gets relevant information from DnBMatchingResult data."""
+        if not data:
+            data = {}
+
+        dnb_match_keys = ('dnb_match', 'no_match', 'matched_by', 'adviser')
+        return {key: value for key, value in data.items() if key in dnb_match_keys}
+
+
+class MatchingInformationAPIView(BaseMatchingInformationAPIView):
+    """APIView for company matching candidates information."""
+
+    def get(self, request, **kwargs):
+        """Get matching information."""
+        return self._get_matching_information()
+
+
+class SelectMatchAPIView(BaseMatchingInformationAPIView):
+    """APIView for selecting matching company."""
+
+    def post(self, request, **kwargs):
+        """Create match selection."""
+        company = self.get_object()
+
+        serializer = SelectMatchingCandidateSerializer(
+            data=request.data,
+            context={**self.get_serializer_context(), 'company': company},
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return self._get_matching_information()
+
+
+class SelectNoMatchAPIView(BaseMatchingInformationAPIView):
+    """APIView for selecting no match."""
+
+    def post(self, request, **kwargs):
+        """Create no match."""
+        company = self.get_object()
+
+        serializer = SelectNoMatchSerializer(
+            data=request.data,
+            context={**self.get_serializer_context(), 'company': company},
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return self._get_matching_information()
+
+
+def _replace_dnb_country_fields(data):
+    """Replace DnB country fields with Data Hub countries."""
+    for country_key in ('global_ultimate_country', 'country'):
+        try:
+            country = data['result']['dnb_match'][country_key]
+        except KeyError:
+            continue
+
+        if isinstance(country, str):
+            dh_country = resolve_dnb_country_to_dh_country_dict(
+                country,
+            )
+            data['result']['dnb_match'][country_key] = dh_country
+
+    if 'candidates' in data:
+        for candidate in data['candidates']:
+            for country_key in ('global_ultimate_country', 'address_country'):
+                country = candidate[country_key]
+                if isinstance(country, str):
+                    dh_country = resolve_dnb_country_to_dh_country_dict(
+                        country,
+                    )
+                    candidate[country_key] = dh_country
+
+    return data


### PR DESCRIPTION
### Description of change

This adds the API for manual company matching.

There are three endpoints available:
`GET /v4/dnb-match/<company_pk>`: gets information about the result of matching and available candidates. The result is stored in `DnBMatchingResult` table and the listed candidates come from `DnBMatchingCSVRecord` record of highest `batch_number`.

`POST /v4/dnb-match/<company_pk>/select-match`: updates the `DnBMatchingResult` with selected candidate data under `dnb_match` key. It accepts `duns_number` in the POST body.

`POST /v4/dnb-match/<company_pk>/select-no-match`: updates `DnBMatchingResult` with information about not being able to find a match under `no_match` key. 

Both POST endpoints also store the adviser information under `adviser` key and mark the information source as `adviser`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
