### PR TITLE
Add theme field to import interactions tool

### DIFF
--- a/changelog/interaction/import-theme-field.feature.rst
+++ b/changelog/interaction/import-theme-field.feature.rst
@@ -1,0 +1,1 @@
+The theme field was added to the import interactions admin site tool. The tool is currently behind the ``admin-interaction-csv-importer`` feature flag as it’s incomplete.

--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -99,6 +99,7 @@ class InteractionCSVRowForm(forms.Form):
         'event': 'event_id',
     }
 
+    theme = forms.ChoiceField(choices=Interaction.THEMES)
     kind = forms.ChoiceField(choices=Interaction.KINDS)
     date = forms.DateField(input_formats=['%d/%m/%Y', '%Y-%m-%d'])
     # Used to attempt to find a matching contact (and company) for the interaction
@@ -339,6 +340,7 @@ class InteractionCSVRowForm(forms.Form):
             'service': data['service'],
             'status': Interaction.STATUSES.complete,
             'subject': subject,
+            'theme': data['theme'],
             'was_policy_feedback_provided': False,
         }
 

--- a/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
@@ -31,6 +31,7 @@
   <table>
     <thead>
       <tr>
+        <th>{% trans 'Theme' %}</th>
         <th>{% trans 'Kind' %}</th>
         <th>{% trans 'Date' %}</th>
         <th>{% trans 'Advisers' %}</th>
@@ -45,6 +46,7 @@
     </thead>
   {% for row in matched_rows %}
     <tr class="{% cycle 'row1' 'row2' %}">
+      <td>{{ row.theme }}</td>
       <td>{{ row.kind }}</td>
       <td>{{ row.date }}</td>
       <td>

--- a/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
@@ -14,6 +14,11 @@
       <th>{% trans 'Description' %}</th>
     </tr>
     <tr>
+      <td><code>{% trans 'theme' %}</code></td>
+      <td>{{ yes }}</td>
+      <td>{% trans '<code>export</code>, <code>investment</code> or <code>other</code>' %}</td>
+    </tr>
+    <tr>
       <td><code>{% trans 'kind' %}</code></td>
       <td>{{ yes }}</td>
       <td>{% trans '<code>interaction</code> or <code>service_delivery</code>' %}</td>

--- a/datahub/interaction/test/admin_csv_import/test_file_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_file_form.py
@@ -51,6 +51,7 @@ class TestUnmatchedRowCollector:
 
         assert csv_rows == [
             [
+                'theme',
                 'kind',
                 'date',
                 'adviser_1',
@@ -59,6 +60,7 @@ class TestUnmatchedRowCollector:
                 'communication_channel',
             ],
             [
+                input_rows[0]['theme'],
                 input_rows[0]['kind'],
                 input_rows[0]['date'],
                 input_rows[0]['adviser_1'],
@@ -67,6 +69,7 @@ class TestUnmatchedRowCollector:
                 input_rows[0]['communication_channel'],
             ],
             [
+                input_rows[1]['theme'],
                 input_rows[1]['kind'],
                 input_rows[1]['date'],
                 input_rows[1]['adviser_1'],
@@ -177,6 +180,7 @@ class TestInteractionCSVForm:
         """
         file = make_csv_file_from_dicts(
             {
+                'theme': 'invalid',
                 'kind': 'invalid',
                 'date': 'invalid',
 

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -75,8 +75,8 @@ class TestCSVRowError:
 
 
 @pytest.mark.django_db
-class TestInteractionCSVRowForm:
-    """Tests for InteractionCSVRowForm."""
+class TestInteractionCSVRowFormValidation:
+    """Tests for validation in InteractionCSVRowForm."""
 
     @pytest.mark.parametrize(
         'data,errors',
@@ -565,6 +565,15 @@ class TestInteractionCSVRowForm:
         form = InteractionCSVRowForm(data=data, duplicate_tracker=duplicate_tracker)
         assert form.errors == expected_errors
 
+
+@pytest.mark.django_db
+class TestInteractionCSVRowFormCleaning:
+    """
+    Tests for field cleaning in InteractionCSVRowForm.
+
+    This includes looking up model objects and the transformation of values (but not validation).
+    """
+
     @pytest.mark.parametrize(
         'field,input_value,expected_value',
         (
@@ -862,6 +871,11 @@ class TestInteractionCSVRowForm:
         else:
             assert not contact
 
+
+@pytest.mark.django_db
+class TestInteractionCSVRowFormGetFlatErrorListIterator:
+    """Tests for InteractionCSVRowForm.get_flat_error_list_iterator()."""
+
     def test_get_flat_error_list_iterator(self):
         """Test that get_flat_error_list_iterator() returns a flat list of errors."""
         data = {
@@ -908,6 +922,14 @@ class TestInteractionCSVRowForm:
             ),
         ]
         assert Counter(form.get_flat_error_list_iterator()) == Counter(expected_errors)
+
+
+class TestInteractionCSVRowFormSerializerUsage:
+    """
+    Tests general logic of InteractionSerializer validators usage in InteractionCSVRowForm.
+
+    (This excludes validation of specific fields which is part of the validation tests above.)
+    """
 
     def test_serializer_error_for_invalid_form(self, monkeypatch):
         """
@@ -965,6 +987,11 @@ class TestInteractionCSVRowForm:
             'adviser_2': ['adviser test error'],
             NON_FIELD_ERRORS: ['non_existent_field: unmapped test error'],
         }
+
+
+@pytest.mark.django_db
+class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
+    """Tests for InteractionCSVRowForm.cleaned_data_as_serializer_dict()."""
 
     def test_cleaned_data_as_serializer_dict_for_interaction(self):
         """Test that cleaned_data_as_serializer_dict() transforms an interaction."""
@@ -1044,6 +1071,11 @@ class TestInteractionCSVRowForm:
             'subject': data['subject'],
             'was_policy_feedback_provided': False,
         }
