### PR TITLE
Use index to speed up looking up advisers in import interactions tool

### DIFF
--- a/datahub/company/migrations/0086_add_adviser_name_index.py
+++ b/datahub/company/migrations/0086_add_adviser_name_index.py
@@ -1,0 +1,27 @@
+"""
+Creates an index on `("is_active", (UPPER("first_name" || ' ' || "last_name" )))` on
+the Advisor model.
+
+As Django does not support creating indexes on expressions, SQL is used.
+
+The migration is run inside a transaction, so CREATE INDEX CONCURRENTLY is not used.
+"""
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('company', '0085_remove_trading_address_from_db'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql=[
+                '''CREATE INDEX "company_advisor_is_active_upper_name_e0ab1b4f"
+ON "company_advisor" ("is_active", (UPPER("first_name" || ' ' || "last_name" )));'''
+            ],
+            reverse_sql=['DROP INDEX "company_advisor_is_active_upper_name_e0ab1b4f";'],
+        ),
+    ]

--- a/datahub/company/models/adviser.py
+++ b/datahub/company/models/adviser.py
@@ -53,6 +53,12 @@ class Advisor(AbstractBaseUser, PermissionsMixin):
     """Adviser model.
 
     Advisor is a legacy name mistakenly used, but hard to change now.
+
+    Additional indexes created via migrations:
+
+        Name: company_advisor_is_active_upper_name_e0ab1b4f
+        Definition: ("is_active", (UPPER("first_name" || ' ' || "last_name" )))
+        Comments: Used by the import interactions tool when looking up an active adviser by name
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)

--- a/datahub/company/models/contact.py
+++ b/datahub/company/models/contact.py
@@ -21,7 +21,19 @@ class ContactPermission(StrEnum):
 
 @reversion.register_base_model()
 class Contact(ArchivableModel, BaseModel):
-    """Contact from CDMS."""
+    """
+    Contact (a person at a company that DIT has had contact with).
+
+    Additional indexes created via migrations:
+
+        Name: company_contact_upper_email_244368
+        Definition: UPPER(email)
+        Comments: For when filtering by email__iexact
+
+        Name: company_contact_upper_email_alternative_eb17a977
+        Definition: UPPER(email_alternative)
+        Comments: For when filtering by email_alternative__iexact
+    """
 
     ADDRESS_VALIDATION_MAPPING = {
         'address_1': {'required': True},
@@ -50,9 +62,6 @@ class Contact(ArchivableModel, BaseModel):
     primary = models.BooleanField()
     telephone_countrycode = models.CharField(max_length=MAX_LENGTH)
     telephone_number = models.CharField(max_length=MAX_LENGTH)
-    # Note: An index on `UPPER(email)` (with name `company_contact_upper_email_244368`) exists
-    # for use with iexact filtering
-    # See the migrations for the definition
     email = models.EmailField()
     address_same_as_company = models.BooleanField(default=False)
     address_1 = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
@@ -65,10 +74,6 @@ class Contact(ArchivableModel, BaseModel):
     )
     address_postcode = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
     telephone_alternative = models.CharField(max_length=MAX_LENGTH, blank=True, null=True)
-    # Note: An index on `UPPER(email_alternative)` (with name
-    # `company_contact_upper_email_alternative_eb17a977`) exists for use with iexact
-    # filtering.
-    # See the migrations for the definition
     email_alternative = models.EmailField(null=True, blank=True)
     notes = models.TextField(null=True, blank=True)
     archived_documents_url_path = models.CharField(

--- a/datahub/metadata/models.py
+++ b/datahub/metadata/models.py
@@ -139,8 +139,11 @@ class Team(BaseConstantModel):
     """
     Team.
 
-    Note: An index on `UPPER(name)` (with name `metadata_team_upper_name_ed973c5a`) exists for
-    use with iexact filtering. See the migrations for the definition.
+    Additional indexes created via migrations:
+
+        Name: metadata_team_upper_name_ed973c5a
+        Definition: UPPER(name)
+        Comments: For when filtering by name__iexact
     """
 
     TAGS = Choices(


### PR DESCRIPTION
### Description of change

This:

* standardises how indexes on expressions created via `django.db.migrations.RunSQL` are documented
* changes the adviser name annotation used when looking up advisers (in the import interactions tool) to an expression that can be used in an index
* adds an index to speed up that look-up

(The reason that the annotation has to be changed was that the previous one used `concat_ws` which cannot be used in indexes. This is because for some inputs (e.g. numbers and timestamps) the output of `contact_ws` (and `contact`) can depend on the environment.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
