### PR TITLE
Remove service answers feature flag

### DIFF
--- a/changelog/interaction/deprecate-service-flow-flag-column.removal.rst
+++ b/changelog/interaction/deprecate-service-flow-flag-column.removal.rst
@@ -1,0 +1,1 @@
+The ``metadata_service.requires_service_answers_flow_feature_flag`` column is deprecated will be removed on or after 22 July 2019.

--- a/changelog/interaction/remove-service-answers-feature-flag.feature.rst
+++ b/changelog/interaction/remove-service-answers-feature-flag.feature.rst
@@ -1,0 +1,1 @@
+The ``interaction_service_answers_flow`` feature flag was removed and the related functionality is no longer behind a feature flag.

--- a/datahub/feature_flag/test/test_utils.py
+++ b/datahub/feature_flag/test/test_utils.py
@@ -3,11 +3,8 @@ from unittest.mock import Mock
 import pytest
 from django.http import Http404
 
-from datahub.core.test.support.factories import PersonFactory
-from datahub.core.test.support.models import Person
 from datahub.feature_flag.test.factories import FeatureFlagFactory
 from datahub.feature_flag.utils import (
-    build_is_feature_flag_active_subquery,
     feature_flagged_view,
     is_feature_flag_active,
 )
@@ -60,34 +57,3 @@ class TestFeatureFlaggedView:
         mock = Mock()
         feature_flagged_view('test-feature-flag')(mock)()
         mock.assert_called_once()
-
-
-class TestBuildIsFeatureFlagActiveSubquery:
-    """Tests for build_is_feature_flag_active_subquery()."""
-
-    @pytest.mark.parametrize('is_active', (True, False))
-    def test_annotation_equals_active_status_for_existent_feature_flag(self, is_active):
-        """
-        Test that the annotation value is same as the is_active value of a feature
-        flag that exists.
-        """
-        code = 'test-flag'
-        FeatureFlagFactory(code=code, is_active=is_active)
-        PersonFactory()
-
-        queryset = Person.objects.annotate(
-            is_feature_flag_active=build_is_feature_flag_active_subquery(code),
-        )
-        assert queryset.first().is_feature_flag_active == is_active
-
-    def test_annotation_is_false_for_non_existent_feature_flag(self):
-        """Test that the annotation value is false with a non-existent feature flag."""
-        code = 'test-flag'
-        PersonFactory()
-
-        queryset = Person.objects.annotate(
-            is_feature_flag_active=build_is_feature_flag_active_subquery(code),
-        )
-        # Explicitly test for False as this reflects how it would be used when filtering a query
-        # set
-        assert queryset.first().is_feature_flag_active is False

--- a/datahub/feature_flag/utils.py
+++ b/datahub/feature_flag/utils.py
@@ -1,6 +1,5 @@
 from functools import wraps
 
-from django.db.models import Exists
 from django.http import Http404
 
 from datahub.feature_flag.models import FeatureFlag
@@ -13,25 +12,6 @@ def is_feature_flag_active(code):
     If feature flag doesn't exist, it returns False.
     """
     return FeatureFlag.objects.filter(code=code, is_active=True).exists()
-
-
-def build_is_feature_flag_active_subquery(code):
-    """
-    Return a subquery that checks if a feature flag is active.
-
-    This can be used e.g. to use a feature flag as part of a filter on a query set.
-
-    For example:
-
-        models.Service.objects.annotate(
-            feature_flag_active=build_is_feature_flag_active_subquery(FEATURE_FLAG),
-        ).filter(
-            Q(requires_service_answers_flow_feature_flag=False) | Q(feature_flag_active=True),
-        )
-    """
-    return Exists(
-        FeatureFlag.objects.filter(code=code, is_active=True),
-    )
 
 
 def feature_flagged_view(code):

--- a/datahub/interaction/constants.py
+++ b/datahub/interaction/constants.py
@@ -1,3 +1,0 @@
-# Feature flag that controls whether services with requires_service_answers_flow_feature_flag
-# set to True are returned from the API
-SERVICE_ANSWERS_FEATURE_FLAG = 'interaction_service_answers_flow'

--- a/datahub/metadata/migrations/0035_remove_requires_service_answers_flow_feature_flag_from_state.py
+++ b/datahub/metadata/migrations/0035_remove_requires_service_answers_flow_feature_flag_from_state.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0034_update_services'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='service',
+            name='requires_service_answers_flow_feature_flag',
+            field=models.BooleanField(default=False, help_text="Temporary field that designates that this service should be hidden unless the 'interaction_service_answers_flow' feature flag is active.", null=True),
+        ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.RemoveField(
+                    model_name='service',
+                    name='requires_service_answers_flow_feature_flag',
+                )
+            ],
+        )
+    ]

--- a/datahub/metadata/models.py
+++ b/datahub/metadata/models.py
@@ -211,11 +211,6 @@ class Service(BaseOrderedConstantModel):
         choices=CONTEXTS,
         blank=True,
     )
-    requires_service_answers_flow_feature_flag = models.BooleanField(
-        default=False,
-        help_text='Temporary field that designates that this service should be hidden unless the '
-                  "'interaction_service_answers_flow' feature flag is active.",
-    )
 
     class Meta(BaseOrderedConstantModel.Meta):
         indexes = [

--- a/datahub/metadata/serializers.py
+++ b/datahub/metadata/serializers.py
@@ -63,21 +63,7 @@ class ServiceSerializer(ConstantModelSerializer):
     """Service serializer."""
 
     contexts = serializers.MultipleChoiceField(choices=Service.CONTEXTS, read_only=True)
-    interaction_questions = serializers.SerializerMethodField()
-
-    def get_interaction_questions(self, obj):
-        """
-        Get the interaction questions if the SERVICE_ANSWERS_FEATURE_FLAG feature flag is
-        active.
-
-        Note: service_answers_feature_flag_is_active is an annotation on service_queryset
-        in datahub.metadata.metadata.
-        """
-        if obj.service_answers_feature_flag_is_active:
-            serializer = ServiceQuestionSerializer(read_only=True, many=True)
-            return serializer.to_representation(obj.interaction_questions.all())
-
-        return []
+    interaction_questions = ServiceQuestionSerializer(many=True, read_only=True)
 
 
 class TeamSerializer(ConstantModelSerializer):


### PR DESCRIPTION
### Description of change

This is to remove checking of the `interaction_service_answers_flow` feature flag.

This PR is to be merged only once the feature flag is no longer required (i.e. once the new functionality is live and the feature flag has been activated in production).

It also removes `Service.requires_service_answers_flow_feature_flag` from the state.

I removed `build_is_feature_flag_active_subquery()` as it's probably unlikely that we'll need it again anytime soon (and can easily re-add it if we do).

~The PR is currently marked as blocked as the new functionality is not live yet.~

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
