### PR TITLE
Make SPI report Celery task restart if interrupted

### DIFF
--- a/changelog/investment/spi-report-restart.bugfix.rst
+++ b/changelog/investment/spi-report-restart.bugfix.rst
@@ -1,0 +1,1 @@
+A fix was applied to the SPI report generation task so that it restarts if it's interrupted.

--- a/datahub/investment/project/report/tasks.py
+++ b/datahub/investment/project/report/tasks.py
@@ -14,7 +14,7 @@ def _get_report_key():
     return key
 
 
-@task(ignore_result=True)
+@task(acks_late=True)
 def generate_spi_report():
     """Celery task that generates SPI report."""
     with tempfile.TemporaryFile(mode='wb+') as file:


### PR DESCRIPTION
### Description of change

This sets `acks_late=True` on the `generate_spi_report` Celery task so that it restarts if it's interrupted.

It also removes `ignore_result=True` so that there's a record of whether it ran successfully or not.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
