### PR TITLE
Add logic for saving imported interactions CSV file

### DIFF
--- a/datahub/interaction/models.py
+++ b/datahub/interaction/models.py
@@ -160,9 +160,20 @@ class Interaction(ArchivableModel, BaseModel):
         choices=STATUSES,
         default=STATUSES.complete,
     )
-    # If source is set, it provides details of an external source that this
-    # interaction represents.  e.g. a calendar event
-    # {'id': 'abc123', 'type': 'calendar'}
+    # Set if the interaction was imported from an external source
+    # (e.g. an .ics (iCalendar) file or a CSV file).
+    #
+    # Examples
+    #
+    # Imported from a CSV file via the import interactions tool in the admin site:
+    #
+    # {
+    #     "file": {
+    #         "name": "<file name>",
+    #         "size": <file size in bytes>,
+    #         "sha256": "<SHA-256 hash>"
+    #     }
+    # }
     source = JSONField(encoder=DjangoJSONEncoder, blank=True, null=True)
     date = models.DateTimeField()
     company = models.ForeignKey(


### PR DESCRIPTION
### Description of change

This adds the remainder of the logic for saving imported interactions.

This will be used in an upcoming PR that will plug the logic into the view.

This sets the source field of imported interactions to:

```json
{
    "file": {
        "name": "<file name>",
        "size": <file size>,
        "sha256": "<SHA-256 hash>",
    },
}
```

(Potentially we could add the row number as well, but I've kept it at that for now.)

I picked SHA-256 for the hash as it's fairly ubiquitous (although Ubuntu comes with `b2sum` these days...)

I would suggest reviewing the two commits separately.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
