### PR TITLE
Remove contact from interaction fixtures

### DIFF
--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -508,7 +508,6 @@
     subject: Provided alpha service
     date: '2017-06-01T00:00:00Z'
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     contacts:
       - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     service: 46cd2e66-dc21-e311-a78e-e4115bead28a
@@ -537,7 +536,6 @@
     subject: Discussed exports event
     date: '2017-06-03T00:00:00Z'
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     contacts:
       - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     service: 46cd2e66-dc21-e311-a78e-e4115bead28a
@@ -566,7 +564,6 @@
     subject: Provided beta service
     date: '2017-06-05T00:00:00Z'
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     contacts:
       - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     event: ~
@@ -599,7 +596,6 @@
     subject: Want to export to the USA
     date: '2018-04-06T00:00:00Z'
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     contacts:
       - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     event: ~
@@ -637,7 +633,6 @@
     subject: Exported to Canada
     date: '2018-06-06T00:00:00Z'
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     contacts:
       - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     event: ~
@@ -675,7 +670,6 @@
     subject: Attended gamma event
     date: '2017-09-05T00:00:00Z'
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 9b1138ab-ec7b-497f-b8c3-27fed21694ef
     contacts:
       - 9b1138ab-ec7b-497f-b8c3-27fed21694ef
     event: bda12a57-433c-4a0c-a7ce-5ebd080e09e8
@@ -709,7 +703,6 @@
     subject: TAP grant
     date: '2017-09-15T00:00:00Z'
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     contacts:
       - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     event: ~
@@ -1371,7 +1364,6 @@
     date: '2017-06-03T00:00:00Z'
     investment_project: 721e2a04-21c3-4172-a321-4368463a4b2d
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     contacts:
       - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     service: 46cd2e66-dc21-e311-a78e-e4115bead28a
@@ -1398,7 +1390,6 @@
     date: '2017-06-05T00:00:00Z'
     investment_project: 721e2a04-21c3-4172-a321-4368463a4b2d
     company: 0f5216e0-849f-11e6-ae22-56b6b6499611
-    contact: 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     contacts:
       - 952232d2-1d25-4c3a-bcac-2f3a30a94da9
     service: 46cd2e66-dc21-e311-a78e-e4115bead28a
@@ -1425,7 +1416,6 @@
     date: '2018-01-02T00:00:00Z'
     investment_project: ba1f0b14-5fe4-4c36-bf6a-ddf115272977
     company: b2c34b41-1d5a-4b4b-9249-7c53ff2868dd
-    contact: 7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b
     contacts:
       - 7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b
     service: 9484b82b-3499-e211-a939-e4115bead28a
@@ -1452,7 +1442,6 @@
     date: '2018-01-10T00:00:00Z'
     investment_project: ba1f0b14-5fe4-4c36-bf6a-ddf115272977
     company: b2c34b41-1d5a-4b4b-9249-7c53ff2868dd
-    contact: 7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b
     contacts:
       - 7d43f9a2-868f-4d85-8e5f-631e5a8c9a3b
     service: 9484b82b-3499-e211-a939-e4115bead28a
@@ -1479,7 +1468,6 @@
     date: '2018-01-05T00:00:00Z'
     investment_project: e32b3c33-80ac-4589-a8c4-dda305d726ba
     company: b2c34b41-1d5a-4b4b-9249-7c53ff2868dd
-    contact: 6791d583-7a52-418f-a0d3-d8d527f20d43
     contacts:
       - 6791d583-7a52-418f-a0d3-d8d527f20d43
     service: 0796b92b-3499-e211-a939-e4115bead28a
@@ -1506,7 +1494,6 @@
     date: '2018-01-02T00:00:00Z'
     investment_project: e32b3c33-80ac-4589-a8c4-dda305d726ba
     company: b2c34b41-1d5a-4b4b-9249-7c53ff2868dd
-    contact: 6791d583-7a52-418f-a0d3-d8d527f20d43
     contacts:
       - 6791d583-7a52-418f-a0d3-d8d527f20d43
     service: 0796b92b-3499-e211-a939-e4115bead28a


### PR DESCRIPTION
### Description of change

The `Interaction.contact` field has been removed from the model state so this updates `test_data.yaml` to not set that field.

### To test

Run `./manage.py loaddata test_data.yaml` (preferably with an empty database). There should be no errors.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
