### PR TITLE
Fix for adviser and team being null

### DIFF
--- a/datahub/activity_stream/interaction/serializers.py
+++ b/datahub/activity_stream/interaction/serializers.py
@@ -54,14 +54,18 @@ class InteractionActivitySerializer(serializers.ModelSerializer):
 
     def _get_dit_participants(self, participants):
         return [
-            {
-                'id': f'dit:DataHubAdviser:{participant.adviser.pk}',
-                'type': ['Person', 'dit:Adviser'],
-                'dit:emailAddress': participant.adviser.contact_email or participant.adviser.email,
-                'name': participant.adviser.name,
-            }
+            self._get_adviser(participant.adviser)
             for participant in participants.all()
+            if participant.adviser is not None
         ]
+
+    def _get_adviser(self, adviser):
+        return {} if adviser is None else {
+            'id': f'dit:DataHubAdviser:{adviser.pk}',
+            'type': ['Person', 'dit:Adviser'],
+            'dit:emailAddress': adviser.contact_email or adviser.email,
+            'name': adviser.name,
+        }
 
     def _get_team(self, team):
         return {} if team is None else {

--- a/datahub/activity_stream/interaction/tests/test_views.py
+++ b/datahub/activity_stream/interaction/tests/test_views.py
@@ -16,6 +16,7 @@ from datahub.interaction.test.factories import (
     InvestmentProjectInteractionFactory,
     ServiceDeliveryFactory,
 )
+from datahub.metadata.test.factories import TeamFactory
 
 
 def _url(name):
@@ -554,3 +555,32 @@ def test_cursor_pagination(api_client, monkeypatch):
     data = response.json()
     assert len(data['orderedItems']) == page_size
     assert data['next'] == next_page_url
+
+
+@pytest.mark.django_db
+def test_null_adviser(api_client):
+    """
+    Test that we can handle dit_participant.adviser being None
+    """
+    interaction = CompanyInteractionFactory(dit_participants=[])
+    InteractionDITParticipantFactory(
+        interaction=interaction,
+        adviser=None,
+        team=TeamFactory(),
+    )
+    response = _hawk_get(api_client, _url('api-v3:activity-stream:interactions'))
+    assert response.status_code == status.HTTP_200_OK
+
+
+@pytest.mark.django_db
+def test_null_team(api_client):
+    """
+    Test that we can handle dit_participant.team being None
+    """
+    interaction = EventServiceDeliveryFactory(dit_participants=[])
+    InteractionDITParticipantFactory(
+        interaction=interaction,
+        team=None,
+    )
+    response = _hawk_get(api_client, _url('api-v3:activity-stream:interactions'))
+    assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
### Description of change

After merging #1721, we found that the following fields are `None` in develop and staging for some records:

1) `InteractionDITParticipant.adviser`
2) `InteractionDITParticipant.team`

This PR reproduces the problem and introduces a fix.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
