### PR TITLE
Add ability to download unmatched rows to the import interactions tool

### DIFF
--- a/changelog/interaction/import-download-unmatched.feature.rst
+++ b/changelog/interaction/import-download-unmatched.feature.rst
@@ -1,0 +1,1 @@
+The ability to download records that could not be matched to contacts was added to the import interactions admin site tool. The tool is currently behind the ``admin-interaction-csv-importer`` feature flag as it’s incomplete.

--- a/datahub/interaction/admin_csv_import/views.py
+++ b/datahub/interaction/admin_csv_import/views.py
@@ -27,9 +27,12 @@ MAX_ERRORS_TO_DISPLAY = 50
 MAX_PREVIEW_ROWS_TO_DISPLAY = 100
 PAGE_TITLE = gettext_lazy('Import interactions')
 
-INVALID_TOKEN_MESSAGE = gettext_lazy(
+INVALID_TOKEN_MESSAGE_DURING_SAVE = gettext_lazy(
     'The CSV file referenced is no longer available and may have expired. Please upload '
     'the file again.',
+)
+INVALID_TOKEN_MESSAGE_POST_SAVE = gettext_lazy(
+    'Sorry, we could not find the results for that import operation. They may have expired.',
 )
 
 
@@ -100,7 +103,7 @@ class InteractionCSVImportAdmin:
         form = InteractionCSVForm.from_token(token)
 
         if not form:
-            self.model_admin.message_user(request, INVALID_TOKEN_MESSAGE, ERROR)
+            self.model_admin.message_user(request, INVALID_TOKEN_MESSAGE_DURING_SAVE, ERROR)
             return _redirect_response('changelist')
 
         if not form.is_valid():
@@ -123,7 +126,7 @@ class InteractionCSVImportAdmin:
         counts_by_status = load_result_counts_by_status(token)
 
         if not counts_by_status:
-            self.model_admin.message_user(request, INVALID_TOKEN_MESSAGE, ERROR)
+            self.model_admin.message_user(request, INVALID_TOKEN_MESSAGE_POST_SAVE, ERROR)
             return _redirect_response('changelist')
 
         return self._complete_response(request, counts_by_status)

--- a/datahub/interaction/admin_csv_import/views.py
+++ b/datahub/interaction/admin_csv_import/views.py
@@ -1,23 +1,30 @@
+import io
+from datetime import timedelta
 from itertools import islice
 
 from django.conf import settings
 from django.contrib.admin.templatetags.admin_urls import admin_urlname
 from django.contrib.auth.decorators import permission_required
 from django.contrib.messages import ERROR
-from django.http import HttpResponseRedirect
+from django.http import FileResponse, HttpResponseRedirect
 from django.template.response import TemplateResponse
 from django.urls import path, reverse
 from django.utils.decorators import method_decorator
+from django.utils.timezone import now
 from django.utils.translation import gettext_lazy
 from django.views.decorators.http import require_POST
 
 from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.core.admin import max_upload_size
+from datahub.core.csv import CSV_CONTENT_TYPE
 from datahub.core.exceptions import DataHubException
 from datahub.feature_flag.utils import feature_flagged_view
 from datahub.interaction.admin_csv_import.cache_utils import (
+    CACHE_VALUE_TIMEOUT,
     load_result_counts_by_status,
+    load_unmatched_rows_csv_contents,
     save_result_counts_by_status,
+    save_unmatched_rows_csv_contents,
 )
 from datahub.interaction.admin_csv_import.file_form import InteractionCSVForm
 from datahub.interaction.models import Interaction, InteractionPermission
@@ -76,6 +83,11 @@ class InteractionCSVImportAdmin:
                 admin_site.admin_view(self.complete),
                 name=f'{model_meta.app_label}_{model_meta.model_name}_import-complete',
             ),
+            path(
+                'import/<token>/download-unmatched',
+                admin_site.admin_view(self.download_unmatched),
+                name=f'{model_meta.app_label}_{model_meta.model_name}_import-download-unmatched',
+            ),
         ]
 
     @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
@@ -110,8 +122,12 @@ class InteractionCSVImportAdmin:
             # This should not happen, so we simply raise an error to alert us if it does
             raise DataHubException('Unexpected form re-validation failure')
 
-        matching_counts = form.save(request.user)
+        matching_counts, unmatched_row_collector = form.save(request.user)
         save_result_counts_by_status(token, matching_counts)
+
+        unmatched_rows_csv_contents = unmatched_row_collector.to_raw_csv()
+        if unmatched_rows_csv_contents:
+            save_unmatched_rows_csv_contents(token, unmatched_rows_csv_contents)
 
         # Redirect to another page to display a confirmation message on success (following the
         # standard Django pattern to limit the possibility of a form resubmission on page
@@ -129,7 +145,27 @@ class InteractionCSVImportAdmin:
             self.model_admin.message_user(request, INVALID_TOKEN_MESSAGE_POST_SAVE, ERROR)
             return _redirect_response('changelist')
 
