### PR TITLE
Replace uses of ugettext with gettext

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 
 from datahub.company.constants import BusinessTypeConstant
@@ -189,10 +189,10 @@ class ContactSerializer(PermittedFieldsModelSerializer):
     """Contact serializer for writing operations V3."""
 
     default_error_messages = {
-        'address_same_as_company_and_has_address': ugettext_lazy(
+        'address_same_as_company_and_has_address': gettext_lazy(
             'Please select either address_same_as_company or enter an address manually, not both!',
         ),
-        'no_address': ugettext_lazy(
+        'no_address': gettext_lazy(
             'Please select either address_same_as_company or enter an address manually.',
         ),
     }
@@ -283,23 +283,23 @@ class BaseCompanySerializer(PermittedFieldsModelSerializer):
     """
 
     default_error_messages = {
-        'invalid_uk_establishment_number_prefix': ugettext_lazy(
+        'invalid_uk_establishment_number_prefix': gettext_lazy(
             'This must be a valid UK establishment number, beginning with BR.',
         ),
-        'invalid_uk_establishment_number_characters': ugettext_lazy(
+        'invalid_uk_establishment_number_characters': gettext_lazy(
             'This field can only contain the letters A to Z and numbers (no symbols, punctuation '
             'or spaces).',
         ),
-        'global_headquarters_hq_type_is_not_global_headquarters': ugettext_lazy(
+        'global_headquarters_hq_type_is_not_global_headquarters': gettext_lazy(
             'Company to be linked as global headquarters must be a global headquarters.',
         ),
-        'invalid_global_headquarters': ugettext_lazy(
+        'invalid_global_headquarters': gettext_lazy(
             'Global headquarters cannot point to itself.',
         ),
-        'global_headquarters_has_subsidiaries': ugettext_lazy(
+        'global_headquarters_has_subsidiaries': gettext_lazy(
             'Subsidiaries have to be unlinked before changing headquarter type.',
         ),
-        'subsidiary_cannot_be_a_global_headquarters': ugettext_lazy(
+        'subsidiary_cannot_be_a_global_headquarters': gettext_lazy(
             'A company cannot both be and have a global headquarters.',
         ),
     }
@@ -543,7 +543,7 @@ class CompanySerializerV3(BaseCompanySerializer):
     """
 
     default_error_messages = {
-        'uk_establishment_not_in_uk': ugettext_lazy(
+        'uk_establishment_not_in_uk': gettext_lazy(
             'A UK establishment (branch of non-UK company) must be in the UK.',
         ),
     }
@@ -735,7 +735,7 @@ class CompanySerializerV4(BaseCompanySerializer):
     }
 
     default_error_messages = {
-        'uk_establishment_not_in_uk': ugettext_lazy(
+        'uk_establishment_not_in_uk': gettext_lazy(
             'A UK establishment (branch of non-UK company) must be in the UK.',
         ),
     }

--- a/datahub/core/exceptions.py
+++ b/datahub/core/exceptions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import status
 from rest_framework.exceptions import APIException
 

--- a/datahub/core/fields.py
+++ b/datahub/core/fields.py
@@ -3,7 +3,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.text import capfirst
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class MultipleChoiceField(ArrayField):

--- a/datahub/event/serializers.py
+++ b/datahub/event/serializers.py
@@ -1,4 +1,4 @@
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 
 from datahub.company.serializers import NestedAdviserField
@@ -12,9 +12,9 @@ class EventSerializer(serializers.ModelSerializer):
     """Event serialiser."""
 
     default_error_messages = {
-        'lead_team_not_in_teams': ugettext_lazy('Lead team must be in teams array.'),
-        'end_date_before_start_date': ugettext_lazy('End date cannot be before start date.'),
-        'uk_region_non_uk_country': ugettext_lazy(
+        'lead_team_not_in_teams': gettext_lazy('Lead team must be in teams array.'),
+        'end_date_before_start_date': gettext_lazy('End date cannot be before start date.'),
+        'uk_region_non_uk_country': gettext_lazy(
             'Cannot specify a UK region for a non-UK country.',
         ),
     }

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -2,7 +2,7 @@ from collections import Counter
 from operator import not_
 
 from django.db.transaction import atomic
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 from rest_framework.settings import api_settings
 
@@ -40,7 +40,7 @@ class InteractionDITParticipantListSerializer(serializers.ListSerializer):
     """Interaction DIT participant list serialiser that adds validation for duplicates."""
 
     default_error_messages = {
-        'duplicate_adviser': ugettext_lazy(
+        'duplicate_adviser': gettext_lazy(
             'You cannot add the same adviser more than once.',
         ),
     }
@@ -114,31 +114,31 @@ class InteractionSerializer(serializers.ModelSerializer):
     """V3 interaction serialiser."""
 
     default_error_messages = {
-        'invalid_for_non_service_delivery': ugettext_lazy(
+        'invalid_for_non_service_delivery': gettext_lazy(
             'This field is only valid for service deliveries.',
         ),
-        'invalid_for_service_delivery': ugettext_lazy(
+        'invalid_for_service_delivery': gettext_lazy(
             'This field is not valid for service deliveries.',
         ),
-        'invalid_for_non_interaction': ugettext_lazy(
+        'invalid_for_non_interaction': gettext_lazy(
             'This field is only valid for interactions.',
         ),
-        'invalid_for_non_interaction_or_service_delivery': ugettext_lazy(
+        'invalid_for_non_interaction_or_service_delivery': gettext_lazy(
             'This value is only valid for interactions and service deliveries.',
         ),
-        'invalid_for_non_event': ugettext_lazy(
+        'invalid_for_non_event': gettext_lazy(
             'This field is only valid for event service deliveries.',
         ),
-        'invalid_when_no_policy_feedback': ugettext_lazy(
+        'invalid_when_no_policy_feedback': gettext_lazy(
             'This field is only valid when policy feedback has been provided.',
         ),
-        'too_many_contacts_for_event_service_delivery': ugettext_lazy(
+        'too_many_contacts_for_event_service_delivery': gettext_lazy(
             'Only one contact can be provided for event service deliveries.',
         ),
-        'one_participant_field': ugettext_lazy(
+        'one_participant_field': gettext_lazy(
             'If dit_participants is provided, dit_adviser and dit_team must be omitted.',
         ),
-        'cannot_unset_theme': ugettext_lazy(
+        'cannot_unset_theme': gettext_lazy(
             "A theme can't be removed once set.",
         ),
     }

--- a/datahub/investment/project/serializers.py
+++ b/datahub/investment/project/serializers.py
@@ -5,7 +5,7 @@ from functools import partial
 import reversion
 from django.db.transaction import atomic
 from django.utils.timezone import now
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 
 import datahub.metadata.models as meta_models
@@ -275,11 +275,11 @@ class IProjectSerializer(PermittedFieldsModelSerializer, NoteAwareModelSerialize
     """Serialiser for investment project endpoints."""
 
     default_error_messages = {
-        'only_pm_or_paa_can_move_to_verify_win': ugettext_lazy(
+        'only_pm_or_paa_can_move_to_verify_win': gettext_lazy(
             'Only the Project Manager or Project Assurance Adviser can move the project'
             ' to the ‘Verify win’ stage.',
         ),
-        'only_ivt_can_move_to_won': ugettext_lazy(
+        'only_ivt_can_move_to_won': gettext_lazy(
             'Only the Investment Verification Team can move the project to the ‘Won’ stage.',
         ),
     }
@@ -529,7 +529,7 @@ class IProjectTeamMemberListSerializer(serializers.ListSerializer):
     """Team member list serialiser that adds validation for duplicates."""
 
     default_error_messages = {
-        'duplicate_adviser': ugettext_lazy(
+        'duplicate_adviser': gettext_lazy(
             'You cannot add the same adviser as a team member more than once.',
         ),
     }

--- a/datahub/metadata/models.py
+++ b/datahub/metadata/models.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import Group
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from model_utils import Choices
 from mptt.models import MPTTModel, TreeForeignKey
 

--- a/datahub/omis/order/admin.py
+++ b/datahub/omis/order/admin.py
@@ -17,7 +17,7 @@ from django.utils.encoding import force_text
 from django.utils.html import format_html, format_html_join
 from django.utils.http import urlquote
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.views.decorators.csrf import csrf_protect
 
 from datahub.core.admin import (

--- a/datahub/omis/order/serializers.py
+++ b/datahub/omis/order/serializers.py
@@ -1,6 +1,6 @@
 from django.db import transaction
 from django.utils.timezone import now
-from django.utils.translation import ugettext_lazy
+from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -75,7 +75,7 @@ class OrderSerializer(serializers.ModelSerializer):
     cancelled_by = NestedRelatedField(Advisor, read_only=True)
 
     default_error_messages = {
-        'readonly': ugettext_lazy('This field cannot be changed at this stage.'),
+        'readonly': gettext_lazy('This field cannot be changed at this stage.'),
     }
 
     class Meta:
@@ -584,7 +584,7 @@ class OrderAssigneeSerializer(serializers.ModelSerializer):
     is_lead = serializers.BooleanField(required=False)
 
     default_error_messages = {
-        'readonly': ugettext_lazy(
+        'readonly': gettext_lazy(
             'This field cannot be changed at this stage.',
         ),
     }

--- a/datahub/omis/payment/admin.py
+++ b/datahub/omis/payment/admin.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.contrib import admin
 from django.core.exceptions import ValidationError
 from django.template.defaultfilters import date as date_formatter
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from datahub.core.admin import BaseModelAdminMixin
 from datahub.omis.order.constants import OrderStatus


### PR DESCRIPTION
### Description of change

This replaces uses of `ugettext()` and `ugettext_lazy()` with `gettext()` and `gettext_lazy()`.

This is because the u-prefixed functions are a remnant from Python 2 support in Django. This is also to be consistent in our code base.

The Django documentation suggests using the non-prefixed versions:

- https://docs.djangoproject.com/en/2.2/ref/utils/#module-django.utils.translation
- https://docs.djangoproject.com/en/2.2/topics/i18n/translation/#internationalization-in-python-code


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
