### PR TITLE
Prevent multiple form submissions in admin site tools

### DIFF
--- a/datahub/company/templates/admin/company/contact/load_email_marketing_opt_outs.html
+++ b/datahub/company/templates/admin/company/contact/load_email_marketing_opt_outs.html
@@ -2,8 +2,9 @@
 {% load i18n admin_urls static %}
 
 {% block extrahead %}
-    {{ block.super }}
-    {{ media }}
+  {{ block.super }}
+  {{ media }}
+  <script src="{% static 'core/admin/js/prevent-multiple-submit.js' %}"></script>
 {% endblock %}
 
 {% block extrastyle %}
@@ -43,7 +44,7 @@
     {% endfor %}
 
     <div>
-      <input type="submit" value="{% trans 'Submit' %}">
+      <input type="submit" value="{% trans 'Submit' %}" data-prevent-multiple-submit>
     </div>
   </form>
 {% endblock %}

--- a/datahub/core/static/core/admin/js/prevent-multiple-submit.js
+++ b/datahub/core/static/core/admin/js/prevent-multiple-submit.js
@@ -1,0 +1,33 @@
+/**
+ * Prevent multiple form submissions by disabling the submit button once it's been
+ * clicked.
+ *
+ * Currently only compatible with <input> (and not <button>).
+ *
+ * Example usage:
+ *
+ * With default loading text:
+ *
+ *   <input type="submit" value="Submit" data-prevent-multiple-submit>
+ *
+ * With custom loading text:
+ *
+ *   <input type="submit" value="Submit" data-prevent-multiple-submit="Submitting...">
+ */
+
+window.addEventListener('DOMContentLoaded', function () {
+  var buttons = window.document.querySelectorAll('input[data-prevent-multiple-submit]');
+
+  Array.prototype.forEach.call(buttons, function (button) {
+    button.addEventListener('click', function (event) {
+      event.preventDefault();
+
+      if (!event.target.form.reportValidity || event.target.form.reportValidity()) {
+        // event.target.getAttribute() used rather than event.target.dataset for IE<11 support
+        event.target.value = event.target.getAttribute('data-prevent-multiple-submit') || 'Please wait...';
+        event.target.disabled = true;
+        event.target.form.submit();
+      }
+    })
+  })
+});

--- a/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
@@ -1,6 +1,11 @@
 {% extends 'admin/interaction/interaction/base_import.html' %}
 {% load admin_urls static i18n %}
 
+{% block extrahead %}
+  {{ block.super }}
+  <script src="{% static 'core/admin/js/prevent-multiple-submit.js' %}"></script>
+{% endblock %}
+
 {% block extrastyle %}
   {{ block.super }}
   <link rel="stylesheet" type="text/css" href="{% static 'interaction/admin/css/import-preview.css' %}">
@@ -93,7 +98,7 @@
     {% csrf_token %}
 
     <div>
-      <input type="submit" value="{{ import }}">
+      <input type="submit" value="{{ import }}" data-prevent-multiple-submit>
     </div>
 
     <p></p>

--- a/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
@@ -1,6 +1,11 @@
 {% extends "admin/interaction/interaction/base_import.html" %}
 {% load i18n admin_urls static %}
 
+{% block extrahead %}
+  {{ block.super }}
+  <script src="{% static 'core/admin/js/prevent-multiple-submit.js' %}"></script>
+{% endblock %}
+
 {% block content %}
   <p>{% trans 'Select a CSV file to import interactions into Data Hub. The CSV file should contain the following columns (in any order):' %}</p>
 
@@ -111,7 +116,7 @@
     {% endfor %}
 
     <div>
-      <input type="submit" value="{% trans 'Submit' %}">
+      <input type="submit" value="{% trans 'Submit' %}" data-prevent-multiple-submit>
     </div>
   </form>
 {% endblock %}


### PR DESCRIPTION
### Description of change

This adds a simple mechanism via JavaScript to prevent multiple form submissions in the admin site load marketing opt-outs and import interactions tools.

I've tested this in IE 11, Firefox and Chrome. It also keeps the HTML 5 validation working.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
