### PR TITLE
Initial work for email ingestion

### DIFF
--- a/config/settings/sample.env
+++ b/config/settings/sample.env
@@ -3,6 +3,9 @@ DEBUG=True
 DATABASE_URL=postgres://localhost/datahub
 MI_DATABASE_URL=postgres://localhost/mi
 ES5_URL=http://localhost:9200
+# Set this if you are using a host for elasticsearch other than localhost
+# ES related tests may hang otherwise
+#TEST_ES_SERVER=es:9200
 ES_INDEX_PREFIX=test
 DOCKER_DEV=True
 AWS_DEFAULT_REGION=eu-west-2

--- a/datahub/email_ingestion/email_processor.py
+++ b/datahub/email_ingestion/email_processor.py
@@ -24,9 +24,4 @@ class EmailProcessor(ABC):
 
             (False, "The email was not sent by a known DIT address")
         """
-        raise NotImplementedError(
-            (
-                'EmailProcessor subclass %s does not implement `process_email` '
-                'method'
-            ) % self.__class__.__name__,
-        )
+        pass

--- a/datahub/email_ingestion/email_processor.py
+++ b/datahub/email_ingestion/email_processor.py
@@ -1,0 +1,32 @@
+from abc import ABC, abstractmethod
+
+
+class EmailProcessor(ABC):
+    """
+    EmailProcessor subclasses should take a message and perform some actions
+    based on it's metadata/content in order to process it.  EmailProcessor is
+    an abstract superclass.
+    """
+
+    @abstractmethod
+    def process_email(self, message):
+        """
+        Perform business logic to process a `mailparser.Message` instance - this
+        may involve interacting with the DB or other services as necessary.
+
+        :param message: mailparser.Message object - the email message to process
+
+        :returns: Tuple of boolean (whether the message was successfully processed
+            by this processor) and string (a meaningful message explaining why
+            this was not processed or explaining that this was processed
+            successfully).
+            e.g.
+
+            (False, "The email was not sent by a known DIT address")
+        """
+        raise NotImplementedError(
+            (
+                'EmailProcessor subclass %s does not implement `process_email` '
+                'method'
+            ) % self.__class__.__name__,
+        )

--- a/datahub/email_ingestion/email_processor.py
+++ b/datahub/email_ingestion/email_processor.py
@@ -24,4 +24,3 @@ class EmailProcessor(ABC):
 
             (False, "The email was not sent by a known DIT address")
         """
-        pass

--- a/datahub/email_ingestion/email_processor.py
+++ b/datahub/email_ingestion/email_processor.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 class EmailProcessor(ABC):
     """
     EmailProcessor subclasses should take a message and perform some actions
-    based on it's metadata/content in order to process it.  EmailProcessor is
+    based on its metadata/content in order to process it.  EmailProcessor is
     an abstract superclass.
     """
 

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -40,7 +40,6 @@ class Mailbox:
         imap_domain,
         mail_processor_classes,
         imap_port=None,
-        use_ssl=True,
     ):
         """
         Initialise a Mailbox object.
@@ -51,8 +50,6 @@ class Mailbox:
         :param mail_processor_classes: iterable - EmailProcessor classes which
             should be used to process incoming mail to this mailbox
         :param imap_port: optional int - the port to use when connecting with imap
-        :param use_ssl: optional boolean - whether or not to use SSL with imap, defaults
-            to True
         """
         self.email = email
         self.password = password
@@ -60,11 +57,7 @@ class Mailbox:
         if imap_port:
             self.imap_port = imap_port
         else:
-            if use_ssl:
-                self.imap_port = 993
-            else:
-                self.imap_port = 465
-        self.use_ssl = use_ssl
+            self.imap_port = 993
         # Make a copy of the processor class iterable
         self.processor_classes = [processor_class for processor_class in mail_processor_classes]
 
