### PR TITLE
Remove Interaction.contact field from the database

### DIFF
--- a/changelog/interaction/contact-from-db.db.rst
+++ b/changelog/interaction/contact-from-db.db.rst
@@ -1,0 +1,1 @@
+The deprecated ``interaction_interaction.contact_id`` column was deleted from the database. Please use the ``interaction_interaction_contacts`` many-to-many table instead.

--- a/changelog/interaction/contact-from-db.removal.rst
+++ b/changelog/interaction/contact-from-db.removal.rst
@@ -1,0 +1,1 @@
+The deprecated ``interaction_interaction.contact_id`` column was deleted from the database. Please use the ``interaction_interaction_contacts`` many-to-many table instead.

--- a/datahub/interaction/migrations/0051_remove_contact_from_db.py
+++ b/datahub/interaction/migrations/0051_remove_contact_from_db.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('interaction', '0050_remove_contact_from_model_state'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name='interaction',
+                    name='contact',
+                    field=models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=models.deletion.CASCADE,
+                        related_name='+',
+                        to='company.Contact',
+                    ),
+                ),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='interaction',
+            name='contact',
+        ),
+    ]


### PR DESCRIPTION
### Description of change

This removes the deprecated `interaction_interaction.contact_id` column from the database in line with [the deprecation and removal process](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/How%20to%20deprecate%20a%20field.md).

This is the follow-up to https://github.com/uktrade/data-hub-leeloo/pull/1556.

The SQL run by the migration is:

```sql
BEGIN;
--
-- Custom state/database change combination
--
--
-- Remove field contact from interaction
--
SET CONSTRAINTS "interaction_interact_contact_id_1e9a4ff8_fk_company_c" IMMEDIATE; ALTER TABLE "interaction_interaction" DROP CONSTRAINT "interaction_interact_contact_id_1e9a4ff8_fk_company_c";
ALTER TABLE "interaction_interaction" DROP COLUMN "contact_id" CASCADE;
COMMIT;
```

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
