### PR TITLE
Add logic for saving a single imported interaction

### DIFF
--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -111,7 +111,19 @@ class InteractionDITParticipantSerializer(serializers.ModelSerializer):
 
 
 class InteractionSerializer(serializers.ModelSerializer):
-    """V3 interaction serialiser."""
+    """
+    Interaction serialiser.
+
+    Note that interactions can also be created and/or modified by:
+
+    - the standard admin site functionality
+    - the import interactions tool in the admin site
+
+    If you're making changes to interaction functionality you should consider if any changes
+    are required to the functionality listed above as well.
+
+    (Also note that the import interactions tool also uses the validators from this class.)
+    """
 
     default_error_messages = {
         'invalid_for_non_service_delivery': gettext_lazy(

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -1,6 +1,7 @@
 from collections import Counter
 from collections.abc import Mapping
 from datetime import date, datetime
+from unittest.mock import Mock
 
 import pytest
 from django.core.exceptions import NON_FIELD_ERRORS
@@ -9,6 +10,7 @@ from rest_framework import serializers
 
 from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.company.test.factories import AdviserFactory, ContactFactory
+from datahub.core.exceptions import DataHubException
 from datahub.core.test_utils import random_obj_for_queryset
 from datahub.event.test.factories import DisabledEventFactory, EventFactory
 from datahub.interaction.admin_csv_import.row_form import (
@@ -775,6 +777,158 @@ class TestInteractionCSVRowForm:
             'subject': data['subject'],
             'was_policy_feedback_provided': False,
         }
+
+    def test_save_interaction(self):
+        """Test saving an interaction."""
+        user = AdviserFactory()
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        contact = ContactFactory(email='unique@company.com')
+        service = random_service()
+        communication_channel = random_communication_channel()
+        source = {'test-source': 'test-value'}
+
+        data = {
+            'kind': Interaction.KINDS.interaction,
+            'date': '02/03/2018',
+            'adviser_1': adviser.name,
+            'contact_email': contact.email,
+            'service': service.name,
+            'communication_channel': communication_channel.name,
+        }
+        form = InteractionCSVRowForm(data=data)
+
+        assert form.is_valid()
+        interaction = form.save(user, source=source)
+        interaction.refresh_from_db()
+
+        assert interaction.kind == data['kind']
+        assert interaction.date == datetime(2018, 3, 2, tzinfo=utc)
+        assert interaction.communication_channel == communication_channel
+        assert interaction.service == service
+        assert interaction.status == Interaction.STATUSES.complete
+        assert interaction.subject == service.name
+        assert interaction.event is None
+        assert interaction.notes == ''
+        assert interaction.created_by == user
+        assert interaction.modified_by == user
+        assert interaction.source == source
+
+        assert list(interaction.contacts.all()) == [contact]
+        assert interaction.dit_participants.count() == 1
+
+        dit_participant = interaction.dit_participants.first()
+        assert dit_participant.adviser == adviser
+        assert dit_participant.team == adviser.dit_team
+
+    def test_save_service_delivery(self):
+        """Test saving a service delivery."""
+        user = AdviserFactory()
+        adviser_1 = AdviserFactory(first_name='Neptune', last_name='Doris')
+        adviser_2 = AdviserFactory(first_name='Pluto', last_name='Greene')
+        contact = ContactFactory(email='unique@company.com')
+        service = random_service()
+        event = EventFactory()
+        source = {'test-source': 'test-value'}
+
+        data = {
+            'kind': Interaction.KINDS.service_delivery,
+            'date': '02/03/2018',
+            'adviser_1': adviser_1.name,
+            'adviser_2': adviser_2.name,
+            'contact_email': contact.email,
+            'service': service.name,
+            'event_id': str(event.pk),
+            'subject': 'Test subject',
+            'notes': 'Some notes',
+        }
+        form = InteractionCSVRowForm(data=data)
+
+        assert form.is_valid()
+        interaction = form.save(user, source=source)
+        interaction.refresh_from_db()
+
+        assert interaction.kind == data['kind']
+        assert interaction.date == datetime(2018, 3, 2, tzinfo=utc)
+        assert interaction.event == event
+        assert interaction.service == service
+        assert interaction.status == Interaction.STATUSES.complete
+        assert interaction.subject == data['subject']
+        assert interaction.event == event
+        assert interaction.notes == data['notes']
+        assert interaction.created_by == user
+        assert interaction.modified_by == user
+        assert interaction.source == source
+
+        assert list(interaction.contacts.all()) == [contact]
+        assert interaction.dit_participants.count() == 2
+
+        actual_advisers_and_teams = Counter(
+            (dit_participant.adviser, dit_participant.team)
+            for dit_participant in interaction.dit_participants.all()
+        )
+        expected_advisers_and_teams = Counter(
+            (
+                (adviser_1, adviser_1.dit_team),
+                (adviser_2, adviser_2.dit_team),
+            ),
+        )
+
+        assert actual_advisers_and_teams == expected_advisers_and_teams
+
+    def test_save_with_unmatched_contact_raises_error(self):
+        """Test that saving an interaction with an unmatched contact raises an error."""
+        user = AdviserFactory()
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        service = random_service()
+        communication_channel = random_communication_channel()
+        source = {'test-source': 'test-value'}
+
+        data = {
+            'kind': Interaction.KINDS.interaction,
+            'date': '02/03/2018',
+            'adviser_1': adviser.name,
+            'contact_email': 'non-existent-contact@company.com',
+            'service': service.name,
+            'communication_channel': communication_channel.name,
+        }
+        form = InteractionCSVRowForm(data=data)
+
+        assert form.is_valid()
+        assert not form.is_matched()
+
+        with pytest.raises(DataHubException):
+            form.save(user, source=source)
+
+    def test_save_rolls_back_on_error(self, monkeypatch):
+        """Test that save() rolls back if there's an error."""
+        monkeypatch.setattr(
+            'datahub.interaction.admin_csv_import.row_form.InteractionDITParticipant',
+            Mock(side_effect=ValueError),
+        )
+
+        user = AdviserFactory()
+        adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
+        contact = ContactFactory(email='unique@company.com')
+        service = random_service()
+        communication_channel = random_communication_channel()
+        source = {'test-source': 'test-value'}
+
+        data = {
+            'kind': Interaction.KINDS.interaction,
+            'date': '02/03/2018',
+            'adviser_1': adviser.name,
+            'contact_email': contact.email,
+            'service': service.name,
+            'communication_channel': communication_channel.name,
+        }
+        form = InteractionCSVRowForm(data=data)
+
+        assert form.is_valid()
+
+        with pytest.raises(ValueError):
+            form.save(user, source=source)
+
+        assert not Interaction.objects.exists()
 
 
 def _resolve_data(data):


### PR DESCRIPTION
### Description of change

This adds the logic for saving a single imported interaction in the import interactions tool.

This will be used when the full logic for completing the import is added.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
