### PR TITLE
Filter company autocomplete by country

### DIFF
--- a/changelog/company/company-autocomplete-filters.api.rst
+++ b/changelog/company/company-autocomplete-filters.api.rst
@@ -1,0 +1,3 @@
+The endpoint ``/v4/search/company/autocomplete`` has been updated to accept an optional parameter of ``country``.
+
+Company typeahead searches are now filterable by ``country`` the filter accepts a single or list of country ids.

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -33,3 +33,11 @@ class PublicSearchCompanyQuerySerializer(EntitySearchQuerySerializer):
 
     archived = serializers.BooleanField(required=False)
     name = serializers.CharField(required=False)
+
+
+class AutcompleteSearchCompanyQueryContextSerializer(serializers.Serializer):
+    """Serializer used for the additional context filters for company autocomplete search."""
+
+    country = SingleOrListField(
+        child=StringUUIDField(allow_null=False), required=False,
+    )

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -282,6 +282,9 @@ def test_mapping(setup_es):
                     'preserve_position_increments': True,
                     'preserve_separators': True,
                     'type': 'completion',
+                    'contexts': [
+                        {'name': 'country', 'type': 'CATEGORY'},
+                    ],
                 },
                 'trading_address_1': {'type': 'text'},
                 'trading_address_2': {'type': 'text'},

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -3,6 +3,7 @@ from collections import Counter
 import pytest
 
 from datahub.company.test.factories import CompanyFactory
+from datahub.core.constants import Country as CountryConstant
 from datahub.search.company.models import Company as ESCompany, get_suggestions
 
 pytestmark = pytest.mark.django_db
@@ -77,30 +78,41 @@ class TestCompanyElasticModel:
         assert len(list(result)) == len(companies)
 
     @pytest.mark.parametrize(
-        'name,trading_names,archived,expected_suggestions',
+        'name,trading_names,archived,registered_address_country,'
+        'expected_input_suggestions,expected_contexts',
         (
             (
                 'Hello Hello uk',
                 ['Good Hello us', 'fr'],
                 False,
+                CountryConstant.united_kingdom.value.id,
                 [
                     'Good', 'uk', 'Hello Hello uk',
                     'us', 'Good Hello us', 'fr', 'Hello',
+                ],
+                [
+                    CountryConstant.united_kingdom.value.id,
                 ],
             ),
             (
                 'Hello      gb',
                 [],
                 False,
+                CountryConstant.canada.value.id,
                 ['Hello', 'gb', 'Hello      gb'],
+                [
+                    CountryConstant.canada.value.id,
+                    CountryConstant.united_kingdom.value.id,
+                ],
             ),
             (
                 'Hello      gb',
                 [],
                 True,
+                CountryConstant.united_kingdom.value.id,
+                {},
                 [],
             ),
-
         ),
     )
     def test_company_get_suggestions(
@@ -108,15 +120,24 @@ class TestCompanyElasticModel:
         name,
         trading_names,
         archived,
-        expected_suggestions,
+        registered_address_country,
+        expected_input_suggestions,
+        expected_contexts,
     ):
         """Test get an autocomplete search suggestions for a company"""
         db_company = CompanyFactory(
             name=name,
             trading_names=trading_names,
             archived=archived,
+            registered_address_country_id=registered_address_country,
+            address_country_id=CountryConstant.united_kingdom.value.id,
         )
 
         result = get_suggestions(db_company)
+        if result:
+            assert Counter(result['input']) == Counter(expected_input_suggestions)
+            assert 'country' in result['contexts']
+            assert Counter(result['contexts']['country']) == Counter(expected_contexts)
 
-        assert Counter(result) == Counter(expected_suggestions)
+        else:
+            assert Counter(result) == Counter(expected_input_suggestions)

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -14,6 +14,7 @@ from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.oauth.scopes import Scope
 from datahub.search.company import CompanySearchApp
 from datahub.search.company.serializers import (
+    AutcompleteSearchCompanyQueryContextSerializer,
     PublicSearchCompanyQuerySerializer,
     SearchCompanyQuerySerializer,
 )
@@ -32,6 +33,7 @@ class SearchCompanyAPIViewMixin:
     required_scopes = (Scope.internal_front_end,)
     search_app = CompanySearchApp
     serializer_class = SearchCompanyQuerySerializer
+    autocomplete_context_serializer_class = AutcompleteSearchCompanyQueryContextSerializer
     es_sort_by_remappings = {
         'name': 'name.keyword',
     }

--- a/datahub/search/execute_query.py
+++ b/datahub/search/execute_query.py
@@ -9,13 +9,14 @@ from datahub.search.query_builder import build_autocomplete_query
 logger = getLogger(__name__)
 
 
