### PR TITLE
 Add ability to save InteractionCSVForm data to the cache 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -123,7 +123,12 @@ def local_memory_cache(monkeypatch):
         'default',
         {'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'},
     )
-    monkeypatch.setattr('django.core.cache.caches', CacheHandler())
+    cache_handler = CacheHandler()
+    monkeypatch.setattr('django.core.cache.caches', cache_handler)
+
+    yield
+
+    cache_handler['default'].clear()
 
 
 @pytest.fixture

--- a/datahub/interaction/test/admin_csv_import/test_file_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_file_form.py
@@ -1,9 +1,16 @@
+import gzip
+
 import pytest
+from django.core.cache import cache
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.core.exceptions import DataHubException
-from datahub.interaction.admin_csv_import.file_form import InteractionCSVForm
+from datahub.interaction.admin_csv_import import file_form
+from datahub.interaction.admin_csv_import.file_form import (
+    _cache_keys_for_token,
+    InteractionCSVForm,
+)
 from datahub.interaction.test.admin_csv_import.utils import (
     make_csv_file_from_dicts,
     make_matched_rows,
@@ -97,3 +104,75 @@ class TestInteractionCSVForm:
 
         with pytest.raises(DataHubException):
             form.get_matching_summary(50)
+
+    @pytest.mark.usefixtures('local_memory_cache')
+    def test_save_to_cache(self, track_return_values):
+        """Test that the form data can be saved to the cache."""
+        tracker = track_return_values(file_form, '_make_token')
+
+        file = make_csv_file_from_dicts(
+            *make_matched_rows(1),
+            filename='cache-test.csv',
+        )
+
+        form = InteractionCSVForm(
+            files={
+                'csv_file': SimpleUploadedFile(file.name, file.getvalue()),
+            },
+        )
+
+        assert form.is_valid()
+        form.save_to_cache()
+
+        assert len(tracker.return_values) == 1
+        token = tracker.return_values[0]
+
+        data_key, name_key = _cache_keys_for_token(token)
+
+        file.seek(0)
+        assert gzip.decompress(cache.get(data_key)) == file.read()
+        assert cache.get(name_key) == file.name
+
+    @pytest.mark.usefixtures('local_memory_cache')
+    def test_from_token_with_valid_token(self):
+        """Test that a form can be restored from the cache."""
+        token = 'test-token'
+        data_key, name_key = _cache_keys_for_token(token)
+        file = make_csv_file_from_dicts(
+            *make_matched_rows(1),
+            filename='cache-test.csv',
+        )
+        compressed_data = gzip.compress(file.read())
+
+        cache.set(data_key, compressed_data)
+        cache.set(name_key, file.name)
+
+        form = InteractionCSVForm.from_token(token)
+
+        assert form.is_valid()
+
+        file.seek(0)
+        assert file.read() == form.cleaned_data['csv_file'].read()
+        assert file.name == form.cleaned_data['csv_file'].name
+
+    @pytest.mark.usefixtures('local_memory_cache')
+    @pytest.mark.parametrize(
+        'cache_data',
+        (
+            # only the file contents
+            {_cache_keys_for_token('test-token')[0]: b'data'},
+            # only the file name
+            {_cache_keys_for_token('test-token')[1]: 'name'},
+            # nothing
+            {},
+        ),
+    )
+    def test_from_token_with_invalid_token(self, cache_data):
+        """
+        Test that from_token() returns None if there is incomplete data for the token in
+        the cache.
+        """
+        cache.set_many(cache_data)
+        form = InteractionCSVForm.from_token('test-token')
+
+        assert form is None


### PR DESCRIPTION
### Description of change

This is part of the import interactions tool.

This allows the uploaded file to be saved to the cache while the preview page is being displayed to the user. The cache is used for simplicity as we are only dealing with small files.

This functionality will be used in an upcoming PR that implements the saving of loaded rows.

### To test

The functionality is not used yet so there is nothing to manually test.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
