### PR TITLE
Reset registered address fields and copy over from companies house table

### DIFF
--- a/changelog/update-company-reg-address-cmd.internal.rst
+++ b/changelog/update-company-reg-address-cmd.internal.rst
@@ -1,0 +1,1 @@
+The ``update_company_registered_address`` Django command is now available for internal use. This copies the ``registered_address`` of all CompaniesHouseCompany records to the corresponding Company record with the same ``company_number``. If a CompaniesHouseCompany is not found, it resets the ``registered_address``.

--- a/datahub/dbmaintenance/management/commands/update_company_registered_address.py
+++ b/datahub/dbmaintenance/management/commands/update_company_registered_address.py
@@ -1,0 +1,119 @@
+from logging import getLogger
+from types import SimpleNamespace
+
+import reversion
+from django.core.management.base import BaseCommand
+
+from datahub.company.models import Company
+from datahub.search.signals import disable_search_signal_receivers
+
+logger = getLogger(__name__)
+
+
+def copy_registered_address(destination_company, source_company):
+    """
+    Copy registered_address field values that are different from source
+    Company to destination Company.
+    :param destination_company: The registered_address fields for this
+    object will be updated.
+    :param source_company: The registered_address fields for this object will
+    be copied to destination object.
+    :returns copy_count: Number of fields that were copied
+    """
+    fields = {
+        'registered_address_1',
+        'registered_address_2',
+        'registered_address_town',
+        'registered_address_county',
+        'registered_address_country',
+        'registered_address_postcode',
+    }
+
+    copy_count = 0
+
+    for field in fields:
+        destination = getattr(destination_company, field)
+        source = getattr(source_company, field)
+        if destination != source:
+            setattr(destination_company, field, source)
+            copy_count += 1
+
+    return copy_count > 0
+
+
+class Command(BaseCommand):
+    """
+    Command to update registered_address for Company with
+    the corresponding ComapiesHouseCompany registered_address.
+    """
+
+    def add_arguments(self, parser):
+        """Define extra arguments."""
+        parser.add_argument(
+            '--simulate',
+            action='store_true',
+            help='Simulates the command by running the code without saving the changes',
+        )
+
+    @staticmethod
+    def _get_companies_queryset():
+        return Company.objects.all()
+
+    @disable_search_signal_receivers(Company)
+    def handle(self, *args, **options):
+        """Handles the command."""
+        logger.info('Started')
+
+        result = {True: 0, False: 0}
+
+        for company in self._get_companies_queryset().iterator():
+            succeeded = self.process_company(
+                company,
+                simulate=options['simulate'],
+            )
+            result[succeeded] += 1
+
+        logger.info(f'Finished - succeeded: {result[True]}, failed: {result[False]}')
+
+    @staticmethod
+    def _process_company(company, simulate=False):
+        """
+        Update the address of the Company to the
+        address of the CompanyHouseCompany.
+        """
+        ch_company = company.companies_house_data
+
+        if ch_company is None:
+            # There is no corresponding CH record so we reset
+            # the address by assigning empty values to fields
+            ch_company = SimpleNamespace(**{
+                'registered_address_1': '',
+                'registered_address_2': '',
+                'registered_address_town': '',
+                'registered_address_county': '',
+                'registered_address_country': None,
+                'registered_address_postcode': '',
+            })
+
+        copied = copy_registered_address(company, ch_company)
+
+        if not simulate and copied:
+            with reversion.create_revision():
+                company.save()
+                reversion.set_comment('Updated registered address using CompaniesHouse data.')
+
+    def process_company(self, company, simulate=False):
+        """
+        Wrapper around _process_company to catch potential problems.
+
+        :param company: Company object
+        :param simulate: if True, the changes will not be saved
+        :returns: bool indicating if the company was processed successfully
+        """
+        try:
+            self._process_company(company, simulate=simulate)
+            logger.info(f'Company {company.name} - OK')
+            return True
+        except Exception as exc:
+            logger.exception(f'Company {company.name} - {company.id} failed: {repr(exc)}')
+            return False

--- a/datahub/dbmaintenance/test/commands/test_update_company_registered_address.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_registered_address.py
@@ -1,51 +1,265 @@
+from unittest.mock import Mock, patch
+
 import pytest
 from django.core.management import call_command
+from reversion.models import Version
 
 from datahub.company.models import Company
 from datahub.company.test.factories import (
     CompaniesHouseCompanyFactory,
     CompanyFactory,
 )
+from datahub.core.constants import Country
+from datahub.dbmaintenance.management.commands.update_company_registered_address import (
+    copy_registered_address,
+)
 
 
 @pytest.fixture()
-def company_company_house_data(db):
+def company(db):
     """
-    Create a CompaniesHouseCompany that has a company number that matches
-    Company and one that doesn't.
+    Create a Company, CompaniesHouseCompany pair with the same address.
     """
