### PR TITLE
Switch from Raven to Sentry SDK

### DIFF
--- a/changelog/sentry-sdk.internal.rst
+++ b/changelog/sentry-sdk.internal.rst
@@ -1,0 +1,1 @@
+The deprecated Raven Sentry client was replaced with the Sentry SDK.

--- a/config/celery.py
+++ b/config/celery.py
@@ -3,8 +3,6 @@ import os
 
 from celery import Celery
 from celery.signals import after_setup_logger
-from raven import Client
-from raven.contrib.celery import register_logger_signal, register_signal
 
 
 # set the default Django settings module for the 'celery' program.
@@ -20,18 +18,6 @@ app.config_from_object('django.conf:settings', namespace='CELERY')
 
 # Load task modules from all registered Django app configs.
 app.autodiscover_tasks()
-
-# config sentry
-client = Client(
-    dsn=os.environ.get('DJANGO_SENTRY_DSN'),
-    environment=os.environ.get('SENTRY_ENVIRONMENT'),
-)
-
-# register a custom filter to filter out duplicate logs
-register_logger_signal(client)
-
-# hook into the Celery error handler
-register_signal(client, ignore_expected=True)
 
 
 @after_setup_logger.connect

--- a/config/settings/common_sentry.py
+++ b/config/settings/common_sentry.py
@@ -1,7 +1,8 @@
-from config.settings.common import *
+import sentry_sdk
+from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
 
