### PR TITLE
Add row errors page for admin site import interactions tool 

### DIFF
--- a/changelog/interaction/import-tool-errors-page.feature.rst
+++ b/changelog/interaction/import-tool-errors-page.feature.rst
@@ -1,0 +1,2 @@
+- **Interactions** Validation of rows in the input file was added to the admin site tool for importing interactions.
+  The tool is currently behind the ``admin-interaction-csv-importer`` feature flag as it is incomplete.

--- a/conftest.py
+++ b/conftest.py
@@ -73,11 +73,11 @@ def api_client():
 class _ReturnValueTracker:
     def __init__(self, cls, method_name):
         self.return_values = []
-        self.original_method = getattr(cls, method_name)
+        self.original_callable = getattr(cls, method_name)
 
     def make_mock(self):
-        def _spy(obj, *args, **kwargs):
-            return_value = self.original_method(obj, *args, **kwargs)
+        def _spy(*args, **kwargs):
+            return_value = self.original_callable(*args, **kwargs)
             self.return_values.append(return_value)
             return return_value
 
@@ -87,20 +87,21 @@ class _ReturnValueTracker:
 @pytest.fixture
 def track_return_values(monkeypatch):
     """
-    Fixture that can be used to track the return values of a method.
+    Fixture that can be used to track the return values of a callable.
 
     Usage example:
 
+        # obj could be a class or a module (for example)
         def test_something(track_return_values):
-            tracker = track_return_values(cls, 'method_name')
+            tracker = track_return_values(obj, 'name_of_callable')
 
             ...
 
             assert tracker.return_values == [1, 2, 3]
     """
-    def _patch(cls, method_name):
-        tracker = _ReturnValueTracker(cls, method_name)
-        monkeypatch.setattr(cls, method_name, tracker.make_mock())
+    def _patch(obj, callable_name):
+        tracker = _ReturnValueTracker(obj, callable_name)
+        monkeypatch.setattr(obj, callable_name, tracker.make_mock())
         return tracker
 
     yield _patch

--- a/datahub/interaction/admin_csv_import/file_form.py
+++ b/datahub/interaction/admin_csv_import/file_form.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.template.defaultfilters import filesizeformat
 
 from datahub.core.admin_csv_import import BaseCSVImportForm
+from datahub.interaction.admin_csv_import.row_form import InteractionCSVRowForm
 
 
 class InteractionCSVForm(BaseCSVImportForm):
@@ -11,10 +12,16 @@ class InteractionCSVForm(BaseCSVImportForm):
     csv_file_field_help_text = (
         f'Maximum file size: {filesizeformat(settings.INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE)}'
     )
-    required_columns = {
-        'kind',
-        'date',
-        'service',
-        'contact_email',
-        'adviser_1',
-    }
+    required_columns = InteractionCSVRowForm.get_required_field_names()
+
+    def are_all_rows_valid(self):
+        """Check if all of the rows in the CSV pass validation."""
+        with self.open_file_as_dict_reader() as dict_reader:
+            return all(InteractionCSVRowForm(data=row).is_valid() for row in dict_reader)
+
+    def get_row_error_iterator(self):
+        """Get a generator of CSVRowError instances."""
+        with self.open_file_as_dict_reader() as dict_reader:
+            for index, row in enumerate(dict_reader):
+                form = InteractionCSVRowForm(row_index=index, data=row)
+                yield from form.get_flat_error_list_iterator()

--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -1,3 +1,5 @@
+from typing import NamedTuple
+
 from django import forms
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy
@@ -28,6 +30,15 @@ INTERACTION_CANNOT_HAVE_AN_EVENT_MESSAGE = gettext_lazy(
 def _validate_not_disabled(obj):
     if obj.disabled_on:
         raise ValidationError(OBJECT_DISABLED_MESSAGE, code='object_is_disabled')
+
+
+class CSVRowError(NamedTuple):
+    """A flattened validation error."""
+
+    source_row: int
+    field: str
+    value: str
+    error: str
 
 
 class NoDuplicatesModelChoiceField(forms.ModelChoiceField):
@@ -100,6 +111,11 @@ class InteractionCSVRowForm(forms.Form):
     subject = forms.CharField(required=False)
     notes = forms.CharField(required=False)
 
+    def __init__(self, *args, row_index=None, **kwargs):
+        """Initialise the form with an optional zero-based row index."""
+        super().__init__(*args, **kwargs)
+        self.row_index = row_index
+
     @classmethod
     def get_required_field_names(cls):
         """Get the required base fields of this form."""
@@ -143,6 +159,14 @@ class InteractionCSVRowForm(forms.Form):
         )
 
         return data
