### PR TITLE
Add dit:jobTitle to activity serializers output

### DIFF
--- a/changelog/activity-stream-contact-job-title.api.rst
+++ b/changelog/activity-stream-contact-job-title.api.rst
@@ -1,0 +1,1 @@
+The activity-stream payload will now contain `dit:jobTitle` for all `dit:DataHubContact`.

--- a/datahub/activity_stream/interaction/tests/test_views.py
+++ b/datahub/activity_stream/interaction/tests/test_views.py
@@ -74,6 +74,7 @@ def test_interaction_activity(api_client):
                                 'id': f'dit:DataHubContact:{contact.pk}',
                                 'type': ['Person', 'dit:Contact'],
                                 'dit:emailAddress': contact.email,
+                                'dit:jobTitle': contact.job_title,
                                 'name': contact.name,
                             }
                             for contact in interaction.contacts.order_by('pk')
@@ -143,6 +144,7 @@ def test_interaction_investment_project_activity(api_client):
                                 'id': f'dit:DataHubContact:{contact.pk}',
                                 'type': ['Person', 'dit:Contact'],
                                 'dit:emailAddress': contact.email,
+                                'dit:jobTitle': contact.job_title,
                                 'name': contact.name,
                             }
                             for contact in interaction.contacts.order_by('pk')
@@ -218,6 +220,7 @@ def test_service_delivery_activity(api_client):
                                 'id': f'dit:DataHubContact:{contact.pk}',
                                 'type': ['Person', 'dit:Contact'],
                                 'dit:emailAddress': contact.email,
+                                'dit:jobTitle': contact.job_title,
                                 'name': contact.name,
                             }
                             for contact in interaction.contacts.order_by('pk')
@@ -286,6 +289,7 @@ def test_service_delivery_event_activity(api_client):
                                 'id': f'dit:DataHubContact:{contact.pk}',
                                 'type': ['Person', 'dit:Contact'],
                                 'dit:emailAddress': contact.email,
+                                'dit:jobTitle': contact.job_title,
                                 'name': contact.name,
                             }
                             for contact in interaction.contacts.order_by('pk')

--- a/datahub/activity_stream/investment/tests/test_views.py
+++ b/datahub/activity_stream/investment/tests/test_views.py
@@ -66,6 +66,7 @@ def test_investment_project_added(api_client):
                                 'id': f'dit:DataHubContact:{contact.pk}',
                                 'type': ['Person', 'dit:Contact'],
                                 'dit:emailAddress': contact.email,
+                                'dit:jobTitle': contact.job_title,
                                 'name': contact.name,
                             }
                             for contact in project.client_contacts.order_by('pk')
@@ -137,6 +138,7 @@ def test_investment_project_with_pm_added(api_client):
                                 'id': f'dit:DataHubContact:{contact.pk}',
                                 'type': ['Person', 'dit:Contact'],
                                 'dit:emailAddress': contact.email,
+                                'dit:jobTitle': contact.job_title,
                                 'name': contact.name,
                             }
                             for contact in project.client_contacts.order_by('pk')
@@ -210,6 +212,7 @@ def test_investment_project_verify_win_added(api_client):
                                 'id': f'dit:DataHubContact:{contact.pk}',
                                 'type': ['Person', 'dit:Contact'],
                                 'dit:emailAddress': contact.email,
+                                'dit:jobTitle': contact.job_title,
                                 'name': contact.name,
                             }
                             for contact in project.client_contacts.order_by('pk')
@@ -282,6 +285,7 @@ def test_investment_project_added_with_gva(api_client):
                                 'id': f'dit:DataHubContact:{contact.pk}',
                                 'type': ['Person', 'dit:Contact'],
                                 'dit:emailAddress': contact.email,
+                                'dit:jobTitle': contact.job_title,
                                 'name': contact.name,
                             }
                             for contact in project.client_contacts.order_by('pk')

--- a/datahub/activity_stream/omis/tests/test_views.py
+++ b/datahub/activity_stream/omis/tests/test_views.py
@@ -56,6 +56,7 @@ def test_omis_order_added_activity(api_client, order_overrides):
                             'id': f'dit:DataHubContact:{order.contact.pk}',
                             'type': ['Person', 'dit:Contact'],
                             'dit:emailAddress': order.contact.email,
+                            'dit:jobTitle': order.contact.job_title,
                             'name': order.contact.name,
                         },
                     ],

--- a/datahub/activity_stream/serializers.py
+++ b/datahub/activity_stream/serializers.py
@@ -29,6 +29,7 @@ class ActivitySerializer(serializers.Serializer):
             'id': f'dit:DataHubContact:{contact.pk}',
             'type': ['Person', 'dit:Contact'],
             'dit:emailAddress': contact.email,
+            'dit:jobTitle': contact.job_title,
             'name': contact.name,
         }
 


### PR DESCRIPTION
### Description of change

We missed this in the spec.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
