### PR TITLE
Spike: notify advisers

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -72,6 +72,7 @@ LOCAL_APPS = [
     'datahub.investment.project.proposition',
     'datahub.investment.project.report',
     'datahub.investment.investor_profile',
+    'datahub.notification',
     'datahub.metadata',
     'datahub.oauth',
     'datahub.admin_report',
@@ -568,3 +569,5 @@ for environ_name in domain_environ_names:
             for domain, auth in domain_details.items()
         }
     )
+
+DATAHUB_NOTIFICATION_API_KEY = env('DATAHUB_NOTIFICATION_API_KEY', default='')

--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -7,22 +7,16 @@ from django.core.exceptions import ValidationError
 from django.utils.timezone import utc
 
 from datahub.company.contact_matching import find_active_contact_by_email_address
-from datahub.company.models.adviser import Advisor
 from datahub.email_ingestion.validation import was_email_sent_by_dit
+from datahub.interaction.email_processors.utils import (
+    get_all_recipients,
+    get_best_match_adviser_by_email,
+)
 
 ICALENDAR_CONTENT_TYPE = 'application/ics'
 BEGIN_VCALENDAR = 'BEGIN:VCALENDAR'
 CALENDAR_STATUS_CONFIRMED = 'CONFIRMED'
 CALENDAR_COMPONENT_VEVENT = 'VEVENT'
-
-
-def _get_all_recipients(message):
-    """
-    Get all of the recipient emails from a MailParser message object.
-
-    :returns: a set of all recipient emails
-    """
-    return {email.strip() for name, email in (*message.to, *message.cc)}
 
 
 def _get_top_company_from_contacts(contacts):
@@ -34,29 +28,6 @@ def _get_top_company_from_contacts(contacts):
     company_counts = Counter(contact.company for contact in contacts)
     top_company, _ = company_counts.most_common(1)[0]
     return top_company
-
-
-def _get_best_match_adviser_by_email(email):
-    """
-    Get the best-guess matching active adviser for a particular correspondence email
-    address.
-
-    This firstly attempts to get the oldest Advisor object with a (case insensitive) matching
-    `contact_email`, it will then attempt to match on (case insensitive) `email`.  We prefer
-    `contact_email` over `email` as this should most closely match the correspondence
-    email address - the context here is that we are dealing with the email
-    accounts that advisers use for setting up meetings/emailing companies.
-
-    :param email: string email address
-    :returns: an Advisor object or None, if a match could not be found
-    """
-    for field in ['contact_email', 'email']:
-        criteria = {f'{field}__iexact': email, 'is_active': True}
-        try:
-            return Advisor.objects.filter(**criteria).earliest('date_joined')
-        except Advisor.DoesNotExist:
-            continue
-    return None
 
 
 def _extract_calendar_string_from_text(message):
@@ -123,10 +94,13 @@ class CalendarInteractionEmailParser:
         except IndexError:
             raise ValidationError('Email was malformed - missing "from" header')
         if not was_email_sent_by_dit(self.message):
-            raise ValidationError('Email not sent by DIT')
-        sender_adviser = _get_best_match_adviser_by_email(sender_email)
+            raise ValidationError(
+                'The meeting email did not pass our minimal checks to be verified as '
+                'having been sent by a valid DIT Adviser email domain.',
+            )
+        sender_adviser = get_best_match_adviser_by_email(sender_email)
         if not sender_adviser:
-            raise ValidationError('Email not sent by recognised DIT Adviser')
+            raise ValidationError('The meeting email was not sent by a recognised DIT Adviser.')
         return sender_adviser
 
     def _extract_and_validate_contacts(self, all_recipients):
@@ -136,7 +110,10 @@ class CalendarInteractionEmailParser:
             if contact:
                 contacts.append(contact)
         if not contacts:
