### PR TITLE
Fix email auth exemption and whitelist logic

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -111,7 +111,7 @@ DIT_EMAIL_INGEST_WHITELIST = [
     'unknown@trade.gov.uk',
 ]
 DIT_EMAIL_DOMAINS = {
-    'trade.gov.uk': ['exempt'],
+    'trade.gov.uk': [['exempt']],
     'digital.trade.gov.uk': [['spf', 'pass'], ['dmarc', 'bestguesspass'], ['dkim', 'pass']],
     'other.trade.gov.uk': [],
 }

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -14,9 +14,9 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
             None,
             True,
         ),
-        # Valid digital.trade.gov.uk email
+        # Valid digital.trade.gov.uk email, ensure whitelist is case insensitive
         (
-            'bill.adama@digital.trade.gov.uk',
+            'bill.Adama@digital.trade.gov.uk',
             '\n'.join([
                 'mx.google.com;',
                 'dkim=pass header.i=@digital.trade.gov.uk header.s=selector1 header.b=foobar;',

--- a/datahub/email_ingestion/validation.py
+++ b/datahub/email_ingestion/validation.py
@@ -52,7 +52,7 @@ def was_email_sent_by_dit(message):
         return False
 
     # TODO: Remove this logic once we are past the pilot period for email ingestion
-    if from_email not in settings.DIT_EMAIL_INGEST_WHITELIST:
+    if from_email.lower() not in settings.DIT_EMAIL_INGEST_WHITELIST:
         return False
 
     try:
@@ -64,7 +64,7 @@ def was_email_sent_by_dit(message):
         #  source exhaustively.
         domain_auth_methods = [*DEFAULT_AUTH_METHODS]
 
-    from_domain_is_authentication_exempt = domain_auth_methods == ['exempt']
+    from_domain_is_authentication_exempt = domain_auth_methods == [['exempt']]
     if from_domain_is_authentication_exempt:
         return True
     authentication_pass = _verify_authentication(message, domain_auth_methods)


### PR DESCRIPTION
### Description of change
This does the following:
- Fixes the logic for making a domain exempt.
- Ensures that we are dealing with fully lower case emails for the `DIT_EMAIL_INGEST_WHITELIST` setting.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
