### PR TITLE
Remove company_field_with_copy_to_name_trigram search model field

### DIFF
--- a/changelog/company-field-sub-fields-usage.internal.rst
+++ b/changelog/company-field-sub-fields-usage.internal.rst
@@ -1,0 +1,1 @@
+The ``company_field_with_copy_to_name_trigram`` search field type was removed and uses of it replaced with ``company_field``. The ``name.keyword``, ``name.trigram`` and ``trading_names.trigram`` sub-fields are now used in search queries. This change also means that the type of the ``name`` sub-field has been corrected from ``keyword`` to ``text``.

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -381,7 +381,7 @@ def test_get_basic_search_query():
                                 'address_country.name.trigram',
                                 'address_postcode_trigram',
                                 'company.name',
-                                'company.name_trigram',
+                                'company.name.trigram',
                                 'company_number',
                                 'contact.name',
                                 'contact.name.trigram',

--- a/datahub/search/contact/models.py
+++ b/datahub/search/contact/models.py
@@ -26,7 +26,7 @@ class Contact(BaseESModel):
     archived_by = fields.contact_or_adviser_field()
     archived_on = Date()
     archived_reason = Text()
-    company = fields.company_field_with_copy_to_name_trigram('company')
+    company = fields.company_field()
     company_sector = fields.sector_field()
     company_uk_region = fields.id_name_field()
     created_by = fields.contact_or_adviser_field(include_dit_team=True)
@@ -84,7 +84,7 @@ class Contact(BaseESModel):
         'email',
         'email_alternative',
         'company.name',
-        'company.name_trigram',
+        'company.name.trigram',
     )
 
     class Meta:

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -103,9 +103,7 @@ def test_mapping(setup_es):
                     'properties': {
                         'id': {'type': 'keyword'},
                         'name': {
-                            'copy_to': ['company.name_trigram'],
-                            'normalizer': 'lowercase_asciifolding_normalizer',
-                            'type': 'keyword',
+                            'type': 'text',
                             'fields': {
                                 'keyword': {
                                     'normalizer': 'lowercase_asciifolding_normalizer',
@@ -117,12 +115,7 @@ def test_mapping(setup_es):
                                 },
                             },
                         },
-                        'name_trigram': {
-                            'analyzer': 'trigram_analyzer',
-                            'type': 'text',
-                        },
                         'trading_names': {
-                            'copy_to': ['company.trading_names_trigram'],
                             'type': 'text',
                             'fields': {
                                 'trigram': {
@@ -130,10 +123,6 @@ def test_mapping(setup_es):
                                     'type': 'text',
                                 },
                             },
-                        },
-                        'trading_names_trigram': {
-                            'analyzer': 'trigram_analyzer',
-                            'type': 'text',
                         },
                     },
                     'type': 'object',
@@ -291,7 +280,7 @@ def test_get_basic_search_query():
                                 'address_country.name.trigram',
                                 'address_postcode_trigram',
                                 'company.name',
-                                'company.name_trigram',
+                                'company.name.trigram',
                                 'company_number',
                                 'contact.name',
                                 'contact.name.trigram',
@@ -411,7 +400,7 @@ def test_get_limited_search_by_entity_query():
                                             'email',
                                             'email_alternative',
                                             'company.name',
-                                            'company.name_trigram',
+                                            'company.name.trigram',
                                         ),
                                         'type': 'cross_fields',
                                         'operator': 'and',

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -26,6 +26,7 @@ class SearchContactAPIViewMixin:
     es_sort_by_remappings = {
         'adviser.name': 'adviser.name.keyword',
         'archived_by.name': 'archived_by.name.keyword',
+        'company.name': 'company.name.keyword',
         'first_name': 'first_name.keyword',
         'last_name': 'last_name.keyword',
         'name': 'name.keyword',
@@ -59,9 +60,9 @@ class SearchContactAPIViewMixin:
         ],
         'company_name': [
             'company.name',
-            'company.name_trigram',
+            'company.name.trigram',
             'company.trading_names',  # to find 2-letter words
-            'company.trading_names_trigram',
+            'company.trading_names.trigram',
         ],
         'company_sector_descends': [
             'company_sector.id',

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -153,43 +153,6 @@ def address_field(index_country=True):
     )
 
 