@@ -76,11 +69,7 @@ class Mailbox:
 
         :yields: An active imaplib server connection object.
         """
-        if self.use_ssl:
-            transport = imaplib.IMAP4_SSL
-        else:
-            transport = imaplib.IMAP4
-        connection = transport(self.imap_domain, self.imap_port)
+        connection = imaplib.IMAP4_SSL(self.imap_domain, self.imap_port)
         connection.login(self.email, self.password)
         connection.select()
         try:

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -1,0 +1,173 @@
+import imaplib
+from contextlib import contextmanager
+from email.errors import MessageParseError
+from logging import getLogger
+
+import mailparser
+from mailparser.exceptions import MailParserError
+
+logger = getLogger(__name__)
+
+
+class Mailbox:
+    """
+    The Mailbox class acts as a gateway to an email inbox - accessed via IMAP.
+    It offers methods for getting new messages from the inbox and processing
+    them using associated processing classes.
+
+    When an email is retrieved from the inbox successfully, it is marked as
+    deleted on the upstream IMAP inbox.  This is the mechanism we use to ensure
+    that emails are only ever processed once.
+
+    The first processor to successfully consume and process the message will stop
+    the chain.  Processors will be called in order - so ordering of
+    `mail_processor_classes` is important.
+    """
+
+    def __init__(
+        self,
+        email,
+        password,
+        imap_domain,
+        mail_processor_classes,
+        imap_port=None,
+        use_ssl=True,
+    ):
+        """
+        Initialise a Mailbox object.
+
+        :param email: string - the email address of the inbox
+        :param password: string - the password for the inbox
+        :param imap_domain: string - the domain of the imap server to connect to
+        :param mail_processor_classes: iterable - EmailProcessor classes which
+            should be used to process incoming mail to this mailbox
+        :param imap_port: optional int - the port to use when connecting with imap
+        :param use_ssl: optional boolean - whether or not to use SSL with imap, defaults
+            to True
+        """
+        self.email = email
+        self.password = password
+        self.imap_domain = imap_domain
+        if imap_port:
+            self.imap_port = imap_port
+        else:
+            if use_ssl:
+                self.imap_port = 993
+            else:
+                self.imap_port = 465
+        self.use_ssl = use_ssl
+        self.processor_classes = []
+        for processor_class in mail_processor_classes:
+            self.processor_classes.append(processor_class)
+
+    @contextmanager
+    def _connect(self):
+        """
+        Connect to the email inbox over IMAP.  The connection is closed down
+        automatically when execution leaves the scope of the context.
+
+        :yields: An active imaplib server connection object.
+        """
+        transport = imaplib.IMAP4_SSL
+        if not self.use_ssl:
+            transport = imaplib.IMAP4
+        server = transport(self.imap_domain, self.imap_port)
+        server.login(self.email, self.password)
+        server.select()
+        try:
+            yield server
+        finally:
+            server.close()
+            server.logout()
+
+    def _get_all_message_ids(self, server):
+        """
+        Fetch all of the message ids that are present in the inbox.
+
+        :param server: imaplib connection object - the active connection to
+            use to retrieve message ids from
+
+        :returns: A list of message id strings.
+        """
+        # Fetch all the message uids
+        response, message_ids = server.uid('search', None, 'ALL')
+        message_id_string = message_ids[0].strip()
+        # Usually `message_id_string` will be a list of space-separated
+        # ids; we must make sure that it isn't an empty string before
+        # splitting into individual UIDs.
+        if message_id_string:
+            return message_id_string.decode().split(' ')
+        return []
+
+    def _process_email(self, message):
+        """
+        Run through the EmailProcessor objects associated with this Mailbox and
+        attempt to process the message.
+
+        The message will be processed by at most one processor; EmailProcessor
+        objects will be called in the order that they were passed in on
+        Mailbox instantiation. The method returns as soon as the message has been
+        successfully processed by a processor.
+
+        :param message: mailparser.Mailparser object - the message to process
+
+        :returns: True if the message was processed, False otherwise.
+        """
+        for processor_class in self.processor_classes:
+            processor = processor_class()
+            processed, message = processor.process_email(message)
+            if processed:
+                processor_name = processor_class.__name__
+                message = f'Email {message} was processed by processor: {processor_name}'
+                logger.info(message)
+                return True
+        return False
+
+    def _parse_message(self, message_bytes):
+        return mailparser.parse_from_bytes(message_bytes)
+
+    def get_new_mail(self):
+        """
+        Generator method which gets new messages from the email inbox. After a
+        message has been yielded, it is flagged as deleted on the inbox so that
+        it will not be ingested again later.
+
+        :yields: A mailparser.Message object for each parsed message.
+        """
+        with self._connect() as server:
+            message_ids = self._get_all_message_ids(server)
+            if not message_ids:
+                # No new messages to ingest
+                return
+
+            for uid in message_ids:
+                try:
+                    typ, msg_contents = server.uid('fetch', uid, '(RFC822)')
+                    if not msg_contents:
+                        continue
+                    try:
+                        message = self._parse_message(msg_contents[0][1])
+                    except TypeError:
+                        # This may happen if another thread/process deletes the
+                        # message between our generating the ID list and our
+                        # processing it here.
+                        raise
+                    yield message
+                except (MessageParseError, MailParserError):
+                    # If we have some problem parsing the email, it's likely
+                    # to be spam/malicious so skip it
+                    continue
+
+                # Mark the email for deletion in the inbox
+                server.uid('store', uid, '+FLAGS', '(\\Deleted)')
+            # Carry out deletion for the emails marked for deletion
+            server.expunge()
+
+    def process_new_mail(self):
+        """
+        Gets all of the new mail in the inbox and goes through the associated
+        EmailProcessor classes to process each message.
+        """
+        messages = self.get_new_mail()
+        for message in messages:
+            self._process_email(message)

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -131,9 +131,9 @@ class Mailbox:
             processor_name = processor_class.__name__
             try:
                 processed, processing_output = processor.process_email(message)
-            except Exception as exc:
+            except Exception:
                 error_message = (
-                    f'Error "{exc.__class__.__name__}" processing email "{message.message_id}" '
+                    f'Error processing email "{message.message_id}" '
                     f'which was processed by processor "{processor_name}"'
                 )
                 logger.exception(error_message)
@@ -145,11 +145,10 @@ class Mailbox:
                 )
                 logger.info(success_message)
                 return True
-            else:
-                logger.debug(
-                    f'Email {message.message_id} could not be processed by {processor_name}. '
-                    f'Reason: "{processing_output}"',
-                )
+            logger.debug(
+                f'Email {message.message_id} could not be processed by {processor_name}. '
+                f'Reason: "{processing_output}"',
+            )
         return False
 
     def _parse_message(self, message_bytes):

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -114,9 +114,17 @@ class Mailbox:
         """
         for processor_class in self.processor_classes:
             processor = processor_class()
