### PR TITLE
Correct various search sort-by values

### DIFF
--- a/datahub/search/contact/serializers.py
+++ b/datahub/search/contact/serializers.py
@@ -21,15 +21,17 @@ class SearchContactQuerySerializer(EntitySearchQuerySerializer):
     created_by = SingleOrListField(child=StringUUIDField(), required=False)
     created_on_exists = serializers.BooleanField(required=False)
 
+    # TODO: Deprecate unused sort by values, and add logging to double-check that they aren't
+    #  being used
     SORT_BY_FIELDS = (
         'address_country.name',
         'address_county',
         'address_same_as_company',
         'address_town',
-        'adviser.name.keyword',
+        'adviser.name',
         'archived',
         'archived_on',
-        'archived_by.name.keyword',
+        'archived_by.name',
         'company.name',
         'accepts_dit_email_marketing',
         'created_on',

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -24,6 +24,8 @@ class SearchContactAPIViewMixin:
     search_app = ContactSearchApp
     serializer_class = SearchContactQuerySerializer
     es_sort_by_remappings = {
+        'adviser.name': 'adviser.name.keyword',
+        'archived_by.name': 'archived_by.name.keyword',
         'first_name': 'first_name.keyword',
         'last_name': 'last_name.keyword',
         'name': 'name.keyword',

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -37,6 +37,8 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
     gross_value_added_start = serializers.IntegerField(required=False, min_value=0)
     gross_value_added_end = serializers.IntegerField(required=False, min_value=0)
 
+    # TODO: Deprecate unused sort by values, and add logging to double-check that they aren't
+    #  being used
     SORT_BY_FIELDS = (
         'actual_land_date',
         'approved_commitment_to_invest',
@@ -46,12 +48,12 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
         'approved_landed',
         'approved_non_fdi',
         'archived',
-        'archived_by.name.keyword',
+        'archived_by.name',
         'average_salary.name',
         'business_activities.name',
         'client_cannot_provide_total_investment',
-        'client_contacts.name.keyword',
-        'client_relationship_manager.name.keyword',
+        'client_contacts.name',
+        'client_relationship_manager.name',
         'created_on',
         'estimated_land_date',
         'export_revenue',
@@ -68,9 +70,9 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
         'new_tech_to_uk',
         'non_fdi_r_and_d_budget',
         'number_new_jobs',
-        'project_assurance_adviser.name.keyword',
+        'project_assurance_adviser.name',
         'project_code',
-        'project_manager.name.keyword',
+        'project_manager.name',
         'r_and_d_budget',
         'referral_source_activity.name',
         'referral_source_activity_event',

--- a/datahub/search/investment/views.py
+++ b/datahub/search/investment/views.py
@@ -23,8 +23,13 @@ class SearchInvestmentProjectAPIViewMixin:
     search_app = InvestmentSearchApp
     serializer_class = SearchInvestmentProjectQuerySerializer
     es_sort_by_remappings = {
+        'archived_by.name': 'archived_by.name.keyword',
+        'client_contacts.name': 'client_contacts.name.keyword',
+        'client_relationship_manager.name': 'client_relationship_manager.name.keyword',
         'investor_company.name': 'investor_company.name.keyword',
         'name': 'name.keyword',
+        'project_assurance_adviser.name': 'project_assurance_adviser.name.keyword',
+        'project_manager.name': 'project_manager.name.keyword',
         'uk_company.name': 'uk_company.name.keyword',
     }
 


### PR DESCRIPTION
### Description of change

In #1643 the sort by options for some search apps were changed, when we should've used remappings instead to keep API compatibility. This corrects that.

However, none of these particular sort-by values appear to be in use. We should, in fact, deprecate them and add logging to make sure they aren't being used. I have left that for a follow-up task.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