-def execute_autocomplete_query(es_model, keyword_search, limit, fields_to_include):
+def execute_autocomplete_query(es_model, keyword_search, limit, fields_to_include, context):
     """Executes the query for autocomplete search returning all suggested documents."""
     autocomplete_search = build_autocomplete_query(
         es_model,
         keyword_search,
         limit,
         fields_to_include,
+        context,
     )
 
     results = autocomplete_search.execute()

--- a/datahub/search/query_builder.py
+++ b/datahub/search/query_builder.py
@@ -112,18 +112,32 @@ def get_search_by_entity_query(
     )
 
 
-def build_autocomplete_query(es_model, keyword_search, limit, fields_to_include):
-    """Builds the query for autocomplete search and applies source filtering."""
+def build_autocomplete_query(es_model, keyword_search, limit, fields_to_include, context):
+    """
+    Builds the query for autocomplete search and applies source filtering.
+
+    context  - if an autocomplete field supports completion contexts (filtering) then an optional
+    context dictionary of filters can be added to the completion search.
+    """
     index = es_model.get_read_alias()
     autocomplete_search = es_model.search(index=index)
     autocomplete_search = _apply_source_filtering_to_query(
         autocomplete_search,
         fields_to_include=fields_to_include,
     )
+
+    completion_dict = {
+        'field': 'suggest',
+        'size': limit,
+    }
+
+    if context:
+        completion_dict['context'] = context
+
     return autocomplete_search.suggest(
         'autocomplete',
         keyword_search,
-        completion={'field': 'suggest', 'size': limit},
+        completion=completion_dict,
     )
 
 

--- a/datahub/search/test/test_deletion.py
+++ b/datahub/search/test/test_deletion.py
@@ -141,6 +141,8 @@ def test_update_es_after_deletions(setup_es):
     Test that the context manager update_es_after_deletions collects and deletes
     all the django objects deleted.
     """
+    assert SimpleModel.objects.count() == 0
+
     obj = SimpleModel.objects.create()
     sync_object(SimpleModelSearchApp, str(obj.pk))
     setup_es.indices.refresh()

--- a/datahub/search/test/test_execute_query.py
+++ b/datahub/search/test/test_execute_query.py
@@ -19,6 +19,7 @@ class TestExecuteQueryBuilder:
                 'hello',
                 10,
                 ['id', 'name'],
+                {},
             )
         assert result == fake_result
         assert mock_es_execute.called

--- a/datahub/search/test/test_utils.py
+++ b/datahub/search/test/test_utils.py
@@ -1,6 +1,12 @@
+from collections import Counter
 from unittest.mock import Mock
 
-from datahub.search.utils import get_model_copy_to_target_field_names
+import pytest
+
+from datahub.search.utils import (
+    get_model_copy_to_target_field_names,
+    get_unique_values_and_exclude_nulls_from_list,
+)
 
 
 def test_get_model_copy_to_field_names(monkeypatch):
@@ -20,3 +26,25 @@ def test_get_model_copy_to_field_names(monkeypatch):
         'copy_to_list1',
         'copy_to_list2',
     }
+
+
+@pytest.mark.parametrize(
+    'data,expected_result',
+    (
+        (
+            [1], [1],
+        ),
+        (
+            [1, 1, 2, 1], [1, 2],
+        ),
+        (
+            [None, 1, 2, None, 2], [1, 2],
+        ),
+        (
+            [None], [],
+        ),
+    ),
+)
+def test_get_unique_values_and_exclude_nulls_from_list(data, expected_result):
+    """Test given a list of values filter unique and remove null values."""
+    assert Counter(get_unique_values_and_exclude_nulls_from_list(data)) == Counter(expected_result)

--- a/datahub/search/utils.py
+++ b/datahub/search/utils.py
@@ -60,3 +60,13 @@ def get_model_non_mapped_field_names(es_model):
 def serialise_mapping(mapping_dict):
     """Serialises a mapping as JSON."""
     return json.dumps(mapping_dict, sort_keys=True, separators=(',', ':')).encode('utf-8')
+
+
+def get_unique_values_and_exclude_nulls_from_list(data):
+    """
+    :param data: a list of values
+    :return: a list of none empty unique values
+    """
+    return list(
+        filter(None, set(data)),
+    )


### PR DESCRIPTION
### Description of change
For large capital profiles we would like to make it easier for the user to find the company they would like to set a profile up for using typeahead search To do this it was decided to filter the company typeahead by country (if provided).

### To Test
-  Rebuild your search index ( `./manage.py migrate_es` you may need to set `CELERY_TASK_ALWAYS_EAGER=True` in your local.py settings file.
- In your browser http://localhost:8000/v4/search/company/autocomplete?term=one&format=json
- You should see 2 companies returned
- Then add france to the search http://localhost:8000/v4/search/company/autocomplete?term=one&country=82756b9a-5d95-e211-a939-e4115bead28a&format=json
- You should see 1 company that is based in france

NB. The DRF Browseable view for company autocomplete seems to be broken (no longer has a queryset defined) on develop so format=json is required to test.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