-            processed, message = processor.process_email(message)
+            processor_name = processor_class.__name__
+            try:
+                processed, message = processor.process_email(message)
+            except Exception as e:
+                message = (
+                    f'Error "{e.__class__.__name__}" processing email "{message}" '
+                    f'which was processed by processor "{processor_name}"'
+                )
+                logger.error(message)
+                raise e
             if processed:
-                processor_name = processor_class.__name__
                 message = f'Email {message} was processed by processor: {processor_name}'
                 logger.info(message)
                 return True

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -56,9 +56,8 @@ class Mailbox:
             else:
                 self.imap_port = 465
         self.use_ssl = use_ssl
-        self.processor_classes = []
-        for processor_class in mail_processor_classes:
-            self.processor_classes.append(processor_class)
+        # Make a copy of the processor class iterable
+        self.processor_classes = [processor_class for processor_class in mail_processor_classes]
 
     @contextmanager
     def _connect(self):

--- a/datahub/email_ingestion/test/test_email_processor.py
+++ b/datahub/email_ingestion/test/test_email_processor.py
@@ -1,0 +1,14 @@
+import pytest
+
+from datahub.email_ingestion.email_processor import EmailProcessor
+
+
+def test_email_processor_not_implemented():
+    """
+    Test that the EmailProcessor base class will raise an appropriate error when
+    it has been incorrectly subclassed.
+    """
+    class BadEmailProcessor(EmailProcessor):
+        pass
+    with pytest.raises(TypeError):
+        BadEmailProcessor()

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -289,13 +289,12 @@ class TestMailbox:
             mail_processor_classes=processor_classes,
         )
         message = mock.Mock()
-        message.__repr__ = lambda self: 'My message'
         with pytest.raises(TypeError):
             mailbox._process_email(message)