+
+    def get_flat_error_list_iterator(self):
+        """Get a generator of CSVRowError instances representing validation errors."""
+        return (
+            CSVRowError(self.row_index, field, self.data.get(field, ''), error)
+            for field, errors in self.errors.items()
+            for error in errors
+        )
 
     def _populate_adviser(self, data, adviser_field, team_field):
         try:

--- a/datahub/interaction/admin_csv_import/views.py
+++ b/datahub/interaction/admin_csv_import/views.py
@@ -1,16 +1,30 @@
+from itertools import islice
+
 from django.conf import settings
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
-from django.core.exceptions import PermissionDenied
+from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
 
 from datahub.core.admin import max_upload_size
 from datahub.feature_flag.utils import feature_flagged_view
 from datahub.interaction.admin_csv_import.file_form import InteractionCSVForm
+from datahub.interaction.models import Interaction, InteractionPermission
 
 INTERACTION_IMPORTER_FEATURE_FLAG_NAME = 'admin-interaction-csv-importer'
+MAX_ERRORS_TO_DISPLAY = 50
+PAGE_TITLE = gettext_lazy('Import interactions')
+
+
+interaction_change_all_permission_required = method_decorator(
+    permission_required(
+        f'interaction.{InteractionPermission.change_all}',
+        raise_exception=True,
+    ),
+)
 
 
 class InteractionCSVImportAdmin:
@@ -38,12 +52,10 @@ class InteractionCSVImportAdmin:
         ]
 
     @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
+    @interaction_change_all_permission_required
     @method_decorator(max_upload_size(settings.INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE))
     def select_file(self, request, *args, **kwargs):
         """View containing a form to select a CSV file to import."""
-        if not self.model_admin.has_change_permission(request):
-            raise PermissionDenied
-
         if request.method != 'POST':
             return self._select_file_form_response(request, InteractionCSVForm())
 
@@ -51,19 +63,44 @@ class InteractionCSVImportAdmin:
         if not form.is_valid():
             return self._select_file_form_response(request, form)
 
+        if not form.are_all_rows_valid():
+            return self._error_list_response(request, form.get_row_error_iterator())
+
         # Next page not yet implemented; redirect to the change list for now
-        changelist_route_name = admin_urlname(self.model_admin.model._meta, 'changelist')
-        changelist_url = reverse(changelist_route_name)
-        return HttpResponseRedirect(changelist_url)
+        return _redirect_response('changelist')
 
     def _select_file_form_response(self, request, form):
-        template_name = 'admin/interaction/interaction/import_select_file.html'
-        title = 'Import interactions'
+        return self._template_response(
+            request,
+            'admin/interaction/interaction/import_select_file.html',
+            PAGE_TITLE,
+            form=form,
+        )
 
+    def _error_list_response(self, request, errors):
+        limited_errors = list(islice(errors, MAX_ERRORS_TO_DISPLAY))
+        are_errors_truncated = bool(next(errors, None))
+
+        return self._template_response(
+            request,
+            'admin/interaction/interaction/import_row_errors.html',
+            PAGE_TITLE,
+            errors=limited_errors,
+            are_errors_truncated=are_errors_truncated,
+            max_errors=MAX_ERRORS_TO_DISPLAY,
+        )
+
+    def _template_response(self, request, template, title, **extra_context):
         context = {
             **self.model_admin.admin_site.each_context(request),
             'opts': self.model_admin.model._meta,
             'title': title,
-            'form': form,
+            **extra_context,
         }
-        return TemplateResponse(request, template_name, context)
+        return TemplateResponse(request, template, context)
+
+
+def _redirect_response(admin_view_name, **kwargs):
+    import_errors_route_name = admin_urlname(Interaction._meta, admin_view_name)
+    import_errors_url = reverse(import_errors_route_name, kwargs=kwargs)
+    return HttpResponseRedirect(import_errors_url)

