### PR TITLE
Make actual_land_date required to move a project to the verify win stage

### DIFF
--- a/changelog/investment/actual_land_date.api.rst
+++ b/changelog/investment/actual_land_date.api.rst
@@ -1,0 +1,2 @@
+The field ``actual_land_date`` is now required to move an investment project
+from active to verify win.

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -117,7 +117,10 @@ class IProjectAbstract(models.Model):
 
     cdms_project_code = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     quotable_as_public_case_study = models.BooleanField(null=True)
-    actual_land_date = models.DateField(blank=True, null=True)
+    actual_land_date = models.DateField(
+        blank=True,
+        null=True,
+    )
     likelihood_to_land = models.ForeignKey(
         'investment.LikelihoodToLand', related_name='+',
         null=True, blank=True, on_delete=models.SET_NULL,

--- a/datahub/investment/project/test/test_validate.py
+++ b/datahub/investment/project/test/test_validate.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import pytest
 
 from datahub.company.test.factories import AdviserFactory, ContactFactory
@@ -291,6 +293,7 @@ def test_validate_verify_win_instance_failure():
         'average_salary': 'This field is required.',
         'client_cannot_provide_foreign_investment': 'This field is required.',
         'foreign_equity_investment': 'This field is required.',
+        'actual_land_date': 'This field is required.',
     }
 
 
@@ -355,6 +358,7 @@ def test_validate_verify_win_instance_with_cond_fields():
         actual_uk_regions=[random_obj_for_model(UKRegion)],
         delivery_partners=[random_obj_for_model(InvestmentDeliveryPartner)],
         average_salary_id=constants.SalaryRange.below_25000.value.id,
+        actual_land_date=date.today(),
     )
     errors = validate(instance=project)
     assert not errors
@@ -399,7 +403,10 @@ class TestValidationConfig:
         assert required_fields['number_new_jobs'] == self.EXPECTED_STAGE
         assert required_fields['strategic_drivers'] == self.EXPECTED_STAGE
         assert required_fields['project_manager'] == constants.InvestmentProjectStage.active.value
-        assert required_fields['actual_land_date'] == constants.InvestmentProjectStage.won.value
+        assert (
+            required_fields['actual_land_date']
+            == constants.InvestmentProjectStage.verify_win.value
+        )
 
     def test_conditional_rules_after_stage(self):
         """Tests get conditional rules after stage for all project stages."""

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -8,6 +8,7 @@ from decimal import Decimal
 from operator import attrgetter
 from unittest import mock
 
+import factory
 import pytest
 import reversion
 from django.utils.timezone import now, utc
@@ -1431,6 +1432,7 @@ class TestPartialUpdateView(APITestMixin):
             'average_salary': ['This field is required.'],
             'client_cannot_provide_foreign_investment': ['This field is required.'],
             'foreign_equity_investment': ['This field is required.'],
+            'actual_land_date': ['This field is required.'],
         }
 
     @pytest.mark.parametrize(
@@ -1465,6 +1467,7 @@ class TestPartialUpdateView(APITestMixin):
             address_postcode='SW1A 2AA',
             delivery_partners=[random_obj_for_model(InvestmentDeliveryPartner)],
             average_salary_id=constants.SalaryRange.below_25000.value.id,
+            actual_land_date=factory.Faker('past_date'),
             **extra,
         )
         url = reverse('api-v3:investment:investment-item', kwargs={'pk': project.pk})

--- a/datahub/investment/project/validate.py
+++ b/datahub/investment/project/validate.py
@@ -70,7 +70,7 @@ class InvestmentProjectStageValidationConfig:
             'address_postcode': Stage.verify_win.value,
             'actual_uk_regions': Stage.verify_win.value,
             'delivery_partners': Stage.verify_win.value,
-            'actual_land_date': Stage.won.value,
+            'actual_land_date': Stage.verify_win.value,
         }
 
     def get_conditional_rules_after_stage(self):


### PR DESCRIPTION
### Description of change
This makes `actual_land_date` required to move a project from `Active` to `Verify win` rather than `Verify Win` to `Won` 

### To Test

- Add an investment project
- Move it through the stages adding all required information
- After moving it to `Active` note that `actual land date` is now required to move the project to verify win
- Fill the information in and move to `Verify win`
- Find a different project that is at the `Verify win` stage check that `actual land date` is still required to move the project to `Won`


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
