### PR TITLE
Improve import interactions tool templates

### DIFF
--- a/datahub/interaction/admin_csv_import/file_form.py
+++ b/datahub/interaction/admin_csv_import/file_form.py
@@ -8,6 +8,7 @@ import reversion
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.template.defaultfilters import filesizeformat
+from django.utils.translation import gettext_lazy
 
 from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.core.admin_csv_import import BaseCSVImportForm
@@ -60,9 +61,12 @@ class UnmatchedRowCollector:
 class InteractionCSVForm(BaseCSVImportForm):
     """Form used for loading a CSV file to import interactions."""
 
-    csv_file_field_label = 'Interaction list (CSV file)'
-    csv_file_field_help_text = (
-        f'Maximum file size: {filesizeformat(settings.INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE)}'
+    csv_file_field_label = gettext_lazy('Interaction list (CSV file)')
+    csv_file_field_help_text = gettext_lazy(
+        'Maximum file size: {max_file_size}. Use the CSV (UTF-8) format when using Microsoft '
+        'Excel.',
+    ).format(
+        max_file_size=filesizeformat(settings.INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE),
     )
     required_columns = InteractionCSVRowForm.get_required_field_names()
 

--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -67,6 +67,21 @@ class CSVRowError(NamedTuple):
         """Returns the field name suitable for displaying to the user."""
         return '' if self.field == NON_FIELD_ERRORS else self.field
 
+    @property
+    def display_source_row(self):
+        """
+        Returns the source row number for displaying to the user.
+
+        This adds 2 to source_row:
+
+        - 1 is added for the header (column titles)
+        - 1 is added to make it one-based (rather than zero-based)
+
+        These make the displayed row numbers align with the row numbers as displayed
+        in a spreadsheet editor.
+        """
+        return self.source_row + 2
+
 
 class NoDuplicatesModelChoiceField(forms.ModelChoiceField):
     """ModelChoiceField subclass that handles MultipleObjectsReturned exceptions."""

--- a/datahub/interaction/admin_csv_import/views.py
+++ b/datahub/interaction/admin_csv_import/views.py
@@ -103,7 +103,7 @@ class InteractionCSVImportAdmin:
             return self._select_file_form_response(request, form)
 
         if not form.are_all_rows_valid():
-            return self._error_list_response(request, form.get_row_error_iterator())
+            return self._error_list_response(request, form)
 
         return self._preview_response(request, form)
 
@@ -175,16 +175,17 @@ class InteractionCSVImportAdmin:
             form=form,
         )
 
-    def _error_list_response(self, request, errors):
+    def _error_list_response(self, request, form):
+        errors = form.get_row_error_iterator()
         limited_errors = list(islice(errors, MAX_ERRORS_TO_DISPLAY))
-        are_errors_truncated = bool(next(errors, None))
+        num_errors_omitted = sum(1 for _ in errors)
 
         return self._template_response(
             request,
             'admin/interaction/interaction/import_row_errors.html',
             PAGE_TITLE,
             errors=limited_errors,
-            are_errors_truncated=are_errors_truncated,
+            num_errors_omitted=num_errors_omitted,
             max_errors=MAX_ERRORS_TO_DISPLAY,
         )
 

--- a/datahub/interaction/templates/admin/interaction/interaction/import_no_matches.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_no_matches.html
@@ -14,8 +14,8 @@
   {% include 'admin/interaction/interaction/fragment_post_import_counts.html' with num_matched=0 num_unmatched=num_unmatched num_multiple_matches=num_multiple_matches only %}
 
   <p>
-    <a href="{% url opts|admin_urlname:'changelist' %}">
-      {% trans 'Return to the interaction list' %}
+    <a href="{% url opts|admin_urlname:'import' %}">
+      {% trans 'Select another file' %}
     </a>
   </p>
 

--- a/datahub/interaction/templates/admin/interaction/interaction/import_row_errors.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_row_errors.html
@@ -7,18 +7,15 @@
     Edit the file and <a href="{% url 'admin:interaction_interaction_import' %}">then try again</a>.
   </p>
 
-  {% if are_errors_truncated %}
-  <p>
-    Only the first {{ max_errors }} errors are displayed.
-  </p>
-  {% endif %}
   <table>
-    <tr>
-      <th>Row</th>
-      <th>Field</th>
-      <th>Value</th>
-      <th>Error</th>
-    </tr>
+    <thead>
+      <tr>
+        <th>{% trans 'Row' %}</th>
+        <th>{% trans 'Field' %}</th>
+        <th>{% trans 'Value' %}</th>
+        <th>{% trans 'Error' %}</th>
+      </tr>
+    </thead>
   {% for error in errors %}
     <tr>
       <td>{{ error.source_row|add:1 }}</td>
