### PR TITLE
Move import interactions tool caching logic to separate module

### DIFF
--- a/datahub/interaction/admin_csv_import/cache_utils.py
+++ b/datahub/interaction/admin_csv_import/cache_utils.py
@@ -1,0 +1,61 @@
+import gzip
+from datetime import timedelta
+
+from django.core.cache import cache
+
+from datahub.core.utils import StrEnum
+
+CACHE_VALUE_TIMEOUT_SECS = int(timedelta(minutes=30).total_seconds())
+
+
+class CacheKeyType(StrEnum):
+    """Types of cache keys used to store information about an import interactions operation."""
+
+    file_name = 'file-name'
+    file_contents = 'file-contents'
+
+
+def load_file_contents_and_name(token):
+    """Load a previously-saved file-contents-and-name pair from the cache."""
+    contents_key = _cache_key_for_token(token, CacheKeyType.file_contents)
+    name_key = _cache_key_for_token(token, CacheKeyType.file_name)
+    cache_keys_and_values = cache.get_many((contents_key, name_key))
+
+    any_cache_keys_missing = {contents_key, name_key} - cache_keys_and_values.keys()
+    if any_cache_keys_missing:
+        return None
+
+    decompressed_contents = gzip.decompress(cache_keys_and_values[contents_key])
+    name = cache_keys_and_values[name_key]
+    return decompressed_contents, name
+
+
+def save_file_contents_and_name(token, contents, name):
+    """
+    Save the contents of a file and the file's name to the cache.
+
+    (This is used to store the file while the preview page is being displayed to the user.)
+    """
+    compressed_contents = gzip.compress(contents)
+
+    contents_key = _cache_key_for_token(token, CacheKeyType.file_contents)
+    name_key = _cache_key_for_token(token, CacheKeyType.file_name)
+
+    cache_keys_and_values = {
+        contents_key: compressed_contents,
+        name_key: name,
+    }
+    cache.set_many(cache_keys_and_values, timeout=CACHE_VALUE_TIMEOUT_SECS)
+
+
+def _cache_key_for_token(token, type_: CacheKeyType):
+    # Technically we should raise TypeError if token is None, but the distinction isn't
+    # particularly important here
+    if not token:
+        raise ValueError('A token is required.')
+
+    if not isinstance(type_, CacheKeyType):
+        raise TypeError('type_ must be an instance of CacheKeyType.')
+
+    prefix = f'interaction-csv-import:{token}'
+    return f'{prefix}:{type_}'

--- a/datahub/interaction/test/admin_csv_import/test_cache_utils.py
+++ b/datahub/interaction/test/admin_csv_import/test_cache_utils.py
@@ -1,0 +1,99 @@
+import gzip
+
+import pytest
+from django.core.cache import cache
+
+from datahub.interaction.admin_csv_import.cache_utils import (
+    _cache_key_for_token,
+    CacheKeyType,
+    load_file_contents_and_name,
+    save_file_contents_and_name,
+)
+
+
+@pytest.mark.usefixtures('local_memory_cache')
+class TestLoadFileContentsAndName:
+    """Tests for load_file_contents_and_name()."""
+
+    def test_loads_contents_and_name(self):
+        """Test load_file_contents_and_name()."""
+        token = 'test-token'
+        contents_key = _cache_key_for_token(token, CacheKeyType.file_contents)
+        name_key = _cache_key_for_token(token, CacheKeyType.file_name)
+
+        contents = b'file-contents'
+        name = 'file-name'
+
+        cache.set(contents_key, gzip.compress(contents))
+        cache.set(name_key, name)
+
+        loaded_contents, loaded_name = load_file_contents_and_name(token)
+
+        assert loaded_contents == contents
+        assert loaded_name == name
+
+    @pytest.mark.parametrize(
+        'cache_data',
+        (
+            # only the file contents
+            {_cache_key_for_token('test-token', CacheKeyType.file_contents): b'data'},
+            # only the file name
+            {_cache_key_for_token('test-token', CacheKeyType.file_name): 'name'},
+            # nothing
+            {},
+        ),
+    )
+    def test_returns_none_if_any_key_not_found(self, cache_data):
+        """Test that load_file_contents_and_name() returns None if a cache key is missing."""
+        cache.set_many(cache_data)
+
+        assert load_file_contents_and_name('test-token') is None
+
+
+@pytest.mark.usefixtures('local_memory_cache')
+class TestSaveFileContentsAndName:
+    """Tests for save_file_contents_and_name()."""
+
+    def test_saves_file_contents_and_name(self):
+        """Test that the file is saved in the cache."""
+        contents = b'file-contents'
+        name = 'file-name'
+        token = 'test-token'
+
+        save_file_contents_and_name(token, contents, name)
+
+        contents_key = _cache_key_for_token(token, CacheKeyType.file_contents)
+        name_key = _cache_key_for_token(token, CacheKeyType.file_name)
+
+        assert cache.get(name_key) == name
+
+        saved_contents = gzip.decompress(cache.get(contents_key))
+        assert saved_contents == contents
+
+
+class TestCacheKeyForToken:
+    """Tests for _cache_key_for_token()."""
+
+    @pytest.mark.parametrize(
+        'token,type_,key',
+        (
+            ('token1', CacheKeyType.file_contents, 'interaction-csv-import:token1:file-contents'),
+            ('token2', CacheKeyType.file_name, 'interaction-csv-import:token2:file-name'),
+        ),
+    )
+    def test_generates_keys(self, token, type_, key):
+        """Test that the expected keys are generated."""
+        assert _cache_key_for_token(token, type_) == key
+
+    @pytest.mark.parametrize(
+        'token,type_,error',
+        (
+            (None, CacheKeyType.file_contents, ValueError),
+            ('', CacheKeyType.file_contents, ValueError),
+            ('token', None, TypeError),
+        ),
+    )
+    def test_raises_error_on_invalid_input(self, token, type_, error):
+        """Test that an error is raised if an invalid token or type_ is provided."""
+        with pytest.raises(error):
+            _cache_key_for_token(token, type_)

