### PR TITLE
Make dit_adviser and dit_team read-only in main interaction API

### DIFF
--- a/changelog/interaction/adviser-team-read-only-main-api.removal.rst
+++ b/changelog/interaction/adviser-team-read-only-main-api.removal.rst
@@ -1,0 +1,2 @@
+``POST /v3/interaction, PATCH /v3/interaction/<id>``: The deprecated ``dit_adviser`` and ``dit_team`` fields
+were made read-only in preparation for their removal. Please use ``dit_participants`` instead.

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -10,7 +10,7 @@ from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
-from datahub.core.constants import Service, Team
+from datahub.core.constants import Service
 from datahub.core.test_utils import APITestMixin, create_test_user, random_obj_for_model
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.models import (
@@ -85,7 +85,7 @@ class TestAddInteraction(APITestMixin):
     )
     def test_add(self, extra_data, permissions):
         """Test add a new interaction."""
-        adviser = create_test_user(permission_codenames=permissions)
+        adviser = create_test_user(permission_codenames=permissions, dit_team=TeamFactory())
         company = CompanyFactory()
         contact = ContactFactory(company=company)
         communication_channel = random_obj_for_model(CommunicationChannel)
@@ -96,11 +96,12 @@ class TestAddInteraction(APITestMixin):
             'communication_channel': communication_channel.pk,
             'subject': 'whatever',
             'date': date.today().isoformat(),
-            'dit_adviser': adviser.pk,
+            'dit_participants': [
+                {'adviser': adviser.pk},
+            ],
             'company': company.pk,
             'contacts': [contact.pk],
             'service': Service.trade_enquiry.value.id,
-            'dit_team': Team.healthcare_uk.value.id,
             'was_policy_feedback_provided': False,
 
             **resolve_data(extra_data),