-def company_field_with_copy_to_name_trigram(field):
-    """
-    Company field with copy to, deprecated in favour of company_field.
-
-    The `name` and `trading_names` fields is being migrated away from using `copy_to` to being a
-    multi-field. The sub-fields and `_trigram`-suffixed fields are both defined while the switch
-    takes place.
-
-    Additionally, the `name` field should have had a data type of text, but it was mistakenly made
-    a keyword field. Hence, a `keyword` sub-field has also been added so type of `name` can be
-    changed to text once sorting operations have been migrated to using the `keyword` sub-field.
-
-    TODO: replace usages of this with company_field once search logic has been updated to use
-     name.keyword, name.trigram and trading_names.trigram where necessary.
-    """
-    return Object(
-        properties={
-            'id': Keyword(),
-            'name': NormalizedKeyword(
-                copy_to=f'{field}.name_trigram',
-                fields={
-                    'trigram': TrigramText(),
-                    'keyword': NormalizedKeyword(),
-                },
-            ),
-            'name_trigram': TrigramText(),
-            'trading_names': Text(
-                copy_to=f'{field}.trading_names_trigram',
-                fields={
-                    'trigram': TrigramText(),
-                },
-            ),
-            'trading_names_trigram': TrigramText(),
-        },
-    )
-
-
 def ch_company_field():
     """Object field with id and company_number sub-fields."""
     return Object(properties={

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -45,7 +45,7 @@ class Interaction(BaseESModel):
     """Elasticsearch representation of Interaction model."""
 
     id = Keyword()
-    company = fields.company_field_with_copy_to_name_trigram('company')
+    company = fields.company_field()
     company_sector = fields.sector_field()
     communication_channel = fields.id_name_field()
     contacts = _contact_field()
@@ -101,7 +101,7 @@ class Interaction(BaseESModel):
     SEARCH_FIELDS = (
         'id',
         'company.name',
-        'company.name_trigram',
+        'company.name.trigram',
         'contacts.name',  # to find 2-letter words
         'contacts.name.trigram',
         'event.name',

--- a/datahub/search/interaction/views.py
+++ b/datahub/search/interaction/views.py
@@ -18,6 +18,9 @@ class SearchInteractionAPIViewMixin:
     required_scopes = (Scope.internal_front_end,)
     search_app = InteractionSearchApp
     serializer_class = SearchInteractionQuerySerializer
+    es_sort_by_remappings = {
+        'company.name': 'company.name.keyword',
+    }
 
     FILTER_FIELDS = (
         'kind',
@@ -56,9 +59,9 @@ class SearchInteractionAPIViewMixin:
     COMPOSITE_FILTERS = {
         'company_name': [
             'company.name',
-            'company.name_trigram',
+            'company.name.trigram',
             'company.trading_names',  # to find 2-letter words
-            'company.trading_names_trigram',
+            'company.trading_names.trigram',
         ],
         'dit_adviser_name': [
             'dit_adviser.name',

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -748,7 +748,7 @@ def test_get_basic_search_query():
                                 'address_country.name.trigram',
                                 'address_postcode_trigram',
                                 'company.name',
-                                'company.name_trigram',
+                                'company.name.trigram',
                                 'company_number',
                                 'contact.name',
                                 'contact.name.trigram',

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -15,7 +15,7 @@ class Order(BaseESModel):
     reference = fields.NormalizedKeyword(copy_to=['reference_trigram'])
     reference_trigram = fields.TrigramText()
     status = fields.NormalizedKeyword()
-    company = fields.company_field_with_copy_to_name_trigram('company')
+    company = fields.company_field()
     contact = fields.contact_or_adviser_field()
     created_by = fields.contact_or_adviser_field(include_dit_team=True)
     created_on = Date()
@@ -91,7 +91,7 @@ class Order(BaseESModel):
         'id',
         'reference_trigram',
         'company.name',
-        'company.name_trigram',
+        'company.name.trigram',
         'contact.name',
         'contact.name.trigram',
         'total_cost_string',

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -157,9 +157,7 @@ def test_mapping(setup_es):
                             'type': 'keyword',
                         },
                         'name': {
-                            'copy_to': ['company.name_trigram'],
-                            'normalizer': 'lowercase_asciifolding_normalizer',
-                            'type': 'keyword',
+                            'type': 'text',
                             'fields': {
                                 'keyword': {
                                     'normalizer': 'lowercase_asciifolding_normalizer',
@@ -171,12 +169,7 @@ def test_mapping(setup_es):
                                 },
                             },
                         },
-                        'name_trigram': {
-                            'analyzer': 'trigram_analyzer',
-                            'type': 'text',
-                        },
                         'trading_names': {
-                            'copy_to': ['company.trading_names_trigram'],
                             'type': 'text',
                             'fields': {
                                 'trigram': {
@@ -184,10 +177,6 @@ def test_mapping(setup_es):
                                     'type': 'text',
                                 },
                             },
-                        },
-                        'trading_names_trigram': {
-                            'analyzer': 'trigram_analyzer',
-                            'type': 'text',
                         },
                     },
                     'type': 'object',

--- a/datahub/search/omis/views.py
+++ b/datahub/search/omis/views.py
@@ -61,9 +61,9 @@ class SearchOrderAPIViewMixin:
         ],
         'company_name': [
             'company.name',
-            'company.name_trigram',
+            'company.name.trigram',
             'company.trading_names',  # to find 2-letter words
-            'company.trading_names_trigram',
+            'company.trading_names.trigram',
         ],
         'sector_descends': [
             'sector.id',


### PR DESCRIPTION
### Description of change

This is the follow-up to #1595.

This removes of `company_field_with_copy_to_name_trigram` and replaces uses of it with `company_field`.

Search logic has been updated to use the `name.trigram`, `name.keyword` and `trading_names` sub-fields.

### To test

I would suggest:

1. Test global search and the collection page filters and sorting options using the front end
1. Run `./manage.py migrate_es` (either with Celery running or with `CELERY_TASK_ALWAYS_EAGER=True`)
1. Test global search and the collection page filters and sorting options using the front end again

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