-            raise ValidationError('No email recipients were recognised as Contacts')
+            raise ValidationError(
+                'No email recipients were recognised as company contacts in Data Hub - please '
+                'ensure that at least one recipient is a company contact known by Data Hub.',
+            )
         return contacts
 
     def _extract_secondary_advisers(self, all_recipients, sender_adviser):
@@ -146,13 +123,16 @@ class CalendarInteractionEmailParser:
         """
         secondary_advisers = []
         for recipient_email in all_recipients:
-            adviser = _get_best_match_adviser_by_email(recipient_email)
+            adviser = get_best_match_adviser_by_email(recipient_email)
             if adviser and adviser != sender_adviser:
                 secondary_advisers.append(adviser)
         return secondary_advisers
 
     def _extract_and_validate_calendar_event_component(self):
-        error = ValidationError('No calendar event could be extracted')
+        error = ValidationError(
+            'No calendar event could be extracted - the iCalendar attachment was either '
+            'missing or badly formatted.',
+        )
         calendar_string = _extract_calendar_string_from_text(self.message)
         if not calendar_string:
             calendar_string = _extract_calendar_string_from_attachments(self.message)
@@ -167,11 +147,11 @@ class CalendarInteractionEmailParser:
             if comp.name == CALENDAR_COMPONENT_VEVENT
         ]
         if len(calendar_event_components) == 0:
-            raise ValidationError('No calendar event was found in the calendar')
+            raise ValidationError('No calendar event was found in the iCalendar attachment.')
         if len(calendar_event_components) > 1:
             raise ValidationError(
                 f'There were {len(calendar_event_components)} events in the calendar '
-                '- expected 1 event',
+                '- expected 1 event in the iCalendar attachment.',
             )
         return calendar_event_components[0]
 
@@ -190,7 +170,9 @@ class CalendarInteractionEmailParser:
 
         meeting_confirmed = calendar_event['status'] == CALENDAR_STATUS_CONFIRMED
         if not meeting_confirmed:
-            raise ValidationError(f'Calendar event was not status: {CALENDAR_STATUS_CONFIRMED}')
+            raise ValidationError(
+                f'The calendar event was not status: {CALENDAR_STATUS_CONFIRMED}.',
+            )
 
         return calendar_event
 
@@ -202,7 +184,7 @@ class CalendarInteractionEmailParser:
         or is invalid according to business logic.
         """
         calendar_event = self._extract_and_validate_calendar_event_metadata()
-        all_recipients = _get_all_recipients(self.message)
+        all_recipients = get_all_recipients(self.message)
         sender = self._extract_and_validate_sender_adviser()
         secondary_advisers = self._extract_secondary_advisers(all_recipients, sender)
         contacts = self._extract_and_validate_contacts(all_recipients)

--- a/datahub/interaction/email_processors/processors.py
+++ b/datahub/interaction/email_processors/processors.py
@@ -9,7 +9,10 @@ from datahub.interaction.email_processors.utils import (
     get_best_match_adviser_by_email,
 )
 from datahub.interaction.models import Interaction
-from datahub.interaction.notify import notify_meeting_ingest_failure
+from datahub.interaction.notify import (
+    notify_meeting_ingest_failure,
+    notify_meeting_ingest_success,
+)
 from datahub.interaction.serializers import InteractionSerializer
 
 
@@ -172,4 +175,5 @@ class CalendarInteractionEmailProcessor(EmailProcessor):
             return (False, 'Meeting already exists as an interaction')
 
         interaction = self.save_serializer_as_interaction(serializer, interaction_data)
+        notify_meeting_ingest_success(interaction_data['sender'], interaction)
         return (True, f'Successfully created interaction #{interaction.id}')

--- a/datahub/interaction/email_processors/processors.py
+++ b/datahub/interaction/email_processors/processors.py
@@ -4,19 +4,24 @@ from rest_framework import serializers
 
 from datahub.email_ingestion.email_processor import EmailProcessor
 from datahub.interaction.email_processors.parsers import CalendarInteractionEmailParser
