### PR TITLE
Remove feature flag from admin site import interactions tool

### DIFF
--- a/changelog/interaction/remove-feature-flag.feature.rst
+++ b/changelog/interaction/remove-feature-flag.feature.rst
@@ -1,0 +1,1 @@
+The admin site import interactions tool is no longer behind a feature flag.

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -11,11 +11,7 @@ from datahub.core.admin import (
     custom_view_permission,
 )
 from datahub.core.utils import join_truthy_strings
-from datahub.feature_flag.utils import is_feature_flag_active
-from datahub.interaction.admin_csv_import.views import (
-    INTERACTION_IMPORTER_FEATURE_FLAG_NAME,
-    InteractionCSVImportAdmin,
-)
+from datahub.interaction.admin_csv_import.views import InteractionCSVImportAdmin
 from datahub.interaction.models import (
     CommunicationChannel,
     Interaction,
@@ -146,21 +142,6 @@ class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
         return format_html('<pre>{0}</pre>', json.dumps(obj.source, indent=2))
 
     pretty_source.short_description = 'source'
-
-    def changelist_view(self, request, extra_context=None):
-        """
-        Change list view with additional data added to the context.
-
-        Based on this example in the Django docs:
-        https://docs.djangoproject.com/en/2.2/ref/contrib/admin/#django.contrib.admin.ModelAdmin.history_view
-        """
-        csv_import_feature_flag = is_feature_flag_active(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
-        extra_context = {
-            **(extra_context or {}),
-            'csv_import_feature_flag': csv_import_feature_flag,
-        }
-
-        return super().changelist_view(request, extra_context=extra_context)
 
     def get_urls(self):
         """Gets the URLs for this model's admin views."""

--- a/datahub/interaction/admin_csv_import/views.py
+++ b/datahub/interaction/admin_csv_import/views.py
@@ -18,7 +18,6 @@ from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.core.admin import max_upload_size
 from datahub.core.csv import CSV_CONTENT_TYPE
 from datahub.core.exceptions import DataHubException
-from datahub.feature_flag.utils import feature_flagged_view
 from datahub.interaction.admin_csv_import.cache_utils import (
     CACHE_VALUE_TIMEOUT,
     load_result_counts_by_status,
@@ -29,7 +28,6 @@ from datahub.interaction.admin_csv_import.cache_utils import (
 from datahub.interaction.admin_csv_import.file_form import InteractionCSVForm
 from datahub.interaction.models import Interaction, InteractionPermission
 
-INTERACTION_IMPORTER_FEATURE_FLAG_NAME = 'admin-interaction-csv-importer'
 MAX_ERRORS_TO_DISPLAY = 50
 MAX_PREVIEW_ROWS_TO_DISPLAY = 100
 PAGE_TITLE = gettext_lazy('Import interactions')
@@ -52,11 +50,7 @@ interaction_change_all_permission_required = method_decorator(
 
 
 class InteractionCSVImportAdmin:
-    """
-    Views related to importing interactions from a CSV file.
-
-    The implementation is not yet complete; hence, views are behind a feature flag.
-    """
+    """Views related to importing interactions from a CSV file."""
 
     def __init__(self, model_admin):
         """Initialises the instance with a reference to an InteractionAdmin instance."""
@@ -90,7 +84,6 @@ class InteractionCSVImportAdmin:
             ),
         ]
 
-    @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
     @interaction_change_all_permission_required
     @method_decorator(max_upload_size(settings.INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE))
     def select_file(self, request, *args, **kwargs):
@@ -108,7 +101,6 @@ class InteractionCSVImportAdmin:
         return self._preview_response(request, form)
 
     @interaction_change_all_permission_required
-    @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
     @method_decorator(require_POST)
     def save(self, request, token=None, *args, **kwargs):
         """Create interactions from a CSV file that was loaded in the select_file view."""
@@ -136,7 +128,6 @@ class InteractionCSVImportAdmin:
         return _redirect_response('import-complete', token=token)
 
     @interaction_change_all_permission_required
-    @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
     def complete(self, request, token=None, *args, **kwargs):
         """Display a confirmation page following a successful import operation."""
         counts_by_status = load_result_counts_by_status(token)
@@ -148,7 +139,6 @@ class InteractionCSVImportAdmin:
         return self._complete_response(request, token, counts_by_status)
 
     @interaction_change_all_permission_required
-    @feature_flagged_view(INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
     def download_unmatched(self, request, token=None, *args, **kwargs):
         """Download unmatched rows as a CSV file following a successful import operation."""
         unmatched_rows_csv_contents = load_unmatched_rows_csv_contents(token)

--- a/datahub/interaction/templates/admin/interaction/interaction/change_list_object_tools.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/change_list_object_tools.html
@@ -1,7 +1,7 @@
 {% extends "admin/change_list_object_tools.html" %}
 
 {% block object-tools-items %}
-  {% if has_change_permission and csv_import_feature_flag %}
+  {% if has_change_permission %}
     <li>
       <a href="{% url 'admin:interaction_interaction_import' %}">
         Import interactions

--- a/datahub/interaction/test/admin_csv_import/test_row_form.py
+++ b/datahub/interaction/test/admin_csv_import/test_row_form.py
@@ -659,11 +659,11 @@ class TestInteractionCSVRowFormSerializerUsage:
 
 
 @pytest.mark.django_db
-class TestInteractionCSVRowFormCleaning:
+class TestInteractionCSVRowFormSuccessfulCleaning:
     """
-    Tests for field cleaning in InteractionCSVRowForm.
+    Tests for successful field cleaning in InteractionCSVRowForm.
 
-    This includes looking up model objects and the transformation of values (but not validation).
+    This includes looking up model objects and the transformation of values.
     """
 
     @pytest.mark.parametrize(
@@ -701,7 +701,7 @@ class TestInteractionCSVRowFormCleaning:
             ),
         ),
     )
-    def test_simple_value_cleaning(self, field, input_value, expected_value):
+    def test_common_non_relations(self, field, input_value, expected_value):
         """Test the conversion and cleaning of various non-relationship fields."""
         adviser = AdviserFactory(first_name='Neptune', last_name='Doris')
         service = random_service()
@@ -749,7 +749,7 @@ class TestInteractionCSVRowFormCleaning:
                 id='adviser_1 look-up (case-insensitive)',
             ),
             pytest.param(
-                'adviser_1',
+                'adviser_2',
                 lambda: AdviserFactory(
                     first_name='Pluto',
                     last_name='Doris',
@@ -758,7 +758,7 @@ class TestInteractionCSVRowFormCleaning:
                 id='adviser_2 look-up (same case)',
             ),
             pytest.param(
-                'adviser_1',
+                'adviser_2',
                 lambda: AdviserFactory(
                     first_name='Pluto',
                     last_name='Doris',
@@ -861,6 +861,13 @@ class TestInteractionCSVRowFormCleaning:
                 lambda obj: str(obj.pk),
                 lambda obj: obj,
                 id='event look-up',
+            ),
+            pytest.param(
+                'event_id',
+                lambda: None,
+                lambda _: '',
+                lambda _: None,
+                id='event can be omitted',
             ),
         ),
     )

--- a/datahub/interaction/test/admin_csv_import/test_views.py
+++ b/datahub/interaction/test/admin_csv_import/test_views.py
@@ -17,14 +17,12 @@ from datahub.company.contact_matching import ContactMatchingStatus
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.exceptions import DataHubException
 from datahub.core.test_utils import AdminTestMixin, create_test_user
-from datahub.feature_flag.test.factories import FeatureFlagFactory
 from datahub.interaction.admin_csv_import.cache_utils import (
     _cache_key_for_token,
     CacheKeyType,
     load_unmatched_rows_csv_contents,
 )
 from datahub.interaction.admin_csv_import.views import (
-    INTERACTION_IMPORTER_FEATURE_FLAG_NAME,
     INVALID_TOKEN_MESSAGE_DURING_SAVE,
     INVALID_TOKEN_MESSAGE_POST_SAVE,
 )
@@ -38,12 +36,6 @@ from datahub.interaction.test.admin_csv_import.utils import (
     random_communication_channel,
     random_service,
 )
-
-
-@pytest.fixture()
-def interaction_importer_feature_flag():
-    """Creates the import interactions tool feature flag."""
-    yield FeatureFlagFactory(code=INTERACTION_IMPORTER_FEATURE_FLAG_NAME)
 
 
 import_interactions_url = reverse(
@@ -60,7 +52,6 @@ import_download_unmatched_urlname = admin_urlname(Interaction._meta, 'import-dow
 class TestInteractionAdminChangeList(AdminTestMixin):
     """Tests for the contact admin change list."""
 
-    @pytest.mark.usefixtures('interaction_importer_feature_flag')
     def test_load_import_link_exists(self):
         """
         Test that there is a link to import interactions on the interaction change list page.
@@ -88,17 +79,7 @@ class TestInteractionAdminChangeList(AdminTestMixin):
         assert f'Select {Interaction._meta.verbose_name} to view' in response.rendered_content
         assert import_interactions_url not in response.rendered_content
 
-    def test_import_link_does_not_exist_if_feature_flag_inactive(self):
-        """
-        Test that there is not a link to import interactions if the feature flag is inactive.
-        """
-        response = self.client.get(interaction_change_list_url)
-        assert response.status_code == status.HTTP_200_OK
 
-        assert import_interactions_url not in response.rendered_content
-
-
-@pytest.mark.usefixtures('interaction_importer_feature_flag')
 @pytest.mark.parametrize(
     'http_method,url',
     (
@@ -155,35 +136,6 @@ class TestAccessRestrictions(AdminTestMixin):
 
 
 @pytest.mark.parametrize(
-    'http_method,url',
-    (
-        ('get', import_interactions_url),
-        ('post', import_interactions_url),
-        ('post', reverse(import_save_urlname, kwargs={'token': 'test-token'})),
-        ('get', reverse(import_complete_urlname, kwargs={'token': 'test-token'})),
-        ('get', reverse(import_download_unmatched_urlname, kwargs={'token': 'test-token'})),
-    ),
-)
-class Test404IfFeatureFlagDisabled(AdminTestMixin):
-    """
-    Tests that import interaction-related views return a 404 if the feature flag is not
-    active.
-
-    (The feature flag not being active is implicit by it not being created,)
-    """
-
-    def test_returns_404_if_feature_flag_inactive(self, http_method, url):
-        """Test that the a 404 is returned if the feature flag is inactive."""
-        response = self.client.generic(
-            http_method,
-            url,
-            data={},
-        )
-
-        assert response.status_code == status.HTTP_404_NOT_FOUND
-
-
-@pytest.mark.parametrize(
     'http_method,url,expected_message',
     (
         (
@@ -203,7 +155,7 @@ class Test404IfFeatureFlagDisabled(AdminTestMixin):
         ),
     ),
 )
-@pytest.mark.usefixtures('interaction_importer_feature_flag', 'local_memory_cache')
+@pytest.mark.usefixtures('local_memory_cache')
 class TestInvalidTokenRedirectView(AdminTestMixin):
     """Tests for handling of invalid tokens in views that require a token."""
 
@@ -232,14 +184,13 @@ class TestInvalidTokenRedirectView(AdminTestMixin):
         assert messages[0].message == expected_message
 
 
-@pytest.mark.usefixtures('interaction_importer_feature_flag', 'local_memory_cache')
+@pytest.mark.usefixtures('local_memory_cache')
 class TestImportInteractionsSelectFileView(AdminTestMixin):
     """Tests for the import interaction select file form."""
 
     def test_displays_page_if_with_correct_permissions(self):
         """
-        Test that the view returns displays the form if the feature flag is active
-        and the user has the correct permissions.
+        Test that the view returns displays the form if the user has the correct permissions.
         """
         response = self.client.get(import_interactions_url)
 
@@ -419,7 +370,7 @@ class TestImportInteractionsSelectFileView(AdminTestMixin):
         assert response.context['num_matched_omitted'] == expected_num_omitted_rows
 
 
-@pytest.mark.usefixtures('interaction_importer_feature_flag', 'local_memory_cache')
+@pytest.mark.usefixtures('local_memory_cache')
 class TestImportInteractionsSaveView(AdminTestMixin):
     """Tests for the import interaction save view."""
 
@@ -551,7 +502,7 @@ class TestImportInteractionsSaveView(AdminTestMixin):
             assert len(list(reader)) == num_unmatched + num_multiple_matches + 1
 
 
-@pytest.mark.usefixtures('interaction_importer_feature_flag', 'local_memory_cache')
+@pytest.mark.usefixtures('local_memory_cache')
 class TestImportInteractionsCompleteView(AdminTestMixin):
     """Tests for the import complete view."""
 
@@ -581,7 +532,7 @@ class TestImportInteractionsCompleteView(AdminTestMixin):
         assert response.context['num_multiple_matches'] == num_multiple_matches
 
 
-@pytest.mark.usefixtures('interaction_importer_feature_flag', 'local_memory_cache')
+@pytest.mark.usefixtures('local_memory_cache')
 class TestImportInteractionsDownloadUnmatchedView(AdminTestMixin):
     """Tests for the download unmatched rows view."""
 


### PR DESCRIPTION
### Description of change

This makes some minor improvements to InteractionCSVRowForm tests and removes the feature flag from the import interactions tool.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
