### PR TITLE
Add gross_value_added field

### DIFF
--- a/datahub/activity_stream/investment/serializers.py
+++ b/datahub/activity_stream/investment/serializers.py
@@ -51,4 +51,7 @@ class IProjectCreatedSerializer(ActivitySerializer):
         if instance.number_new_jobs is not None:
             project['object']['dit:numberNewJobs'] = instance.number_new_jobs
 
+        if instance.gross_value_added is not None:
+            project['object']['dit:grossValueAdded'] = instance.gross_value_added
+
         return project

--- a/datahub/activity_stream/investment/tests/test_views.py
+++ b/datahub/activity_stream/investment/tests/test_views.py
@@ -3,6 +3,7 @@ from rest_framework import status
 
 from datahub.activity_stream.tests import hawk
 from datahub.activity_stream.tests.utils import get_url
+from datahub.core import constants
 from datahub.core.test_utils import format_date_or_datetime
 from datahub.investment.project.test.factories import (
     AssignPMInvestmentProjectFactory,
@@ -196,6 +197,78 @@ def test_investment_project_verify_win_added(api_client):
                     'dit:totalInvestment': project.total_investment,
                     'dit:foreignEquityInvestment': project.foreign_equity_investment,
                     'dit:numberNewJobs': project.number_new_jobs,
+                    'attributedTo': [
+                        {
+                            'id': f'dit:DataHubCompany:{project.investor_company.pk}',
+                            'dit:dunsNumber': project.investor_company.duns_number,
+                            'dit:companiesHouseNumber': project.investor_company.company_number,
+                            'type': ['Organization', 'dit:Company'],
+                            'name': project.investor_company.name,
+                        },
+                        *[
+                            {
+                                'id': f'dit:DataHubContact:{contact.pk}',
+                                'type': ['Person', 'dit:Contact'],
+                                'dit:emailAddress': contact.email,
+                                'name': contact.name,
+                            }
+                            for contact in project.client_contacts.order_by('pk')
+                        ],
+                    ],
+                    'url': project.get_absolute_url(),
+                },
+            },
+        ],
+    }
+
+
+@pytest.mark.django_db
+def test_investment_project_added_with_gva(api_client):
+    """
+    This test adds the necessary fields to compute gross_value_added property
+    and tests if its included in the response.
+    """
+    project = InvestmentProjectFactory(
+        foreign_equity_investment=10000,
+        sector_id=constants.Sector.aerospace_assembly_aircraft.value.id,
+        investment_type_id=constants.InvestmentType.fdi.value.id,
+    )
+    response = hawk.get(api_client, get_url('api-v3:activity-stream:investment-project-added'))
+    assert response.status_code == status.HTTP_200_OK
+
+    assert response.json() == {
+        '@context': 'https://www.w3.org/ns/activitystreams',
+        'summary': 'Investment Activities Added',
+        'type': 'OrderedCollectionPage',
+        'id': 'http://testserver/v3/activity-stream/investment/project-added',
+        'partOf': 'http://testserver/v3/activity-stream/investment/project-added',
+        'previous': None,
+        'next': None,
+        'orderedItems': [
+            {
+                'id': f'dit:DataHubInvestmentProject:{project.id}:Add',
+                'type': 'Add',
+                'published': format_date_or_datetime(project.created_on),
+                'generator': {'name': 'dit:dataHub', 'type': 'Application'},
+                'actor': {
+                    'id': f'dit:DataHubAdviser:{project.created_by.pk}',
+                    'type': ['Person', 'dit:Adviser'],
+                    'dit:emailAddress':
+                        project.created_by.contact_email or project.created_by.email,
+                    'name': project.created_by.name,
+                },
+                'object': {
+                    'id': f'dit:DataHubInvestmentProject:{project.id}',
+                    'type': ['dit:InvestmentProject'],
+                    'name': project.name,
+                    'dit:investmentType': {
+                        'name': project.investment_type.name,
+                    },
+                    'dit:estimatedLandDate': format_date_or_datetime(
+                        project.estimated_land_date,
+                    ),
+                    'dit:foreignEquityInvestment': 10000.0,
+                    'dit:grossValueAdded': 581.0,
                     'attributedTo': [
                         {
                             'id': f'dit:DataHubCompany:{project.investor_company.pk}',


### PR DESCRIPTION
### Description of change

Adding the gross_value_added field to the response when it is available. New design can be found [here](https://drive.google.com/drive/u/3/folders/1UDKG1iOrGHISVyPF6z1tvGdllAZZj0gd).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?