+from datahub.interaction.email_processors.utils import (
+    get_all_recipients,
+    get_best_match_adviser_by_email,
+)
 from datahub.interaction.models import Interaction
+from datahub.interaction.notify import notify_meeting_ingest_failure
 from datahub.interaction.serializers import InteractionSerializer
 
 
-def _flatten_serializer_errors_to_string(serializer_errors):
+def _flatten_serializer_errors_to_list(serializer_errors):
     """
-    Flatten DRF Serializer validation errors to a string with one field per line.
+    Flatten DRF Serializer validation errors to a list with one field per item.
     """
-    error_parts = []
+    field_errors = []
     for field_name, details in serializer_errors.items():
         details_string = ','.join([str(detail) for detail in details])
-        error_parts.append(f'{field_name}: {details_string}')
-    return '\n'.join(error_parts)
+        field_errors.append(f'{field_name}: {details_string}')
+    return field_errors
 
 
 def _filter_contacts_to_single_company(contacts, company):
@@ -58,6 +63,17 @@ class CalendarInteractionEmailProcessor(EmailProcessor):
     meeting, parses meeting information and creates a draft Interaction model
     instance for it if the information is valid.
     """
+
+    def _notify_meeting_ingest_failure(self, message, errors):
+        try:
+            sender_email = message.from_[0][1]
+        except IndexError:
+            return
+        sender_adviser = get_best_match_adviser_by_email(sender_email)
+        if not sender_adviser:
+            return
+        recipient_emails = get_all_recipients(message)
+        notify_meeting_ingest_failure(sender_adviser, errors, recipient_emails)
 
     def _to_serializer_format(self, data):
         dit_participants = [
@@ -121,7 +137,9 @@ class CalendarInteractionEmailProcessor(EmailProcessor):
         try:
             interaction_data = email_parser.extract_interaction_data_from_email()
         except ValidationError as exc:
-            return (False, exc.message)  # noqa: B306
+            error_message = exc.args[0]
+            self._notify_meeting_ingest_failure(message, [error_message])
+            return (False, error_message)
 
         # Make the same-company check easy to remove later if we allow Interactions
         # to have contacts from more than one company
@@ -142,7 +160,9 @@ class CalendarInteractionEmailProcessor(EmailProcessor):
         try:
             serializer = self.validate_with_serializer(interaction_data)
         except serializers.ValidationError as exc:
-            return (False, _flatten_serializer_errors_to_string(exc.detail))
+            errors = _flatten_serializer_errors_to_list(exc.detail)
+            self._notify_meeting_ingest_failure(message, errors)
+            return (False, '\n'.join(errors))
 
         # For our initial iteration of this feature, we are ignoring meeting updates
         matching_interactions = Interaction.objects.filter(

--- a/datahub/interaction/email_processors/utils.py
+++ b/datahub/interaction/email_processors/utils.py
@@ -1,0 +1,33 @@
+from datahub.company.models import Advisor
+
+
+def get_best_match_adviser_by_email(email):
+    """
+    Get the best-guess matching active adviser for a particular correspondence email
+    address.
+
+    This firstly attempts to get the oldest Advisor object with a (case insensitive) matching
+    `contact_email`, it will then attempt to match on (case insensitive) `email`.  We prefer
+    `contact_email` over `email` as this should most closely match the correspondence
+    email address - the context here is that we are dealing with the email
+    accounts that advisers use for setting up meetings/emailing companies.
+
+    :param email: string email address
+    :returns: an Advisor object or None, if a match could not be found
+    """
+    for field in ['contact_email', 'email']:
+        criteria = {f'{field}__iexact': email, 'is_active': True}
+        try:
+            return Advisor.objects.filter(**criteria).earliest('date_joined')
+        except Advisor.DoesNotExist:
+            continue
+    return None
+
+
+def get_all_recipients(message):
+    """
+    Get all of the recipient emails from a MailParser message object.
+
+    :returns: a set of all recipient emails
+    """
+    return {email.strip() for name, email in (*message.to, *message.cc)}

--- a/datahub/interaction/notify.py
+++ b/datahub/interaction/notify.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from datahub.notification.notify import notify_adviser
+from datahub.notification.notify import notify_adviser_by_email
 
 
 class Templates(Enum):
@@ -9,15 +9,34 @@ class Templates(Enum):
     """
 
     meeting_ingest_failure = 'fc2c07d5-9f3b-4647-853e-68c324565577'
