### PR TITLE
Email invite interaction subject

### DIFF
--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -158,7 +158,7 @@ class CalendarInteractionEmailParser:
         secondary_advisers = []
         for recipient_email in all_recipients:
             adviser = _get_best_match_adviser_by_email(recipient_email)
-            if adviser:
+            if adviser and adviser != sender_adviser:
                 secondary_advisers.append(adviser)
         return secondary_advisers
 

--- a/datahub/interaction/email_processors/processors.py
+++ b/datahub/interaction/email_processors/processors.py
@@ -46,7 +46,7 @@ def _get_meeting_subject(sender, contacts, secondary_advisers):
         except IndexError:
             # This is not going to be a valid interaction, but this helper function
             # should not raise an exception
-            contact_names = ['A company']
+            contact_names = ['a company']
     all_names = (*adviser_names, *contact_names)
     comma_names = ', '.join(all_names[:-1])
     return f'Meeting between {comma_names} and {all_names[-1]}'

--- a/datahub/interaction/test/email_processors/conftest.py
+++ b/datahub/interaction/test/email_processors/conftest.py
@@ -10,17 +10,21 @@ def calendar_data_fixture():
     Create advisers, contacts and companies so that our email samples can be
     attributed to some DB entities.
     """
-    adviser_emails = [
-        'adviser1@trade.gov.uk',
-        'adviser2@digital.trade.gov.uk',
+    advisers = [
+        ('adviser1@trade.gov.uk', 'Adviser', '1'),
+        ('adviser2@digital.trade.gov.uk', 'Adviser', '2'),
     ]
     AdviserFactory.create_batch(
-        len(adviser_emails),
-        email=factory.Iterator(adviser_emails),
+        len(advisers),
+        email=factory.Iterator(advisers, getter=lambda a: a[0]),
+        first_name=factory.Iterator(advisers, getter=lambda a: a[1]),
+        last_name=factory.Iterator(advisers, getter=lambda a: a[2]),
         contact_email=factory.SelfAttribute('email'),
     )
     AdviserFactory(
         email='adviser3@digital.trade.gov.uk',
+        first_name='Adviser',
+        last_name='3',
         contact_email='correspondence3@digital.trade.gov.uk',
     )
     company_1 = CompanyFactory(name='Company 1')

--- a/datahub/interaction/test/email_processors/email_samples/valid/gmail/sample.eml
+++ b/datahub/interaction/test/email_processors/email_samples/valid/gmail/sample.eml
@@ -82,7 +82,7 @@ Message-ID: <0000000000002a99a005853a155c@google.com>
 Date: Fri, 29 Mar 2019 11:36:33 +0000
 Subject: Invitation: initial @ Fri 29 Mar 2019 4:30pm - 5:30pm (GMT) (bill.adama@example.net)
 From: correspondence3@digital.trade.gov.uk
-To: bill.adama@example.net,saul.tigh@example.net,unknown@example.net
+To: bill.adama@example.net,saul.tigh@example.net,unknown@example.net,adviser3@digital.trade.gov.uk
 CC: laura.roslin@example.net,saul.tigh@example.net,adviser2@digital.trade.gov.uk
 Content-Type: multipart/mixed; boundary="0000000000002a998305853a155b"
 

--- a/datahub/interaction/test/email_processors/test_parsers.py
+++ b/datahub/interaction/test/email_processors/test_parsers.py
@@ -170,10 +170,13 @@ class TestCalendarInteractionEmailParser:
         parser = self._get_parser_for_email_file(email_file)
         interaction_data = parser.extract_interaction_data_from_email()
         assert interaction_data['sender'].email == expected_interaction_data['adviser_email']
-        for contact in interaction_data['contacts']:
-            assert contact.email in expected_interaction_data['contact_emails']
-        for adviser in interaction_data['secondary_advisers']:
-            assert adviser.email in expected_interaction_data['secondary_adviser_emails']
+        contact_emails = {contact.email for contact in interaction_data['contacts']}
+        assert contact_emails == set(expected_interaction_data['contact_emails'])
+        secondary_adviser_emails = {
+            adviser.email for adviser in interaction_data['secondary_advisers']
+        }
+        expected_secondary_adviser_emails = expected_interaction_data['secondary_adviser_emails']
+        assert secondary_adviser_emails == set(expected_secondary_adviser_emails)
         assert (
             interaction_data['top_company'].name == expected_interaction_data['top_company_name']
         )

--- a/datahub/interaction/test/email_processors/test_processors.py
+++ b/datahub/interaction/test/email_processors/test_processors.py
@@ -68,29 +68,39 @@ class TestCalendarInteractionEmailProcessor:
         return email_parser_mock
 
     @pytest.mark.parametrize(
-        'interaction_data_overrides',
+        'interaction_data_overrides,expected_subject',
         (
             # Simple case; just the base interaction data
-            {},
+            (
+                {},
+                'Meeting between Adviser 1, Bill Adama and Saul Tigh',
+            ),
             # Including secondary advisers
-            {
-                'secondary_adviser_emails': [
-                    'adviser2@digital.trade.gov.uk',
-                    'adviser3@digital.trade.gov.uk',
-                ],
-            },
+            (
+                {
+                    'secondary_adviser_emails': [
+                        'adviser2@digital.trade.gov.uk',
+                        'adviser3@digital.trade.gov.uk',
+                    ],
+                },
+                'Meeting between Adviser 1, Adviser 2, Adviser 3, Bill Adama and Saul Tigh',
+            ),
             # Contacts from different companies
-            {
-                'contact_emails': [
-                    'bill.adama@example.net',
-                    'laura.roslin@example.net',
-                ],
-            },
+            (
+                {
+                    'contact_emails': [
+                        'bill.adama@example.net',
+                        'laura.roslin@example.net',
+                    ],
+                },
+                'Meeting between Adviser 1 and Bill Adama',
+            ),
         ),
     )
     def test_process_email_successful(
         self,
         interaction_data_overrides,
+        expected_subject,
         calendar_data_fixture,
         base_interaction_data_fixture,
         monkeypatch,
@@ -136,7 +146,7 @@ class TestCalendarInteractionEmailProcessor:
         assert interaction.source == {
             'meeting': {'id': interaction_data['meeting_details']['uid']},
         }
-        assert interaction.subject == interaction_data['subject']
+        assert interaction.subject == expected_subject
         assert interaction.status == Interaction.STATUSES.draft
 
     def test_process_email_meeting_exists(


### PR DESCRIPTION
### Description of change

This PR achieves two things:
- Ensures that the sender adviser is not included in the list of `secondary_advisers` returned by the email invite parser class.
- Reworks the interaction subject to be a templated string of `"Meeting between {recipients}"` - this is a business requirement as we cannot be sure that meeting subjects will be suitable as an interaction subject.

### Points of note
- The meeting subject template string is not wrapped with ugettext calls.  I couldn't find a suitable solution for translating a (varied length) list of entities e.g. "{recipient_1}, {recipient_2}, {recipient_3} and {recipient_4}".  I'm certain that different languages will handle "lists of things" in different ways - can anybody suggest a clean way to wrap in translation in this case?

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