-        expected_message = (
+        expected_error_message = (
             'datahub.email_ingestion.mailbox',
             40,
-            'Error "TypeError" processing email "My message" which was processed by '
+            f'Error "TypeError" processing email "{message.message_id}" which was processed by '
             'processor "Processor 0"',
         )
-        assert expected_message in caplog.record_tuples
+        assert expected_error_message in caplog.record_tuples

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -1,0 +1,258 @@
+import copy
+from contextlib import contextmanager
+from email.errors import MessageParseError
+from unittest import mock
+
+import pytest
+
+from datahub.email_ingestion.email_processor import EmailProcessor
+from datahub.email_ingestion.mailbox import Mailbox
+
+EXPECTED_EMAIL_MESSAGES = [
+    {
+        'uid': 'abc1',
+        'message_content': 'abc1foobar',
+    },
+    {
+        'uid': 'abc2',
+        'message_content': 'abc2foobar',
+    },
+    {
+        'uid': 'abc3',
+        'message_content': 'abc3foobar',
+    },
+]
+
+
+class TestMailbox:
+    """
+    Test the Mailbox class.
+    """
+
+    @contextmanager
+    def patch_imap(self, email_messages):
+        """
+        Helper contextmanager to patch IMAP4_SSL which is used in the Mailbox
+        class. We can specify email details returned by our mocked instance by
+        providing sample email messages.
+
+        :param email_messages: iterable of email message dictionaries with keys
+            uid (the email uid) and message_content (a string of message payload)
+        :yields: A mock.Mock object which has been patched in place of the IMAP4_SSL
+            object in the datahub.email_ingestion.mailbox module
+        """
+        with mock.patch('datahub.email_ingestion.mailbox.imaplib.IMAP4_SSL') as mocked_imap_class:
+            mocked_imap = mocked_imap_class.return_value
+            email_ids = [message['uid'] for message in email_messages]
+            email_bodies = {
+                message['uid']: message['message_content'].encode('utf-8')
+                for message in email_messages
+            }
+            encoded_ids = ' '.join(email_ids).encode('utf-8')
+
+            # Set our mocked imap server's uid method to return certain values
+            # when called with certain signatures
+            def uid_side_effect(action, *args):
+                # A search call should return our email message ids
+                if action == 'search':
+                    return (None, (encoded_ids,))
+                # Fetch calls should return the email message bodies in the expected
+                # format
+                if action == 'fetch':
+                    # The expected format is pretty naff...
+                    return (None, ((None, email_bodies[args[0]]),))
+            mocked_imap.uid.side_effect = uid_side_effect
+            yield mocked_imap
+
+    def mock_mailbox_parse_message(self, mailbox):
+        """
+        Helper to ensure that the _parse_message method of a supplied mailbox
+        object is mocked.
+        """
+        mailbox._parse_message = mock.Mock()
+
+        def parse_message_side_effect(message):
+            return message.decode()
+        mailbox._parse_message.side_effect = parse_message_side_effect
+
+    def test_get_new_mail(self):
+        """
+        Functional test for get_new_mail method. We must mock out a couple of
+        external dependencies here; namely the IMAP gateway and message parsing
+        code.
+        """
+        expected_email_messages = copy.deepcopy(EXPECTED_EMAIL_MESSAGES)
+        with self.patch_imap(expected_email_messages) as mocked_imap:
+            mailbox = Mailbox(
+                'foobar@example.net',
+                'foobarbaz1',
+                'domain.example.net',
+                mail_processor_classes=[],
+            )
+            # Ensure that we also mock the Mailbox._parse_message method - this should
+            # mean that the mailbox method gives us our messages in an expected format
+            self.mock_mailbox_parse_message(mailbox)
+
+            messages = list(mailbox.get_new_mail())
+            assert len(messages) == len(expected_email_messages)
+            # Go through all of the returned messages and ensure that the parsed
+            # message content is as expected
+            for count, message in enumerate(messages):
+                expected_email_message = expected_email_messages[count]
+                # Ensure that the messages our mailbox retrieves are those that we expect
+                assert message == expected_email_message['message_content']
+                # Ensure that a deletion call was made for each message retrieved
+                mocked_imap.uid.assert_any_call(
+                    'store',
+                    expected_email_message['uid'],
+                    '+FLAGS',
+                    '(\\Deleted)',
+                )
+            # Ensure that an expunge was called on the imap server - to clear the
+            # messages flagged for deletion
+            mocked_imap.expunge.assert_called_once()
+            # Ensure that the imap connection was cleaned up
+            mocked_imap.close.assert_called_once()
+            mocked_imap.logout.assert_called_once()
+
+    def test_get_new_mail_parsing_failure(self):
+        """
+        Functional test to ensure that the get_new_mail method can handle a
+        parsing failure as expected.
+        """
+        expected_email_messages = copy.deepcopy(EXPECTED_EMAIL_MESSAGES)
+        with self.patch_imap(expected_email_messages) as mocked_imap:
+            mailbox = Mailbox(
+                'foobar@example.net',
+                'foobarbaz1',
+                'domain.example.net',
+                mail_processor_classes=[],
+            )
+
+            # Mock the Mailbox._parse_message method - this allows us to simulate
+            # a problem when parsing a particular message
+            mailbox._parse_message = mock.Mock()
+
+            def parse_message_side_effect(message):
+                message_str = message.decode()
+                if message_str == 'abc2foobar':
+                    raise MessageParseError()
+                return message_str
+            mailbox._parse_message.side_effect = parse_message_side_effect
+
+            messages = list(mailbox.get_new_mail())
+            # We expect that the messages returned will omit the problematic message
+            expected_email_messages.pop(1)
+            assert len(messages) == len(expected_email_messages)
+            # Go through all of the returned messages and ensure that the parsed
+            # message content is as expected
+            for count, message in enumerate(messages):
+                expected_email_message = expected_email_messages[count]
+                # Ensure that the messages our mailbox retrieves are those that we expect
+                assert message == expected_email_message['message_content']
+                # Ensure that a deletion call was made for each message retrieved
+                mocked_imap.uid.assert_any_call(
+                    'store',
+                    expected_email_message['uid'],
+                    '+FLAGS',
+                    '(\\Deleted)',
+                )
+            # Ensure that an expunge was called on the imap server - to clear the
+            # messages flagged for deletion
+            mocked_imap.expunge.assert_called_once()
+            # Ensure that the imap connection was cleaned up
+            mocked_imap.close.assert_called_once()
+            mocked_imap.logout.assert_called_once()
+
+    def test_process_new_mail(self):
+        """
+        Functional test to ensure that a processor class has the opportunity to
+        process messages as expected.
+        """
+        expected_email_messages = copy.deepcopy(EXPECTED_EMAIL_MESSAGES)
+        with self.patch_imap(expected_email_messages):
+            processor_class = mock.Mock(spec=EmailProcessor)
+            processor = processor_class.return_value
+            processor.process_email.return_value = (False, 'Bad email')
+            mailbox = Mailbox(
+                'foobar@example.net',
+                'foobarbaz1',
+                'domain.example.net',
+                mail_processor_classes=[processor_class],
+            )
+            # Ensure that we also mock the Mailbox._parse_message method - this should
+            # mean that the mailbox method gives us our messages in an expected format
+            self.mock_mailbox_parse_message(mailbox)
+
+            mailbox.process_new_mail()
+            for message in expected_email_messages:
+                processor.process_email.assert_any_call(message['message_content'])
+
+    @pytest.mark.parametrize(
+        'processor_count,processor_results,email_processed',
+        (
+            # Ensure that if no processors could process the message the method
+            # reports that it was not processed
+            (
+                3,
+                (
+                    (False, 'Could not be processed'),
+                    (False, 'Could not be processed'),
+                    (False, 'Could not be processed'),
+                ),
+                False,
+            ),
+            # Ensure that the processing stops once a processor successfully
+            # processes the message
+            (
+                3,
+                (
+                    (False, 'Could not be processed'),
+                    (True, 'Processed successfully'),
+                ),
+                True,
+            ),
+            # Ensure that when there are no processors, the email is not processed
+            (
+                0,
+                tuple(),
+                False,
+            ),
+        ),
+    )
+    def test_process_email(self, processor_count, processor_results, email_processed):
+        """
+        Unit test of _process_email method to ensure that the chain of email
+        processing works as expected.
+        """
+        processor_classes = []
+        # Set up our mocked processor classes, ensuring that they return the
+        # results we expect
+        for i in range(processor_count):
+            mocked_processor_class = mock.Mock(spec=EmailProcessor)
+            mocked_processor_class.__name__ = ''
+            mocked_processor = mocked_processor_class.return_value
+            try:
+                mocked_processor.process_email.return_value = processor_results[i]
+            except IndexError:
+                continue
+            processor_classes.append(mocked_processor_class)
+        mailbox = Mailbox(
+            'foobar@example.net',
+            'foobarbaz1',
+            'domain.example.net',
+            mail_processor_classes=processor_classes,
+        )
+        message = mock.Mock()
+        processed = mailbox._process_email(message)
+        # Ensure that the processing result is as expected
+        assert processed == email_processed
+        # Ensure that the processor classes were called/not called as specified in
+        # processor_results
+        for count, processor_class in enumerate(processor_classes):
+            processor = processor_class.return_value
+            try:
+                processor_results[count]
+                assert processor.process_email.called_with(message)
+            except IndexError:
+                assert not processor.process_email.called

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -321,7 +321,7 @@ class TestMailbox:
             # Ensure that when there are no processors, the email is not processed
             (
                 0,
-                tuple(),
+                (),
                 False,
             ),
         ),