@@ -27,5 +24,18 @@
       <td>{{ error.error }}</td>
     </tr>
   {% endfor %}
+
+  {% if num_errors_omitted %}
+    <tfoot>
+      <tr>
+        <td colspan="4">
+          {% blocktrans %}
+            ...and {{ num_errors_omitted }} more errors (not shown)
+          {% endblocktrans %}
+        </td>
+      </tr>
+    </tfoot>
+  {% endif %}
+
   </table>
 {% endblock %}

--- a/datahub/interaction/templates/admin/interaction/interaction/import_row_errors.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_row_errors.html
@@ -18,7 +18,7 @@
     </thead>
   {% for error in errors %}
     <tr>
-      <td>{{ error.source_row|add:1 }}</td>
+      <td>{{ error.display_source_row }}</td>
       <td>{{ error.display_field }}</td>
       <td>{{ error.value }}</td>
       <td>{{ error.error }}</td>

--- a/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
@@ -8,11 +8,13 @@
   {% trans "No" as no %}
 
   <table>
-    <tr>
-      <th>{% trans 'Column name' %}</th>
-      <th>{% trans 'Required' %}</th>
-      <th>{% trans 'Description' %}</th>
-    </tr>
+    <thead>
+      <tr>
+        <th>{% trans 'Column name' %}</th>
+        <th>{% trans 'Required' %}</th>
+        <th>{% trans 'Description' %}</th>
+      </tr>
+    </thead>
     <tr>
       <td><code>{% trans 'theme' %}</code></td>
       <td>{{ yes }}</td>
@@ -85,11 +87,11 @@
   <p>
     {% blocktrans %}
       Interactions are matched to a contact by looking for a unique match on all contacts' primary email addresses.
-      If no match is found, alternative email addresses are then checked.
+      If no match is found, alternative email addresses are then checked. (If multiple matches are found at either of those two stages, the interaction will be skipped.)
     {% endblocktrans %}
   </p>
   <p>
-    {% trans 'The interaction will not be loaded if multiple matches are found at either stage of matching.' %}
+    {% trans 'Interaction will also be duplicate-checked using the service, contact and date fields. If duplicates are detected, the load will be blocked.' %}
   </p>
   <p>
     {% trans 'You will have a chance to review the records that will be loaded on the next page.' %}

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -73,6 +73,18 @@ class TestCSVRowError:
         csv_row_error = CSVRowError(1, field, '', '')
         assert csv_row_error.display_field == expected_display_field
 
+    @pytest.mark.parametrize(
+        'source_row,expected_display_source_row',
+        (
+            (0, 2),
+            (1, 3),
+        ),
+    )
+    def test_display_source_row(self, source_row, expected_display_source_row):
+        """Test the display_source_row property."""
+        csv_row_error = CSVRowError(source_row, 'some_field', '', '')
+        assert csv_row_error.display_source_row == expected_display_source_row
+
 
 @pytest.mark.django_db
 class TestInteractionCSVRowFormValidation:

--- a/datahub/interaction/test/admin_csv_import/test_views.py
+++ b/datahub/interaction/test/admin_csv_import/test_views.py
@@ -296,16 +296,16 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
         )
 
     @pytest.mark.parametrize(
-        'max_errors,should_be_truncated',
+        'max_errors,expected_num_errors_omitted',
         (
-            (5, True),
-            (12, False),
+            (5, 7),
+            (12, 0),
         ),
     )
     def test_displays_errors_for_file_with_invalid_rows(
         self,
         max_errors,
-        should_be_truncated,
+        expected_num_errors_omitted,
         monkeypatch,
     ):
         """Test that errors are displayed for a file with invalid rows."""
@@ -330,7 +330,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.context['errors']) == min(12, max_errors)
-        assert response.context['are_errors_truncated'] == should_be_truncated
+        assert response.context['num_errors_omitted'] == expected_num_errors_omitted
 
     def test_displays_no_matches_message_if_no_matches(self):
         """


### PR DESCRIPTION
### Description of change

This:

- updates the table header styling and some bits of text on the 'select file' page
- updates the table header styling on the errors page and adds a count of omitted errors in the table footer
- changes the final link on import interactions tool 'no matches' page to link back to the 'select file' page
- adds one to the row numbers on the import interactions tool errors page (to account for the header row)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
