### PR TITLE
Fix non-deterministic import interactions tool tests

### DIFF
--- a/datahub/interaction/test/admin_csv_import/test_file_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_file_form.py
@@ -117,7 +117,7 @@ class TestInteractionCSVForm:
         matched_rows = make_matched_rows(num_matching)
         unmatched_rows = make_unmatched_rows(num_unmatched)
         multiple_matches_rows = make_multiple_matches_rows(num_multiple_matches)
-        user = AdviserFactory()
+        user = AdviserFactory(first_name='Admin', last_name='User')
 
         file = make_csv_file_from_dicts(
             *matched_rows,
@@ -149,7 +149,7 @@ class TestInteractionCSVForm:
         matched_rows = make_matched_rows(num_matching)
         unmatched_rows = make_unmatched_rows(num_unmatched)
         multiple_matches_rows = make_multiple_matches_rows(num_multiple_matches)
-        user = AdviserFactory()
+        user = AdviserFactory(first_name='Admin', last_name='User')
 
         file = make_csv_file_from_dicts(
             *matched_rows,
@@ -196,7 +196,7 @@ class TestInteractionCSVForm:
         """Test that save() creates versions using django-reversion."""
         num_matching = 5
         matched_rows = make_matched_rows(num_matching)
-        user = AdviserFactory()
+        user = AdviserFactory(first_name='Admin', last_name='User')
 
         file = make_csv_file_from_dicts(*matched_rows)
         file_contents = file.getvalue()
@@ -225,7 +225,7 @@ class TestInteractionCSVForm:
 
     def test_save_rolls_back_on_error(self):
         """Test that save() rolls back if one row can't be saved."""
-        user = AdviserFactory()
+        user = AdviserFactory(first_name='Admin', last_name='User')
 
         file = make_csv_file_from_dicts(
             *make_matched_rows(5),

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -795,7 +795,7 @@ class TestInteractionCSVRowForm:
 
     def test_save_interaction(self):
         """Test saving an interaction."""
-        user = AdviserFactory()
+        user = AdviserFactory(first_name='Admin', last_name='User')
         adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
         contact = ContactFactory(email='unique@company.com')
         service = random_service()
@@ -837,7 +837,7 @@ class TestInteractionCSVRowForm:
 
     def test_save_service_delivery(self):
         """Test saving a service delivery."""
-        user = AdviserFactory()
+        user = AdviserFactory(first_name='Admin', last_name='User')
         adviser_1 = AdviserFactory(first_name='Neptune', last_name='Doris')
         adviser_2 = AdviserFactory(first_name='Pluto', last_name='Greene')
         contact = ContactFactory(email='unique@company.com')
@@ -892,7 +892,7 @@ class TestInteractionCSVRowForm:
 
     def test_save_with_unmatched_contact_raises_error(self):
         """Test that saving an interaction with an unmatched contact raises an error."""
-        user = AdviserFactory()
+        user = AdviserFactory(first_name='Admin', last_name='User')
         adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
         service = random_service()
         communication_channel = random_communication_channel()
@@ -921,7 +921,7 @@ class TestInteractionCSVRowForm:
             Mock(side_effect=ValueError),
         )
 
-        user = AdviserFactory()
+        user = AdviserFactory(first_name='Admin', last_name='User')
         adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
         contact = ContactFactory(email='unique@company.com')
         service = random_service()

--- a/datahub/interaction/test/admin_csv_import/utils.py
+++ b/datahub/interaction/test/admin_csv_import/utils.py
@@ -59,7 +59,10 @@ def make_csv_file_from_dicts(*rows, fieldnames=None, encoding='utf-8-sig', filen
 
 def make_matched_rows(num_records):
     """Make multiple interaction CSV rows that should pass contact matching."""
-    adviser = AdviserFactory()
+    adviser = AdviserFactory(
+        first_name='Adviser for',
+        last_name='Matched interaction',
+    )
     service = random_service()
     communication_channel = random_communication_channel()
     contacts = ContactFactory.create_batch(
@@ -82,7 +85,10 @@ def make_matched_rows(num_records):
 
 def make_multiple_matches_rows(num_records):
     """Make multiple interaction CSV rows that should have multiple contact matches."""
-    adviser = AdviserFactory()
+    adviser = AdviserFactory(
+        first_name='Adviser for',
+        last_name='Multi-matched interaction',
+    )
     service = random_service()
     communication_channel = random_communication_channel()
 
@@ -104,7 +110,10 @@ def make_multiple_matches_rows(num_records):
 
 def make_unmatched_rows(num_records):
     """Make multiple interaction CSV rows that should have no contact matches."""
-    adviser = AdviserFactory()
+    adviser = AdviserFactory(
+        first_name='Adviser for',
+        last_name='Unmatched interaction',
+    )
     service = random_service()
     communication_channel = random_communication_channel()
 


### PR DESCRIPTION
### Description of change

Some tests for the import interactions tool were occasionally failing due to duplicate advisers being created during the tests.

This change explicitly sets adviser names to avoid that possibility.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
