### PR TITLE
Fix existing interaction migration to make location not-null

### DIFF
--- a/datahub/interaction/migrations/0054_location_not_null.py
+++ b/datahub/interaction/migrations/0054_location_not_null.py
@@ -11,6 +11,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='interaction',
             name='location',
-            field=models.CharField(blank=True, max_length=255),
+            field=models.CharField(blank=True, max_length=255, default=''),
+            preserve_default=False,
         ),
     ]


### PR DESCRIPTION
### Description of change

This fixes the migration to make location not null; we had an error 'IntegrityError: column "location" contains null values' when running this on an environment with existing data.

### Test method

- I brought up a docker compose project pointing at the develop commit before the one to migrate meeting fields to "not null" - commit hash `c48dee917d2c77800af1d03a9f8062bdffb9bccc` 
- Run migrations on this and load test data.
- I then checkout the problematic commit (head of develop), ran the migrations and observed the described IntegrityError.
- Checking out the `fix/interaction-preserve-location-default` branch and running the migrations again fixes the issue and allows migrations to complete successfully.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