@@ -147,14 +148,14 @@ class TestAddInteraction(APITestMixin):
                         'name': adviser.name,
                     },
                     'team': {
-                        'id': str(Team.healthcare_uk.value.id),
-                        'name': Team.healthcare_uk.value.name,
+                        'id': str(adviser.dit_team.pk),
+                        'name': adviser.dit_team.name,
                     },
                 },
             ],
             'dit_team': {
-                'id': str(Team.healthcare_uk.value.id),
-                'name': Team.healthcare_uk.value.name,
+                'id': str(adviser.dit_team.pk),
+                'name': adviser.dit_team.name,
             },
             'notes': request_data.get('notes', ''),
             'company': {
@@ -207,6 +208,7 @@ class TestAddInteraction(APITestMixin):
                 {
                     'contacts': ['This field is required.'],
                     'date': ['This field is required.'],
+                    'dit_participants': ['This field is required.'],
                     'subject': ['This field is required.'],
                     'company': ['This field is required.'],
                     'was_policy_feedback_provided': ['This field is required.'],
@@ -222,8 +224,9 @@ class TestAddInteraction(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
-                    'dit_team': Team.healthcare_uk.value.id,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
                 },
@@ -240,9 +243,10 @@ class TestAddInteraction(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'was_policy_feedback_provided': False,
                 },
                 {
@@ -258,9 +262,10 @@ class TestAddInteraction(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
 
                     'was_policy_feedback_provided': True,
@@ -280,9 +285,10 @@ class TestAddInteraction(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
 
                     'was_policy_feedback_provided': True,
@@ -306,9 +312,10 @@ class TestAddInteraction(APITestMixin):
                     'notes': 'hello',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
 
@@ -357,14 +364,12 @@ class TestAddInteraction(APITestMixin):
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
 
                     # fields where None is not allowed
-                    'dit_adviser': None,
-                    'dit_team': None,
+                    'dit_participants': None,
                     'was_policy_feedback_provided': None,
                     'policy_feedback_notes': None,
                 },
                 {
-                    'dit_adviser': ['This field may not be null.'],
-                    'dit_team': ['This field may not be null.'],
+                    'dit_participants': ['This field may not be null.'],
                     'was_policy_feedback_provided': ['This field may not be null.'],
                     'policy_feedback_notes': ['This field may not be null.'],
                 },
@@ -378,9 +383,10 @@ class TestAddInteraction(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
 
@@ -400,9 +406,10 @@ class TestAddInteraction(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'was_policy_feedback_provided': False,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
 
@@ -412,24 +419,6 @@ class TestAddInteraction(APITestMixin):
                 {
                     'is_event': ['This field is only valid for service deliveries.'],
                     'event': ['This field is only valid for service deliveries.'],
-                },
-            ),
-
-            # dit_participants cannot be None
-            (
-                {
-                    'kind': Interaction.KINDS.interaction,
-                    'date': date.today().isoformat(),
-                    'subject': 'whatever',
-                    'company': CompanyFactory,
-                    'contacts': [ContactFactory],
-                    'service': Service.trade_enquiry.value.id,
-                    'was_policy_feedback_provided': False,
-
-                    'dit_participants': None,
-                },
-                {
-                    'dit_participants': ['This field may not be null.'],
                 },
             ),
 
@@ -461,6 +450,9 @@ class TestAddInteraction(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
                     'was_policy_feedback_provided': False,
                     'status': 'foobar',
@@ -476,6 +468,9 @@ class TestAddInteraction(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
                     'was_policy_feedback_provided': False,
                     'status': None,
@@ -519,11 +514,12 @@ class TestAddInteraction(APITestMixin):
                 'communication_channel': random_obj_for_model(CommunicationChannel).pk,
                 'subject': 'whatever',
                 'date': date.today().isoformat(),
-                'dit_adviser': requester.pk,
+                'dit_participants': [
+                    {'adviser': requester.pk},
+                ],
                 'notes': 'hello',
                 'investment_project': project.pk,
                 'service': Service.trade_enquiry.value.id,
-                'dit_team': Team.healthcare_uk.value.id,
                 'was_policy_feedback_provided': False,
             },
         )
@@ -557,11 +553,12 @@ class TestAddInteraction(APITestMixin):
                 'communication_channel': random_obj_for_model(CommunicationChannel).pk,
                 'subject': 'whatever',
                 'date': date.today().isoformat(),
-                'dit_adviser': requester.pk,
+                'dit_participants': [
+                    {'adviser': requester.pk},
+                ],
                 'notes': 'hello',
                 'investment_project': project.pk,
                 'service': Service.trade_enquiry.value.id,
-                'dit_team': Team.healthcare_uk.value.id,
                 'was_policy_feedback_provided': False,
             },
         )
@@ -590,10 +587,11 @@ class TestAddInteraction(APITestMixin):
                 'communication_channel': random_obj_for_model(CommunicationChannel).pk,
                 'subject': 'whatever',
                 'date': date.today().isoformat(),
-                'dit_adviser': requester.pk,
+                'dit_participants': [
+                    {'adviser': requester.pk},
+                ],
                 'notes': 'hello',
                 'service': Service.trade_enquiry.value.id,
-                'dit_team': Team.healthcare_uk.value.id,
                 'was_policy_feedback_provided': False,
             },
         )
@@ -628,6 +626,7 @@ class TestGetInteraction(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         response_data = response.json()
         response_data['contacts'].sort(key=itemgetter('id'))
+        response_data['dit_participants'].sort(key=lambda item: item['adviser']['id'])
         assert response_data == {
             'id': response_data['id'],
             'kind': Interaction.KINDS.interaction,
@@ -666,16 +665,17 @@ class TestGetInteraction(APITestMixin):
             'dit_participants': [
                 {
                     'adviser': {
-                        'id': str(interaction.dit_adviser.pk),
-                        'first_name': interaction.dit_adviser.first_name,
-                        'last_name': interaction.dit_adviser.last_name,
-                        'name': interaction.dit_adviser.name,
+                        'id': str(dit_participant.adviser.pk),
+                        'first_name': dit_participant.adviser.first_name,
+                        'last_name': dit_participant.adviser.last_name,
+                        'name': dit_participant.adviser.name,
                     },
                     'team': {
-                        'id': str(interaction.dit_team.pk),
-                        'name': interaction.dit_team.name,
+                        'id': str(dit_participant.team.pk),
+                        'name': dit_participant.team.name,
                     },
-                },
+                }
+                for dit_participant in interaction.dit_participants.order_by('pk')
             ],
             'dit_team': {
                 'id': str(interaction.dit_team.pk),

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -8,7 +8,7 @@ from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
-from datahub.core.constants import Service, Team
+from datahub.core.constants import Service
 from datahub.core.test_utils import APITestMixin, random_obj_for_model
 from datahub.event.test.factories import EventFactory
 from datahub.interaction.models import (
@@ -86,11 +86,12 @@ class TestAddServiceDelivery(APITestMixin):
             'kind': Interaction.KINDS.service_delivery,
             'subject': 'whatever',
             'date': date.today().isoformat(),
-            'dit_adviser': adviser.pk,
+            'dit_participants': [
+                {'adviser': adviser.pk},
+            ],
             'company': company.pk,
             'contacts': [contact.pk],
             'service': Service.trade_enquiry.value.id,
-            'dit_team': Team.healthcare_uk.value.id,
             'was_policy_feedback_provided': False,
 
             **resolve_data(extra_data),
@@ -133,14 +134,14 @@ class TestAddServiceDelivery(APITestMixin):
                         'name': adviser.name,
                     },
                     'team': {
-                        'id': str(Team.healthcare_uk.value.id),
-                        'name': Team.healthcare_uk.value.name,
+                        'id': str(adviser.dit_team.pk),
+                        'name': adviser.dit_team.name,
                     },
                 },
             ],
             'dit_team': {
-                'id': str(Team.healthcare_uk.value.id),
-                'name': Team.healthcare_uk.value.name,
+                'id': str(adviser.dit_team.pk),
+                'name': adviser.dit_team.name,
             },
             'notes': request_data.get('notes', ''),
             'company': {
@@ -193,6 +194,7 @@ class TestAddServiceDelivery(APITestMixin):
                 {
                     'contacts': ['This field is required.'],
                     'date': ['This field is required.'],
+                    'dit_participants': ['This field is required.'],
                     'subject': ['This field is required.'],
                     'company': ['This field is required.'],
                     'was_policy_feedback_provided': ['This field is required.'],
@@ -207,8 +209,9 @@ class TestAddServiceDelivery(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
-                    'dit_team': Team.healthcare_uk.value.id,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'was_policy_feedback_provided': False,
                 },
                 {
@@ -226,9 +229,10 @@ class TestAddServiceDelivery(APITestMixin):
                     'notes': 'hello',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'is_event': True,
                     'event': EventFactory,
                     'service_delivery_status': partial(
@@ -253,9 +257,10 @@ class TestAddServiceDelivery(APITestMixin):
                     'notes': 'hello',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'is_event': True,
                     'event': EventFactory,
                     'service_delivery_status': partial(
@@ -283,9 +288,10 @@ class TestAddServiceDelivery(APITestMixin):
                     'notes': 'hello',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'is_event': True,
                     'event': EventFactory,
                     'service_delivery_status': partial(
@@ -326,9 +332,8 @@ class TestAddServiceDelivery(APITestMixin):
                     'notes': 'hello',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': None,
+                    'dit_participants': None,
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': None,
                     'is_event': True,
                     'event': EventFactory,
                     'service_delivery_status': partial(
@@ -342,8 +347,7 @@ class TestAddServiceDelivery(APITestMixin):
                     'policy_feedback_notes': None,
                 },
                 {
-                    'dit_adviser': ['This field may not be null.'],
-                    'dit_team': ['This field may not be null.'],
+                    'dit_participants': ['This field may not be null.'],
                     'was_policy_feedback_provided': ['This field may not be null.'],
                     'policy_feedback_notes': ['This field may not be null.'],
                 },
@@ -358,9 +362,10 @@ class TestAddServiceDelivery(APITestMixin):
                     'notes': 'hello',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'service_delivery_status': partial(
                         random_obj_for_model, ServiceDeliveryStatus,
                     ),
@@ -385,9 +390,10 @@ class TestAddServiceDelivery(APITestMixin):
                     'subject': 'whatever',
                     'company': CompanyFactory,
                     'contacts': [ContactFactory],
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'service_delivery_status': partial(
                         random_obj_for_model, ServiceDeliveryStatus,
                     ),
@@ -410,9 +416,10 @@ class TestAddServiceDelivery(APITestMixin):
                     'date': date.today().isoformat(),
                     'subject': 'whatever',
                     'company': CompanyFactory,
-                    'dit_adviser': AdviserFactory,
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
                     'service': Service.trade_enquiry.value.id,
-                    'dit_team': Team.healthcare_uk.value.id,
                     'service_delivery_status': partial(
                         random_obj_for_model, ServiceDeliveryStatus,
                     ),
@@ -427,24 +434,6 @@ class TestAddServiceDelivery(APITestMixin):
                 },
                 {
                     'contacts': ['Only one contact can be provided for event service deliveries.'],
-                },
-            ),
-
-            # dit_participants cannot be None
-            (
-                {
-                    'kind': Interaction.KINDS.service_delivery,
-                    'date': date.today().isoformat(),
-                    'subject': 'whatever',
-                    'company': CompanyFactory,
-                    'contacts': [ContactFactory],
-                    'service': Service.trade_enquiry.value.id,
-                    'was_policy_feedback_provided': False,
-
-                    'dit_participants': None,
-                },
-                {
-                    'dit_participants': ['This field may not be null.'],
                 },
             ),
 


### PR DESCRIPTION
### Description of change

This makes the `dit_adviser` and `dit_team` read-only in `POST /v3/interaction` and `PATCH /v3/interaction/<id>` as an interim step towards removing them completely.

As a result the logic about `dit_participants` being required was simplified, and the logic for copying `dit_adviser` and `dit_team` to `dit_participants` was removed as it's no longer required.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
