### PR TITLE
Add team to the interaction activity payload

### DIFF
--- a/changelog/interaction-activity-stream-team.api.rst
+++ b/changelog/interaction-activity-stream-team.api.rst
@@ -1,0 +1,1 @@
+The activity-stream payload will now contain ``dit:team`` for all ``dit:DataHubAdviser``.

--- a/datahub/activity_stream/interaction/serializers.py
+++ b/datahub/activity_stream/interaction/serializers.py
@@ -42,9 +42,15 @@ class InteractionActivitySerializer(ActivitySerializer):
             context = {}
         return context
 
+    def _get_adviser_with_team(self, participant):
+        adviser = self._get_adviser(participant.adviser)
+        if participant.team is not None:
+            adviser['dit:team'] = self._get_team(participant.team)
+        return adviser
+
     def _get_dit_participants(self, participants):
         return [
-            self._get_adviser(participant.adviser)
+            self._get_adviser_with_team(participant)
             for participant in participants.all()
             if participant.adviser is not None
         ]

--- a/datahub/activity_stream/interaction/tests/test_views.py
+++ b/datahub/activity_stream/interaction/tests/test_views.py
@@ -66,6 +66,11 @@ def test_interaction_activity(api_client):
                                 'dit:emailAddress':
                                     participant.adviser.contact_email or participant.adviser.email,
                                 'name': participant.adviser.name,
+                                'dit:team': {
+                                    'id': f'dit:DataHubTeam:{participant.team.pk}',
+                                    'type': ['Group', 'dit:Team'],
+                                    'name': participant.team.name,
+                                },
                             }
                             for participant in interaction.dit_participants.order_by('pk')
                         ],
@@ -137,6 +142,11 @@ def test_interaction_investment_project_activity(api_client):
                                 'dit:emailAddress':
                                     participant.adviser.contact_email or participant.adviser.email,
                                 'name': participant.adviser.name,
+                                'dit:team': {
+                                    'id': f'dit:DataHubTeam:{participant.team.pk}',
+                                    'type': ['Group', 'dit:Team'],
+                                    'name': participant.team.name,
+                                },
                             }
                             for participant in interaction.dit_participants.order_by('pk')
                         ],
@@ -214,6 +224,11 @@ def test_service_delivery_activity(api_client):
                                 'dit:emailAddress':
                                     participant.adviser.contact_email or participant.adviser.email,
                                 'name': participant.adviser.name,
+                                'dit:team': {
+                                    'id': f'dit:DataHubTeam:{participant.team.pk}',
+                                    'type': ['Group', 'dit:Team'],
+                                    'name': participant.team.name,
+                                },
                             }
                             for participant in interaction.dit_participants.order_by('pk')
                         ],
@@ -284,6 +299,11 @@ def test_service_delivery_event_activity(api_client):
                                 'dit:emailAddress':
                                     participant.adviser.contact_email or participant.adviser.email,
                                 'name': participant.adviser.name,
+                                'dit:team': {
+                                    'id': f'dit:DataHubTeam:{participant.team.pk}',
+                                    'type': ['Group', 'dit:Team'],
+                                    'name': participant.team.name,
+                                },
                             }
                             for participant in interaction.dit_participants.order_by('pk')
                         ],


### PR DESCRIPTION
### Description of change

When we first implemented activity streams, there was a bit of confusion around `dit:team`. This was because `interactions.dit_participants[..].team` is the team that an adviser *was* part of at the time the interaction was recorded.

We now have confirmed with product that this is indeed what we want to display and so this PR includes the `dit:team` in the interactions activity payload.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