@@ -335,8 +335,7 @@ class TestMailbox:
         # Set up our mocked processor classes, ensuring that they return the
         # results we expect
         for i in range(processor_count):
-            mocked_processor_class = mock.Mock(spec=EmailProcessor)
-            mocked_processor_class.__name__ = ''
+            mocked_processor_class = mock.Mock(spec=EmailProcessor, __name__='')
             mocked_processor = mocked_processor_class.return_value
             try:
                 mocked_processor.process_email.return_value = processor_results[i]
@@ -377,9 +376,7 @@ class TestMailbox:
             processor_classes.append(mocked_processor_class)
         bad_processor = processor_classes[0].return_value
 
-        def processing_error(*args, **kwargs):
-            raise TypeError('Ooops!')
-        bad_processor.process_email.side_effect = processing_error
+        bad_processor.process_email.side_effect = TypeError('Ooops!')
         uncalled_processor = processor_classes[1].return_value
         mailbox = Mailbox(
             'foobar@example.net',
@@ -396,7 +393,7 @@ class TestMailbox:
         expected_error_message = (
             'datahub.email_ingestion.mailbox',
             40,
-            f'Error "TypeError" processing email "{message.message_id}" which was processed by '
+            f'Error processing email "{message.message_id}" which was processed by '
             'processor "Processor 0"',
         )
         assert expected_error_message in caplog.record_tuples

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -66,6 +66,15 @@ def patch_imap(email_messages):
     return patch_imap_decorator
 
 
+class MockedParsedMessage(str):
+    """
+    A simple mock to replace MailParser objects - subclassing string is convenient
+    for equality checks.
+    """
+
+    message_id = 'foobar'
+
+
 class TestMailbox:
     """
     Test the Mailbox class.
@@ -78,8 +87,9 @@ class TestMailbox:
         """
         mailbox._parse_message = mock.Mock()
 
-        def parse_message_side_effect(message):
-            return message.decode()
+        def parse_message_side_effect(message_body_bytes):
+            parsed_message = MockedParsedMessage(message_body_bytes.decode())
+            return parsed_message
         mailbox._parse_message.side_effect = parse_message_side_effect
 
     @patch_imap(EXPECTED_EMAIL_MESSAGES)

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -108,16 +108,13 @@ class TestMailbox:
             expected_email_message = expected_email_messages[count]
             # Ensure that the messages our mailbox retrieves are those that we expect
             assert message == expected_email_message['message_content']
-            # Ensure that a deletion call was made for each message retrieved
+            # Ensure that a call was made to mark each message retrieved as SEEN
             mocked_imap.uid.assert_any_call(
                 'store',
                 expected_email_message['uid'],
                 '+FLAGS',
-                '(\\Deleted)',
+                '(\\SEEN)',
             )
-        # Ensure that an expunge was called on the imap server - to clear the
-        # messages flagged for deletion
-        mocked_imap.expunge.assert_called_once()
         # Ensure that the imap connection was cleaned up
         mocked_imap.close.assert_called_once()
         mocked_imap.logout.assert_called_once()
@@ -157,16 +154,13 @@ class TestMailbox:
             expected_email_message = expected_email_messages[count]
             # Ensure that the messages our mailbox retrieves are those that we expect
             assert message == expected_email_message['message_content']
-            # Ensure that a deletion call was made for each message retrieved
+            # Ensure that a call was made to mark each message retrieved as SEEN
             mocked_imap.uid.assert_any_call(
                 'store',
                 expected_email_message['uid'],
                 '+FLAGS',
-                '(\\Deleted)',
+                '(\\SEEN)',
             )
-        # Ensure that an expunge was called on the imap server - to clear the
-        # messages flagged for deletion
-        mocked_imap.expunge.assert_called_once()
         # Ensure that the imap connection was cleaned up
         mocked_imap.close.assert_called_once()
         mocked_imap.logout.assert_called_once()

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -124,7 +124,7 @@ class TestMailbox:
     @patch_imap([])
     def test_get_new_mail_no_new_messages(self, mocked_imap):
         """
-        Functional test to ensure that get_new_mail operates as expected when 
+        Functional test to ensure that get_new_mail operates as expected when
         there are no email messages to ingest.
 
         """

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -181,7 +181,7 @@ class TestSearch(APITestMixin):
                 {
                     'gross_value_added_start': 99999999999999,
                 },
-                ['99999989999999991808'],
+                ['99999989999999999990'],
                 ['won project'],
             ),
             (

--- a/requirements.in
+++ b/requirements.in
@@ -29,6 +29,9 @@ boto3==1.9.137
 
 notifications-python-client==5.3.0
 
+# Email
+mail-parser==3.9.3
+
 # REDIS
 django-redis==4.10.0
 redis==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -60,6 +60,7 @@ greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
 idna==2.8                 # via requests
 incremental==17.5.0       # via towncrier
+ipaddress==1.0.22         # via mail-parser
 ipdb==0.12
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.5.0
@@ -68,6 +69,7 @@ jinja2==2.10.1            # via towncrier
 jmespath==0.9.4           # via boto3, botocore
 kombu==4.5.0
 lxml==4.3.3
+mail-parser==3.9.3
 markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 mohawk==1.0.0
@@ -111,7 +113,8 @@ requests-mock==1.6.0
 requests==2.21.0
 requests_toolbelt==0.9.1
 s3transfer==0.2.0         # via boto3
-six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mohawk, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest, pytest-xdist, python-dateutil, requests-mock, traitlets
+simplejson==3.16.0        # via mail-parser
+six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mail-parser, mohawk, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest, pytest-xdist, python-dateutil, requests-mock, traitlets
 snowballstemmer==1.2.1    # via pydocstyle
 sqlparse==0.3.0           # via django, django-debug-toolbar
 termcolor==1.1.0          # via pytest-sugar


### PR DESCRIPTION
### Description of change
This adds a `Mailbox` and `EmailProcessor` class under a new `email_ingestion` package.

`Mailbox` acts as a gateway for an IMAP email inbox and allows convenience methods for getting new "unread" mail and providing hooks for processing that mail.
`EmailProcessor` is an abstract superclass which provides a pattern for any email processing business logic that we need.

The overall aspiration is to tie these components together, such that the datahub backend can monitor multiple IMAP mailboxes and a mailbox can have one or more concrete email processor classes for processing incoming mail.  Right now, this PR is concerned with providing the building blocks in a way that is well tested.

### Points of note

- The tests for `Mailbox` are fairly mock-heavy.  I've used a mixture of testing the end-to-end logic of public methods (with IMAP/mail processing mocked out) and some unit tests.  I did debate making wrapper classes for IMAP/mail processing in a way that we could use dependency injection to swap out the concrete classes, but I decided against this: it adds more layers and I can't see us needing to swap out these libraries in future.  It probably would have made the tests cleaner, however.

### simplejson
The failing test case for investment/GVA searches  has now been fixed.

Since we now have simplejson as a dependency, py-elasticsearch will use that when serializing/deserializing JSON for the elasticsearch API.  This means that any floats that we are indexing to elasticsearch have the potential to be more accurate.  

To use the data indexed for the GVA test case as an example, here is some sample code for the differences between py-elasticsearch using `json` and `simplejson` for serialization:
```
import json
import simplejson
from decimal import Decimal

from elasticsearch.serializer import JSONSerializer

gva_multiplier = Decimal('9.999999')
foreign_equity_investment = 9999999999999999999
# A decimal value
gva = foreign_equity_investment * gva_multiplier

# Simulate py-elasticsearch serialization using json
json_result = json.dumps(gva, default=JSONSerializer().default)
# Simulate py-elasticsearch serialization using simplejson
simplejson_result = simplejson.dumps(gva, default=JSONSerializer().default)

print("json result:")
print(json_result)
print("simplejson result:")
print(simplejson_result)
```
Yields the following output:
```
json result:
9.999998999999999e+19
simplejson result:
99999989999999999990.000001
```

**The implication here is that when we deploy this, floats across the codebase which are saved to elasticsearch will become more accurate.  We should discuss whether we need to fully rebuild the ES indexes because of this.**

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
