### PR TITLE
Sync related OMIS orders to ES when a company or a contact name changes

### DIFF
--- a/changelog/omis/es-re-sync.bugfix.rst
+++ b/changelog/omis/es-re-sync.bugfix.rst
@@ -1,0 +1,1 @@
+When a company or a contact name changes, related OMIS orders are now synced to ElasticSearch.

--- a/datahub/search/omis/signals.py
+++ b/datahub/search/omis/signals.py
@@ -1,6 +1,7 @@
 from django.db import transaction
 from django.db.models.signals import post_delete, post_save
 
+from datahub.company.models import Company as DBCompany, Contact as DBContact
 from datahub.omis.order.models import (
     Order as DBOrder,
     OrderAssignee as DBOrderAssignee,
@@ -8,7 +9,7 @@ from datahub.omis.order.models import (
 )
 from datahub.search.omis import OrderSearchApp
 from datahub.search.signals import SignalReceiver
-from datahub.search.sync_object import sync_object_async
+from datahub.search.sync_object import sync_object_async, sync_related_objects_async
 
 
 def order_sync_es(instance):
@@ -23,10 +24,19 @@ def related_order_sync_es(instance):
     order_sync_es(instance.order)
 
 
+def sync_related_orders_to_es(instance):
+    """Sync related orders."""
+    transaction.on_commit(
+        lambda: sync_related_objects_async(instance, 'orders'),
+    )
+
+
 receivers = (
     SignalReceiver(post_save, DBOrder, order_sync_es),
     SignalReceiver(post_save, DBOrderSubscriber, related_order_sync_es),
     SignalReceiver(post_delete, DBOrderSubscriber, related_order_sync_es),
     SignalReceiver(post_save, DBOrderAssignee, related_order_sync_es),
     SignalReceiver(post_delete, DBOrderAssignee, related_order_sync_es),
+    SignalReceiver(post_save, DBCompany, sync_related_orders_to_es),
+    SignalReceiver(post_save, DBContact, sync_related_orders_to_es),
 )


### PR DESCRIPTION
### Description of change

If/when a company name or a contact name changes, the related ES OMIS order documents are now updated automatically.

I noticed this bug when reverting back DnB changes to a company.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
