### PR TITLE
Add save view to import interactions tool

### DIFF
--- a/changelog/interaction/import-save.feature.rst
+++ b/changelog/interaction/import-save.feature.rst
@@ -1,0 +1,1 @@
+The ability to save loaded interactions was added to the import interactions admin site tool. The tool is currently behind the ``admin-interaction-csv-importer`` feature flag as it’s incomplete.

--- a/datahub/interaction/admin_csv_import/cache_utils.py
+++ b/datahub/interaction/admin_csv_import/cache_utils.py
@@ -13,6 +13,7 @@ class CacheKeyType(StrEnum):
 
     file_name = 'file-name'
     file_contents = 'file-contents'
+    result_counts_by_status = 'result_counts_by_status'
 
 
 def load_file_contents_and_name(token):
@@ -46,6 +47,18 @@ def save_file_contents_and_name(token, contents, name):
         name_key: name,
     }
     cache.set_many(cache_keys_and_values, timeout=CACHE_VALUE_TIMEOUT_SECS)
+
+
+def load_result_counts_by_status(token):
+    """Load counts by matching status from the cache for a completed import operation."""
+    result_counts_cache_key = _cache_key_for_token(token, CacheKeyType.result_counts_by_status)
+    return cache.get(result_counts_cache_key)
+
+
+def save_result_counts_by_status(token, counts_by_status):
+    """Saves counts by matching status to the cache for a completed import operation."""
+    result_counts_cache_key = _cache_key_for_token(token, CacheKeyType.result_counts_by_status)
+    cache.set(result_counts_cache_key, counts_by_status, CACHE_VALUE_TIMEOUT_SECS)
 
 
 def _cache_key_for_token(token, type_: CacheKeyType):

--- a/datahub/interaction/admin_csv_import/views.py
+++ b/datahub/interaction/admin_csv_import/views.py
@@ -3,15 +3,22 @@ from itertools import islice
 from django.conf import settings
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.contrib.auth.decorators import permission_required
+from django.contrib.messages import ERROR
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
+from django.views.decorators.http import require_POST
 
 from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.core.admin import max_upload_size
+from datahub.core.exceptions import DataHubException
 from datahub.feature_flag.utils import feature_flagged_view
+from datahub.interaction.admin_csv_import.cache_utils import (
+    load_result_counts_by_status,
+    save_result_counts_by_status,
+)
 from datahub.interaction.admin_csv_import.file_form import InteractionCSVForm
 from datahub.interaction.models import Interaction, InteractionPermission
 
@@ -19,6 +26,11 @@ INTERACTION_IMPORTER_FEATURE_FLAG_NAME = 'admin-interaction-csv-importer'
 MAX_ERRORS_TO_DISPLAY = 50
 MAX_PREVIEW_ROWS_TO_DISPLAY = 100
 PAGE_TITLE = gettext_lazy('Import interactions')
+
+INVALID_TOKEN_MESSAGE = gettext_lazy(
+    'The CSV file referenced is no longer available and may have expired. Please upload '
+    'the file again.',
+)
 
 
 interaction_change_all_permission_required = method_decorator(
@@ -51,6 +63,16 @@ class InteractionCSVImportAdmin:
                 admin_site.admin_view(self.select_file),
                 name=f'{model_meta.app_label}_{model_meta.model_name}_import',
             ),
+            path(
+                'import/<token>/save',
+                admin_site.admin_view(self.save),
+                name=f'{model_meta.app_label}_{model_meta.model_name}_import-save',
+            ),
+            path(
+                'import/<token>/results',
+                admin_site.admin_view(self.complete),
+                name=f'{model_meta.app_label}_{model_meta.model_name}_import-complete',
+            ),
         ]
 
     @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
@@ -69,6 +91,42 @@ class InteractionCSVImportAdmin:
             return self._error_list_response(request, form.get_row_error_iterator())
 
         return self._preview_response(request, form)
