### PR TITLE
Add ability to link companies with a duns_number

### DIFF
--- a/changelog/company/linking-companies.api.rst
+++ b/changelog/company/linking-companies.api.rst
@@ -1,0 +1,1 @@
+``PATCH /v4/company/<uuid:pk>``: ``headquarter_type`` and ``global_headquarters`` can now always be changed. They were previously read-only if a company had a non-empty ``duns_number`` set.

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -462,8 +462,6 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'business_type',
             'employee_range',
             'turnover_range',
-            'headquarter_type',
-            'global_headquarters',
             'address',
             'registered_address',
         )


### PR DESCRIPTION
### Description of change

**Before**: 
if a company had a non-empty duns_number, it was not possible to change the headquarter type or linking to/unlinking from another company.

**After**: 
it's now possible to do so.

### How to test it

```python
from datahub.company.test.factories import CompanyFactory
company = CompanyFactory(duns_number='665544332')
ghq = Company.objects.filter(headquarter_type='43281c5e-92a4-4794-867b-b4d5f801e6f3').first()
```

``PATCH /v4/company/<company.id>`` using

```
'headquarter_type': '3e6debb4-1596-40c5-aa25-f00da0e05af9',
'global_headquarters_id': '<ghq.id>'
```

The response should returned 200 with the updated fields.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
