### PR TITLE
Raise a custom exception when email ingestion does not recognise an email address

### DIFF
--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -99,7 +99,7 @@ class EmailNotSentByDITException(Exception):
     Exception for flagging that an email could not be verified as sent by a DIT
     adviser.
 
-    TODO: Remove this exception and it's uses once we are past calendar invite
+    TODO: Remove this exception and its uses once we are past calendar invite
     ingestion pilot stage.
     """
 

--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -94,6 +94,16 @@ def _get_utc_datetime(localised_datetime):
         return localised_datetime
 
 
+class EmailNotSentByDITException(Exception):
+    """
+    Exception for flagging that an email could not be verified as sent by a DIT
+    adviser.
+
+    TODO: Remove this exception and it's uses once we are past calendar invite
+    ingestion pilot stage.
+    """
+
+
 class CalendarInteractionEmailParser:
     """
     Parses and extracts calendar interaction information from a MailParser email
@@ -113,7 +123,18 @@ class CalendarInteractionEmailParser:
         except IndexError:
             raise ValidationError('Email was malformed - missing "from" header')
         if not was_email_sent_by_dit(self.message):
-            raise ValidationError('Email not sent by DIT')
+            sender_domain = sender_email.rsplit('@', maxsplit=1)[1]
+            message_id = self.message.message_id
+            # TODO: This raises a EmailNotSentByDITException for debugging purposes.
+            # change this back to a ValidationError when we are past the pilot stage for
+            # calendar invite ingestion
+            raise EmailNotSentByDITException(
+                f'Email with ID "{message_id}" and sender domain "{sender_domain}" '
+                'was not recognised as being sent by an authenticated DIT domain. '
+                'Either the domain was unrecognised, or it did not pass our requirements for '
+                'Authentication-Results. Further investigation is needed during the pilot for '
+                'email ingestion.',
+            )
         sender_adviser = _get_best_match_adviser_by_email(sender_email)
         if not sender_adviser:
             raise ValidationError('Email not sent by recognised DIT Adviser')

--- a/datahub/interaction/test/email_processors/test_parsers.py
+++ b/datahub/interaction/test/email_processors/test_parsers.py
@@ -250,6 +250,6 @@ class TestCalendarInteractionEmailParser:
         raises ValidationErrors as expected in a number of situations.
         """
         parser = self._get_parser_for_email_file(email_file)
-        with pytest.raises(expected_error.__class__) as exc:
+        with pytest.raises(expected_error.__class__) as excinfo:
             parser.extract_interaction_data_from_email()
-        assert exc.value.args[0] == expected_error.args[0]
+        assert excinfo.value.args[0] == expected_error.args[0]


### PR DESCRIPTION
### Description of change

For the initial release period (and pilot) of the calendar invite ingestion work, we need to study emails which would be rejected by sender verification logic.  The `was_email_sent_by_dit` helper function operates by ensuring that the sender domain is a domain that is recognised by the app (in `DIT_EMAIL_DOMAINS`) and also that the message has some verified authentication headers (DKIM, SPF, DMARC).

Since we do not have good visibility of all of the domains that advisers might send emails with, we need to know about those that would be rejected in this case to review whether they should be added to the `DIT_EMAIL_DOMAINS` whitelist.

We do not have good visibility of the authentication checks that these domains offer, so we need to study these emails when they are rejected for bad authentication results or unexpected email domains.

This change raises a custom exception for this purpose.  The aim is that I will review these exceptions in sentry and adjust the whitelist/authentication validation appropriately.

### Points of note

- A note on how this exception will be surfaced, email processors are called through the following process:
  - `datahub.email_ingestion.tasks.ingest_emails()` will iterate through all active `Mailbox` objects from the `MailboxHandler` singleton.
  - The `ingest_emails` task will call the `process_new_mail()` for each `Mailbox` object.
  - This in turn will call the `_process_email()` helper method on the `Mailbox` object. This method has handling for unexpected exceptions with a catch-all `except Exception` block.  This will log the exception and exception details (to sentry in production). https://github.com/uktrade/data-hub-leeloo/commit/c48dee917d2c77800af1d03a9f8062bdffb9bccc#diff-afec21fadd19510c01151786df2464c3R134

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
