### PR TITLE
Increase timeout for acceptance test environment setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "8000:8000"
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 60s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 120s
     env_file: .env
     depends_on:
       - postgres
@@ -23,7 +23,7 @@ services:
       context: .
     volumes:
       - .:/app
-    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 60s
+    entrypoint: dockerize -wait tcp://postgres:5432 -wait tcp://mi-postgres:5432 -wait tcp://es:9200 -wait tcp://redis:6379 -timeout 120s
     env_file: .env
     command: watchmedo auto-restart -d . -R -p '*.py' -- celery worker -A config -l info -Q celery -B
 

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -3,7 +3,7 @@
 # on circleCI. For more information about how this is used please see
 # https://github.com/uktrade/data-hub-frontend#continuous-integration
 
-dockerize -wait ${POSTGRES_URL} -wait ${MI_POSTGRES_URL} -wait ${ES5_URL} -timeout 60s
+dockerize -wait ${POSTGRES_URL} -wait ${MI_POSTGRES_URL} -wait ${ES5_URL} -timeout 120s
 python /app/manage.py migrate
 python /app/manage.py migrate --database mi
 python /app/manage.py init_es


### PR DESCRIPTION
### Description of change

It appears that the dependencies take more than 60 seconds to start when running on MACs. Updated the timeout to wait for the dependencies to start to 120 seconds as it seems to reliably work. 

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [x] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