-    CompanyFactory(company_number='1')
-    CompaniesHouseCompanyFactory(company_number='1')
-    CompanyFactory(company_number='2')
-    CompaniesHouseCompanyFactory(company_number='3')
+    address = {
+        'registered_address_1': '12',
+        'registered_address_2': 'Foo St.',
+        'registered_address_town': 'London',
+        'registered_address_county': 'Westminster',
+        'registered_address_country_id': Country.united_kingdom.value.id,
+        'registered_address_postcode': 'SW1 T2E',
+    }
+    company = CompanyFactory(company_number='1', **address)
+    CompaniesHouseCompanyFactory(company_number='1', **address)
+
+    return company
 
 
-def _is_address_same(company1, company2):
+def is_address_same(company_number):
     """
-    Check if the given companies have same
-    address.
+    Check if address is the same for the Company & CompaniesHouseCompany
+    with the given company_number.
     """
-    fields = [
-        'registered_address_town',
-        'registered_address_town',
+    fields = {
         'registered_address_1',
         'registered_address_2',
+        'registered_address_town',
         'registered_address_county',
         'registered_address_country',
         'registered_address_postcode',
-    ]
+    }
+
+    company = Company.objects.get(company_number=company_number)
+    ch_company = company.companies_house_data
+
     field_matches = [
-        getattr(company1, field) == getattr(company2, field)
+        getattr(company, field) == getattr(ch_company, field)
         for field in fields
     ]
+
     return all(field_matches)
 
 
-@pytest.mark.usefixtures('company_company_house_data')
-def test_run():
-    """."""
+@pytest.mark.parametrize(
+    'field, value',
+    (
+        ('registered_address_1', '10'),
+        ('registered_address_2', 'Bar St.'),
+        ('registered_address_town', 'Brighton'),
+        ('registered_address_county', 'Surrey'),
+        ('registered_address_country_id', Country.italy.value.id),
+        ('registered_address_postcode', 'TW3 2YT'),
+    ),
+)
+def test_different_address(field, value, company):
+    """
+    The command should copy the registered_address from CompaniesHouseCompany
+    to Company and this should create a revision.
+    """
+    setattr(company, field, value)
+    company.save()
+
     call_command('update_company_registered_address')
