### PR TITLE
Add format_json_as_html() utility function for admin

### DIFF
--- a/datahub/core/admin.py
+++ b/datahub/core/admin.py
@@ -1,3 +1,4 @@
+import json
 from functools import wraps
 from urllib.parse import urlencode
 
@@ -327,6 +328,29 @@ def get_change_link(obj, site=admin.site):
         return ''
 
     return format_html('<a href="{url}">{name}</a>'.format(url=url, name=obj))
+
+
+def format_json_as_html(value):
+    """
+    Serialises an object as pretty JSON, and HTML-encodes it in a <pre> tag.
+
+    This is useful for displaying JSON fields in the admin site.
+
+    Usage example:
+
+        class InteractionAdmin(ModelAdmin):
+            readonly_fields = (
+                # also make sure source is not included
+                'pretty_source',
+            )
+
+            def pretty_source(self, obj):
+                return format_json_as_html(obj.source)
+
+            pretty_source.short_description = 'source'
+
+    """
+    return format_html('<pre>{0}</pre>', json.dumps(value, indent=2))
 
 
 def _make_admin_permission_getter(codename):

--- a/datahub/core/test/test_admin.py
+++ b/datahub/core/test/test_admin.py
@@ -12,6 +12,7 @@ from datahub.core.admin import (
     custom_change_permission,
     custom_delete_permission,
     custom_view_permission,
+    format_json_as_html,
     get_change_link,
     get_change_url,
     RawIdWidget,
@@ -250,3 +251,26 @@ class TestGetChangeLink:
     def test_returns_empty_string_if_obj_is_none(self):
         """Test that if None is passed, an empty link is returned."""
         assert get_change_link(None) == ''
+
+
+class TestFormatJsonAsHtml:
+    """Tests for format_json_as_html()."""
+
+    @pytest.mark.parametrize(
+        'value,expected_output',
+        (
+            (
+                None,
+                '<pre>null</pre>',
+            ),
+            (
+                {1: '<'},
+                """<pre>{
+  &quot;1&quot;: &quot;&lt;&quot;
+}</pre>""",
+            ),
+        ),
+    )
+    def test_format_json_as_html(self, value, expected_output):
+        """Test that various values are serialised and escaped as expected."""
+        assert format_json_as_html(value) == expected_output

--- a/datahub/interaction/admin.py
+++ b/datahub/interaction/admin.py
@@ -1,7 +1,4 @@
-import json
-
 from django.contrib import admin
-from django.utils.html import format_html
 from reversion.admin import VersionAdmin
 
 from datahub.core.admin import (
@@ -9,6 +6,7 @@ from datahub.core.admin import (
     custom_add_permission,
     custom_change_permission,
     custom_view_permission,
+    format_json_as_html,
 )
 from datahub.core.utils import join_truthy_strings
 from datahub.interaction.admin_csv_import.views import InteractionCSVImportAdmin
@@ -139,7 +137,7 @@ class InteractionAdmin(BaseModelAdminMixin, VersionAdmin):
         """
         Return the source field formatted with indentation.
         """
-        return format_html('<pre>{0}</pre>', json.dumps(obj.source, indent=2))
+        return format_json_as_html(obj.source)
 
     pretty_source.short_description = 'source'
 

--- a/datahub/user_event_log/admin.py
+++ b/datahub/user_event_log/admin.py
@@ -1,9 +1,6 @@
-import json
-
 from django.contrib import admin
-from django.utils.html import format_html
 
-from datahub.core.admin import get_change_link, ViewOnlyAdmin
+from datahub.core.admin import format_json_as_html, get_change_link, ViewOnlyAdmin
 from datahub.user_event_log.models import UserEvent
 
 
@@ -32,6 +29,6 @@ class UserEventAdmin(ViewOnlyAdmin):
 
     def pretty_data(self, obj):
         """Returns the data field formatted with indentation."""
-        return format_html('<pre>{0}</pre>', json.dumps(obj.data, indent=2))
+        return format_json_as_html(obj.data)
 
     pretty_data.short_description = 'data'


### PR DESCRIPTION
### Description of change

This adds a shared utility function `format_json_as_html()` to use in the admin site for displaying JSON fields.

This is split from https://github.com/uktrade/data-hub-leeloo/pull/1772 to try and reduce the size of that PR.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
