### PR TITLE
Activate email ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `SSO_ENABLED` | Yes | Whether single sign-on via RFC 7662 token introspection is enabled |
 | `VCAP_SERVICES` | No | Set by GOV.UK PaaS when using their backing services. Contains connection details for Elasticsearch and Redis. |
 | `WEB_CONCURRENCY` | No | Number of Gunicorn workers (set automatically by Heroku, otherwise defaults to 1). |
-| `ENABLE_EMAIL_INGESTION` | No | 1 or 0.  Whether or not to activate the celery beat task for ingesting emails |
+| `ENABLE_EMAIL_INGESTION` | No | True or False.  Whether or not to activate the celery beat task for ingesting emails |
 | `MAILBOX_MEETINGS_EMAIL` | No | Email address of the inbox for ingesting meeting invites via IMAP |
 | `MAILBOX_MEETINGS_PASSWORD` | No | Password for the inbox for ingesting meeting invites via IMAP |
 | `MAILBOX_MEETINGS_IMAP_DOMAIN` | No | IMAP domain for the inbox for ingesting meeting invites via IMAP |

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `VCAP_SERVICES` | No | Set by GOV.UK PaaS when using their backing services. Contains connection details for Elasticsearch and Redis. |
 | `WEB_CONCURRENCY` | No | Number of Gunicorn workers (set automatically by Heroku, otherwise defaults to 1). |
 | `ENABLE_EMAIL_INGESTION` | No | True or False.  Whether or not to activate the celery beat task for ingesting emails |
-| `MAILBOX_MEETINGS_EMAIL` | No | Email address of the inbox for ingesting meeting invites via IMAP |
+| `MAILBOX_MEETINGS_USERNAME` | No | Username of the inbox for ingesting meeting invites via IMAP (likely to be the same as the email for the mailbox) |
 | `MAILBOX_MEETINGS_PASSWORD` | No | Password for the inbox for ingesting meeting invites via IMAP |
 | `MAILBOX_MEETINGS_IMAP_DOMAIN` | No | IMAP domain for the inbox for ingesting meeting invites via IMAP |
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,10 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `SSO_ENABLED` | Yes | Whether single sign-on via RFC 7662 token introspection is enabled |
 | `VCAP_SERVICES` | No | Set by GOV.UK PaaS when using their backing services. Contains connection details for Elasticsearch and Redis. |
 | `WEB_CONCURRENCY` | No | Number of Gunicorn workers (set automatically by Heroku, otherwise defaults to 1). |
+| `ENABLE_EMAIL_INGESTION` | No | 1 or 0.  Whether or not to activate the celery beat task for ingesting emails |
+| `MAILBOX_MEETINGS_EMAIL` | No | Email address of the inbox for ingesting meeting invites via IMAP |
+| `MAILBOX_MEETINGS_PASSWORD` | No | Password for the inbox for ingesting meeting invites via IMAP |
+| `MAILBOX_MEETINGS_IMAP_DOMAIN` | No | IMAP domain for the inbox for ingesting meeting invites via IMAP |
 
 
 ## Management commands

--- a/changelog/interaction/meeting-invite-ingestion.feature.rst
+++ b/changelog/interaction/meeting-invite-ingestion.feature.rst
@@ -1,4 +1,4 @@
-Activated a feature for ingesting meeting invite emails sent to a shared mailbox as draft
+A feature was activated for ingesting meeting invite emails sent to a shared mailbox as draft
 interactions. This enables DIT advisers to create interactions more easily.
 
 This is the first instance of a Data Hub app using the framework provided by the

