### PR TITLE
Add news fragment for upcoming registered address data change

### DIFF
--- a/changelog/company/registered_address_corrected.db.rst
+++ b/changelog/company/registered_address_corrected.db.rst
@@ -1,0 +1,10 @@
+On the 4th of May 2019, all data in the ``company_company`` registered address fields will be replaced by the official data from the Companies House record identified by the ``company_company.company_number`` field.
+In cases where ``company_company.company_number`` is invalid or blank (e.g. for non-UK companies), the registered address fields will be made blank and the related data lost.
+List of registered address fields:
+
+- ``registered_address_1``
+- ``registered_address_2``
+- ``registered_address_town``
+- ``registered_address_county``
+- ``registered_address_postcode``
+- ``registered_address_country_id``


### PR DESCRIPTION
### Description of change

This adds a news fragment so that people can prepare for the upcoming data change related to registered addresses of all Data Hub companies.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
