### PR TITLE
Add form for validating rows for import interactions tool

### DIFF
--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -1,0 +1,173 @@
+from django import forms
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy
+
+from datahub.company.models import Advisor
+from datahub.core.query_utils import get_full_name_expression
+from datahub.event.models import Event
+from datahub.interaction.models import CommunicationChannel, Interaction
+from datahub.metadata.models import Service, Team
+
+
+OBJECT_DISABLED_MESSAGE = gettext_lazy('This option is disabled.')
+ADVISER_NOT_FOUND_MESSAGE = gettext_lazy(
+    'An active adviser could not be found with the specified name.',
+)
+ADVISER_WITH_TEAM_NOT_FOUND_MESSAGE = gettext_lazy(
+    'An active adviser could not be found with the specified name and team.',
+)
+MULTIPLE_ADVISERS_FOUND_MESSAGE = gettext_lazy(
+    'Multiple matching advisers were found.',
+)
+INTERACTION_CANNOT_HAVE_AN_EVENT_MESSAGE = gettext_lazy(
+    'An interaction cannot have an event.',
+)
+
+
+def _validate_not_disabled(obj):
+    if obj.disabled_on:
+        raise ValidationError(OBJECT_DISABLED_MESSAGE, code='object_is_disabled')
+
+
+class NoDuplicatesModelChoiceField(forms.ModelChoiceField):
+    """ModelChoiceField subclass that handles MultipleObjectsReturned exceptions."""
+
+    default_error_messages = {
+        'multiple_matches': gettext_lazy('There is more than one matching %(verbose_name)s.'),
+    }
+
+    def to_python(self, value):
+        """Looks up value using the query set, handling MultipleObjectsReturned exceptions."""
+        model = self.queryset.model
+        try:
+            return super().to_python(value)
+        except model.MultipleObjectsReturned:
+            raise ValidationError(
+                self.error_messages['multiple_matches'],
+                code='multiple_matches',
+                params={
+                    'verbose_name': model._meta.verbose_name,
+                },
+            )
+
+
+class InteractionCSVRowForm(forms.Form):
+    """Form used for validating a single row in a CSV of interactions."""
+
+    kind = forms.ChoiceField(choices=Interaction.KINDS)
+    date = forms.DateField(input_formats=['%d/%m/%Y', '%Y-%m-%d'])
+    contact_email = forms.EmailField()
+    # Represents an InteractionDITParticipant for the interaction.
+    # The adviser will be looked up by name (case-insensitive) with inactive advisers
+    # excluded.
+    # If team_1 is provided, this will also be used to narrow down the match (useful
+    # when, for example, two advisers have the same name).
+    adviser_1 = forms.CharField()
+    team_1 = NoDuplicatesModelChoiceField(
+        Team.objects.all(),
+        to_field_name='name__iexact',
+        required=False,
+    )
+    # Represents an additional InteractionDITParticipant for the interaction
+    # adviser_2 is looked up in the same way as adviser_1 (described above)
+    adviser_2 = forms.CharField(required=False)
+    team_2 = NoDuplicatesModelChoiceField(
+        Team.objects.all(),
+        to_field_name='name__iexact',
+        required=False,
+    )
+    service = NoDuplicatesModelChoiceField(
+        Service.objects.all(),
+        to_field_name='name__iexact',
+        validators=[_validate_not_disabled],
+    )
+    communication_channel = NoDuplicatesModelChoiceField(
+        CommunicationChannel.objects.all(),
+        to_field_name='name__iexact',
+        required=False,
+        validators=[_validate_not_disabled],
+    )
+    event_id = forms.ModelChoiceField(
+        Event.objects.all(),
+        required=False,
+        validators=[_validate_not_disabled],
+    )
+    # Subject is optional as it defaults to the name of the service
+    subject = forms.CharField(required=False)
+    notes = forms.CharField(required=False)
+
+    @classmethod
+    def get_required_field_names(cls):
+        """Get the required base fields of this form."""
+        return {name for name, field in cls.base_fields.items() if field.required}
+
+    def clean(self):
+        """Validate and clean the data for this row."""
+        data = super().clean()
+
+        kind = data.get('kind')
+        event = data.get('event_id')
+        subject = data.get('subject')
+        service = data.get('service')
+
+        # Ignore communication channel for service deliveries (as it is not a valid field for
+        # service deliveries, but we are likely to get it in provided data anyway)
+        if kind == Interaction.KINDS.service_delivery:
+            data['communication_channel'] = None
+
+        # Reject if an event has been given but it's an interaction (as the event field is only
+        # valid for service deliveries – we don't know if the kind field is wrong or the event
+        # has been set in error)
+        if kind == Interaction.KINDS.interaction and event:
+            error = ValidationError(
+                INTERACTION_CANNOT_HAVE_AN_EVENT_MESSAGE,
+                code='interaction_cannot_have_event',
+            )
+            self.add_error('event_id', error)
+
+        # Look up values for adviser_1 and adviser_2 (adding errors if the look-up fails)
+        self._populate_adviser(data, 'adviser_1', 'team_1')
+        self._populate_adviser(data, 'adviser_2', 'team_2')
+
+        # If no subject was provided, set it to the name of the service
+        if not subject and service:
+            data['subject'] = service.name
+
+        return data
+
+    def _populate_adviser(self, data, adviser_field, team_field):
+        try:
+            data[adviser_field] = self._look_up_adviser(
+                data.get(adviser_field),
+                data.get(team_field),
+            )
+        except ValidationError as exc:
+            self.add_error(adviser_field, exc)
+
+    @staticmethod
+    def _look_up_adviser(adviser_name, team):
+        if not adviser_name:
+            return None
+
+        get_kwargs = {
+            'is_active': True,
+            'name__iexact': adviser_name,
+        }
+
+        if team:
+            get_kwargs['dit_team'] = team
+
+        queryset = Advisor.objects.annotate(name=get_full_name_expression())
+
+        try:
+            return queryset.get(**get_kwargs)
+        except Advisor.DoesNotExist:
+            if team:
+                raise ValidationError(
+                    ADVISER_WITH_TEAM_NOT_FOUND_MESSAGE,
+                    code='adviser_and_team_not_found',
+                )
+
+            raise ValidationError(ADVISER_NOT_FOUND_MESSAGE, code='adviser_not_found')
+        except Advisor.MultipleObjectsReturned:
+            raise ValidationError(MULTIPLE_ADVISERS_FOUND_MESSAGE, code='multiple_advisers_found')

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -1,0 +1,497 @@
+from collections.abc import Mapping
+from datetime import date
+
+import pytest
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.core.test_utils import random_obj_for_queryset
+from datahub.event.test.factories import DisabledEventFactory, EventFactory
+from datahub.interaction.admin_csv_import.row_form import (
+    ADVISER_NOT_FOUND_MESSAGE,
+    ADVISER_WITH_TEAM_NOT_FOUND_MESSAGE,
+    INTERACTION_CANNOT_HAVE_AN_EVENT_MESSAGE,
+    InteractionCSVRowForm,
+    MULTIPLE_ADVISERS_FOUND_MESSAGE,
+    OBJECT_DISABLED_MESSAGE,
+)
+from datahub.interaction.models import CommunicationChannel, Interaction
+from datahub.interaction.test.factories import CommunicationChannelFactory
+from datahub.metadata.models import Service
+from datahub.metadata.test.factories import ServiceFactory, TeamFactory
+
+
+@pytest.mark.django_db
+class TestInteractionCSVRowForm:
+    """Tests for InteractionCSVRowForm."""
+
+    @pytest.mark.parametrize(
+        'data,errors',
+        (
+            # kind blank
+            (
+                {'kind': ''},
+                {'kind': ['This field is required.']},
+            ),
+            # kind invalid
+            (
+                {'kind': 'invalid'},
+                {'kind': ['Select a valid choice. invalid is not one of the available choices.']},
+            ),
+            # date blank
+            (
+                {'date': ''},
+                {'date': ['This field is required.']},
+            ),
+            # invalid date
+            (
+                {'date': '08/31/2020'},
+                {'date': ['Enter a valid date.']},
+            ),
+            # invalid contact_email
+            (
+                {'contact_email': 'invalid'},
+                {'contact_email': ['Enter a valid email address.']},
+            ),
+            # blank adviser_1
+            (
+                {'adviser_1': ''},
+                {'adviser_1': ['This field is required.']},
+            ),
+            # adviser_1 doesn't exist
+            (
+                {'adviser_1': 'Non-existent adviser'},
+                {'adviser_1': [ADVISER_NOT_FOUND_MESSAGE]},
+            ),
+            # multiple matching values for adviser_1
+            (
+                {
+                    'adviser_1': lambda: AdviserFactory.create_batch(
+                        2,
+                        first_name='Pluto',
+                        last_name='Doris',
+                    )[0].name,
+                },
+                {'adviser_1': [MULTIPLE_ADVISERS_FOUND_MESSAGE]},
+            ),
+            # adviser_1 and team_1 mismatch
+            (
+                {
+                    'adviser_1': lambda: AdviserFactory(
+                        first_name='Pluto',
+                        last_name='Doris',
+                        dit_team__name='Team Advantage',
+                    ).name,
+                    'team_1': lambda: TeamFactory(
+                        name='Team Disadvantage',
+                    ).name,
+                },
+                {'adviser_1': [ADVISER_WITH_TEAM_NOT_FOUND_MESSAGE]},
+            ),
+            # adviser_2 doesn't exist
+            (
+                {'adviser_2': 'Non-existent adviser'},
+                {'adviser_2': [ADVISER_NOT_FOUND_MESSAGE]},
+            ),
+            # multiple matching values for adviser_2
+            (
+                {
+                    'adviser_2': lambda: AdviserFactory.create_batch(
+                        2,
+                        first_name='Pluto',
+                        last_name='Doris',
+                    )[0].name,
+                },
+                {'adviser_2': [MULTIPLE_ADVISERS_FOUND_MESSAGE]},
+            ),
+            # adviser_2 and team_2 mismatch
+            (
+                {
+                    'adviser_2': lambda: AdviserFactory(
+                        first_name='Pluto',
+                        last_name='Doris',
+                        dit_team__name='Team Advantage',
+                    ).name,
+                    'team_2': lambda: TeamFactory(
+                        name='Team Disadvantage',
+                    ).name,
+                },
+                {'adviser_2': [ADVISER_WITH_TEAM_NOT_FOUND_MESSAGE]},
+            ),
+            # service doesn't exist
+            (
+                {'service': 'Non-existent service'},
+                {
+                    'service': [
+                        'Select a valid choice. That choice is not one of the available choices.',
+                    ],
+                },
+            ),
+            # service is disabled
+            (
+                {
+                    'service': lambda: _random_service(disabled=True).name,
+                },
+                {
+                    'service': [OBJECT_DISABLED_MESSAGE],
+                },
+            ),
+            # Multiple matching services
+            (
+                {
+                    'service': lambda: ServiceFactory.create_batch(2, name='Duplicate')[0].name,
+                },
+                {
+                    'service': ['There is more than one matching service.'],
+                },
+            ),
+            # communication_channel doesn't exist
+            (
+                {'communication_channel': 'Non-existent communication channel'},
+                {
+                    'communication_channel': [
+                        'Select a valid choice. That choice is not one of the available choices.',
+                    ],
+                },
+            ),
+            # Multiple matching communication channels
+            (
+                {
+                    'communication_channel': lambda: CommunicationChannelFactory.create_batch(
+                        2,
+                        name='Duplicate',
+                    )[0].name,
+                },
+                {
+                    'communication_channel': [
+                        'There is more than one matching communication channel.',
+                    ],
+                },
+            ),
+            # communication_channel is disabled
+            (
+                {
+                    'communication_channel': lambda: _random_communication_channel(
+                        disabled=True,
+                    ).name,
+                },
+                {
+                    'communication_channel': [OBJECT_DISABLED_MESSAGE],
+                },
+            ),
+            # event_id invalid
+            (
+                {'event_id': 'non_existent_event_id'},
+                {
+                    'event_id': [
+                        "'non_existent_event_id' is not a valid UUID.",
+                    ],
+                },
+            ),
+            # event_id is for a disabled event
+            (
+                {
+                    'event_id': lambda: str(DisabledEventFactory().pk),
+                },
+                {
+                    'event_id': [OBJECT_DISABLED_MESSAGE],
+                },
+            ),
+            # event_id non-existent
+            (
+                {'event_id': '00000000-0000-0000-0000-000000000000'},
+                {
+                    'event_id': [
+                        'Select a valid choice. That choice is not one of the available '
+                        'choices.',
+                    ],
+                },
+            ),
+            # cannot specify event_id for an interaction
+            (
+                {
+                    'kind': Interaction.KINDS.interaction,
+                    'event_id': lambda: str(EventFactory().pk),
+                },
+                {
+                    'event_id': [INTERACTION_CANNOT_HAVE_AN_EVENT_MESSAGE],
+                },
+            ),
+        ),
+    )
+    def test_validation_errors(self, data, errors):
+        """Test validation for various fields."""
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        service = _random_service()
+
+        resolved_data = {
+            'kind': 'interaction',
+            'date': '01/01/2018',
+            'adviser_1': adviser.name,
+            'contact_email': 'person@company.com',
+            'service': service.name,
+
+            **_resolve_data(data),
+        }
+
+        form = InteractionCSVRowForm(data=resolved_data)
+        assert form.errors == errors
+
+    @pytest.mark.parametrize(
+        'field,input_value,expected_value',
+        (
+            # UK date format without leading zeroes
+            (
+                'date',
+                '1/2/2013',
+                date(2013, 2, 1),
+            ),
+            # UK date format with leading zeroes
+            (
+                'date',
+                '03/04/2015',
+                date(2015, 4, 3),
+            ),
+            # ISO date format
+            (
+                'date',
+                '2016-05-04',
+                date(2016, 5, 4),
+            ),
+            # Subject
+            (
+                'subject',
+                'A subject',
+                'A subject',
+            ),
+            # Notes (trailing blank lines are stripped)
+            (
+                'notes',
+                'Notes with\nmultiple lines\n',
+                'Notes with\nmultiple lines',
+            ),
+        ),
+    )
+    def test_simple_value_cleaning(self, field, input_value, expected_value):
+        """Test the conversion and cleaning of various non-relationship fields."""
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        service = _random_service()
+
+        resolved_data = {
+            'kind': 'interaction',
+            'date': '01/01/2018',
+            'adviser_1': adviser.name,
+            'contact_email': 'person@company.com',
+            'service': service.name,
+
+            field: input_value,
+        }
+
+        form = InteractionCSVRowForm(data=resolved_data)
+        assert not form.errors
+        assert form.cleaned_data[field] == expected_value
+
+    @pytest.mark.parametrize(
+        'kind',
+        (Interaction.KINDS.interaction, Interaction.KINDS.service_delivery),
+    )
+    @pytest.mark.parametrize(
+        'field,object_creator,input_transformer',
+        (
+            # adviser_1 look-up (same case)
+            (
+                'adviser_1',
+                lambda: AdviserFactory(
+                    first_name='Pluto',
+                    last_name='Doris',
+                ),
+                lambda obj: obj.name,
+            ),
+            # adviser_1 look-up (case-insensitive)
+            (
+                'adviser_1',
+                lambda: AdviserFactory(
+                    first_name='Pluto',
+                    last_name='Doris',
+                ),
+                lambda obj: obj.name.upper(),
+            ),
+            # adviser_2 look-up (same case)
+            (
+                'adviser_1',
+                lambda: AdviserFactory(
+                    first_name='Pluto',
+                    last_name='Doris',
+                ),
+                lambda obj: obj.name,
+            ),
+            # adviser_2 look-up (case-insensitive)
+            (
+                'adviser_1',
+                lambda: AdviserFactory(
+                    first_name='Pluto',
+                    last_name='Doris',
+                ),
+                lambda obj: obj.name.upper(),
+            ),
+            # service look-up (same case)
+            (
+                'service',
+                lambda: ServiceFactory(name='UNIQUE EXPORT DEAL'),
+                lambda obj: obj.name,
+            ),
+            # service look-up (case-insensitive)
+            (
+                'service',
+                lambda: ServiceFactory(name='UNIQUE EXPORT DEAL'),
+                lambda obj: obj.name.lower(),
+            ),
+        ),
+    )
+    def test_common_relation_fields(self, kind, field, object_creator, input_transformer):
+        """
+        Test the looking up of values for relationship fields common to interactions and
+        service deliveries.
+        """
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        service = _random_service()
+        obj = object_creator()
+
+        resolved_data = {
+            'kind': kind,
+            'date': '01/01/2018',
+            'adviser_1': adviser.name,
+            'contact_email': 'person@company.com',
+            'service': service.name,
+
+            field: input_transformer(obj),
+        }
+
+        form = InteractionCSVRowForm(data=resolved_data)
+        assert not form.errors
+        assert form.cleaned_data[field] == obj
+
+    @pytest.mark.parametrize(
+        'field,object_creator,input_transformer',
+        (
+            # communication channel look-up (same case)
+            (
+                'communication_channel',
+                lambda: _random_communication_channel(),
+                lambda obj: obj.name,
+            ),
+            # communication channel look-up (case-insensitive)
+            (
+                'communication_channel',
+                lambda: _random_communication_channel(),
+                lambda obj: obj.name.upper(),
+            ),
+        ),
+    )
+    def test_interaction_relation_fields(self, field, object_creator, input_transformer):
+        """Test the looking up of values for relationship fields specific to interactions."""
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        service = _random_service()
+        obj = object_creator()
+
+        resolved_data = {
+            'kind': 'interaction',
+            'date': '01/01/2018',
+            'adviser_1': adviser.name,
+            'contact_email': 'person@company.com',
+            'service': service.name,
+
+            field: input_transformer(obj),
+        }
+
+        form = InteractionCSVRowForm(data=resolved_data)
+        assert not form.errors
+        assert form.cleaned_data[field] == obj
+
+    @pytest.mark.parametrize(
+        'field,object_creator,input_transformer,expected_value_transformer',
+        (
+            # communication channel should be ignored
+            (
+                'communication_channel',
+                lambda: _random_communication_channel(),
+                lambda obj: obj.name,
+                lambda obj: None,
+            ),
+            # event look-up
+            (
+                'event_id',
+                lambda: EventFactory(),
+                lambda obj: str(obj.pk),
+                lambda obj: obj,
+            ),
+        ),
+    )
+    def test_service_delivery_relation_fields(
+        self,
+        field,
+        object_creator,
+        input_transformer,
+        expected_value_transformer,
+    ):
+        """Test the looking up of values for relationship fields specific to service deliveries."""
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        service = _random_service()
+        obj = object_creator()
+
+        resolved_data = {
+            'kind': 'service_delivery',
+            'date': '01/01/2018',
+            'adviser_1': adviser.name,
+            'contact_email': 'person@company.com',
+            'service': service.name,
+
+            field: input_transformer(obj),
+        }
+
+        form = InteractionCSVRowForm(data=resolved_data)
+        assert not form.errors
+        assert form.cleaned_data[field] == expected_value_transformer(obj)
+
+    @pytest.mark.parametrize(
+        'kind',
+        (Interaction.KINDS.interaction, Interaction.KINDS.service_delivery),
+    )
+    def test_subject_falls_back_to_service(self, kind):
+        """Test that if subject is not specified, the name of the service is used instead."""
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        service = _random_service()
+
+        data = {
+            'kind': kind,
+            'date': '01/01/2018',
+            'adviser_1': adviser.name,
+            'contact_email': 'person@company.com',
+            'service': service.name,
+        }
+
+        form = InteractionCSVRowForm(data=data)
+        assert not form.errors
+        assert form.cleaned_data['subject'] == service.name
+
+
+def _random_communication_channel(disabled=False):
+    return random_obj_for_queryset(
+        CommunicationChannel.objects.filter(disabled_on__isnull=not disabled),
+    )
+
+
+def _random_service(disabled=False):
+    return random_obj_for_queryset(
+        Service.objects.filter(disabled_on__isnull=not disabled),
+    )
+
+
+def _resolve_data(data):
+    """Resolve callables in values used in parametrised tests."""
+    if isinstance(data, Mapping):
+        return {key: _resolve_data(value) for key, value in data.items()}
+
+    if callable(data):
+        return data()
+
+    return data

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import factory
 from django.utils.timezone import utc
 
@@ -14,6 +16,16 @@ from datahub.interaction.models import (
     ServiceDeliveryStatus,
 )
 from datahub.investment.project.test.factories import InvestmentProjectFactory
+
+
+class CommunicationChannelFactory(factory.django.DjangoModelFactory):
+    """CommunicationChannel factory."""
+
+    id = factory.LazyFunction(uuid4)
+    name = factory.Faker('word')
+
+    class Meta:
+        model = 'interaction.CommunicationChannel'
 
 
 class InteractionFactoryBase(factory.django.DjangoModelFactory):


### PR DESCRIPTION
### Description of change

This adds a form that will be used to validate CSV rows when importing interactions via the admin site. The form will only be used for validation; it will not be displayed anywhere.

For context, please see previous related PRs: #1619, #1623, #1632 and #1650.

The spec the rows are being validated against is covered in on the select file page:

![image](https://user-images.githubusercontent.com/12693549/56048682-ec486100-5d3f-11e9-9819-41eb7cc92678.png)

### To test

The form is not used yet, so there is nothing to manually test. However, you can look at #1660 if you want to see how it will be used.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
