### PR TITLE
Refactor admin CSV import functionality slightly

### DIFF
--- a/datahub/company/admin/contact.py
+++ b/datahub/company/admin/contact.py
@@ -32,11 +32,17 @@ class LoadEmailMarketingOptOutsForm(BaseCSVImportForm):
         reversion.set_user(user)
         reversion.set_comment('Loaded bulk email opt-out list.')
 
+        with self.open_file_as_dict_reader() as dict_reader:
+            return self._save(dict_reader, user)
+
+    save.alters_data = True
+
+    def _save(self, dict_reader, user):
         num_contacts_matched = 0
         num_contacts_updated = 0
         num_non_matching_email_addresses = 0
 
-        for row in self.cleaned_data['csv_file']:
+        for row in dict_reader:
             email = row['email'].strip()
 
             if not email:
@@ -62,8 +68,6 @@ class LoadEmailMarketingOptOutsForm(BaseCSVImportForm):
             num_contacts_updated,
             num_non_matching_email_addresses,
         )
-
-    save.alters_data = True
 
 
 class _ProcessOptOutResult(NamedTuple):

--- a/datahub/core/test/test_admin_csv_import.py
+++ b/datahub/core/test/test_admin_csv_import.py
@@ -36,10 +36,11 @@ row2é\r
         )
 
         assert form.is_valid()
-        assert list(form.cleaned_data['csv_file']) == [
-            {'data': 'row1à'},
-            {'data': 'row2é'},
-        ]
+        with form.open_file_as_dict_reader() as dict_reader:
+            assert list(dict_reader) == [
+                {'data': 'row1à'},
+                {'data': 'row2é'},
+            ]
 
     @pytest.mark.parametrize('filename', ('noext', 'file.blah', 'test.test', 'test.csv.docx'))
     def test_does_not_allow_invalid_file_extensions(self, filename):

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -12,7 +12,7 @@ from datahub.core.admin import (
 )
 from datahub.core.utils import join_truthy_strings
 from datahub.feature_flag.utils import is_feature_flag_active
-from datahub.interaction.admin_csv_import import (
+from datahub.interaction.admin_csv_import.views import (
     INTERACTION_IMPORTER_FEATURE_FLAG_NAME,
     InteractionCSVImportAdmin,
 )

--- a/datahub/interaction/admin_csv_import/file_form.py
+++ b/datahub/interaction/admin_csv_import/file_form.py
@@ -1,0 +1,20 @@
+from django.conf import settings
+from django.template.defaultfilters import filesizeformat
+
+from datahub.core.admin_csv_import import BaseCSVImportForm
+
+
+class InteractionCSVForm(BaseCSVImportForm):
+    """Form used for loading a CSV file to import interactions."""
+
+    csv_file_field_label = 'Interaction list (CSV file)'
+    csv_file_field_help_text = (
+        f'Maximum file size: {filesizeformat(settings.INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE)}'
+    )
+    required_columns = {
+        'kind',
+        'date',
+        'service',
+        'contact_email',
+        'adviser_1',
+    }

--- a/datahub/interaction/admin_csv_import/views.py
+++ b/datahub/interaction/admin_csv_import/views.py
@@ -2,33 +2,15 @@ from django.conf import settings
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
-from django.template.defaultfilters import filesizeformat
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
 
 from datahub.core.admin import max_upload_size
-from datahub.core.admin_csv_import import BaseCSVImportForm
 from datahub.feature_flag.utils import feature_flagged_view
-
+from datahub.interaction.admin_csv_import.file_form import InteractionCSVForm
 
 INTERACTION_IMPORTER_FEATURE_FLAG_NAME = 'admin-interaction-csv-importer'
-
-
-class InteractionCSVForm(BaseCSVImportForm):
-    """Form used for loading a CSV file to import interactions."""
-
-    csv_file_field_label = 'Interaction list (CSV file)'
-    csv_file_field_help_text = (
-        f'Maximum file size: {filesizeformat(settings.INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE)}'
-    )
-    required_columns = {
-        'kind',
-        'date',
-        'service',
-        'contact_email',
-        'adviser_1',
-    }
 
 
 class InteractionCSVImportAdmin:

--- a/datahub/interaction/test/admin_csv_import/test_views.py
+++ b/datahub/interaction/test/admin_csv_import/test_views.py
@@ -10,7 +10,7 @@ from rest_framework import status
 
 from datahub.core.test_utils import AdminTestMixin, create_test_user
 from datahub.feature_flag.test.factories import FeatureFlagFactory
-from datahub.interaction.admin_csv_import import INTERACTION_IMPORTER_FEATURE_FLAG_NAME
+from datahub.interaction.admin_csv_import.views import INTERACTION_IMPORTER_FEATURE_FLAG_NAME
 from datahub.interaction.models import Interaction, InteractionPermission
 
 

--- a/datahub/interaction/test/views/test_admin_csv_import.py
+++ b/datahub/interaction/test/views/test_admin_csv_import.py
@@ -31,7 +31,8 @@ interaction_change_list_url = reverse(
 class TestInteractionAdminChangeList(AdminTestMixin):
     """Tests for the contact admin change list."""
 
-    def test_load_import_link_exists(self, interaction_importer_feature_flag):
+    @pytest.mark.usefixtures('interaction_importer_feature_flag')
+    def test_load_import_link_exists(self):
         """
         Test that there is a link to import interactions on the interaction change list page.
         """
@@ -71,7 +72,8 @@ class TestInteractionAdminChangeList(AdminTestMixin):
 class TestImportInteractionsSelectFileView(AdminTestMixin):
     """Tests for the import interaction select file form."""
 
-    def test_redirects_to_login_page_if_not_logged_in(self, interaction_importer_feature_flag):
+    @pytest.mark.usefixtures('interaction_importer_feature_flag')
+    def test_redirects_to_login_page_if_not_logged_in(self):
         """Test that the view redirects to the login page if the user isn't authenticated."""
         client = Client()
         response = client.get(import_interactions_url, follow=True)
@@ -82,7 +84,8 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
             import_interactions_url,
         )
 
-    def test_redirects_to_login_page_if_not_staff(self, interaction_importer_feature_flag):
+    @pytest.mark.usefixtures('interaction_importer_feature_flag')
+    def test_redirects_to_login_page_if_not_staff(self):
         """Test that the view redirects to the login page if the user isn't a member of staff."""
         user = create_test_user(is_staff=False, password=self.PASSWORD)
 
@@ -95,10 +98,8 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
             import_interactions_url,
         )
 