--- a/datahub/interaction/test/admin_csv_import/test_file_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_file_form.py
@@ -10,11 +10,8 @@ from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.exceptions import DataHubException
 from datahub.interaction.admin_csv_import import file_form
-from datahub.interaction.admin_csv_import.file_form import (
-    _cache_keys_for_token,
-    InteractionCSVForm,
-    REVISION_COMMENT,
-)
+from datahub.interaction.admin_csv_import.cache_utils import _cache_key_for_token, CacheKeyType
+from datahub.interaction.admin_csv_import.file_form import InteractionCSVForm, REVISION_COMMENT
 from datahub.interaction.models import Interaction
 from datahub.interaction.test.admin_csv_import.utils import (
     make_csv_file_from_dicts,
@@ -92,6 +89,7 @@ class TestInteractionCSVForm:
             {
                 'kind': 'invalid',
                 'date': 'invalid',
+
                 'adviser_1': 'invalid',
                 'contact_email': 'invalid',
                 'service': 'invalid',
@@ -249,7 +247,7 @@ class TestInteractionCSVForm:
     @pytest.mark.usefixtures('local_memory_cache')
     def test_save_to_cache(self, track_return_values):
         """Test that the form data can be saved to the cache."""
-        tracker = track_return_values(file_form, '_make_token')
+        tracker = track_return_values(file_form, 'token_urlsafe')
 
         file = make_csv_file_from_dicts(
             *make_matched_rows(1),
@@ -268,24 +266,26 @@ class TestInteractionCSVForm:
         assert len(tracker.return_values) == 1
         token = tracker.return_values[0]
 
-        data_key, name_key = _cache_keys_for_token(token)
+        contents_key = _cache_key_for_token(token, CacheKeyType.file_contents)
+        name_key = _cache_key_for_token(token, CacheKeyType.file_name)
 
         file.seek(0)
-        assert gzip.decompress(cache.get(data_key)) == file.read()
+        assert gzip.decompress(cache.get(contents_key)) == file.read()
         assert cache.get(name_key) == file.name
 
     @pytest.mark.usefixtures('local_memory_cache')
     def test_from_token_with_valid_token(self):
         """Test that a form can be restored from the cache."""
         token = 'test-token'
-        data_key, name_key = _cache_keys_for_token(token)
+        contents_key = _cache_key_for_token(token, CacheKeyType.file_contents)
+        name_key = _cache_key_for_token(token, CacheKeyType.file_name)
         file = make_csv_file_from_dicts(
             *make_matched_rows(1),
             filename='cache-test.csv',
         )
         compressed_data = gzip.compress(file.read())
 
-        cache.set(data_key, compressed_data)
+        cache.set(contents_key, compressed_data)
         cache.set(name_key, file.name)
 
         form = InteractionCSVForm.from_token(token)
@@ -301,9 +301,9 @@ class TestInteractionCSVForm:
         'cache_data',
         (
             # only the file contents
-            {_cache_keys_for_token('test-token')[0]: b'data'},
+            {_cache_key_for_token('test-token', CacheKeyType.file_contents): b'data'},
             # only the file name
-            {_cache_keys_for_token('test-token')[1]: 'name'},
+            {_cache_key_for_token('test-token', CacheKeyType.file_name): 'name'},
             # nothing
             {},
         ),


### PR DESCRIPTION
### Description of change

This is a small refactor that moves the cache-related logic in the import interactions tool to a separate module. This is to keep it in one place as a couple of other things will need to be stored in the cache in some upcoming PRs.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
