### PR TITLE
Email ingestion adviser whitelist

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -546,6 +546,8 @@ MAILBOXES = {
     },
 }
 
+# TODO: Remove this setting once we are past the pilot period for email ingestion
+DIT_EMAIL_INGEST_WHITELIST = env.list('DIT_EMAIL_INGEST_WHITELIST', default=[])
 DIT_EMAIL_DOMAINS = {}
 domain_environ_names = [
     environ_name 

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -99,6 +99,17 @@ DOCUMENT_BUCKETS = {
     }
 }
 
+# TODO: Remove this setting once we are past the pilot period for email ingestion
+DIT_EMAIL_INGEST_WHITELIST = [
+    'bill.adama@digital.trade.gov.uk',
+    'bill.adama@other.trade.gov.uk',
+    'bill.adama@trade.gov.uk',
+    'adviser1@trade.gov.uk',
+    'adviser2@digital.trade.gov.uk',
+    'adviser3@digital.trade.gov.uk',
+    'correspondence3@digital.trade.gov.uk',
+    'unknown@trade.gov.uk',
+]
 DIT_EMAIL_DOMAINS = {
     'trade.gov.uk': ['exempt'],
     'digital.trade.gov.uk': [['spf', 'pass'], ['dmarc', 'bestguesspass'], ['dkim', 'pass']],

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -28,7 +28,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
             ]),
             True,
         ),
-        # Invalid domain - passes during trial period
+        # Invalid domain - not on DIT adviser whitelist
         (
             'bill.adama@gmail.com',
             '\n'.join([
@@ -39,8 +39,8 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) header.from=gmail.com',
                 'compauth=pass (reason=109)',
             ]),
-            # TODO: Change this to False after trial period, when we tighten sender verification
-            True,
+            # TODO: Will need review as we adjust domain verification during trial
+            False,
         ),
         # Invalid authentication results - dkim
         (

--- a/datahub/email_ingestion/validation.py
+++ b/datahub/email_ingestion/validation.py
@@ -51,7 +51,7 @@ def was_email_sent_by_dit(message):
     except IndexError:
         return False
 
-    # TODO: Remove this logic once we are past the pilo5 period for email ingestion
+    # TODO: Remove this logic once we are past the pilot period for email ingestion
     if from_email not in settings.DIT_EMAIL_INGEST_WHITELIST:
         return False
 

--- a/datahub/email_ingestion/validation.py
+++ b/datahub/email_ingestion/validation.py
@@ -46,9 +46,13 @@ def was_email_sent_by_dit(message):
     :returns: True if the email passed our minimal level of email authentication checks.
     """
     try:
-        from_email = message.from_[0][1]
+        from_email = message.from_[0][1].strip()
         from_domain = from_email.rsplit('@', maxsplit=1)[1]
     except IndexError:
+        return False
+
+    # TODO: Remove this logic once we are past the pilo5 period for email ingestion
+    if from_email not in settings.DIT_EMAIL_INGEST_WHITELIST:
         return False
 
     try:

--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -94,16 +94,6 @@ def _get_utc_datetime(localised_datetime):
         return localised_datetime
 
 
-class EmailNotSentByDITException(Exception):
-    """
-    Exception for flagging that an email could not be verified as sent by a DIT
-    adviser.
-
-    TODO: Remove this exception and its uses once we are past calendar invite
-    ingestion pilot stage.
-    """
-
-
 class CalendarInteractionEmailParser:
     """
     Parses and extracts calendar interaction information from a MailParser email
@@ -123,18 +113,7 @@ class CalendarInteractionEmailParser:
         except IndexError:
             raise ValidationError('Email was malformed - missing "from" header')
         if not was_email_sent_by_dit(self.message):
-            sender_domain = sender_email.rsplit('@', maxsplit=1)[1]
-            message_id = self.message.message_id
-            # TODO: This raises a EmailNotSentByDITException for debugging purposes.
-            # change this back to a ValidationError when we are past the pilot stage for
-            # calendar invite ingestion
-            raise EmailNotSentByDITException(
-                f'Email with ID "{message_id}" and sender domain "{sender_domain}" '
-                'was not recognised as being sent by an authenticated DIT domain. '
-                'Either the domain was unrecognised, or it did not pass our requirements for '
-                'Authentication-Results. Further investigation is needed during the pilot for '
-                'email ingestion.',
-            )
+            raise ValidationError('Email not sent by DIT')
         sender_adviser = _get_best_match_adviser_by_email(sender_email)
         if not sender_adviser:
             raise ValidationError('Email not sent by recognised DIT Adviser')

--- a/datahub/interaction/test/email_processors/test_parsers.py
+++ b/datahub/interaction/test/email_processors/test_parsers.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime
+from datetime import datetime
 from pathlib import PurePath
 
 import mailparser
@@ -68,12 +68,13 @@ class TestCalendarInteractionEmailParser:
                     'uid': '5iggr1e2luglss6c789b0scvgr@google.com',
                 },
             ),
+            # Sample email only specifies the day for start/end instead of date/time
             (
                 'email_samples/valid/outlook_iphone/sample.eml',
                 {
                     'subject': 'Test meeting iPhone 5',
-                    'start': date(2019, 5, 19),
-                    'end': date(2019, 5, 20),
+                    'start': datetime(2019, 5, 19, tzinfo=utc),
+                    'end': datetime(2019, 5, 20, tzinfo=utc),
                     'sent': datetime(2019, 5, 13, 10, 34, 50, tzinfo=utc),
                     'location': '',
                     'status': 'CONFIRMED',

--- a/datahub/interaction/test/email_processors/test_parsers.py
+++ b/datahub/interaction/test/email_processors/test_parsers.py
@@ -6,10 +6,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.utils.timezone import utc
 
-from datahub.interaction.email_processors.parsers import (
-    CalendarInteractionEmailParser,
-    EmailNotSentByDITException,
-)
+from datahub.interaction.email_processors.parsers import CalendarInteractionEmailParser
 
 
 @pytest.mark.django_db
@@ -189,15 +186,7 @@ class TestCalendarInteractionEmailParser:
         (
             (
                 'email_samples/invalid/email_not_sent_by_dit.eml',
-                # TODO: Swap this expected error out for a ValidationError when
-                # we are past the pilot stage for email ingestion
-                EmailNotSentByDITException(
-                    'Email with ID "<CWXP123MB2008236F14A5E2A22B2B65FFC90F0@CWXP123MB2008.'
-                    'GBRP123.PROD.OUTLOOK.COM>" and sender domain "unknown.net" was not recognised'
-                    ' as being sent by an authenticated DIT domain. Either the domain was '
-                    'unrecognised, or it did not pass our requirements for Authentication-Results.'
-                    ' Further investigation is needed during the pilot for email ingestion.',
-                ),
+                ValidationError('Email not sent by DIT'),
             ),
             (
                 'email_samples/invalid/no_from_header.eml',


### PR DESCRIPTION
### Description of change
For the email ingestion project, it was agreed with stakeholders to limit data hub to only ingest emails from advisers on a limited whitelist.  This is to satisfy security concerns during the initial roll out of email ingestion.

This change:
- Introduces an `DIT_EMAIL_INGEST_WHITELIST` setting for the adviser whitelist and enforces it in the `was_email_sent_by_dit` validation function.
- Reverts work done previously to flag received emails that do not meet our minimum level of email validation (as this could be quite noisy in conjunction with the whitelist).  This may be re-instated as we remove the whitelist later.
- Fixes an issue where meeting invites that only specified a date could not be successfully ingested.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
