### PR TITLE
Extend email domain verification to allow configurable auth methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `MAILBOX_MEETINGS_USERNAME` | No | Username of the inbox for ingesting meeting invites via IMAP (likely to be the same as the email for the mailbox) |
 | `MAILBOX_MEETINGS_PASSWORD` | No | Password for the inbox for ingesting meeting invites via IMAP |
 | `MAILBOX_MEETINGS_IMAP_DOMAIN` | No | IMAP domain for the inbox for ingesting meeting invites via IMAP |
-| `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass|spf:pass|dkim:pass |
+| `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass\|spf:pass\|dkim:pass |
 
 
 ## Management commands

--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `MAILBOX_MEETINGS_USERNAME` | No | Username of the inbox for ingesting meeting invites via IMAP (likely to be the same as the email for the mailbox) |
 | `MAILBOX_MEETINGS_PASSWORD` | No | Password for the inbox for ingesting meeting invites via IMAP |
 | `MAILBOX_MEETINGS_IMAP_DOMAIN` | No | IMAP domain for the inbox for ingesting meeting invites via IMAP |
+| `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass|spf:pass|dkim:pass |
 
 
 ## Management commands

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -549,7 +549,7 @@ MAILBOXES = {
 DIT_EMAIL_DOMAINS = {}
 domain_environ_names = [
     environ_name 
-    for environ_name in os.environ.keys()
+    for environ_name in env.ENVIRON.keys()
     if environ_name.startswith('DIT_EMAIL_DOMAIN_')
 ]
 

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -546,5 +546,23 @@ MAILBOXES = {
     },
 }
 
-DIT_EMAIL_DOMAINS = env.list('DIT_EMAIL_DOMAINS', default=[])
-DIT_EMAIL_DOMAINS_AUTHENTICATION_EXEMPT = env.list('DIT_EMAIL_DOMAINS_AUTHENTICATION_EXEMPT', default=[])
+DIT_EMAIL_DOMAINS = {}
+domain_environ_names = [
+    environ_name 
+    for environ_name in os.environ.keys()
+    if environ_name.startswith('DIT_EMAIL_DOMAIN_')
+]
+
+# Go through all DIT_EMAIL_DOMAIN_* environment variables and extract
+# dictionary with key email domain and value consisting of 
+# authentication method/minimum pass result pairs e.g.
+# example.com=dmarc:pass|spf:pass|dkim:pass becomes
+# {'example.com': [['dmarc', 'pass'], ['spf', 'pass'], ['dkim', 'pass']]}
+for environ_name in domain_environ_names:
+    domain_details = env.dict(environ_name)
+    DIT_EMAIL_DOMAINS.update(
+        {
+            domain: [method.split(':') for method in auth.split('|')]
+            for domain, auth in domain_details.items()
+        }
+    )

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -99,8 +99,11 @@ DOCUMENT_BUCKETS = {
     }
 }
 
-DIT_EMAIL_DOMAINS = ['trade.gov.uk', 'digital.trade.gov.uk']
-DIT_EMAIL_DOMAINS_AUTHENTICATION_EXEMPT = ['trade.gov.uk']
+DIT_EMAIL_DOMAINS = {
+    'trade.gov.uk': ['exempt'],
+    'digital.trade.gov.uk': [['spf', 'pass'], ['dmarc', 'bestguesspass'], ['dkim', 'pass']],
+    'other.trade.gov.uk': [],
+}
 
 ACTIVITY_STREAM_OUTGOING_URL = 'http://activity.stream/'
 ACTIVITY_STREAM_OUTGOING_ACCESS_KEY_ID = 'some-outgoing-id'

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -24,10 +24,11 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'XX.XXX.XX.XX as permitted sender) smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
                 'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
                 'header.from=digital.trade.gov.uk',
+                'compauth=pass (reason=109)',
             ]),
             True,
         ),
-        # Invalid domain
+        # Invalid domain - passes during trial period
         (
             'bill.adama@gmail.com',
             '\n'.join([
@@ -36,8 +37,10 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'spf=pass (google.com: domain of bill.adama@gmail.com designates '
                 'XX.XXX.XX.XX as permitted sender) smtp.mailfrom=bill.adama@gmail.com;',
                 'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) header.from=gmail.com',
+                'compauth=pass (reason=109)',
             ]),
-            False,
+            # TODO: Change this to False after trial period, when we tighten sender verification
+            True,
         ),
         # Invalid authentication results - dkim
         (
@@ -51,6 +54,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                     'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
                     'header.from=digital.trade.gov.uk'
                 ),
+                'compauth=pass (reason=109)',
             ]),
             False,
         ),
@@ -66,6 +70,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                     'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
                     'header.from=digital.trade.gov.uk'
                 ),
+                'compauth=pass (reason=109)',
             ]),
             False,
         ),
@@ -81,6 +86,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                     'dmarc=fail (p=QUARANTINE sp=QUARANTINE dis=NONE) '
                     'header.from=digital.trade.gov.uk'
                 ),
+                'compauth=pass (reason=109)',
             ]),
             False,
         ),
@@ -94,6 +100,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                     'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
                     'header.from=digital.trade.gov.uk'
                 ),
+                'compauth=pass (reason=109)',
             ]),
             False,
         ),
@@ -108,6 +115,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
                 'header.from=digital.trade.gov.uk;',
                 'sender-id=fail header.from=example.com',
+                'compauth=pass (reason=109)',
             ]),
             True,
         ),
@@ -117,10 +125,11 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
             '\n'.join([
                 'mx.google.com;',
                 'dkim=fail header.i=@digital.trade.gov.uk header.s=selector1 header.b=foobar;',
-                'spf=pass (google.com: domain of bill.adama@digital.trade.gov.uk designates '
+                'spf=fail (google.com: domain of bill.adama@digital.trade.gov.uk designates '
                 'XX.XXX.XX.XX as permitted sender) smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
                 'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
                 'header.from=digital.trade.gov.uk;',
+                'compauth=pass (reason=109)',
             ]),
             False,
         ),

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -111,6 +111,19 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
             ]),
             True,
         ),
+        # Domain with no auth methods set, uses default methods and fails
+        (
+            'bill.adama@other.trade.gov.uk',
+            '\n'.join([
+                'mx.google.com;',
+                'dkim=fail header.i=@digital.trade.gov.uk header.s=selector1 header.b=foobar;',
+                'spf=pass (google.com: domain of bill.adama@digital.trade.gov.uk designates '
+                'XX.XXX.XX.XX as permitted sender) smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
+                'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
+                'header.from=digital.trade.gov.uk;',
+            ]),
+            False,
+        ),
     ),
 )
 def test_email_sent_by_dit(email, authentication_results, expected_result):


### PR DESCRIPTION
### Description of change

- This changes email domain verification so that we can have a configuration for authentication methods for each DIT adviser email domain.
- It also relaxes the default authentication so that **any** domain is set as valid, as long as it passes a minimum level of `dmarc=bestguesspass spf=pass compauth=pass`.  This is a temporary measure to make the launch of email ingestion as friction-less for advisers as possible - since it is so difficult to find out the exhaustive list of domains (and their authentication methods) that advisers use in practice.  This is explored in depth in this analysis document: https://docs.google.com/document/d/1p7JzIsSX6KF98DsCuFOGtd52y3pyq5PurS9btEkC4LE/edit

The new `DIT_EMAIL_DOMAIN_..` environment variables replace both the `DIT_EMAIL_DOMAINS` and `DIT_EMAIL_DOMAINS_AUTHENTICATION_EXEMPT` environment variables.  The `DIT_EMAIL_DOMAIN_..` variables are collected in to a revamped `DIT_EMAIL_DOMAINS` django setting which presents a data structure of domains and authentication methods.  This introduces some extra logic in to the `common.py` settings file, but this achieves the aim of keeping the necessary details secret while making the environment variable names relatively readable.
Here is an example set of environment variables that we might use: https://docs.google.com/document/d/1n_sJrMlCi-IZyRt5pXIXXgrN-lJmTzgBrF1FNflFOjk/edit

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