--- a/changelog/interaction/meeting-invite-ingestion.feature.rst
+++ b/changelog/interaction/meeting-invite-ingestion.feature.rst
@@ -1,0 +1,7 @@
+Activated a feature for ingesting meeting invite emails sent to a shared mailbox as draft
+interactions. This enables DIT advisers to create interactions more easily.
+
+This is the first instance of a Data Hub app using the framework provided by the
+``datahub.email_ingestion`` app.  There will be subsequent iterations on the 
+``CalendarInteractionEmailProcessor`` class to improve the user experience - most
+notably sending notifications of bounce/receipt to advisers.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -389,7 +389,7 @@ if REDIS_BASE_URL:
     if env.bool('ENABLE_EMAIL_INGESTION', False):
         CELERY_BEAT_SCHEDULE['email_ingestion'] = {
             'task': 'datahub.email_ingestion.tasks.ingest_emails',
-            'schedule': 10.0, # Every 10 seconds
+            'schedule': 30.0, # Every 30 seconds
         }
 
     CELERY_WORKER_LOG_FORMAT = (

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -536,12 +536,12 @@ DOCUMENT_BUCKETS = {
 }
 
 MAILBOXES = {
-    "meetings": {
-        "email": env("MAILBOX_MEETINGS_EMAIL", default=''),
-        "password": env("MAILBOX_MEETINGS_PASSWORD", default=''),
-        "imap_domain": env("MAILBOX_MEETINGS_IMAP_DOMAIN", default=''),
-        "processor_classes": [
-            "datahub.interaction.email_processors.processors.CalendarInteractionEmailProcessor",
+    'meetings': {
+        'username': env('MAILBOX_MEETINGS_USERNAME', default=''),
+        'password': env('MAILBOX_MEETINGS_PASSWORD', default=''),
+        'imap_domain': env('MAILBOX_MEETINGS_IMAP_DOMAIN', default=''),
+        'processor_classes': [
+            'datahub.interaction.email_processors.processors.CalendarInteractionEmailProcessor',
         ],
     },
 }

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -63,6 +63,7 @@ LOCAL_APPS = [
     'datahub.core',
     'datahub.company',
     'datahub.documents',
+    'datahub.email_ingestion',
     'datahub.event',
     'datahub.feature_flag.apps.FeatureFlagConfig',
     'datahub.interaction',
@@ -385,6 +386,12 @@ if REDIS_BASE_URL:
             'schedule': crontab(minute=0, hour=1),
         }
 
+    if env.bool('ENABLE_EMAIL_INGESTION', False):
+        CELERY_BEAT_SCHEDULE['email_ingestion'] = {
+            'task': 'datahub.email_ingestion.tasks.ingest_emails',
+            'schedule': 10.0, # Every 10 seconds
+        }
+
     CELERY_WORKER_LOG_FORMAT = (
         "[%(asctime)s: %(levelname)s/%(processName)s] [%(name)s] %(message)s"
     )
@@ -529,16 +536,14 @@ DOCUMENT_BUCKETS = {
 }
 
 MAILBOXES = {
-    # Illustrative example...
-    # TODO: remove this when we have a real mailbox
-    #"meetings": {
-    #    "email": env("MAILBOX_MEETINGS_EMAIL", default=''),
-    #    "password": env("MAILBOX_MEETINGS_PASSWORD", default=''),
-    #    "imap_domain": env("MAILBOX_MEETINGS_IMAP_DOMAIN", default=''),
-    #    "processor_classes": [
-    #        "datahub.interaction.email_processors.CalendarInteractionEmailProcessor",
-    #    ],
-    #},
+    "meetings": {
+        "email": env("MAILBOX_MEETINGS_EMAIL", default=''),
+        "password": env("MAILBOX_MEETINGS_PASSWORD", default=''),
+        "imap_domain": env("MAILBOX_MEETINGS_IMAP_DOMAIN", default=''),
+        "processor_classes": [
+            "datahub.interaction.email_processors.processors.CalendarInteractionEmailProcessor",
+        ],
+    },
 }
 
 DIT_EMAIL_DOMAINS = env.list('DIT_EMAIL_DOMAINS', default=[])

--- a/datahub/email_ingestion/__init__.py
+++ b/datahub/email_ingestion/__init__.py
@@ -1,3 +1,4 @@
 from datahub.email_ingestion.mailbox import MailboxHandler
 
+default_app_config = 'datahub.email_ingestion.apps.EmailIngestionConfig'
 mailbox_handler = MailboxHandler()

--- a/datahub/email_ingestion/apps.py
+++ b/datahub/email_ingestion/apps.py
@@ -1,0 +1,9 @@
+from django.apps import AppConfig
+
+
+class EmailIngestionConfig(AppConfig):
+    name = 'datahub.email_ingestion'
+
+    def ready(self):
+        from datahub.email_ingestion import mailbox_handler
+        mailbox_handler.initialise_mailboxes()

--- a/datahub/email_ingestion/apps.py
+++ b/datahub/email_ingestion/apps.py
@@ -2,8 +2,17 @@ from django.apps import AppConfig
 
 
 class EmailIngestionConfig(AppConfig):
+    """
+    App config for email_ingestion app.  This ensures that the package's mailbox_handler
+    singleton is only initialised when Django's apps are ready; often the email
+    processor classes that it instantiates will depend on Django models etc.
+    """
+
     name = 'datahub.email_ingestion'
 
     def ready(self):
+        """
+        Initialises the mailbox_handler singleton.
+        """
         from datahub.email_ingestion import mailbox_handler
         mailbox_handler.initialise_mailboxes()

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -248,7 +248,6 @@ class MailboxHandler:
         Initialise the MailboxHandler object.
         """
         self.mailboxes = {}
-        self.initialise_mailboxes()
 
     def initialise_mailboxes(self):
         """

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -53,7 +53,7 @@ class Mailbox:
 
     def __init__(
         self,
-        email,
+        username,
         password,
         imap_domain,
         mail_processor_classes,
@@ -62,14 +62,14 @@ class Mailbox:
         """
         Initialise a Mailbox object.
 
-        :param email: string - the email address of the inbox
+        :param username: string - the username of the inbox
         :param password: string - the password for the inbox
         :param imap_domain: string - the domain of the imap server to connect to
         :param mail_processor_classes: iterable - EmailProcessor classes which
             should be used to process incoming mail to this mailbox
         :param imap_port: optional int - the port to use when connecting with imap
         """
-        self.email = email
+        self.username = username
         self.password = password
         self.imap_domain = imap_domain
         if imap_port:
@@ -88,7 +88,7 @@ class Mailbox:
         :yields: An active imaplib server connection object.
         """
         connection = imaplib.IMAP4_SSL(self.imap_domain, self.imap_port)
-        connection.login(self.email, self.password)
+        connection.login(self.username, self.password)
         connection.select()
         try:
             yield connection
@@ -192,7 +192,7 @@ class Mailbox:
                     # If we have some problem parsing the email, it's likely
                     # to be spam/malicious so skip it
                     error_message = (
-                        f'Mailbox "{self.email}" failed to parse message'
+                        f'Mailbox "{self.username}" failed to parse message'
                     )
                     logger.exception(error_message)
                     # Just set the message to None so that we still mark it as
@@ -202,7 +202,7 @@ class Mailbox:
                     # We should fail and exit immediately in this case, as it's
                     # probable that another process is processing the inbox
                     error_message = (
-                        f'Mailbox "{self.email}" could not retrieve message {uid} successfully'
+                        f'Mailbox "{self.username}" could not retrieve message {uid} successfully'
                     )
                     logger.exception(error_message)
                     return
@@ -254,7 +254,7 @@ class MailboxHandler:
         Initialise all of the mailboxes detailed in the MAILBOXES django setting.
         """
         for mailbox_name, config in settings.MAILBOXES.items():
-            properly_configured = config.keys() >= {'email', 'password', 'imap_domain'}
+            properly_configured = config.keys() >= {'username', 'password', 'imap_domain'}
             if not properly_configured:
                 message = f'Mailbox "{mailbox_name}" was not configured properly in settings'
                 raise ImproperlyConfigured(message)
@@ -264,7 +264,7 @@ class MailboxHandler:
                 processor_class = import_string(processor_class_path)
                 processor_classes.append(processor_class)
             mailbox = Mailbox(
-                config['email'],
+                config['username'],
                 config['password'],
                 config['imap_domain'],
                 processor_classes,

--- a/datahub/email_ingestion/tasks.py
+++ b/datahub/email_ingestion/tasks.py
@@ -3,6 +3,8 @@ from celery.utils.log import get_task_logger
 from django_pglocks import advisory_lock
 
 from datahub.email_ingestion import mailbox_handler
+from datahub.feature_flag.models import FeatureFlag
+from datahub.interaction import INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME
 
 logger = get_task_logger(__name__)
 
@@ -13,6 +15,19 @@ def ingest_emails():
     Ingest and process new emails for all mailboxes in the application - i.e.
     those in the MAILBOXES django setting.
     """
+    # TODO: remove feature flag check once we are happy with meeting invite
+    # email processing
+    try:
+        FeatureFlag.objects.get(
+            code=INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME,
+            is_active=True,
+        )
+    except FeatureFlag.DoesNotExist:
+        logger.info(
+            f'Feature flag "{INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME}" is not active, '
+            'exiting.',
+        )
+        return
     # Acquire a processing lock for the duration of the current DB session -
     # this will ensure that multiple ingestion workers do not run at the same
     # time and therefore prevent the chance of messages being processed more

--- a/datahub/email_ingestion/tasks.py
+++ b/datahub/email_ingestion/tasks.py
@@ -3,7 +3,7 @@ from celery.utils.log import get_task_logger
 from django_pglocks import advisory_lock
 
 from datahub.email_ingestion import mailbox_handler
-from datahub.feature_flag.models import FeatureFlag
+from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.interaction import INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME
 
 logger = get_task_logger(__name__)
@@ -17,12 +17,7 @@ def ingest_emails():
     """
     # TODO: remove feature flag check once we are happy with meeting invite
     # email processing
-    try:
-        FeatureFlag.objects.get(
-            code=INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME,
-            is_active=True,
-        )
-    except FeatureFlag.DoesNotExist:
+    if not is_feature_flag_active(INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME):
         logger.info(
             f'Feature flag "{INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME}" is not active, '
             'exiting.',

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -423,7 +423,7 @@ class TestMailboxHandler:
         for mailbox_name, mailbox_config in MAILBOXES_SETTING.items():
             instantiated_mailbox = mailbox_handler.get_mailbox(mailbox_name)
             # ensure that the Mailbox object has the expected attributes
-            assert instantiated_mailbox.email == mailbox_config['email']
+            assert instantiated_mailbox.username == mailbox_config['username']
             assert instantiated_mailbox.password == mailbox_config['password']
             assert instantiated_mailbox.imap_domain == mailbox_config['imap_domain']
             # ensure that the processor class paths were imported

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -419,6 +419,7 @@ class TestMailboxHandler:
         # Mock import_string to avoid import errors for processor_class path strings
         import_string_mock = mock_import_string(monkeypatch)
         mailbox_handler = MailboxHandler()
+        mailbox_handler.initialise_mailboxes()
         for mailbox_name, mailbox_config in MAILBOXES_SETTING.items():
             instantiated_mailbox = mailbox_handler.get_mailbox(mailbox_name)
             # ensure that the Mailbox object has the expected attributes
@@ -440,7 +441,8 @@ class TestMailboxHandler:
         when badly configured.
         """
         with pytest.raises(ImproperlyConfigured):
-            MailboxHandler()
+            mailbox_handler = MailboxHandler()
+            mailbox_handler.initialise_mailboxes()
 
     @override_settings(MAILBOXES={})
     def test_handler_initialisation_no_mailboxes(self):
@@ -449,4 +451,5 @@ class TestMailboxHandler:
         there are no mailboxes in the application settings.
         """
         mailbox_handler = MailboxHandler()
+        mailbox_handler.initialise_mailboxes()
         assert mailbox_handler.get_all_mailboxes() == []

--- a/datahub/email_ingestion/test/test_tasks.py
+++ b/datahub/email_ingestion/test/test_tasks.py
@@ -28,9 +28,11 @@ class TestIngestEmails:
             process_new_mail_patch,
         )
         # Refresh the mailbox_handler singleton as we have overidden the MAILBOXES setting
+        mailbox_handler = MailboxHandler()
+        mailbox_handler.initialise_mailboxes()
         monkeypatch.setattr(
             'datahub.email_ingestion.tasks.mailbox_handler',
-            MailboxHandler(),
+            mailbox_handler,
         )
         ingest_emails()
         assert process_new_mail_patch.call_count == 2

--- a/datahub/email_ingestion/test/test_tasks.py
+++ b/datahub/email_ingestion/test/test_tasks.py
@@ -6,14 +6,26 @@ from django.test.utils import override_settings
 from datahub.email_ingestion.mailbox import MailboxHandler
 from datahub.email_ingestion.tasks import ingest_emails
 from datahub.email_ingestion.test.utils import MAILBOXES_SETTING, mock_import_string
+from datahub.feature_flag.models import FeatureFlag
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.interaction import INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME
 
 
+@pytest.fixture()
+def interaction_email_ingestion_feature_flag():
+    """
+    Creates the email ingestion feature flag.
+    """
+    yield FeatureFlagFactory(code=INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME)
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures('interaction_email_ingestion_feature_flag')
 class TestIngestEmails:
     """
     Test ingest_emails celery task.
     """
 
-    @pytest.mark.django_db
     @override_settings(MAILBOXES=MAILBOXES_SETTING)
     def test_ingest_emails_lock_acquired(self, monkeypatch):
         """
@@ -53,6 +65,24 @@ class TestIngestEmails:
         advisory_lock_mock = mock.MagicMock()
         advisory_lock_mock.return_value.__enter__.return_value = False
         monkeypatch.setattr('datahub.email_ingestion.tasks.advisory_lock', advisory_lock_mock)
+
+        ingest_emails()
+        assert process_new_mail_patch.called is False
+
+    @override_settings(MAILBOXES=MAILBOXES_SETTING)
+    def test_ingest_feature_flag_inactive(self, monkeypatch):
+        """
+        Test that our mailboxes are not processed when the feature flag is not active.
+        """
+        process_new_mail_patch = mock.Mock()
+        # ensure that the process_new_mail method is a mock so we can interrogate later
+        monkeypatch.setattr(
+            'datahub.email_ingestion.mailbox.Mailbox.process_new_mail',
+            process_new_mail_patch,
+        )
+        flag = FeatureFlag.objects.get(code=INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME)
+        flag.is_active = False
+        flag.save()
 
         ingest_emails()
         assert process_new_mail_patch.called is False

--- a/datahub/email_ingestion/test/utils.py
+++ b/datahub/email_ingestion/test/utils.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 MAILBOXES_SETTING = {
     'mybox1': {
-        'email': 'mybox1@example.net',
+        'username': 'mybox1@example.net',
         'password': 'foobarbaz1',
         'imap_domain': 'imap.example.net',
         'processor_classes': [
@@ -12,7 +12,7 @@ MAILBOXES_SETTING = {
         ],
     },
     'mybox2': {
-        'email': 'mybox2@example.net',
+        'username': 'mybox2@example.net',
         'password': 'foobarbaz2',
         'imap_domain': 'imap.example.net',
         'processor_classes': [
@@ -25,7 +25,7 @@ MAILBOXES_SETTING = {
 # Mailbox missing password configuration
 BAD_MAILBOXES_SETTING = {
     'mybox1': {
-        'email': 'mybox1@example.net',
+        'username': 'mybox1@example.net',
         'imap_domain': 'imap.example.net',
         'processor_classes': [
             'datahub.email_ingestion.processor_1.Processor',

--- a/datahub/email_ingestion/validation.py
+++ b/datahub/email_ingestion/validation.py
@@ -1,4 +1,3 @@
-from authres import AuthenticationResultsHeader
 from django.conf import settings
 
 
@@ -16,11 +15,10 @@ def _verify_authentication(message, auth_methods=None):
     if not auth_methods:
         auth_methods = ('dkim', 'spf', 'dmarc')
     header_contents = ' '.join(message.authentication_results.splitlines())
-    auth_parser = AuthenticationResultsHeader.parse(f'Authentication-Results: {header_contents}')
     auth_results = {auth_method: False for auth_method in auth_methods}
-    for auth_mechanism in auth_parser.results:
-        if auth_mechanism.method in auth_results.keys():
-            auth_results[auth_mechanism.method] = auth_mechanism.result == 'pass'
+    for auth_method in auth_methods:
+        if f'{auth_method}=pass' in header_contents:
+            auth_results[auth_method] = True
     all_auth_pass = all(auth_results.values())
     return all_auth_pass
 

--- a/datahub/interaction/__init__.py
+++ b/datahub/interaction/__init__.py
@@ -1,0 +1,1 @@
+INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME = 'interaction-email-ingestion'

--- a/fixtures/test_data.yaml
+++ b/fixtures/test_data.yaml
@@ -501,6 +501,25 @@
     modified_on: '2018-06-05T00:00:00Z'
     archived_documents_url_path: '/documents/123'
 
+- model: company.contact
+  pk: 1430e18a-52ac-4185-b71d-b2be5a771fd0
+  fields:
+    first_name: Fred
+    last_name: Peterson
+    company: b2c34b41-1d5a-4b4b-9249-7c53ff2868dd  # Mars Exports Ltd
+    primary: false
+    telephone_countrycode: +44
+    telephone_number: 78801234322
+    email: fred.peterson@example.com
+    address_1: 123 Fake Street
+    address_town: Fake Town
+    address_postcode: BN2 9QB
+    address_country: 80756b9a-5d95-e211-a939-e4115bead28a
+    accepts_dit_email_marketing: false
+    notes: This is a dummy contact for testing
+    created_on: '2018-02-28T15:00:00Z'
+    modified_on: '2018-06-05T00:00:00Z'
+
 - model: interaction.interaction
   pk: 236b656c-ae26-43ca-bb51-c72d553383f3
   fields:

--- a/requirements.in
+++ b/requirements.in
@@ -32,7 +32,6 @@ notifications-python-client==5.3.0
 # Email
 mail-parser==3.9.3
 icalendar==4.0.3
-authres==1.1.1
 
 # REDIS
 django-redis==4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ apipkg==1.5               # via execnet
 argh==0.26.2              # via watchdog
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via flake8-bugbear, pytest
-authres==1.1.1
 backcall==0.1.0           # via ipython
 billiard==3.6.0.0
 boto3==1.9.159


### PR DESCRIPTION
### Description of change

This change switches on the `ingest_emails()` task in the `email_ingestion` app.  The task is run on a celery beat schedule - once every 10 seconds.

It is activated behind a feature flag.  Additionally, the `MAILBOXES` setting was populated so that we add a mailbox for calendar invite ingestion and wire this mailbox up with the associated email processor (created in https://github.com/uktrade/data-hub-leeloo/pull/1732).

### Points of note

- The approach of using a package-level singleton - `mailbox_handler` - initialised in `email_ingestion/__init__.py` did not work in practice.  The problem was that the package (django app) was being imported by Django (as it is now in `INSTALLED_APPS`) before django was fully initialised; so any model imports etc were failing with a message `django.core.exceptions.AppRegistryNotReady: Apps aren't loaded yet`.  
This has been fixed so that the singleton is instantiated in `email_ingestion/__init__.py`, but the `initialise_mailboxes()` method is called externally in an AppConfig class defined in `email_ingestion/apps.py` - once all apps are ready.  Please feel free to comment if you can think of a better pattern to follow here, as my solution has made the `MailboxHandler` instantiation a two-step process. 
- Unfortunately, it turns out that the authres library is not fit for purpose for some of the Authentication-Results headers that emails actual DIT advisers have.  This has been exposed through a sampling activity that we are conducting in parallel.  I have swapped it out for a simpler solution as it does not accommodate a number of real world cases (failing with `SyntaxError` exceptions).

### To test

1. Pull down the branch and ensure that the fixtures in your working copy are up to date: `./manage.py loaddata fixtures/test_data.yaml`
1. Add an active feature flag with code `"interaction-email-ingestion"`.
1. Ensure that the following environment variables are specified in the environment under which leeloo runs: `DIT_EMAIL_DOMAINS`, `ENABLE_EMAIL_INGESTION`, `MAILBOX_MEETINGS_EMAIL`, `MAILBOX_MEETINGS_PASSWORD`, `MAILBOX_MEETINGS_IMAP_DOMAIN`.  See https://docs.google.com/document/d/1ARHW2PiuJYOym8KkGsiwIV3A_ZeKqowQLubf84RavDo/edit for good settings in dev.
1. Ensure that a celery worker is running.  You should see in the log that `Task datahub.email_ingestion.tasks.ingest_emails` is running periodically.  **Note** it might be helpful to run this at debug log level as this will show log messages for email rejection reasons.
1. Add an active adviser for your own @digital.trade.gov.uk email address.
1. In gmail, create a new calendar entry.  Include fred.peterson@example.com and the email alias for the dev mailbox as recipients.  Add a subject, start time, end time and location.  Send the calendar invite.
1. You should see that the celery task processes the email as expected and that a draft interaction is created with the pertinent details for that meeting invite - associated to Mars Exports Ltd.
- **Note** that we are using a shared resource here, so we may need to coordinate a little over slack - if you do not see your interactions showing up this could be an indicator that somebody else is also consuming the mailbox.
 
### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