+    meeting_ingest_success = '47418011-3f53-4b39-860a-30969b29781b'
 
 
 def notify_meeting_ingest_failure(adviser, errors, recipients):
+    """
+    Notify an adviser that a meeting ingest has failed - including error
+    details.
+    """
     flat_recipients = ', '.join(recipients)
-    notify_adviser(
+    notify_adviser_by_email(
         adviser,
         Templates.meeting_ingest_failure.value,
         context={
             'errors': errors,
             'recipients': flat_recipients,
+        },
+    )
+
+
+def notify_meeting_ingest_success(adviser, interaction):
+    """
+    Notify an adviser that a meeting ingest has succeeeded - including a link
+    to the interaction.
+    """
+    notify_adviser_by_email(
+        adviser,
+        Templates.meeting_ingest_success.value,
+        context={
+            'interaction_url': interaction.get_absolute_url(),
         },
     )

--- a/datahub/interaction/notify.py
+++ b/datahub/interaction/notify.py
@@ -1,0 +1,25 @@
+from enum import Enum
+
+from datahub.notification.notify import notify_adviser
+
+
+class Templates(Enum):
+    """GOV.UK notifications template ids."""
+
+    meeting_invite_ingest_failure = 'fc2c07d5-9f3b-4647-853e-68c324565577'
+
+
+def notify_meeting_ingest_failure(adviser, errors, recipients):
+    flat_errors = [
+        'Subject: This should be less than 80 characters',
+        'Contacts: There were no recipients known by as contacts in Data Hub',
+    ]
+    flat_recipients = ', '.join(recipients)
+    notify_adviser(
+        adviser,
+        Templates.meeting_invite_ingest_failure.value,
+        context={
+            'errors': flat_errors,
+            'recipients': flat_recipients,
+        },
+    )

--- a/datahub/interaction/notify.py
+++ b/datahub/interaction/notify.py
@@ -4,22 +4,20 @@ from datahub.notification.notify import notify_adviser
 
 
 class Templates(Enum):
-    """GOV.UK notifications template ids."""
+    """
+    GOV.UK notifications template ids.
+    """
 
-    meeting_invite_ingest_failure = 'fc2c07d5-9f3b-4647-853e-68c324565577'
+    meeting_ingest_failure = 'fc2c07d5-9f3b-4647-853e-68c324565577'
 
 
 def notify_meeting_ingest_failure(adviser, errors, recipients):
-    flat_errors = [
-        'Subject: This should be less than 80 characters',
-        'Contacts: There were no recipients known by as contacts in Data Hub',
-    ]
     flat_recipients = ', '.join(recipients)
     notify_adviser(
         adviser,
-        Templates.meeting_invite_ingest_failure.value,
+        Templates.meeting_ingest_failure.value,
         context={
-            'errors': flat_errors,
+            'errors': errors,
             'recipients': flat_recipients,
         },
     )

--- a/datahub/notification/__init__.py
+++ b/datahub/notification/__init__.py
@@ -1,0 +1,1 @@
+from datahub.notification import core

--- a/datahub/notification/__init__.py
+++ b/datahub/notification/__init__.py
@@ -1,1 +1,3 @@
 from datahub.notification import core
+
+client = core.client

--- a/datahub/notification/constants.py
+++ b/datahub/notification/constants.py
@@ -1,0 +1,3 @@
+TEMPLATES = {
+    'meeting_invite_ingestion_failure': 'fc2c07d5-9f3b-4647-853e-68c324565577',
+}

--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -1,0 +1,44 @@
+import warnings
+from unittest import mock
+
+from django.conf import settings
+from notifications_python_client.notifications import NotificationsAPIClient
+
+
+class NotificationClient:
+    """
+    """
+
+    def __init__(self):
+        """Init underlying notification client."""
+        if settings.DATAHUB_NOTIFICATION_API_KEY:
+            self.client = NotificationsAPIClient(
+                settings.DATAHUB_NOTIFICATION_API_KEY,
+            )
+        else:
+            self.client = mock.Mock(spec_set=NotificationsAPIClient)
+            warnings.warn(
+                '`settings.DATAHUB_NOTIFICATION_API_KEY` not specified therefore all '
+                'Data Hub notifications will be mocked. '
+                "You might want to change this if it's not a "
+                'testing or development environment.',
+                RuntimeWarning,
+                stacklevel=2,
+            )
+
+    def send_email_notification(
+        self,
+        recipient_email,
+        template_identifier,
+        context=None,
+    ):
+        if not context:
+            context = {}
+        self.client.send_email_notification(
+            email_address=recipient_email,
+            template_id=template_identifier,
+            personalisation=context,
+        )
+
+
+client = NotificationClient()

--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -7,6 +7,7 @@ from notifications_python_client.notifications import NotificationsAPIClient
 
 class NotificationClient:
     """
+    Class for accessing underlying GOVUK notification service.
     """
 
     def __init__(self):
@@ -32,6 +33,9 @@ class NotificationClient:
         template_identifier,
         context=None,
     ):
