### PR TITLE
Add contact matching logic to import interaction tool

### DIFF
--- a/datahub/company/contact_matching.py
+++ b/datahub/company/contact_matching.py
@@ -1,0 +1,59 @@
+from enum import IntEnum
+from typing import Optional, Tuple
+
+from datahub.company.models import Contact
+
+
+class ContactMatchingStatus(IntEnum):
+    """Matching status (for when searching for a contact by email address)."""
+
+    matched = 1
+    unmatched = 2
+    multiple_matches = 3
+
+
+def find_active_contact_by_email_address(email) -> Tuple[Optional[Contact], ContactMatchingStatus]:
+    """
+    Attempts to find a contact by email address.
+
+    Used e.g. when importing interactions to match interactions to contacts using an
+    email address.
+
+    Only non-archived contacts are checked.
+
+    The following the logic is used:
+    - if a unique match is found using Contact.email, this is used
+    - if there are multiple matches found using Contact.email, matching aborts
+    - otherwise, if there is a unique match on Contact.email_alternative, this is used
+    """
+    contact, matching_status = _find_active_contact_using_field(email, 'email')
+    if matching_status == ContactMatchingStatus.unmatched:
+        contact, matching_status = _find_active_contact_using_field(email, 'email_alternative')
+
+    return contact, matching_status
+
+
+def _find_active_contact_using_field(value, lookup_field):
+    """
+    Looks up a contact by performing a case-insensitive search on a particular field.
+
+    Only non-archived contacts are considered.
+
+    :param value: The value to search for
+    :param lookup_field: The name of the field to search
+    """
+    contact = None
+    get_kwargs = {
+        'archived': False,
+        f'{lookup_field}__iexact': value,
+    }
+
+    try:
+        contact = Contact.objects.get(**get_kwargs)
+        contact_matching_status = ContactMatchingStatus.matched
+    except Contact.DoesNotExist:
+        contact_matching_status = ContactMatchingStatus.unmatched
+    except Contact.MultipleObjectsReturned:
+        contact_matching_status = ContactMatchingStatus.multiple_matches
+
+    return contact, contact_matching_status