--- a/datahub/interaction/templates/admin/interaction/interaction/base_import.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/base_import.html
@@ -1,0 +1,26 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media }}
+{% endblock %}
+
+{% block extrastyle %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+{% endblock %}

--- a/datahub/interaction/templates/admin/interaction/interaction/import_row_errors.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_row_errors.html
@@ -1,0 +1,31 @@
+{% extends "admin/interaction/interaction/base_import.html" %}
+{% load i18n admin_urls static %}
+
+{% block content %}
+  <p>
+    The file selected could not be loaded due the following errors.
+    Edit the file and <a href="{% url 'admin:interaction_interaction_import' %}">then try again</a>.
+  </p>
+
+  {% if are_errors_truncated %}
+  <p>
+    Only the first {{ max_errors }} errors are displayed.
+  </p>
+  {% endif %}
+  <table>
+    <tr>
+      <th>Row</th>
+      <th>Field</th>
+      <th>Value</th>
+      <th>Error</th>
+    </tr>
+  {% for error in errors %}
+    <tr>
+      <td>{{ error.source_row|add:1 }}</td>
+      <td>{{ error.field }}</td>
+      <td>{{ error.value }}</td>
+      <td>{{ error.error }}</td>
+    </tr>
+  {% endfor %}
+  </table>
+{% endblock %}

--- a/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
@@ -1,26 +1,5 @@
-{% extends "admin/base_site.html" %}
+{% extends "admin/interaction/interaction/base_import.html" %}
 {% load i18n admin_urls static %}
-
-{% block extrahead %}
-  {{ block.super }}
-  {{ media }}
-{% endblock %}
-
-{% block extrastyle %}
-{{ block.super }}
-<link rel="stylesheet" type="text/css" href="{% static 'admin/css/forms.css' %}">
-{% endblock %}
-
-{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}{% endblock %}
-
-{% block breadcrumbs %}
-<div class="breadcrumbs">
-<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
-&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
-&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
-&rsaquo; {{ title }}
-</div>
-{% endblock %}
 
 {% block content %}
   <p>{% trans 'Select a CSV file to import interactions into Data Hub. The CSV file should contain the following columns (in any order):' %}</p>

--- a/datahub/interaction/test/admin_csv_import/test_views.py
+++ b/datahub/interaction/test/admin_csv_import/test_views.py
@@ -1,3 +1,4 @@
+import csv
 import io
 
 import pytest
@@ -8,6 +9,7 @@ from django.test import Client
 from django.urls import reverse
 from rest_framework import status
 
+from datahub.company.test.factories import AdviserFactory
 from datahub.core.test_utils import AdminTestMixin, create_test_user
 from datahub.feature_flag.test.factories import FeatureFlagFactory
 from datahub.interaction.admin_csv_import.views import INTERACTION_IMPORTER_FEATURE_FLAG_NAME
@@ -71,35 +73,42 @@ class TestInteractionAdminChangeList(AdminTestMixin):
 
 @pytest.mark.usefixtures('interaction_importer_feature_flag')
 @pytest.mark.parametrize(
-    'url',
+    'http_method,url',
     (
-        import_interactions_url,
+        ('get', import_interactions_url),
+        ('post', import_interactions_url),
     ),
 )
 class TestAccessRestrictions(AdminTestMixin):
     """Tests permissions and other access restrictions on import interaction-related views."""
 
-    def test_redirects_to_login_page_if_not_logged_in(self, url):
+    def test_redirects_to_login_page_if_not_logged_in(self, http_method, url):
         """Test that the view redirects to the login page if the user isn't authenticated."""
         client = Client()
-        response = client.get(url, follow=True)
+        # Note: Client.generic() doesn't support follow=True
+        request_func = getattr(client, http_method)
+        response = request_func(url, follow=True)
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        assert response.redirect_chain == [
+            (self.login_url_with_redirect(url), status.HTTP_302_FOUND),
+        ]
 
-    def test_redirects_to_login_page_if_not_staff(self, url):
+    def test_redirects_to_login_page_if_not_staff(self, url, http_method):
         """Test that the view redirects to the login page if the user isn't a member of staff."""
         user = create_test_user(is_staff=False, password=self.PASSWORD)
 
         client = self.create_client(user=user)
-        response = client.get(url, follow=True)
+        # Note: Client.generic() doesn't support follow=True
+        request_func = getattr(client, http_method)
+        response = request_func(url, follow=True)
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == self.login_url_with_redirect(url)
+        assert response.redirect_chain == [
+            (self.login_url_with_redirect(url), status.HTTP_302_FOUND),
+        ]
 
-    def test_permission_denied_if_staff_and_without_change_permission(self, url):
+    def test_permission_denied_if_staff_and_without_change_permission(self, url, http_method):
         """
         Test that the view returns a 403 response if the staff user does not have the
         change interaction permission.
@@ -111,7 +120,7 @@ class TestAccessRestrictions(AdminTestMixin):
         )
 
         client = self.create_client(user=user)
-        response = client.get(url)
+        response = client.generic(http_method, url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
@@ -141,7 +150,7 @@ class Test404IfFeatureFlagDisabled(AdminTestMixin):
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
-@pytest.mark.usefixtures('interaction_importer_feature_flag')
+@pytest.mark.usefixtures('interaction_importer_feature_flag', 'local_memory_cache')
 class TestImportInteractionsSelectFileView(AdminTestMixin):
     """Tests for the import interaction select file form."""
 
@@ -157,8 +166,10 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
 
     def test_does_not_allow_file_without_correct_columns(self):
         """Test that the form rejects a CSV file that doesn't have the required columns."""
-        file = io.BytesIO(b'test\r\nrow')
-        file.name = 'test.csv'
+        file = _make_csv(
+            ('test',),
+            ('row',),
+        )
 
         response = self.client.post(
             import_interactions_url,
@@ -204,11 +215,11 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
 
     def test_redirects_on_valid_file(self):
         """Test that the user is redirected to the change list when a valid file is loaded."""
-        filename = 'filea.csv'
-        file = io.BytesIO("""kind,date,adviser_1,contact_email,service\r
-interaction,01/01/2018,John Dreary,person@company,Account Management
-""".encode(encoding='utf-8'))
-        file.name = filename
+        adviser = AdviserFactory()
+        file = _make_csv(
+            ('kind', 'date', 'adviser_1', 'contact_email', 'service'),
+            ('interaction', '01/01/2018', adviser.name, 'person@company.uk', 'Account Management'),
+        )
 
         response = self.client.post(
             import_interactions_url,
@@ -219,5 +230,55 @@ interaction,01/01/2018,John Dreary,person@company,Account Management
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.redirect_chain) == 1
-        assert response.redirect_chain[0][0] == interaction_change_list_url
+        assert response.redirect_chain == [
+            (interaction_change_list_url, status.HTTP_302_FOUND),
+        ]
+
+    @pytest.mark.parametrize(
+        'max_errors,should_be_truncated',
+        (
+            (5, True),
+            (10, False),
+        ),
+    )
+    def test_displays_errors_for_file_with_invalid_rows(
+        self,
+        max_errors,
+        should_be_truncated,
+        monkeypatch,
+    ):
+        """Test that errors are displayed for a file with invalid rows."""
+        monkeypatch.setattr(
+            'datahub.interaction.admin_csv_import.views.MAX_ERRORS_TO_DISPLAY',
+            max_errors,
+        )
+
+        # This file should have 10 errors
+        file = _make_csv(
+            ('kind', 'date', 'adviser_1', 'contact_email', 'service'),
+            ('invalid', 'invalid', 'invalid', 'invalid', 'invalid'),
+            ('invalid', 'invalid', 'invalid', 'invalid', 'invalid'),
+        )
+
+        response = self.client.post(
+            import_interactions_url,
+            data={
+                'csv_file': file,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.context['errors']) == min(10, max_errors)
+        assert response.context['are_errors_truncated'] == should_be_truncated
+
+
+def _make_csv(*rows, encoding='utf-8', filename='test.csv'):
+    with io.StringIO() as text_stream:
+        writer = csv.writer(text_stream)
+        writer.writerows(rows)
+
+        data = text_stream.getvalue().encode(encoding)
+
+    stream = io.BytesIO(data)
+    stream.name = filename
+    return stream


### PR DESCRIPTION
### Description of change

This adds the display of row-level validation errors to the admin site import interactions tool.

A maximum of 50 errors are displayed.

Files are stored in Redis between requests. Redis was chosen for simplicity, and as the files involved are relatively small.

For context, please see previous related PRs: #1619, #1623, #1632, #1650 and #1659.

### Screenshot

![image](https://user-images.githubusercontent.com/12693549/56905707-9fcb8800-6a98-11e9-8b46-21b4a6c59d65.png)

### To test

1. Create the `admin-interaction-csv-importer` feature flag and set it as active
1. Navigate to the interaction change list page in the admin site
1. Click on the 'Import interaction' link
1. Create a valid or invalid CSV file according to the spec on the page
1. Select your CSV file
1. Submit the form
1. If the file is valid, you should be redirected to the change list page. Otherwise, a list of errors should be displayed.

Example of a valid CSV file (replacing the `team_1` and `adviser_1` values):

```
team_1,adviser_1,adviser_2,contact_email,communication_channel,service,kind,date,event_id,notes
Digital Data Hub - Live Service,<an adviser name>,,fooimport@bar.com,Email/Website,Account managemenT,interaction,22/02/2019,,some notes
```

Example of an invalid CSV file:

```
kind,date,adviser_1,contact_email,service
invalid,invalid,invalid,invalid,invalid
invalid,invalid,invalid,invalid,invalid
```

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