-    for company in Company.objects.all():
-        ch_data = company.companies_house_data
-        if ch_data is not None:
-            assert _is_address_same(company, ch_data)
+
+    assert is_address_same(company.company_number)
+
+    versions = Version.objects.get_for_object(company)
+    assert versions.count() == 1
+
+
+def test_same_address(company):
+    """
+    When the address is same, we do not create a new revision.
+    """
+    call_command('update_company_registered_address')
+
+    versions = Version.objects.get_for_object(company)
+    assert versions.count() == 0
+
+
+def test_no_ch_company(company):
+    """
+    When there is no matching CompaniesHouseCompany for a
+    Company, we reset the address to blank and create revision.
+    """
+    company.company_number = 'NOT 1'
+    company.save()
+    call_command('update_company_registered_address')
+
+    company.refresh_from_db()
+    assert company.registered_address_1 == ''
+    assert company.registered_address_2 == ''
+    assert company.registered_address_town == ''
+    assert company.registered_address_county == ''
+    assert company.registered_address_country is None
+    assert company.registered_address_postcode == ''
+
+    versions = Version.objects.get_for_object(company)
+    assert versions.count() == 1
+
+
+def test_no_ch_company_address_blank(company):
+    """
+    When there is no matching CompaniesHouseCompany for a
+    Company and the address is already blank, we do not
+    create a revision.
+    """
+    company.company_number = 'NOT 1'
+    company.registered_address_1 = ''
+    company.registered_address_2 = ''
+    company.registered_address_town = ''
+    company.registered_address_county = ''
+    company.registered_address_country = None
+    company.registered_address_postcode = ''
+    company.save()
+
+    call_command('update_company_registered_address')
+
+    versions = Version.objects.get_for_object(company)
+    assert versions.count() == 0
+
+
+def test_simulate(company):
+    """
+    When the command is run in simulate mode, we do not save
+    the changes or create a revision.
+    """
+    company.registered_address_postcode = 'TW3 2TY'
+    company.save()
+    call_command('update_company_registered_address', simulate=True)
+
+    assert not is_address_same(company.company_number)
+
+    versions = Version.objects.get_for_object(company)
+    assert versions.count() == 0
+
+
+@pytest.mark.usefixtures('company')
+@pytest.mark.parametrize('simulate', [True, False])
+def test_logs(simulate, caplog):
+    """
+    The normal as well as simulated run of the command should produce logs
+    when there are no exceptions.
+    """
+    with caplog.at_level('INFO'):
+        call_command('update_company_registered_address', simulate=simulate)
+        assert caplog.records[0].message == 'Started'
+        assert caplog.records[-1].message == 'Finished - succeeded: 1, failed: 0'
+
+
+@pytest.mark.usefixtures('company')
+@patch(
+    'datahub.dbmaintenance.management.commands'
+    '.update_company_registered_address.Command'
+    '._process_company',
+    side_effect=Exception('Testing'),
+)
+@pytest.mark.parametrize('simulate', [True, False])
+def test_logs_fail(_, simulate, caplog):
+    """
+    The normal as well as simulated run of the command should produce logs
+    when it encounters exceptions.
+    """
+    with caplog.at_level('INFO'):
+        call_command('update_company_registered_address', simulate=simulate)
+        assert caplog.records[-1].message == 'Finished - succeeded: 0, failed: 1'
+
+
+@pytest.mark.parametrize(
+    'field, value',
+    (
+        ('registered_address_1', '10'),
+        ('registered_address_2', 'Bar St.'),
+        ('registered_address_town', 'Brighton'),
+        ('registered_address_county', 'Surrey'),
+        ('registered_address_country_id', Country.italy.value.id),
+        ('registered_address_postcode', 'TW3 2YT'),
+    ),
+)
+def test_copy_registered_address_different(field, value, company):
+    """
+    copy_registered_address should return True if any single field
+    of the registered_address for the destination and source companies
+    are different.
+    """
+    setattr(company, field, value)
+    company.save()
+    ch_company = company.companies_house_data
+    assert copy_registered_address(company, ch_company)
+    company.save()
+    assert is_address_same(company.company_number)
+
+
+def test_copy_registered_address_same(company):
+    """
+    copy_registered_address should return False if all registered_address
+    fields are the same.
+    """
+    ch_company = company.companies_house_data
+    assert not copy_registered_address(company, ch_company)
+
+
+def test_process_company_fail(company, caplog):
+    """
+    Test that failure in processing a company doesn't mean we do not
+    process subsequent companies.
+    """
+    # Change one of the fields of company
+    company.registered_address_postcode = 'TW3 2TY'
+    company.save()
+
+    # Set up another company
+    company_fail = CompanyFactory(
+        company_number='2',
+        registered_address_1='Fail St.',
+    )
+    CompaniesHouseCompanyFactory(
+        company_number='2',
+        registered_address_1='CH Fail St.',
+    )
+
+    # Set the new company to raise an Exception
+    def companies_house_data_fail():
+        raise Exception('Test')
+
+    company_fail.companies_house_data = companies_house_data_fail
+
+    # Set a mock queryset that includes the company_fail object
+    mock_companies_queryset = Mock()
+    mock_companies_queryset.iterator.return_value = (
+        company_fail, company,
+    )
+
+    with patch(
+        'datahub.dbmaintenance.management.commands'
+        '.update_company_registered_address.Command'
+        '._get_companies_queryset',
+        return_value=mock_companies_queryset,
+    ):
+        with caplog.at_level('INFO'):
+            call_command('update_company_registered_address')
+            assert caplog.records[-1].message == 'Finished - succeeded: 1, failed: 1'
+
+        # Failing company was not updated
+        assert not is_address_same(company_fail.company_number)
+        # Normal company is updated
+        assert is_address_same(company.company_number)

--- a/datahub/dbmaintenance/test/commands/test_update_company_registered_address.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_registered_address.py
@@ -1,0 +1,51 @@
+import pytest
+from django.core.management import call_command
+
+from datahub.company.models import Company
+from datahub.company.test.factories import (
+    CompaniesHouseCompanyFactory,
+    CompanyFactory,
+)
+
+
+@pytest.fixture()
+def company_company_house_data(db):
+    """
+    Create a CompaniesHouseCompany that has a company number that matches
+    Company and one that doesn't.
+    """
+    CompanyFactory(company_number='1')
+    CompaniesHouseCompanyFactory(company_number='1')
+    CompanyFactory(company_number='2')
+    CompaniesHouseCompanyFactory(company_number='3')
+
+
+def _is_address_same(company1, company2):
+    """
+    Check if the given companies have same
+    address.
+    """
+    fields = [
+        'registered_address_town',
+        'registered_address_town',
+        'registered_address_1',
+        'registered_address_2',
+        'registered_address_county',
+        'registered_address_country',
+        'registered_address_postcode',
+    ]
+    field_matches = [
+        getattr(company1, field) == getattr(company2, field)
+        for field in fields
+    ]
+    return all(field_matches)
+
+
+@pytest.mark.usefixtures('company_company_house_data')
+def test_run():
+    """."""
+    call_command('update_company_registered_address')
+    for company in Company.objects.all():
+        ch_data = company.companies_house_data
+        if ch_data is not None:
+            assert _is_address_same(company, ch_data)


### PR DESCRIPTION
### Description of change

Add a Django command: `updated_company_registered_address` that copies the `registered_address` from `CompaniesHouseCompany` to `Company`. 

If a `Company` doesn't have a corresponding `CompaniesHouseCompany`, the `registered_address` fields are set to blank.

The command has a `simulate` flag that does everything except `.save()`.

The command creates revisions for the updates to the `registered_address` fields and tried to ensure that the revisions are only created if there is an actual change in the state. 

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?