### PR TITLE
Make email ingestion adviser lookups case insensitive

### DIFF
--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -41,8 +41,8 @@ def _get_best_match_adviser_by_email(email):
     Get the best-guess matching active adviser for a particular correspondence email
     address.
 
-    This firstly attempts to get the oldest Advisor object with a matching
-    `contact_email`, it will then attempt to match on `email`.  We prefer
+    This firstly attempts to get the oldest Advisor object with a (case insensitive) matching
+    `contact_email`, it will then attempt to match on (case insensitive) `email`.  We prefer
     `contact_email` over `email` as this should most closely match the correspondence
     email address - the context here is that we are dealing with the email
     accounts that advisers use for setting up meetings/emailing companies.
@@ -51,7 +51,7 @@ def _get_best_match_adviser_by_email(email):
     :returns: an Advisor object or None, if a match could not be found
     """
     for field in ['contact_email', 'email']:
-        criteria = {field: email, 'is_active': True}
+        criteria = {f'{field}__iexact': email, 'is_active': True}
         try:
             return Advisor.objects.filter(**criteria).earliest('date_joined')
         except Advisor.DoesNotExist:

--- a/datahub/interaction/test/email_processors/email_samples/valid/gmail/sample.eml
+++ b/datahub/interaction/test/email_processors/email_samples/valid/gmail/sample.eml
@@ -81,7 +81,7 @@ Sender: Google Calendar <calendar-notification@google.com>
 Message-ID: <0000000000002a99a005853a155c@google.com>
 Date: Fri, 29 Mar 2019 11:36:33 +0000
 Subject: Invitation: initial @ Fri 29 Mar 2019 4:30pm - 5:30pm (GMT) (bill.adama@example.net)
-From: correspondence3@digital.trade.gov.uk
+From: Correspondence3@digital.trade.gov.uk
 To: bill.adama@example.net,saul.tigh@example.net,unknown@example.net,adviser3@digital.trade.gov.uk
 CC: laura.roslin@example.net,saul.tigh@example.net,adviser2@digital.trade.gov.uk
 Content-Type: multipart/mixed; boundary="0000000000002a998305853a155b"

--- a/datahub/interaction/test/email_processors/test_parsers.py
+++ b/datahub/interaction/test/email_processors/test_parsers.py
@@ -136,7 +136,8 @@ class TestCalendarInteractionEmailParser:
             ),
             # Test that interaction data can be extracted for a complicated case
             # with many advisers, contacts and some unknown contacts,
-            # sample uses sender adviser's contact_email which is different to their email
+            # sample uses sender adviser's contact_email which is different to their email,
+            # email's From field has different case to the saved Adviser's contact_email field
             (
                 'email_samples/valid/gmail/sample.eml',
                 {


### PR DESCRIPTION
### Description of change

This modifies the adviser lookups for meeting invite email ingestion to be case insensitive.  This was a little naive before as unexpected capital letters in the email's `From` field were tripping up adviser matching.

### Points of note

I've decided not to add any new indexes for now following Reupen's observation that the number of advisers is so low that this should not be problematic.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
