### PR TITLE
Validate that kind is not service_delivery for investment interactions

### DIFF
--- a/changelog/interaction/reject-investment-service-delivery.api.rst
+++ b/changelog/interaction/reject-investment-service-delivery.api.rst
@@ -1,0 +1,1 @@
+``POST /v3/interaction, PATCH /v3/interaction/<id>``: The API now correctly returns an error if ``service_delivery`` is specified for ``kind`` when ``theme`` is ``investment``.

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -127,6 +127,9 @@ class InteractionSerializer(serializers.ModelSerializer):
     """
 
     default_error_messages = {
+        'invalid_for_investment': gettext_lazy(
+            "This value can't be selected for investment interactions.",
+        ),
         'invalid_for_non_service_delivery': gettext_lazy(
             'This field is only valid for service deliveries.',
         ),
@@ -387,6 +390,11 @@ class InteractionSerializer(serializers.ModelSerializer):
                     'required',
                     OperatorRule('service', bool),
                     when=EqualsRule('status', Interaction.STATUSES.complete),
+                ),
+                ValidationRule(
+                    'invalid_for_investment',
+                    EqualsRule('kind', Interaction.KINDS.interaction),
+                    when=EqualsRule('theme', Interaction.THEMES.investment),
                 ),
                 ValidationRule(
                     'invalid_for_non_interaction',

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -114,6 +114,16 @@ class TestInteractionCSVRowFormValidation:
                 id='theme invalid',
             ),
             pytest.param(
+                {
+                    'kind': Interaction.KINDS.service_delivery,
+                    'theme': Interaction.THEMES.investment,
+                },
+                {
+                    'kind': ["This value can't be selected for investment interactions."],
+                },
+                id='investment service delivery',
+            ),
+            pytest.param(
                 {'date': ''},
                 {'date': ['This field is required.']},
                 id='date blank',

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -47,9 +47,13 @@ class TestAddInteraction(APITestMixin):
             # company interaction
             {
             },
-            # company interaction with theme
+            # company interaction with export theme
             {
                 'theme': Interaction.THEMES.export,
+            },
+            # company interaction with investment theme
+            {
+                'theme': Interaction.THEMES.investment,
             },
             # company interaction with blank notes
             {

--- a/datahub/interaction/test/views/test_service_delivery.py
+++ b/datahub/interaction/test/views/test_service_delivery.py
@@ -353,6 +353,33 @@ class TestAddServiceDelivery(APITestMixin):
                 },
             ),
 
+            # theme=investment not allowed
+            (
+                {
+                    'kind': Interaction.KINDS.service_delivery,
+                    'date': date.today().isoformat(),
+                    'subject': 'whatever',
+                    'company': CompanyFactory,
+                    'contacts': [ContactFactory],
+                    'dit_participants': [
+                        {'adviser': AdviserFactory},
+                    ],
+                    'service': Service.trade_enquiry.value.id,
+                    'service_delivery_status': partial(
+                        random_obj_for_model, ServiceDeliveryStatus,
+                    ),
+                    'grant_amount_offered': '1111.11',
+                    'net_company_receipt': '8888.11',
+                    'was_policy_feedback_provided': False,
+                    'is_event': False,
+
+                    'theme': Interaction.THEMES.investment,
+                },
+                {
+                    'kind': ["This value can't be selected for investment interactions."],
+                },
+            ),
+
             # event field not allowed for non-event service delivery
             (
                 {


### PR DESCRIPTION
### Description of change

This adds a validation rule to to the interaction serialiser that checks that `service_delivery` is not specified for the `kind` field when `theme` is `investment`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