-MIDDLEWARE.append('raven.contrib.django.raven_compat.middleware.SentryResponseErrorIdMiddleware')
-INSTALLED_APPS.append('raven.contrib.django.raven_compat')
+from config.settings.common import *
 
 # Logging
 LOGGING = {
@@ -9,7 +10,7 @@ LOGGING = {
     'disable_existing_loggers': False,
     'root': {
         'level': 'INFO',
-        'handlers': ['sentry', 'console'],
+        'handlers': ['console'],
     },
     'formatters': {
         'verbose': {
@@ -17,10 +18,6 @@ LOGGING = {
         },
     },
     'handlers': {
-        'sentry': {
-            'level': 'ERROR',
-            'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler'
-        },
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
@@ -33,21 +30,15 @@ LOGGING = {
             'handlers': ['console'],
             'propagate': False,
         },
-        'raven': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
-        },
-        'sentry.errors': {
-            'level': 'DEBUG',
-            'handlers': ['console'],
-            'propagate': False,
-        },
     },
 }
 
-RAVEN_CONFIG = {
-    'dsn': env('DJANGO_SENTRY_DSN'),
-    'include_paths': ['datahub'],
-    'environment': env('SENTRY_ENVIRONMENT'),
-}
+sentry_sdk.init(
+    dsn=env('DJANGO_SENTRY_DSN'),
+    environment=env('SENTRY_ENVIRONMENT'),
+    integrations=[
+        CeleryIntegration(),
+        DjangoIntegration(),
+    ],
+    in_app_include=['datahub'],
+)

--- a/datahub/company/test/timeline/test_views.py
+++ b/datahub/company/test/timeline/test_views.py
@@ -128,7 +128,7 @@ class TestCompanyTimelineViews(APITestMixin):
         """Test the behaviour when an error is returned from the upstream service."""
         error_reference = 'error-ref-1'
         monkeypatch.setattr(
-            'raven.contrib.django.models.client.captureException',
+            'sentry_sdk.capture_exception',
             Mock(return_value=error_reference),
         )
         stubbed_url = urljoin(
@@ -161,7 +161,7 @@ class TestCompanyTimelineViews(APITestMixin):
         """
         error_reference = 'error-ref-1'
         monkeypatch.setattr(
-            'raven.contrib.django.models.client.captureException',
+            'sentry_sdk.capture_exception',
             Mock(return_value=error_reference),
         )
 

--- a/datahub/company/timeline/client.py
+++ b/datahub/company/timeline/client.py
@@ -1,6 +1,6 @@
+import sentry_sdk
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from raven.contrib.django.models import client
 from requests import HTTPError
 from rest_framework import status
 from rest_framework.exceptions import APIException, ValidationError
@@ -60,7 +60,7 @@ class DataScienceCompanyAPIClient:
             response = self._api_client.request('get', path, **kwargs)
         except HTTPError as exc:
             if exc.response.status_code != status.HTTP_404_NOT_FOUND:
-                event_id = client.captureException()
+                event_id = sentry_sdk.capture_exception()
                 raise APIException(
                     f'Error communicating with the company timeline API. Error '
                     f'reference: {event_id}.',
@@ -75,7 +75,7 @@ def _transform_events_response(data):
     try:
         serializer.is_valid(raise_exception=True)
     except ValidationError as exc:
-        event_id = client.captureException()
+        event_id = sentry_sdk.capture_exception()
         raise APIException(
             f'Unexpected response data format received from the company '
             f'timeline API. Error reference: {event_id}.',

--- a/datahub/core/test/test_thread_pool.py
+++ b/datahub/core/test/test_thread_pool.py
@@ -12,8 +12,8 @@ def _synchronous_executor_submit(fn, *args, **kwargs):
 
 
 @mock.patch('datahub.core.thread_pool._executor.submit', _synchronous_executor_submit)
-@mock.patch('datahub.core.thread_pool.client')
-def test_error_raises_exception(mock_raven_client):
+@mock.patch('sentry_sdk.capture_exception')
+def test_error_raises_exception(mock_capture_exception):
     """
     Test that if an error occurs whilst executing a thread pool task,
     the exception is raised and sent to sentry.
@@ -23,4 +23,4 @@ def test_error_raises_exception(mock_raven_client):
     with pytest.raises(ValueError):
         submit_to_thread_pool(mock_task)
 
-    assert mock_raven_client.captureException.called
+    assert mock_capture_exception.called

--- a/datahub/core/thread_pool.py
+++ b/datahub/core/thread_pool.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 
+import sentry_sdk
 from django.db import close_old_connections
-from raven.contrib.django.models import client
 
 from datahub.core.utils import logger
 
@@ -42,7 +42,7 @@ def _make_thread_pool_task(fn, *args, **kwargs):
         except Exception:
             msg = f'Error running thread pool task {fn.__name__}'
             logger.exception(msg)
-            client.captureException(msg)
+            sentry_sdk.capture_exception()
             raise
         finally:
             close_old_connections()

--- a/requirements.in
+++ b/requirements.in
@@ -81,6 +81,6 @@ pydocstyle==3.0.0
 gunicorn==19.9.0
 gevent==1.4.0
 mohawk==1.0.0
-raven==6.10.0
 requests==2.22.0
 requests_toolbelt==0.9.1
+sentry_sdk==0.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ billiard==3.6.0.0
 boto3==1.9.164
 botocore==1.12.164        # via boto3, s3transfer
 celery[redis]==4.3
-certifi==2019.3.9         # via requests
+certifi==2019.3.9         # via requests, sentry-sdk
 chardet==3.0.4
 click==7.0                # via pip-tools, towncrier
 coverage==4.5.3           # via pytest-cov
@@ -109,13 +109,13 @@ pytest==4.6.2
 python-dateutil==2.8.0
 pytz==2019.1              # via celery, django, icalendar
 pyyaml==5.1.1
-raven==6.10.0
 redis==3.2.1
 requests-futures==0.9.9   # via piprot
 requests-mock==1.6.0
 requests==2.22.0
 requests_toolbelt==0.9.1
 s3transfer==0.2.0         # via boto3
+sentry_sdk==0.9.0
 simplejson==3.16.0        # via mail-parser
 six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mail-parser, mohawk, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest, pytest-xdist, python-dateutil, requests-mock, traitlets
 snowballstemmer==1.2.1    # via pydocstyle
@@ -125,7 +125,7 @@ text-unidecode==1.2       # via faker
 toml==0.10.0              # via towncrier
 towncrier==19.2.0
 traitlets==4.3.2          # via ipython
-urllib3==1.25.3           # via botocore, elasticsearch, requests
+urllib3==1.25.3           # via botocore, elasticsearch, requests, sentry-sdk
 vine==1.3.0               # via amqp, celery
 watchdog==0.9.0
 wcwidth==0.1.7            # via prompt-toolkit, pytest


### PR DESCRIPTION
### Description of change

This switches from the deprecated Raven Sentry client to the new Sentry SDK.

See https://docs.sentry.io/platforms/python/ (new client documentation) and https://docs.sentry.io/clients/python/ (old client documentation).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