-        return self._complete_response(request, counts_by_status)
+        return self._complete_response(request, token, counts_by_status)
+
+    @interaction_change_all_permission_required
+    @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
+    def download_unmatched(self, request, token=None, *args, **kwargs):
+        """Download unmatched rows as a CSV file following a successful import operation."""
+        unmatched_rows_csv_contents = load_unmatched_rows_csv_contents(token)
+
+        if not unmatched_rows_csv_contents:
+            self.model_admin.message_user(request, INVALID_TOKEN_MESSAGE_POST_SAVE, ERROR)
+            return _redirect_response('changelist')
+
+        timestamp = now().strftime('%Y-%m-%d-%H-%M-%S')
+        filename = f'Unmatched interactions - {timestamp}.csv'
+
+        return FileResponse(
+            io.BytesIO(unmatched_rows_csv_contents),
+            as_attachment=True,
+            content_type=CSV_CONTENT_TYPE,
+            filename=filename,
+        )
 
     def _select_file_form_response(self, request, form):
         return self._template_response(
@@ -171,11 +207,13 @@ class InteractionCSVImportAdmin:
             token=token,
         )
 
-    def _complete_response(self, request, counts_by_status):
+    def _complete_response(self, request, token, counts_by_status):
         return self._template_response(
             request,
             f'admin/interaction/interaction/import_complete.html',
             PAGE_TITLE,
+            token=token,
+            download_timeout_mins=CACHE_VALUE_TIMEOUT // timedelta(minutes=1),
             num_matched=counts_by_status[ContactMatchingStatus.matched],
             num_unmatched=counts_by_status[ContactMatchingStatus.unmatched],
             num_multiple_matches=counts_by_status[ContactMatchingStatus.multiple_matches],

--- a/datahub/interaction/templates/admin/interaction/interaction/import_complete.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_complete.html
@@ -13,6 +13,15 @@
 
   {% include 'admin/interaction/interaction/fragment_post_import_counts.html' with num_matched=num_matched num_unmatched=num_unmatched num_multiple_matches=num_multiple_matches only %}
 
+  {% if num_unmatched or num_multiple_matches %}
+    <p>
+      {% url opts|admin_urlname:'import-download-unmatched' token=token as unmatched_download_url %}
+      {% blocktrans %}
+        <a href="{{ unmatched_download_url }}">Download unmatched interactions</a> (link valid for {{ download_timeout_mins }} minutes after importing)
+      {% endblocktrans %}
+    </p>
+  {% endif %}
+
   <p>
     <a href="{% url opts|admin_urlname:'changelist' %}">
       {% trans 'Return to the interaction list' %}

--- a/datahub/interaction/test/admin_csv_import/test_file_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_file_form.py
@@ -142,8 +142,8 @@ class TestInteractionCSVForm:
     @pytest.mark.parametrize('num_unmatched', (0, 6))
     @pytest.mark.parametrize('num_multiple_matches', (0, 6))
     @pytest.mark.usefixtures('local_memory_cache')
-    def test_save_stores_correct_counts(self, num_matching, num_unmatched, num_multiple_matches):
-        """Test that save() stores the expected counts in the cache."""
+    def test_save_returns_correct_counts(self, num_matching, num_unmatched, num_multiple_matches):
+        """Test that save() returns the expected counts for each matching status."""
         matched_rows = make_matched_rows(num_matching)
         unmatched_rows = make_unmatched_rows(num_unmatched)
         multiple_matches_rows = make_multiple_matches_rows(num_multiple_matches)


### PR DESCRIPTION
### Description of change

This adds the ability to the import interactions tool to download rows that could not be matched with active contacts following a successful import operation.

The download is a CSV file is in the same file format as input files so it's possible to re-upload it at a later date to try again.

Similar to previous steps, this data is temporarily held in the cache following a successful import.

I would suggest reviewing the commits individually.

### Screenshots

#### With unmatched contacts

![image](https://user-images.githubusercontent.com/12693549/58692837-5a47f680-8387-11e9-864e-9d6411caf3f7.png)

#### Without unmatched contacts

![image](https://user-images.githubusercontent.com/12693549/58693907-b875d900-8389-11e9-8fd3-2c4bc16e188d.png)

### To test

1. Create the `admin-interaction-csv-importer` feature flag and set it as active
1. Navigate to the interaction change list page in the admin site
1. Click on the 'Import interaction' link
1. Create a valid CSV file according to the spec on the page (containing some rows where `contact_email` matches an active contact and some where it doesn't)
1. Select your CSV file
1. Submit the form to bring up the preview page
1. Click the import button on the preview page
1. Click the download unmatched rows link and save the file
1. Compare the contents of the downloaded file with the one originally uploaded (it should contain the expected rows and data)
1. Try to import the downloaded file (the unmatched records page should be displayed)

Example of a valid CSV file (replacing the `team_1`, `adviser_1` and `contact_email` values as necessary):

```
team_1,adviser_1,adviser_2,contact_email,communication_channel,service,kind,date,event_id,notes
Digital Data Hub - Live Service,<an adviser name>,,fooimport@bar.com,Email/Website,Account managemenT,interaction,25/02/2019,,some notes
```

Note that if debug mode is on, it can be slow to load large files. I would suggest turning debug mode off if testing with more than a few dozen rows.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