-    def test_permission_denied_if_staff_and_without_change_permission(
-        self,
-        interaction_importer_feature_flag,
-    ):
+    @pytest.mark.usefixtures('interaction_importer_feature_flag')
+    def test_permission_denied_if_staff_and_without_change_permission(self):
         """
         Test that the view returns a 403 response if the staff user does not have the
         change interaction permission.
@@ -113,7 +114,8 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
         response = client.get(import_interactions_url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_displays_page_if_with_correct_permissions(self, interaction_importer_feature_flag):
+    @pytest.mark.usefixtures('interaction_importer_feature_flag')
+    def test_displays_page_if_with_correct_permissions(self):
         """
         Test that the view returns displays the form if the feature flag is active
         and the user has the correct permissions.
@@ -123,10 +125,8 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert 'form' in response.context
 
-    def test_does_not_allow_file_without_correct_columns(
-        self,
-        interaction_importer_feature_flag,
-    ):
+    @pytest.mark.usefixtures('interaction_importer_feature_flag')
+    def test_does_not_allow_file_without_correct_columns(self):
         """Test that the form rejects a CSV file that doesn't have the required columns."""
         file = io.BytesIO(b'test\r\nrow')
         file.name = 'test.csv'
@@ -148,7 +148,8 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
             'adviser_1, contact_email, date, kind, service.',
         ]
 
-    def test_rejects_large_files(self, interaction_importer_feature_flag):
+    @pytest.mark.usefixtures('interaction_importer_feature_flag')
+    def test_rejects_large_files(self):
         """
         Test that large files are rejected.
 
@@ -173,11 +174,9 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
             'The file test.csv was too large. Files must be less than 1.0 KB.'
         )
 
-    def test_redirects_on_valid_file(self, interaction_importer_feature_flag):
-        """
-        Test that accepts_dit_email_marketing is updated for the contacts specified in the CSV
-        file.
-        """
+    @pytest.mark.usefixtures('interaction_importer_feature_flag')
+    def test_redirects_on_valid_file(self):
+        """Test that the user is redirected to the change list when a valid file is loaded."""
         filename = 'filea.csv'
         file = io.BytesIO("""kind,date,adviser_1,contact_email,service\r
 interaction,01/01/2018,John Dreary,person@company,Account Management


### PR DESCRIPTION
### Description of change

This refactors the admin CSV import functionality slightly:

* tidies up the tests slightly by using `pytest.mark.usefixtures` where appropriate
* refactors the fle-handling in `BaseCSVImportForm` slightly
* splits up `datahub.interaction.admin_csv_import` into a sub-package

### To test

You can test the 'Load email marketing opt-outs' functionality at http://localhost:8000/admin/company/contact/load-email-marketing-opt-outs.

You can also test the incomplete 'Import interactions' functionality at http://localhost:8000/admin/interaction/interaction/import (after creating the `admin-interaction-csv-importer` feature flag).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