+
+    @interaction_change_all_permission_required
+    @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
+    @method_decorator(require_POST)
+    def save(self, request, token=None, *args, **kwargs):
+        """Create interactions from a CSV file that was loaded in the select_file view."""
+        form = InteractionCSVForm.from_token(token)
+
+        if not form:
+            self.model_admin.message_user(request, INVALID_TOKEN_MESSAGE, ERROR)
+            return _redirect_response('changelist')
+
+        if not form.is_valid():
+            # This should not happen, so we simply raise an error to alert us if it does
+            raise DataHubException('Unexpected form re-validation failure')
+
+        matching_counts = form.save(request.user)
+        save_result_counts_by_status(token, matching_counts)
+
+        # Redirect to another page to display a confirmation message on success (following the
+        # standard Django pattern to limit the possibility of a form resubmission on page
+        # refresh).
+        # For consistency, the required state is kept in the cache.
+        return _redirect_response('import-complete', token=token)
+
+    @interaction_change_all_permission_required
+    @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
+    def complete(self, request, token=None, *args, **kwargs):
+        """Display a confirmation page following a successful import operation."""
+        counts_by_status = load_result_counts_by_status(token)
+
+        if not counts_by_status:
+            self.model_admin.message_user(request, INVALID_TOKEN_MESSAGE, ERROR)
+            return _redirect_response('changelist')
+
+        return self._complete_response(request, counts_by_status)
 
     def _select_file_form_response(self, request, form):
         return self._template_response(
@@ -92,6 +150,7 @@ class InteractionCSVImportAdmin:
         )
 
     def _preview_response(self, request, form):
+        token = form.save_to_cache()
         matching_counts, matched_rows = form.get_matching_summary(MAX_PREVIEW_ROWS_TO_DISPLAY)
         num_matched = matching_counts[ContactMatchingStatus.matched]
 
@@ -106,6 +165,17 @@ class InteractionCSVImportAdmin:
             num_multiple_matches=matching_counts[ContactMatchingStatus.multiple_matches],
             matched_rows=matched_rows,
             num_matched_omitted=num_matched - len(matched_rows),
+            token=token,
+        )
+
+    def _complete_response(self, request, counts_by_status):
+        return self._template_response(
+            request,
+            f'admin/interaction/interaction/import_complete.html',
+            PAGE_TITLE,
+            num_matched=counts_by_status[ContactMatchingStatus.matched],
+            num_unmatched=counts_by_status[ContactMatchingStatus.unmatched],
+            num_multiple_matches=counts_by_status[ContactMatchingStatus.multiple_matches],
         )
 
     def _template_response(self, request, template, title, **extra_context):

--- a/datahub/interaction/templates/admin/interaction/interaction/fragment_post_import_counts.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/fragment_post_import_counts.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+<ul>
+  {% trans 'interaction created' as matched_singular_text %}
+  {% trans 'interactions created' as matched_plural_text %}
+  {% include 'admin/interaction/interaction/fragment_import_count_line.html' with count=num_matched singular_text=matched_singular_text plural_text=matched_plural_text only %}
+
+  {% trans 'record skipped as it could not be matched with an active contact' as unmatched_singular_text %}
+  {% trans 'records skipped as they could not be matched with an active contact' as unmatched_plural_text %}
+  {% include 'admin/interaction/interaction/fragment_import_count_line.html' with count=num_unmatched singular_text=unmatched_singular_text plural_text=unmatched_plural_text only %}
+
+  {% trans 'record skipped as it was matched with more than one active contact' as multiple_matches_singular_text %}
+  {% trans 'records skipped as they were matched with more than one active contact' as multiple_matches_plural_text %}
+  {% include 'admin/interaction/interaction/fragment_import_count_line.html' with count=num_multiple_matches singular_text=multiple_matches_singular_text plural_text=multiple_matches_plural_text only %}
+</ul>

--- a/datahub/interaction/templates/admin/interaction/interaction/import_complete.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_complete.html
@@ -7,11 +7,11 @@
 {% endblock %}
 
 {% block content %}
-  <h2>{% trans 'No matching contacts found' %}</h2>
+  <h2>
+    {% trans 'Import complete' %}
+  </h2>
 