--- a/datahub/company/migrations/0083_add_email_alternative_upper_index.py
+++ b/datahub/company/migrations/0083_add_email_alternative_upper_index.py
@@ -1,0 +1,27 @@
+"""
+Creates an index on UPPER(email_alternative) on the Contact model (for use with the
+iexact filter look-up).
+
+As Django does not support creating indexes on expressions, SQL is used.
+
+The migration is run inside a transaction, so CREATE INDEX CONCURRENTLY is not used.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('company', '0082_make_registered_address_country_optional'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                '''CREATE INDEX "company_contact_upper_email_alternative_eb17a977"
+ON "company_contact" (UPPER("email_alternative"));'''
+            ],
+            reverse_sql=['DROP INDEX "company_contact_upper_email_alternative_eb17a977";'],
+        ),
+    ]

--- a/datahub/company/models/contact.py
+++ b/datahub/company/models/contact.py
@@ -50,8 +50,9 @@ class Contact(ArchivableModel, BaseModel):
     primary = models.BooleanField()
     telephone_countrycode = models.CharField(max_length=MAX_LENGTH)
     telephone_number = models.CharField(max_length=MAX_LENGTH)
-    # Note: An index on UPPER(email) exists for use with iexact filtering
-    # See the 0038_add_index_contact_email_upper migration
+    # Note: An index on `UPPER(email)` (with name `company_contact_upper_email_244368`) exists
+    # for use with iexact filtering
+    # See the migrations for the definition
     email = models.EmailField()
     address_same_as_company = models.BooleanField(default=False)
     address_1 = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
@@ -64,6 +65,10 @@ class Contact(ArchivableModel, BaseModel):
     )
     address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     telephone_alternative = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
+    # Note: An index on `UPPER(email_alternative)` (with name
+    # `company_contact_upper_email_alternative_eb17a977`) exists for use with iexact
+    # filtering.
+    # See the migrations for the definition
     email_alternative = models.EmailField(null=True, blank=True)
     notes = models.TextField(null=True, blank=True)
     archived_documents_url_path = models.CharField(

--- a/datahub/company/test/test_contact_matching.py
+++ b/datahub/company/test/test_contact_matching.py
@@ -1,0 +1,86 @@
+import pytest
+
+from datahub.company.contact_matching import (
+    ContactMatchingStatus,
+    find_active_contact_by_email_address,
+)
+from datahub.company.test.factories import ContactFactory
+
+
+EMAIL_MATCHING_CONTACT_TEST_DATA = [
+    {
+        'email': 'unique1@primary.com',
+        'email_alternative': 'unique1@alternative.com',
+        'archived': False,
+    },
+    {
+        'email': 'duplicate@primary.com',
+        'email_alternative': '',
+        'archived': False,
+    },
+    {
+        'email': 'duplicate@primary.com',
+        'email_alternative': '',
+        'archived': False,
+    },
+    {
+        'email': 'unique2@primary.com',
+        'email_alternative': 'duplicate@alternative.com',
+        'archived': False,
+    },
+    {
+        'email': 'unique3@primary.com',
+        'email_alternative': 'duplicate@alternative.com',
+        'archived': False,
+    },
+    {
+        'email': 'archived1@primary.com',
+        'email_alternative': 'archived1@alternative.com',
+        'archived': True,
+    },
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'email,expected_matching_status,match_on_alternative',
+    (
+        # same case, match on email
+        ('unique1@primary.com', ContactMatchingStatus.matched, False),
+        # same case, match on email_alternative
+        ('unique1@alternative.com', ContactMatchingStatus.matched, True),
+        # different case, match on email
+        ('UNIQUE1@PRIMARY.COM', ContactMatchingStatus.matched, False),
+        # different case, match on email_alternative
+        ('UNIQUE1@ALTERNATIVE.COM', ContactMatchingStatus.matched, True),
+        # different
+        ('UNIQUE@COMPANY.IO', ContactMatchingStatus.unmatched, None),
+        # duplicate on email
+        ('duplicate@primary.com', ContactMatchingStatus.multiple_matches, None),
+        # duplicate on email_alternative
+        ('duplicate@alternative.com', ContactMatchingStatus.multiple_matches, None),
+        # archived contact ignored (email value specified)
+        ('archived1@primary.com', ContactMatchingStatus.unmatched, None),
+        # archived contact ignored (email_alternative value specified)
+        ('archived1@alternative.com', ContactMatchingStatus.unmatched, None),
+    ),
+)
+def test_find_active_contact_by_email_address(
+    email,
+    expected_matching_status,
+    match_on_alternative,
+):
+    """Test finding a contact by email address for various scenarios."""
+    for factory_kwargs in EMAIL_MATCHING_CONTACT_TEST_DATA:
+        ContactFactory(**factory_kwargs)
+
+    contact, actual_matching_status = find_active_contact_by_email_address(email)
+
+    assert actual_matching_status == actual_matching_status
+
+    if actual_matching_status == ContactMatchingStatus.matched:
+        assert contact
+        actual_email = contact.email_alternative if match_on_alternative else contact.email
+        assert actual_email.lower() == email.lower()
+    else:
+        assert not contact

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -3,7 +3,8 @@ from datetime import date
 
 import pytest
 
-from datahub.company.test.factories import AdviserFactory
+from datahub.company.contact_matching import ContactMatchingStatus
+from datahub.company.test.factories import AdviserFactory, ContactFactory
 from datahub.core.test_utils import random_obj_for_queryset
 from datahub.event.test.factories import DisabledEventFactory, EventFactory
 from datahub.interaction.admin_csv_import.row_form import (
@@ -18,6 +19,26 @@ from datahub.interaction.models import CommunicationChannel, Interaction
 from datahub.interaction.test.factories import CommunicationChannelFactory
 from datahub.metadata.models import Service
 from datahub.metadata.test.factories import ServiceFactory, TeamFactory
+
+
+EMAIL_MATCHING_CONTACT_TEST_DATA = [
+    {
+        'email': 'unique1@primary.com',
+        'email_alternative': '',
+    },
+    {
+        'email': 'unique2@primary.com',
+        'email_alternative': 'unique2@alternative.com',
+    },
+    {
+        'email': 'duplicate@primary.com',
+        'email_alternative': '',
+    },
+    {
+        'email': 'duplicate@primary.com',
+        'email_alternative': '',
+    },
+]
 
 
 @pytest.mark.django_db
@@ -472,6 +493,56 @@ class TestInteractionCSVRowForm:
         form = InteractionCSVRowForm(data=data)
         assert not form.errors
         assert form.cleaned_data['subject'] == service.name
+
+    @pytest.mark.parametrize(
+        'input_email,matching_status,match_on_alternative',
+        (
+            # unique match of a contact on primary email
+            ('unique1@primary.com', ContactMatchingStatus.matched, False),
+            # unique match of a contact on alternative email
+            ('unique2@alternative.com', ContactMatchingStatus.matched, True),
+            # no match of a contact
+            ('UNIQUE@COMPANY.IO', ContactMatchingStatus.unmatched, False),
+            # multiple matches of a contact
+            ('duplicate@primary.com', ContactMatchingStatus.multiple_matches, None),
+        ),
+    )
+    def test_contact_lookup(self, input_email, matching_status, match_on_alternative):
+        """
+        Test that various contact matching scenarios.
+
+        Note that the matching logic is tested more extensively in the company app.
+        """
+        for factory_kwargs in EMAIL_MATCHING_CONTACT_TEST_DATA:
+            ContactFactory(**factory_kwargs)
+
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        service = random_obj_for_queryset(
+            Service.objects.filter(disabled_on__isnull=True),
+        )
+
+        data = {
+            'kind': 'interaction',
+            'date': '01/01/2018',
+            'adviser_1': adviser.name,
+            'service': service.name,
+
+            'contact_email': input_email,
+        }
+        form = InteractionCSVRowForm(data=data)
+        assert not form.errors
+
+        assert form.cleaned_data['contact_matching_status'] == matching_status
+
+        assert 'contact' in form.cleaned_data
+        contact = form.cleaned_data['contact']
+
+        if matching_status == ContactMatchingStatus.matched:
+            assert contact
+            actual_email = contact.email_alternative if match_on_alternative else contact.email
+            assert actual_email.lower() == input_email.lower()
+        else:
+            assert not contact
 
 
 def _random_communication_channel(disabled=False):


### PR DESCRIPTION
### Description of change

This adds the contact matching logic for the import interactions admin site tool.

Interactions are matched with contacts by email address.

The logic works as follows:

- First, `Contact.email` is checked. If a unique match is found, this is used.
- If multiple matches were found using `Contact.email`, matching aborts.
- Otherwise, `Contact.email_alternative` is checked. If there is a unique match, this is used.

An index on `UPPER(email_alternative)` for the `company_contact` table was also added in the same way as was done for the `email` field in https://github.com/uktrade/data-hub-leeloo/pull/1181. The migration should take about half a second, so is more than quick enough.

For additional context, see previous PRs related to the import interactions tool:
https://github.com/uktrade/data-hub-leeloo/issues?utf8=%E2%9C%93&q=label%3A%22import+interactions%22

### To test

Matched contacts are not yet used so there is nothing to manually test.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