+
+
+@pytest.mark.django_db
+class TestInteractionCSVRowFormSaving:
+    """Tests for InteractionCSVRowForm.save()."""
 
     def test_save_interaction(self):
         """Test saving an interaction."""

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -91,6 +91,16 @@ class TestInteractionCSVRowFormValidation:
                 {'kind': 'invalid'},
                 {'kind': ['Select a valid choice. invalid is not one of the available choices.']},
             ),
+            # theme blank
+            (
+                {'theme': ''},
+                {'theme': ['This field is required.']},
+            ),
+            # theme invalid
+            (
+                {'theme': 'invalid'},
+                {'theme': ['Select a valid choice. invalid is not one of the available choices.']},
+            ),
             # date blank
             (
                 {'date': ''},
@@ -306,6 +316,7 @@ class TestInteractionCSVRowFormValidation:
         communication_channel = random_communication_channel()
 
         resolved_data = {
+            'theme': Interaction.THEMES.export,
             'kind': 'interaction',
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -433,6 +444,7 @@ class TestInteractionCSVRowFormValidation:
             )
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': Interaction.KINDS.interaction,
             'adviser_1': adviser.name,
             'communication_channel': communication_channel.name,
@@ -553,6 +565,7 @@ class TestInteractionCSVRowFormValidation:
             duplicate_tracker.add_item(resolved_duplicate_item)
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': Interaction.KINDS.interaction,
             'adviser_1': adviser.name,
             'communication_channel': communication_channel.name,
@@ -617,6 +630,7 @@ class TestInteractionCSVRowFormSerializerUsage:
         communication_channel = random_communication_channel()
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': Interaction.KINDS.interaction,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -682,6 +696,7 @@ class TestInteractionCSVRowFormCleaning:
         communication_channel = random_communication_channel()
 
         resolved_data = {
+            'theme': Interaction.THEMES.export,
             'kind': 'interaction',
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -764,6 +779,7 @@ class TestInteractionCSVRowFormCleaning:
         obj = object_creator()
 
         resolved_data = {
+            'theme': Interaction.THEMES.export,
             'kind': kind,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -803,6 +819,7 @@ class TestInteractionCSVRowFormCleaning:
         obj = object_creator()
 
         resolved_data = {
+            'theme': Interaction.THEMES.export,
             'kind': 'interaction',
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -849,6 +866,7 @@ class TestInteractionCSVRowFormCleaning:
         obj = object_creator()
 
         resolved_data = {
+            'theme': Interaction.THEMES.export,
             'kind': 'service_delivery',
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -873,6 +891,7 @@ class TestInteractionCSVRowFormCleaning:
         communication_channel = random_communication_channel()
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': kind,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -914,6 +933,7 @@ class TestInteractionCSVRowFormCleaning:
         communication_channel = random_communication_channel()
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': 'interaction',
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -945,6 +965,7 @@ class TestInteractionCSVRowFormGetFlatErrorListIterator:
     def test_get_flat_error_list_iterator(self):
         """Test that get_flat_error_list_iterator() returns a flat list of errors."""
         data = {
+            'theme': 'invalid',
             'kind': 'invalid',
             'date': 'invalid',
             'adviser_1': '',
@@ -959,6 +980,12 @@ class TestInteractionCSVRowFormGetFlatErrorListIterator:
             CSVRowError(
                 5,
                 'kind',
+                'invalid',
+                'Select a valid choice. invalid is not one of the available choices.',
+            ),
+            CSVRowError(
+                5,
+                'theme',
                 'invalid',
                 'Select a valid choice. invalid is not one of the available choices.',
             ),
@@ -1002,6 +1029,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
         communication_channel = random_communication_channel()
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': Interaction.KINDS.interaction,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -1029,6 +1057,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
             'service': service,
             'status': Interaction.STATUSES.complete,
             'subject': service.name,
+            'theme': data['theme'],
             'was_policy_feedback_provided': False,
         }
 
@@ -1040,6 +1069,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
         event = EventFactory()
 
         data = {
+            'theme': Interaction.THEMES.other,
             'kind': Interaction.KINDS.service_delivery,
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -1070,6 +1100,7 @@ class TestInteractionCSVRowFormCleanedDataAsSerializerDict:
             'service': service,
             'status': Interaction.STATUSES.complete,
             'subject': data['subject'],
+            'theme': data['theme'],
             'was_policy_feedback_provided': False,
         }
 
@@ -1088,6 +1119,7 @@ class TestInteractionCSVRowFormSaving:
         source = {'test-source': 'test-value'}
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': Interaction.KINDS.interaction,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
@@ -1101,6 +1133,7 @@ class TestInteractionCSVRowFormSaving:
         interaction = form.save(user, source=source)
         interaction.refresh_from_db()
 
+        assert interaction.theme == data['theme']
         assert interaction.kind == data['kind']
         assert interaction.date == datetime(2018, 3, 2, tzinfo=utc)
         assert interaction.communication_channel == communication_channel
@@ -1131,6 +1164,7 @@ class TestInteractionCSVRowFormSaving:
         source = {'test-source': 'test-value'}
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': Interaction.KINDS.service_delivery,
             'date': '02/03/2018',
             'adviser_1': adviser_1.name,
@@ -1147,6 +1181,7 @@ class TestInteractionCSVRowFormSaving:
         interaction = form.save(user, source=source)
         interaction.refresh_from_db()
 
+        assert interaction.theme == data['theme']
         assert interaction.kind == data['kind']
         assert interaction.date == datetime(2018, 3, 2, tzinfo=utc)
         assert interaction.event == event
@@ -1184,6 +1219,7 @@ class TestInteractionCSVRowFormSaving:
         source = {'test-source': 'test-value'}
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': Interaction.KINDS.interaction,
             'date': '02/03/2018',
             'adviser_1': adviser.name,
@@ -1214,6 +1250,7 @@ class TestInteractionCSVRowFormSaving:
         source = {'test-source': 'test-value'}
 
         data = {
+            'theme': Interaction.THEMES.export,
             'kind': Interaction.KINDS.interaction,
             'date': '02/03/2018',
             'adviser_1': adviser.name,

--- a/datahub/interaction/test/admin_csv_import/test_views.py
+++ b/datahub/interaction/test/admin_csv_import/test_views.py
@@ -267,7 +267,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
         assert 'csv_file' in form.errors
         assert form.errors['csv_file'] == [
             'This file is missing the following required columns: '
-            'adviser_1, contact_email, date, kind, service.',
+            'adviser_1, contact_email, date, kind, service, theme.',
         ]
 
     def test_rejects_large_files(self):
@@ -299,7 +299,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
         'max_errors,should_be_truncated',
         (
             (5, True),
-            (10, False),
+            (12, False),
         ),
     )
     def test_displays_errors_for_file_with_invalid_rows(
@@ -314,11 +314,11 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
             max_errors,
         )
 
-        # This file should have 10 errors
+        # This file should have 12 errors
         file = make_csv_file(
-            ('kind', 'date', 'adviser_1', 'contact_email', 'service'),
-            ('invalid', 'invalid', 'invalid', 'invalid', 'invalid'),
-            ('invalid', 'invalid', 'invalid', 'invalid', 'invalid'),
+            ('theme', 'kind', 'date', 'adviser_1', 'contact_email', 'service'),
+            ('invalid', 'invalid', 'invalid', 'invalid', 'invalid', 'invalid'),
+            ('invalid', 'invalid', 'invalid', 'invalid', 'invalid', 'invalid'),
         )
 
         response = self.client.post(
@@ -329,7 +329,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
         )
 
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.context['errors']) == min(10, max_errors)
+        assert len(response.context['errors']) == min(12, max_errors)
         assert response.context['are_errors_truncated'] == should_be_truncated
 
     def test_displays_no_matches_message_if_no_matches(self):
@@ -342,6 +342,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
         communication_channel = random_communication_channel()
         file = make_csv_file(
             (
+                'theme',
                 'kind',
                 'date',
                 'adviser_1',
@@ -350,6 +351,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
                 'communication_channel',
             ),
             (
+                Interaction.THEMES.export,
                 'interaction',
                 '01/01/2018',
                 adviser.name,

--- a/datahub/interaction/test/admin_csv_import/utils.py
+++ b/datahub/interaction/test/admin_csv_import/utils.py
@@ -7,7 +7,7 @@ import factory
 
 from datahub.company.test.factories import AdviserFactory, ContactFactory
 from datahub.core.test_utils import random_obj_for_queryset
-from datahub.interaction.models import CommunicationChannel
+from datahub.interaction.models import CommunicationChannel, Interaction
 from datahub.metadata.models import Service
 
 
@@ -72,6 +72,7 @@ def make_matched_rows(num_records):
 
     return [
         {
+            'theme': Interaction.THEMES.export,
             'kind': 'interaction',
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -97,6 +98,7 @@ def make_multiple_matches_rows(num_records):
 
     return [
         {
+            'theme': Interaction.THEMES.export,
             'kind': 'interaction',
             'date': '01/01/2018',
             'adviser_1': adviser.name,
@@ -119,6 +121,7 @@ def make_unmatched_rows(num_records):
 
     return [
         {
+            'theme': Interaction.THEMES.export,
             'kind': 'interaction',
             'date': '01/01/2018',
             'adviser_1': adviser.name,


### PR DESCRIPTION
### Description of change

This:

- reorganises the InteractionCSVRowForm tests so that they are more logically grouped
- adds the recently-added `theme` field to the input file format

As usual, I‘d recomment reviewing commits individually.

(I realised that there could be more in the way of tests with valid data for InteractionCSVRowForm – will pick that up in another PR.)

### Screenshots

#### Select file page

![image](https://user-images.githubusercontent.com/12693549/58714341-71550b80-83bc-11e9-82be-6a940510783f.png)

#### Preview page

![image](https://user-images.githubusercontent.com/12693549/58714291-58e4f100-83bc-11e9-8361-022047fac63f.png)

#### Missing theme column

![image](https://user-images.githubusercontent.com/12693549/58715032-f12fa580-83bd-11e9-9c0d-26bc428d1793.png)

#### Blank and invalid values in theme column

![image](https://user-images.githubusercontent.com/12693549/58715097-17eddc00-83be-11e9-8b5d-0c4e18249baa.png)

### To test

1. Create the `admin-interaction-csv-importer` feature flag and set it as active
1. Navigate to the interaction change list page in the admin site
1. Click on the 'Import interaction' link
1. Create a valid (with theme field) or invalid (without theme field) CSV file according to the spec on the page
1. Select your CSV file
1. Submit the form to bring up the preview page
1. Click the import button on the preview page

Example of a valid CSV file (replacing the `team_1`, `adviser_1` and `contact_email` values as necessary):

```
theme,team_1,adviser_1,adviser_2,contact_email,communication_channel,service,kind,date,event_id,notes
export,Digital Data Hub - Live Service,<an adviser name>,,fooimport@bar.com,Email/Website,Account managemenT,interaction,25/02/2019,,some notes
```

Note that if debug mode is on, it can be slow to load large files. I‘d suggest turning debug mode off if testing with more than a few dozen rows.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