-  <p>{% trans 'No interactions have been imported as none of the loaded interactions could be matched to active contacts.' %}</p>
-
-  {% include 'admin/interaction/interaction/fragment_post_import_counts.html' with num_matched=0 num_unmatched=num_unmatched num_multiple_matches=num_multiple_matches only %}
+  {% include 'admin/interaction/interaction/fragment_post_import_counts.html' with num_matched=num_matched num_unmatched=num_unmatched num_multiple_matches=num_multiple_matches only %}
 
   <p>
     <a href="{% url opts|admin_urlname:'changelist' %}">

--- a/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
@@ -25,7 +25,7 @@
   </ul>
 
   <p>
-    {% trans 'Review the interactions that will be imported below and click Import to complete the process.' %}
+    {% trans 'Review the interactions that will be imported below and click the import button to complete the process.' %}
   </p>
 
   <table>
@@ -83,13 +83,25 @@
 
   </table>
 
-  <p>
-  </p>
+  <p></p>
 
-  <p>
-    <a href="{% url opts|admin_urlname:'changelist' %}">
-      {% trans 'Cancel and return to the interaction list' %}
-    </a>
-  </p>
+  {% blocktrans count count=num_matched asvar import %}Import {{ count }} row{% plural %}Import {{ count }} rows{% endblocktrans %}
+
+  <form action="{% url opts|admin_urlname:'import-save' token=token %}" method="post" enctype="multipart/form-data">
+    {% csrf_token %}
+
+    <div>
+      <input type="submit" value="{{ import }}">
+    </div>
+
+    <p></p>
+
+    <div>
+      <a href="{% url opts|admin_urlname:'import' %}">
+        {% trans 'Cancel and select another file' %}
+      </a>
+    </div>
+
+  </form>
 
 {% endblock %}

--- a/datahub/interaction/test/admin_csv_import/test_file_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_file_form.py
@@ -111,8 +111,9 @@ class TestInteractionCSVForm:
     @pytest.mark.parametrize('num_matching', (5, 10))
     @pytest.mark.parametrize('num_unmatched', (0, 6))
     @pytest.mark.parametrize('num_multiple_matches', (0, 6))
-    def test_save_returns_correct_counts(self, num_matching, num_unmatched, num_multiple_matches):
-        """Test that save() returns the expected counts."""
+    @pytest.mark.usefixtures('local_memory_cache')
+    def test_save_stores_correct_counts(self, num_matching, num_unmatched, num_multiple_matches):
+        """Test that save() stores the expected counts in the cache."""
         matched_rows = make_matched_rows(num_matching)
         unmatched_rows = make_unmatched_rows(num_unmatched)
         multiple_matches_rows = make_multiple_matches_rows(num_multiple_matches)


### PR DESCRIPTION
### Description of change

This adds a button to the preview page import interactions tool that performs the actual saving of loaded rows, and a confirmation page that is displayed afterwards.

The standard Django pattern of redirecting to another page when a form is successfully submitted is used. (This pattern limits the possibility of form resubmissions on page refresh.)

All state is kept in the cache for consistency.

### To test

1. Create the `admin-interaction-csv-importer` feature flag and set it as active
1. Navigate to the interaction change list page in the admin site
1. Click on the 'Import interaction' link
1. Create a valid CSV file according to the spec on the page
1. Select your CSV file
1. Submit the form to bring up the preview page
1. Click the import button on the preview page

Example of a valid CSV file (replacing the `team_1`, `adviser_1` and `contact_email` values as necessary):

```
team_1,adviser_1,adviser_2,contact_email,communication_channel,service,kind,date,event_id,notes
Digital Data Hub - Live Service,<an adviser name>,,fooimport@bar.com,Email/Website,Account managemenT,interaction,22/02/2019,,some notes
```

Note that if debug mode is on, it can be slow to load large files. I would suggest turning debug mode off if testing with more than a few dozen rows.

### Screenshots

#### Import button

![image](https://user-images.githubusercontent.com/12693549/58330038-eb6e1900-7e2d-11e9-8859-be58ad2a4bf6.png)

#### Confirmation page

![image](https://user-images.githubusercontent.com/12693549/58188585-cb651b00-7cb0-11e9-8f9e-0c87d7efcf58.png)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
