### PR TITLE
Fix allow nulls for investor type field on large capital profile

### DIFF
--- a/changelog/investment/large-capital-profiles-allow-nulls.api.rst
+++ b/changelog/investment/large-capital-profiles-allow-nulls.api.rst
@@ -1,0 +1,6 @@
+The endpoint ``/v4/large-investor-profile`` has been updated to
+allow the following fields to be set to empty values.
+
+- investor_type
+- minimum_return_rate
+- minimum_equity_percentage

--- a/datahub/investment/investor_profile/serializers.py
+++ b/datahub/investment/investor_profile/serializers.py
@@ -123,6 +123,7 @@ class LargeCapitalInvestorProfileSerializer(serializers.ModelSerializer):
     investor_type = NestedRelatedField(
         InvestorType,
         required=False,
+        allow_null=True,
     )
 
     required_checks_conducted = NestedRelatedField(
@@ -154,6 +155,7 @@ class LargeCapitalInvestorProfileSerializer(serializers.ModelSerializer):
     minimum_return_rate = NestedRelatedField(
         ReturnRate,
         required=False,
+        allow_null=True,
     )
 
     time_horizons = NestedRelatedField(
@@ -177,6 +179,7 @@ class LargeCapitalInvestorProfileSerializer(serializers.ModelSerializer):
     minimum_equity_percentage = NestedRelatedField(
         EquityPercentage,
         required=False,
+        allow_null=True,
     )
 
     desired_deal_roles = NestedRelatedField(

--- a/datahub/investment/investor_profile/test/test_serializers.py
+++ b/datahub/investment/investor_profile/test/test_serializers.py
@@ -1,0 +1,42 @@
+import pytest
+
+from datahub.investment.investor_profile.serializers import LargeCapitalInvestorProfileSerializer
+from datahub.investment.investor_profile.test.factories import CompleteLargeInvestorProfileFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestLargeCapitalInvestorProfileSerializer:
+    """Tests for LargeCapitalInvestorProfileSerializer."""
+
+    @pytest.mark.parametrize(
+        'field,empty_value,expected_value',
+        (
+            ('global_assets_under_management', None, None),
+            ('investable_capital', None, None),
+            ('investor_type', '', None),
+            ('investor_type', None, None),
+            ('deal_ticket_sizes', [], []),
+            ('investment_types', [], []),
+            ('minimum_return_rate', '', None),
+            ('time_horizons', [], []),
+            ('restrictions', [], []),
+            ('construction_risks', [], []),
+            ('minimum_equity_percentage', '', None),
+            ('desired_deal_roles', [], []),
+            ('uk_region_locations', [], []),
+            ('other_countries_being_considered', [], []),
+            ('asset_classes_of_interest', [], []),
+            ('notes_on_locations', '', ''),
+        ),
+    )
+    def test_validate_fields_allow_null(self, field, empty_value, expected_value):
+        """Test validates fields allow null or empty values."""
+        profile = CompleteLargeInvestorProfileFactory()
+        serializer = LargeCapitalInvestorProfileSerializer(
+            data={field: empty_value},
+            instance=profile,
+            partial=True,
+        )
+        assert serializer.is_valid(), serializer.errors
+        assert serializer.validated_data[field] == expected_value


### PR DESCRIPTION
### Description of change
Updated LargeCapitalInvestorProfileSerializer to allow nulls to be set for `investor_type`, `minimum_return_rate` and `minimum_equity_percentage`.

### How to test
- Go to http://localhost:8000/v4/large-investor-profile
- Create a profile by selecting an `investor company` and setting `required checks conducted` to `Not yet cleared`
- Go to http://localhost:8000/v4/large-investor-profile/id/
- PATCH http://localhost:8000/v4/large-investor-profile/id/
```
{
    "investor_type": "",
    "minimum_return_rate": "",
    "minimum_equity_percentage": ""
}
```
- Check profile has been saved and no errors are returned

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
