### PR TITLE
Update Dependabot default reviewers

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -4,8 +4,7 @@ update_configs:
     directory: "/"
     update_schedule: "weekly"
     default_reviewers:
+    - "alixedi"
     - "currycoder"
     - "elcct"
-    - "marcofucci"
-    - "marcuspp"
     - "reupen"


### PR DESCRIPTION
This removes some people that have left and adds one that has joined.