### PR TITLE
Disable atomic requests for /whoami/

### DIFF
--- a/changelog/whoami-non-atomic-requests.internal.rst
+++ b/changelog/whoami-non-atomic-requests.internal.rst
@@ -1,0 +1,1 @@
+The ``/whoami/`` endpoint was opted out of atomic requests as it does not require them. This change is intended to help reduce the occurence of a race condition that occurs when two requests perform OAuth2 introspection on the same token.

--- a/datahub/user/views.py
+++ b/datahub/user/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -6,9 +7,20 @@ from datahub.user.serializers import WhoAmISerializer
 
 
 @api_view()
+@transaction.non_atomic_requests
 @permission_classes([IsAuthenticated])
 def who_am_i(request):
-    """Return the current user. This view is behind a login."""
+    """
+    Return the current user. This view is behind a login.
+
+    As this endpoint does not directly modify the database, it is opted out of atomic requests
+    so that it does not cause a transaction to be used for the lifetime of the request.
+
+    This should also ensure that when OAuth2 token introspection causes an access token to be
+    inserted into the database, it is visible to other requests as soon as possible.
+
+    See also: `datahub.core.reversion.NonAtomicRevisionMiddleware`.
+    """
     serializer = WhoAmISerializer(request.user)
 
     return Response(data=serializer.data)


### PR DESCRIPTION
### Description of change

As the `/whoami/` endpoint does not directly modify the database, this opts it out of atomic requests so that it does not cause a transaction to be used for the lifetime of the request.

This should also ensure that when OAuth2 token introspection causes an access token to be inserted into the database (for requests to this endpoint), it is visible to other requests as soon as possible.

The hope is that this helps with the occasional `IntegrityError`s we get when django-oauth-toolkit tries to insert access tokens into the database during OAuth2 introspection (which primarily happens with this endpoint).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
