### PR TITLE
Correct position of non_atomic_requests decorator in who_am_i view

### DIFF
--- a/datahub/user/views.py
+++ b/datahub/user/views.py
@@ -6,8 +6,8 @@ from rest_framework.response import Response
 from datahub.user.serializers import WhoAmISerializer
 
 
-@api_view()
 @transaction.non_atomic_requests
+@api_view()
 @permission_classes([IsAuthenticated])
 def who_am_i(request):
     """


### PR DESCRIPTION
### Description of change

Unfortunately, the decorators in #1829 were not ordered correctly (and so the `non_atomic_requests` decorator was not effective). This corrects that.

(I did have a go at writing a test for this – the tests use a transaction by default, using a transaction test case works around that but it then fails to flush the database on test teardown, so that's a no go for now unfortunately...)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
