### PR TITLE
Remove Service.requires_service_answers_flow_feature_flag from database 

### DIFF
--- a/changelog/interaction/service-flow-flag-column.db.rst
+++ b/changelog/interaction/service-flow-flag-column.db.rst
@@ -1,0 +1,1 @@
+The ``metadata_service.requires_service_answers_flow_feature_flag`` column was removed from the database.

--- a/changelog/interaction/service-flow-flag-column.removal.rst
+++ b/changelog/interaction/service-flow-flag-column.removal.rst
@@ -1,0 +1,1 @@
+The ``metadata_service.requires_service_answers_flow_feature_flag`` column was removed from the database.

--- a/datahub/metadata/migrations/0036_remove_requires_service_answers_flow_feature_flag_from_db.py
+++ b/datahub/metadata/migrations/0036_remove_requires_service_answers_flow_feature_flag_from_db.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0035_remove_requires_service_answers_flow_feature_flag_from_state'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name='service',
+                    name='requires_service_answers_flow_feature_flag',
+                    field=models.BooleanField(default=False, null=True),
+                ),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='service',
+            name='requires_service_answers_flow_feature_flag',
+        )
+    ]


### PR DESCRIPTION
### Description of change

This removes the `metadata_service.requires_service_answers_flow_feature_flag` column from the database.

~Currently blocked as this depends on #1825 being released.~

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
