### PR TITLE
Validate that advisers are different in import interactions tool

### DIFF
--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -33,6 +33,9 @@ ADVISER_WITH_TEAM_NOT_FOUND_MESSAGE = gettext_lazy(
 MULTIPLE_ADVISERS_FOUND_MESSAGE = gettext_lazy(
     'Multiple matching advisers were found.',
 )
+ADVISER_2_IS_THE_SAME_AS_ADVISER_1 = gettext_lazy(
+    'Adviser 2 cannot be the same person as adviser 1.',
+)
 
 
 def _validate_not_disabled(obj):
@@ -176,6 +179,7 @@ class InteractionCSVRowForm(forms.Form):
         # Look up values for adviser_1 and adviser_2 (adding errors if the look-up fails)
         self._populate_adviser(data, 'adviser_1', 'team_1')
         self._populate_adviser(data, 'adviser_2', 'team_2')
+        self._check_adviser_1_and_2_are_different(data)
 
         # If no subject was provided, set it to the name of the service
         if not subject and service:
@@ -262,6 +266,17 @@ class InteractionCSVRowForm(forms.Form):
             )
         except ValidationError as exc:
             self.add_error(adviser_field, exc)
+
+    def _check_adviser_1_and_2_are_different(self, data):
+        adviser_1 = data.get('adviser_1')
+        adviser_2 = data.get('adviser_2')
+
+        if adviser_1 and adviser_1 == adviser_2:
+            err = ValidationError(
+                ADVISER_2_IS_THE_SAME_AS_ADVISER_1,
+                code='adviser_2_is_the_same_as_adviser_1',
+            )
+            self.add_error('adviser_2', err)
 
     def cleaned_data_as_serializer_dict(self):
         """

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -14,6 +14,7 @@ from datahub.core.exceptions import DataHubException
 from datahub.core.test_utils import random_obj_for_queryset
 from datahub.event.test.factories import DisabledEventFactory, EventFactory
 from datahub.interaction.admin_csv_import.row_form import (
+    ADVISER_2_IS_THE_SAME_AS_ADVISER_1,
     ADVISER_NOT_FOUND_MESSAGE,
     ADVISER_WITH_TEAM_NOT_FOUND_MESSAGE,
     CSVRowError,
@@ -163,6 +164,20 @@ class TestInteractionCSVRowForm:
                     ).name,
                 },
                 {'adviser_2': [ADVISER_WITH_TEAM_NOT_FOUND_MESSAGE]},
+            ),
+            # adviser_2 same as adviser_1
+            (
+                {
+                    'adviser_1': lambda: AdviserFactory(
+                        first_name='Pluto',
+                        last_name='Doris',
+                        dit_team__name='Team Advantage',
+                    ).name,
+                    'team_1': 'Team Advantage',
+                    'adviser_2': 'Pluto Doris',
+                    'team_2': 'Team Advantage',
+                },
+                {'adviser_2': [ADVISER_2_IS_THE_SAME_AS_ADVISER_1]},
             ),
             # service doesn't exist
             (


### PR DESCRIPTION
### Description of change

This adds validation to the import interactions tool to make sure that `adviser_1` and `adviser_2` refer to different advisers.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