+        """
+        Send an email notification using the GOVUK notification service.
+        """
         if not context:
             context = {}
         self.client.send_email_notification(

--- a/datahub/notification/notify.py
+++ b/datahub/notification/notify.py
@@ -1,5 +1,9 @@
 from datahub.notification.tasks import send_email_notification
 
 
-def notify_adviser(adviser, template_identifier, context):
+def notify_adviser_by_email(adviser, template_identifier, context):
+    """
+    Notify an adviser by email, using a GOVUK notify template and some template
+    context.
+    """
     send_email_notification.apply_async(args=(adviser.email, template_identifier, context))

--- a/datahub/notification/notify.py
+++ b/datahub/notification/notify.py
@@ -1,0 +1,5 @@
+from datahub.notification.tasks import send_email_notification
+
+
+def notify_adviser(adviser, template_identifier, context):
+    send_email_notification.apply_async(args=(adviser.email, template_identifier, context))

--- a/datahub/notification/tasks.py
+++ b/datahub/notification/tasks.py
@@ -9,4 +9,8 @@ def send_email_notification(
     template_identifier,
     context=None,
 ):
+    """
+    Celery task to call the notify API to send a templated email notification
+    to an email address.
+    """
     client.send_email_notification(recipient_email, template_identifier, context)

--- a/datahub/notification/tasks.py
+++ b/datahub/notification/tasks.py
@@ -1,0 +1,12 @@
+from celery import shared_task
+
+from datahub.notification.core import client
+
+
+@shared_task(acks_late=True, priority=9)
+def send_email_notification(
+    recipient_email,
+    template_identifier,
+    context=None,
+):
+    client.send_email_notification(recipient_email, template_identifier, context)


### PR DESCRIPTION
### Description of change

**This PR will not be merged**

This PR adds a new notification app for accessing the GOVUK notification service.  This PR is designed to be reviewed in tandem with a short spec document: https://docs.google.com/document/d/1Zfyu3esSsyP-Hpvln_PYEj5pW_1k4eUro7NarhWTxDw/edit?usp=sharing
This doc explains the business rationale, walks through the design approach and differences with OMIS notifications.  It also explores possible extensions that we could make in the future.

Broadly, a lot of the approaches here are lifted from OMIS notifications as they stand - with the idea that the notification-specific logic can be extricated from that django app to provide some reusable tools.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
