### PR TITLE
Add basic permission logic to activity feed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,6 @@ job_defaults: &job_defaults
   environment:
     ACTIVITY_STREAM_ACCESS_KEY_ID: some-id
     ACTIVITY_STREAM_SECRET_ACCESS_KEY: some-secret
-    ACTIVITY_STREAM_OUTGOING_URL: http://activity.stream/
-    ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID: some-outgoing-id
-    ACTIVITY_STREAM_OUTGOING_SECRET_ACCESS_KEY: some-outgoing-secret
     DATABASE_URL: postgresql://postgres@localhost/datahub
     MI_DATABASE_URL: postgresql://postgres@mi-postgres/mi
     DEBUG: 'True'

--- a/changelog/activity-feed-basic-perms.api.rst
+++ b/changelog/activity-feed-basic-perms.api.rst
@@ -1,0 +1,1 @@
+``GET /v4/activity-feed`` now returns an empty list if the authenticated user doesn't have permissions to view all interactions, investment projects or OMIS orders.

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -101,3 +101,7 @@ DOCUMENT_BUCKETS = {
 
 DIT_EMAIL_DOMAINS = ['trade.gov.uk', 'digital.trade.gov.uk']
 DIT_EMAIL_DOMAINS_AUTHENTICATION_EXEMPT = ['trade.gov.uk']
+
+ACTIVITY_STREAM_OUTGOING_URL = 'http://activity.stream/'
+ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID = 'some-outgoing-id'
+ACTIVITY_STREAM_OUTGOING_SECRET_ACCESS_KEY = 'some-outgoing-secret'

--- a/datahub/activity_feed/views.py
+++ b/datahub/activity_feed/views.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.http.multipartparser import parse_header
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework import HTTP_HEADER_ENCODING, status
@@ -15,14 +15,25 @@ class ActivityFeedView(APIView):
 
     At the moment it just authenticates the user using the default authentication
     for the internal_front_end and acts as a proxy for reading from Activity Stream.
+
+    If the authenticated user doesn't have permissions on all activity models,
+    it returns an empty list.
     """
 
     required_scopes = (Scope.internal_front_end,)
     permission_classes = (IsAuthenticatedOrTokenHasScope,)
 
+    ACTIVITY_MODELS_PERMISSIONS_REQUIRED = (
+        'interaction.view_all_interaction',
+        'investment.view_all_investmentproject',
+        'order.view_order',
+    )
+
     def get(self, request):
         """Proxy for GET requests."""
         content_type = request.content_type or ''
+
+        # check that the content type of the request is json
         base_media_type, _ = parse_header(content_type.encode(HTTP_HEADER_ENCODING))
         if base_media_type != 'application/json':
             return HttpResponse(
@@ -30,6 +41,29 @@ class ActivityFeedView(APIView):
                 status=status.HTTP_406_NOT_ACCEPTABLE,
             )
 
+        # if the user doesn't have permissions on all activity models, return an empty list
+        # TODO: instead of returning an empty list, we need to filter out the
+        # activities that the user doesn't have access to
+        if not request.user.has_perms(self.ACTIVITY_MODELS_PERMISSIONS_REQUIRED):
+            return JsonResponse(
+                {
+                    'hits': {
+                        'total': 0,
+                        'hits': [],
+                    },
+                },
+                status=status.HTTP_200_OK,
+                content_type=content_type,
+            )
+
+        upstream_response = self._get_upstream_response(request)
+        return HttpResponse(
+            upstream_response.text,
+            status=upstream_response.status_code,
+            content_type=upstream_response.headers.get('content-type'),
+        )
+
+    def _get_upstream_response(self, request):
         hawk_auth = HawkAuth(
             settings.ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID,
             settings.ACTIVITY_STREAM_OUTGOING_SECRET_ACCESS_KEY,
@@ -41,16 +75,11 @@ class ActivityFeedView(APIView):
             hawk_auth,
             raise_for_status=False,
         )
-        response = api_client.request(
+        return api_client.request(
             request.method,
             '',
             data=request.body,
             headers={
                 'Content-Type': request.content_type,
             },
-        )
-        return HttpResponse(
-            response.text,
-            status=response.status_code,
-            content_type=response.headers.get('content-type'),
         )


### PR DESCRIPTION
### Description of change

This makes sure `/v4/activity-feed` returns an empty list if the authenticated user doesn't have permissions to view all interactions, investment projects or OMIS orders.

I decided to return an empty list instead of status code 403 as the ideal implementation would be to filter out all activities that the user can't see. Open to suggestions though.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
