### PR TITLE
Add a mechanism to suppress email ingest connect errors until a threshold is reached

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `MAILBOX_MEETINGS_PASSWORD` | No | Password for the inbox for ingesting meeting invites via IMAP |
 | `MAILBOX_MEETINGS_IMAP_DOMAIN` | No | IMAP domain for the inbox for ingesting meeting invites via IMAP |
 | `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass\|spf:pass\|dkim:pass |
+| `EMAIL_INGESTION_FREQUENCY_SECONDS` | No | The frequency (in seconds) that the email ingestion beat should run, defaults to 30.0 |
+| `EMAIL_INGESTION_CONNECT_FAILURE_THRESHOLD` | No | The number of acceptable email inbox connection failures within a window of 10 tries, before an error should be raised |
 
 
 ## Management commands

--- a/changelog/interaction/email-ingest-error-suppression.internal.rst
+++ b/changelog/interaction/email-ingest-error-suppression.internal.rst
@@ -1,0 +1,4 @@
+A mechanism was added to suppress email ingestion IMAP connection errors until
+a configurable threshold is met within a window of 10 tries. This helps reduce
+noise in error reporting occurring from occasional connection errors to flaky
+external IMAP endpoints.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -337,6 +337,10 @@ if REDIS_BASE_URL:
         }
     }
 
+# Every 30 seconds, by default
+EMAIL_INGESTION_FREQUENCY_SECONDS = env.float('EMAIL_INGESTION_FREQUENCY_SECONDS', 30.0)
+# Our limit before reporting connection failures in a particular window (out of 10 tries)
+EMAIL_INGESTION_CONNECT_FAILURE_THRESHOLD = env.int('EMAIL_INGESTION_CONNECT_FAILURE_THRESHOLD', 5)
 
 if REDIS_BASE_URL:
     REDIS_CELERY_DB = env('REDIS_CELERY_DB', default=1)
@@ -389,7 +393,7 @@ if REDIS_BASE_URL:
     if env.bool('ENABLE_EMAIL_INGESTION', False):
         CELERY_BEAT_SCHEDULE['email_ingestion'] = {
             'task': 'datahub.email_ingestion.tasks.ingest_emails',
-            'schedule': 30.0, # Every 30 seconds
+            'schedule': EMAIL_INGESTION_FREQUENCY_SECONDS,
         }
 
     CELERY_WORKER_LOG_FORMAT = (

--- a/datahub/email_ingestion/tasks.py
+++ b/datahub/email_ingestion/tasks.py
@@ -1,12 +1,50 @@
 from celery import shared_task
 from celery.utils.log import get_task_logger
+from django.conf import settings
+from django.core.cache import cache
 from django_pglocks import advisory_lock
 
 from datahub.email_ingestion import mailbox_handler
+from datahub.email_ingestion.mailbox import EmailInboxConnectionError
 from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.interaction import INTERACTION_EMAIL_INGESTION_FEATURE_FLAG_NAME
 
 logger = get_task_logger(__name__)
+
+
+def handle_connection_error(exc, mailbox_identifier):
+    """
+    Handles an EmailInboxConnectionError exception which has been raised when connecting to an
+    email inbox.  This will keep a count of the number of failures within the last 10
+    attempts and will raise an EmailInboxConnectionError exception if the number
+    of failures has exceeded the EMAIL_INGESTION_CONNECT_FAILURE_THRESHOLD setting.
+
+    This will only raise one exception each time that the number of connection errors
+    exceeds EMAIL_INGESTION_CONNECT_FAILURE_THRESHOLD within the 10 attempt window.
+    e.g. If we have a threshold of 5, one exception will be raised to represent
+    the first 5 failures and a second exception will only be raised after another
+    subsequent 5 failures. This stops the exceptions from being too noisy.
+    """
+    email_ingest_failures_key = f'email_ingest_failures_{mailbox_identifier}'
+    window_size = 10
+    try:
+        failures = cache.incr(email_ingest_failures_key)
+    except ValueError:
+        # We are not tracking failures for the current window, so we need to add a new cache entry
+        failures = 1
+        failure_window = int(settings.EMAIL_INGESTION_FREQUENCY_SECONDS) * window_size
+        cache.set(email_ingest_failures_key, failures, failure_window)
+
+    if failures >= settings.EMAIL_INGESTION_CONNECT_FAILURE_THRESHOLD:
+        # Delete the failure tracker cache entry - so that we need to hit the threshold
+        # again before raising the next error
+        cache.delete(email_ingest_failures_key)
+        original_exc_message = exc.args[0]
+        raise EmailInboxConnectionError(
+            f'Connecting to mailbox {mailbox_identifier} has failed {failures} times out of '
+            f'{window_size} connection attempts. The latest failure was: '
+            f'{original_exc_message}',
+        ) from exc
 
 
 @shared_task(acks_late=True, priority=9)
@@ -32,4 +70,7 @@ def ingest_emails():
             logger.info('Emails are already being ingested by another worker')
             return
         for mailbox in mailbox_handler.get_all_mailboxes():
-            mailbox.process_new_mail()
+            try:
+                mailbox.process_new_mail()
+            except EmailInboxConnectionError as exc:
+                handle_connection_error(exc, mailbox.username)


### PR DESCRIPTION
### Description of change

There are some occasional (4 in the past week) connection errors flagged on sentry which are raised from the `ingest_emails` task while connecting to IMAP.  This change aims to suppress these errors until we really need to hear about them.  In our case, I've made it so that we only raise the exception after there has been 5 failures within the last 10 tries.  The suppression mechanism uses redis to track the failures within the period of time of the last 10 runs.

I considered making this a general purpose error suppression utility, but I can't see many uses for it yet.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
