### PR TITLE
Improve approach for matching contacts for meeting invite ingestion

### DIFF
--- a/changelog/interaction/email-invites-contact-multi-match.internal.rst
+++ b/changelog/interaction/email-invites-contact-multi-match.internal.rst
@@ -1,0 +1,5 @@
+The meeting email invites ingestion parsing logic was adjusted to use a new ``max_interactions``
+strategy for finding a contact.  This ensures that when multiple contacts are
+found which match the same email address, the contact with the most interactions
+attributed to it takes precedence.  It's an imperfect solution, but acts as a best
+guess for imperfect data.

--- a/datahub/company/contact_matching.py
+++ b/datahub/company/contact_matching.py
@@ -25,7 +25,7 @@ class ContactMatchingStatus(IntEnum):
 
 def find_active_contact_by_email_address(
     email,
-    match_strategy='default',
+    match_strategy=MatchStrategyName.DEFAULT,
 ) -> Tuple[Optional[Contact], ContactMatchingStatus]:
     """
     Attempts to find a contact by email address.

--- a/datahub/company/contact_matching.py
+++ b/datahub/company/contact_matching.py
@@ -5,6 +5,11 @@ from django.db.models import Count
 
 from datahub.company.models import Contact
 
+# NOTE: We may want to review our approach with this utility mechanism if we
+# need to add further strategies.  It could be that a better approach is to move
+# logic to the model layer - as part of a Manager class - and also use exceptions
+# to better signpost matching problems as opposed to returning a value and status
+
 
 def _match_contact(filter_criteria):
     """

--- a/datahub/company/test/test_contact_matching.py
+++ b/datahub/company/test/test_contact_matching.py
@@ -3,7 +3,7 @@ import pytest
 from datahub.company.contact_matching import (
     ContactMatchingStatus,
     find_active_contact_by_email_address,
-    MatchStrategyName,
+    MatchStrategy,
 )
 from datahub.company.test.factories import ContactFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
@@ -50,125 +50,125 @@ EMAIL_MATCHING_CONTACT_TEST_DATA = [
     'email,expected_matching_status,match_on_alternative,match_strategy',
     (
         # same case, match on email
-        ('unique1@primary.com', ContactMatchingStatus.matched, False, MatchStrategyName.DEFAULT),
+        ('unique1@primary.com', ContactMatchingStatus.matched, False, MatchStrategy.DEFAULT),
         # same case, match on email_alternative
         (
             'unique1@alternative.com',
             ContactMatchingStatus.matched,
             True,
-            MatchStrategyName.DEFAULT,
+            MatchStrategy.DEFAULT,
         ),
         # different case, match on email
         (
             'UNIQUE1@PRIMARY.COM',
             ContactMatchingStatus.matched,
             False,
-            MatchStrategyName.DEFAULT,
+            MatchStrategy.DEFAULT,
         ),
         # different case, match on email_alternative
         (
             'UNIQUE1@ALTERNATIVE.COM',
             ContactMatchingStatus.matched,
             True,
-            MatchStrategyName.DEFAULT,
+            MatchStrategy.DEFAULT,
         ),
         # different
         (
             'UNIQUE@COMPANY.IO',
             ContactMatchingStatus.unmatched,
             None,
-            MatchStrategyName.DEFAULT,
+            MatchStrategy.DEFAULT,
         ),
         # duplicate on email
         (
             'duplicate@primary.com',
             ContactMatchingStatus.multiple_matches,
             None,
-            MatchStrategyName.DEFAULT,
+            MatchStrategy.DEFAULT,
         ),
         # duplicate on email_alternative
         (
             'duplicate@alternative.com',
             ContactMatchingStatus.multiple_matches,
             None,
-            MatchStrategyName.DEFAULT,
+            MatchStrategy.DEFAULT,
         ),
         # archived contact ignored (email value specified)
         (
             'archived1@primary.com',
             ContactMatchingStatus.unmatched,
             None,
-            MatchStrategyName.DEFAULT,
+            MatchStrategy.DEFAULT,
         ),
         # archived contact ignored (email_alternative value specified)
         (
             'archived1@alternative.com',
             ContactMatchingStatus.unmatched,
             None,
-            MatchStrategyName.DEFAULT,
+            MatchStrategy.DEFAULT,
         ),
         # same case, match on email
         (
             'unique1@primary.com',
             ContactMatchingStatus.matched,
             False,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
         # same case, match on email_alternative
         (
             'unique1@alternative.com',
             ContactMatchingStatus.matched,
             True,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
         # different case, match on email
         (
             'UNIQUE1@PRIMARY.COM',
             ContactMatchingStatus.matched,
             False,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
         # different case, match on email_alternative
         (
             'UNIQUE1@ALTERNATIVE.COM',
             ContactMatchingStatus.matched,
             True,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
         # different
         (
             'UNIQUE@COMPANY.IO',
             ContactMatchingStatus.unmatched,
             None,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
         # duplicate on email
         (
             'duplicate@primary.com',
             ContactMatchingStatus.matched,
             None,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
         # duplicate on email_alternative
         (
             'duplicate@alternative.com',
             ContactMatchingStatus.matched,
             True,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
         # archived contact ignored (email value specified)
         (
             'archived1@primary.com',
             ContactMatchingStatus.unmatched,
             None,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
         # archived contact ignored (email_alternative value specified)
         (
             'archived1@alternative.com',
             ContactMatchingStatus.unmatched,
             None,
-            MatchStrategyName.MAX_INTERACTIONS,
+            MatchStrategy.MAX_INTERACTIONS,
         ),
     ),
 )

--- a/datahub/company/test/test_contact_matching.py
+++ b/datahub/company/test/test_contact_matching.py
@@ -3,6 +3,7 @@ import pytest
 from datahub.company.contact_matching import (
     ContactMatchingStatus,
     find_active_contact_by_email_address,
+    MatchStrategyName,
 )
 from datahub.company.test.factories import ContactFactory
 from datahub.interaction.test.factories import CompanyInteractionFactory
@@ -49,41 +50,126 @@ EMAIL_MATCHING_CONTACT_TEST_DATA = [
     'email,expected_matching_status,match_on_alternative,match_strategy',
     (
         # same case, match on email
-        ('unique1@primary.com', ContactMatchingStatus.matched, False, 'default'),
+        ('unique1@primary.com', ContactMatchingStatus.matched, False, MatchStrategyName.DEFAULT),
         # same case, match on email_alternative
-        ('unique1@alternative.com', ContactMatchingStatus.matched, True, 'default'),
+        (
+            'unique1@alternative.com',
+            ContactMatchingStatus.matched,
+            True,
+            MatchStrategyName.DEFAULT,
+        ),
         # different case, match on email
-        ('UNIQUE1@PRIMARY.COM', ContactMatchingStatus.matched, False, 'default'),
+        (
+            'UNIQUE1@PRIMARY.COM',
+            ContactMatchingStatus.matched,
+            False,
+            MatchStrategyName.DEFAULT,
+        ),
         # different case, match on email_alternative
-        ('UNIQUE1@ALTERNATIVE.COM', ContactMatchingStatus.matched, True, 'default'),
+        (
+            'UNIQUE1@ALTERNATIVE.COM',
+            ContactMatchingStatus.matched,
+            True,
+            MatchStrategyName.DEFAULT,
+        ),
         # different
-        ('UNIQUE@COMPANY.IO', ContactMatchingStatus.unmatched, None, 'default'),
+        (
+            'UNIQUE@COMPANY.IO',
+            ContactMatchingStatus.unmatched,
+            None,
+            MatchStrategyName.DEFAULT,
+        ),
         # duplicate on email
-        ('duplicate@primary.com', ContactMatchingStatus.multiple_matches, None, 'default'),
+        (
+            'duplicate@primary.com',
+            ContactMatchingStatus.multiple_matches,
+            None,
+            MatchStrategyName.DEFAULT,
+        ),
         # duplicate on email_alternative
-        ('duplicate@alternative.com', ContactMatchingStatus.multiple_matches, None, 'default'),
+        (
+            'duplicate@alternative.com',
+            ContactMatchingStatus.multiple_matches,
+            None,
+            MatchStrategyName.DEFAULT,
+        ),
         # archived contact ignored (email value specified)
-        ('archived1@primary.com', ContactMatchingStatus.unmatched, None, 'default'),
+        (
+            'archived1@primary.com',
+            ContactMatchingStatus.unmatched,
+            None,
+            MatchStrategyName.DEFAULT,
+        ),
         # archived contact ignored (email_alternative value specified)
-        ('archived1@alternative.com', ContactMatchingStatus.unmatched, None, 'default'),
+        (
+            'archived1@alternative.com',
+            ContactMatchingStatus.unmatched,
+            None,
+            MatchStrategyName.DEFAULT,
+        ),
         # same case, match on email
-        ('unique1@primary.com', ContactMatchingStatus.matched, False, 'max_interactions'),
+        (
+            'unique1@primary.com',
+            ContactMatchingStatus.matched,
+            False,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
         # same case, match on email_alternative
-        ('unique1@alternative.com', ContactMatchingStatus.matched, True, 'max_interactions'),
+        (
+            'unique1@alternative.com',
+            ContactMatchingStatus.matched,
+            True,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
         # different case, match on email
-        ('UNIQUE1@PRIMARY.COM', ContactMatchingStatus.matched, False, 'max_interactions'),
+        (
+            'UNIQUE1@PRIMARY.COM',
+            ContactMatchingStatus.matched,
+            False,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
         # different case, match on email_alternative
-        ('UNIQUE1@ALTERNATIVE.COM', ContactMatchingStatus.matched, True, 'max_interactions'),
+        (
+            'UNIQUE1@ALTERNATIVE.COM',
+            ContactMatchingStatus.matched,
+            True,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
         # different
-        ('UNIQUE@COMPANY.IO', ContactMatchingStatus.unmatched, None, 'max_interactions'),
+        (
+            'UNIQUE@COMPANY.IO',
+            ContactMatchingStatus.unmatched,
+            None,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
         # duplicate on email
-        ('duplicate@primary.com', ContactMatchingStatus.matched, None, 'max_interactions'),
+        (
+            'duplicate@primary.com',
+            ContactMatchingStatus.matched,
+            None,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
         # duplicate on email_alternative
-        ('duplicate@alternative.com', ContactMatchingStatus.matched, True, 'max_interactions'),
+        (
+            'duplicate@alternative.com',
+            ContactMatchingStatus.matched,
+            True,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
         # archived contact ignored (email value specified)
-        ('archived1@primary.com', ContactMatchingStatus.unmatched, None, 'max_interactions'),
+        (
+            'archived1@primary.com',
+            ContactMatchingStatus.unmatched,
+            None,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
         # archived contact ignored (email_alternative value specified)
-        ('archived1@alternative.com', ContactMatchingStatus.unmatched, None, 'max_interactions'),
+        (
+            'archived1@alternative.com',
+            ContactMatchingStatus.unmatched,
+            None,
+            MatchStrategyName.MAX_INTERACTIONS,
+        ),
     ),
 )
 def test_find_active_contact_by_email_address(

--- a/datahub/company/test/test_contact_matching.py
+++ b/datahub/company/test/test_contact_matching.py
@@ -5,6 +5,7 @@ from datahub.company.contact_matching import (
     find_active_contact_by_email_address,
 )
 from datahub.company.test.factories import ContactFactory
+from datahub.interaction.test.factories import CompanyInteractionFactory
 
 
 EMAIL_MATCHING_CONTACT_TEST_DATA = [
@@ -17,6 +18,7 @@ EMAIL_MATCHING_CONTACT_TEST_DATA = [
         'email': 'duplicate@primary.com',
         'email_alternative': '',
         'archived': False,
+        'interactions': 10,
     },
     {
         'email': 'duplicate@primary.com',
@@ -27,6 +29,7 @@ EMAIL_MATCHING_CONTACT_TEST_DATA = [
         'email': 'unique2@primary.com',
         'email_alternative': 'duplicate@alternative.com',
         'archived': False,
+        'interactions': 10,
     },
     {
         'email': 'unique3@primary.com',
@@ -43,40 +46,64 @@ EMAIL_MATCHING_CONTACT_TEST_DATA = [
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    'email,expected_matching_status,match_on_alternative',
+    'email,expected_matching_status,match_on_alternative,match_strategy',
     (
         # same case, match on email
-        ('unique1@primary.com', ContactMatchingStatus.matched, False),
+        ('unique1@primary.com', ContactMatchingStatus.matched, False, 'default'),
         # same case, match on email_alternative
-        ('unique1@alternative.com', ContactMatchingStatus.matched, True),
+        ('unique1@alternative.com', ContactMatchingStatus.matched, True, 'default'),
         # different case, match on email
-        ('UNIQUE1@PRIMARY.COM', ContactMatchingStatus.matched, False),
+        ('UNIQUE1@PRIMARY.COM', ContactMatchingStatus.matched, False, 'default'),
         # different case, match on email_alternative
-        ('UNIQUE1@ALTERNATIVE.COM', ContactMatchingStatus.matched, True),
+        ('UNIQUE1@ALTERNATIVE.COM', ContactMatchingStatus.matched, True, 'default'),
         # different
-        ('UNIQUE@COMPANY.IO', ContactMatchingStatus.unmatched, None),
+        ('UNIQUE@COMPANY.IO', ContactMatchingStatus.unmatched, None, 'default'),
         # duplicate on email
-        ('duplicate@primary.com', ContactMatchingStatus.multiple_matches, None),
+        ('duplicate@primary.com', ContactMatchingStatus.multiple_matches, None, 'default'),
         # duplicate on email_alternative
-        ('duplicate@alternative.com', ContactMatchingStatus.multiple_matches, None),
+        ('duplicate@alternative.com', ContactMatchingStatus.multiple_matches, None, 'default'),
         # archived contact ignored (email value specified)
-        ('archived1@primary.com', ContactMatchingStatus.unmatched, None),
+        ('archived1@primary.com', ContactMatchingStatus.unmatched, None, 'default'),
         # archived contact ignored (email_alternative value specified)
-        ('archived1@alternative.com', ContactMatchingStatus.unmatched, None),
+        ('archived1@alternative.com', ContactMatchingStatus.unmatched, None, 'default'),
+        # same case, match on email
+        ('unique1@primary.com', ContactMatchingStatus.matched, False, 'max_interactions'),
+        # same case, match on email_alternative
+        ('unique1@alternative.com', ContactMatchingStatus.matched, True, 'max_interactions'),
+        # different case, match on email
+        ('UNIQUE1@PRIMARY.COM', ContactMatchingStatus.matched, False, 'max_interactions'),
+        # different case, match on email_alternative
+        ('UNIQUE1@ALTERNATIVE.COM', ContactMatchingStatus.matched, True, 'max_interactions'),
+        # different
+        ('UNIQUE@COMPANY.IO', ContactMatchingStatus.unmatched, None, 'max_interactions'),
+        # duplicate on email
+        ('duplicate@primary.com', ContactMatchingStatus.matched, None, 'max_interactions'),
+        # duplicate on email_alternative
+        ('duplicate@alternative.com', ContactMatchingStatus.matched, True, 'max_interactions'),
+        # archived contact ignored (email value specified)
+        ('archived1@primary.com', ContactMatchingStatus.unmatched, None, 'max_interactions'),
+        # archived contact ignored (email_alternative value specified)
+        ('archived1@alternative.com', ContactMatchingStatus.unmatched, None, 'max_interactions'),
     ),
 )
 def test_find_active_contact_by_email_address(
     email,
     expected_matching_status,
     match_on_alternative,
+    match_strategy,
 ):
     """Test finding a contact by email address for various scenarios."""
     for factory_kwargs in EMAIL_MATCHING_CONTACT_TEST_DATA:
-        ContactFactory(**factory_kwargs)
+        interaction_count = 0
+        if factory_kwargs.get('interactions'):
+            interaction_count = factory_kwargs.pop('interactions')
+        created_contact = ContactFactory(**factory_kwargs)
+        for _ in range(interaction_count):
+            CompanyInteractionFactory(contacts=[created_contact])
 
-    contact, actual_matching_status = find_active_contact_by_email_address(email)
+    contact, actual_matching_status = find_active_contact_by_email_address(email, match_strategy)
 
-    assert actual_matching_status == actual_matching_status
+    assert actual_matching_status == expected_matching_status
 
     if actual_matching_status == ContactMatchingStatus.matched:
         assert contact

--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -6,7 +6,10 @@ import icalendar
 from django.core.exceptions import ValidationError
 from django.utils.timezone import utc
 
-from datahub.company.contact_matching import find_active_contact_by_email_address
+from datahub.company.contact_matching import (
+    find_active_contact_by_email_address,
+    MatchStrategyName,
+)
 from datahub.company.models.adviser import Advisor
 from datahub.email_ingestion.validation import was_email_sent_by_dit
 
@@ -132,7 +135,10 @@ class CalendarInteractionEmailParser:
     def _extract_and_validate_contacts(self, all_recipients):
         contacts = []
         for recipient_email in all_recipients:
-            contact, _ = find_active_contact_by_email_address(recipient_email, 'max_interactions')
+            contact, _ = find_active_contact_by_email_address(
+                recipient_email,
+                MatchStrategyName.MAX_INTERACTIONS,
+            )
             if contact:
                 contacts.append(contact)
         if not contacts:

--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -8,7 +8,7 @@ from django.utils.timezone import utc
 
 from datahub.company.contact_matching import (
     find_active_contact_by_email_address,
-    MatchStrategyName,
+    MatchStrategy,
 )
 from datahub.company.models.adviser import Advisor
 from datahub.email_ingestion.validation import was_email_sent_by_dit
@@ -137,7 +137,7 @@ class CalendarInteractionEmailParser:
         for recipient_email in all_recipients:
             contact, _ = find_active_contact_by_email_address(
                 recipient_email,
-                MatchStrategyName.MAX_INTERACTIONS,
+                MatchStrategy.MAX_INTERACTIONS,
             )
             if contact:
                 contacts.append(contact)

--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -132,7 +132,7 @@ class CalendarInteractionEmailParser:
     def _extract_and_validate_contacts(self, all_recipients):
         contacts = []
         for recipient_email in all_recipients:
-            contact, _ = find_active_contact_by_email_address(recipient_email)
+            contact, _ = find_active_contact_by_email_address(recipient_email, 'max_interactions')
             if contact:
                 contacts.append(contact)
         if not contacts:

--- a/datahub/interaction/test/email_processors/conftest.py
+++ b/datahub/interaction/test/email_processors/conftest.py
@@ -1,7 +1,9 @@
 import factory
 import pytest
 
+from datahub.company.models import Contact
 from datahub.company.test.factories import AdviserFactory, CompanyFactory, ContactFactory
+from datahub.interaction.test.factories import CompanyInteractionFactory
 
 
 @pytest.fixture()
@@ -33,6 +35,8 @@ def calendar_data_fixture():
         ('Bill Adama', company_1),
         ('Saul Tigh', company_1),
         ('Laura Roslin', company_2),
+        ('Sharon Valerii', company_1),
+        ('Sharon Valerii', company_2),
     ]
     for name, company in contacts:
         first_name, last_name = name.split(' ')
@@ -44,4 +48,12 @@ def calendar_data_fixture():
             email=email,
             company=company,
         )
+    # Ensure that our contact who appears on multiple companies
+    # with a single email address has more interactions for the
+    # contact attributed to 'Company 1'
+    contact_with_interactions = Contact.objects.get(
+        email='sharon.valerii@example.net',
+        company=company_1,
+    )
+    CompanyInteractionFactory(contacts=[contact_with_interactions], company=company_1)
     yield

--- a/datahub/interaction/test/email_processors/email_samples/valid/gmail/sample.eml
+++ b/datahub/interaction/test/email_processors/email_samples/valid/gmail/sample.eml
@@ -82,7 +82,7 @@ Message-ID: <0000000000002a99a005853a155c@google.com>
 Date: Fri, 29 Mar 2019 11:36:33 +0000
 Subject: Invitation: initial @ Fri 29 Mar 2019 4:30pm - 5:30pm (GMT) (bill.adama@example.net)
 From: Correspondence3@digital.trade.gov.uk
-To: bill.adama@example.net,saul.tigh@example.net,unknown@example.net,adviser3@digital.trade.gov.uk
+To: bill.adama@example.net,saul.tigh@example.net,unknown@example.net,adviser3@digital.trade.gov.uk,sharon.valerii@example.net
 CC: laura.roslin@example.net,saul.tigh@example.net,adviser2@digital.trade.gov.uk
 Content-Type: multipart/mixed; boundary="0000000000002a998305853a155b"
 

--- a/datahub/interaction/test/email_processors/test_parsers.py
+++ b/datahub/interaction/test/email_processors/test_parsers.py
@@ -122,7 +122,9 @@ class TestCalendarInteractionEmailParser:
                 'email_samples/valid/outlook_online/sample.eml',
                 {
                     'adviser_email': 'adviser1@trade.gov.uk',
-                    'contact_emails': ['bill.adama@example.net'],
+                    'contact_details': [
+                        ('bill.adama@example.net', 'Company 1'),
+                    ],
                     'secondary_adviser_emails': [],
                     'top_company_name': 'Company 1',
                     'date': datetime(2019, 3, 29, 12, 0, tzinfo=utc),
@@ -142,10 +144,11 @@ class TestCalendarInteractionEmailParser:
                 'email_samples/valid/gmail/sample.eml',
                 {
                     'adviser_email': 'adviser3@digital.trade.gov.uk',
-                    'contact_emails': [
-                        'bill.adama@example.net',
-                        'saul.tigh@example.net',
-                        'laura.roslin@example.net',
+                    'contact_details': [
+                        ('bill.adama@example.net', 'Company 1'),
+                        ('saul.tigh@example.net', 'Company 1'),
+                        ('laura.roslin@example.net', 'Company 2'),
+                        ('sharon.valerii@example.net', 'Company 1'),
                     ],
                     'secondary_adviser_emails': ['adviser2@digital.trade.gov.uk'],
                     'top_company_name': 'Company 1',
@@ -169,8 +172,11 @@ class TestCalendarInteractionEmailParser:
         parser = self._get_parser_for_email_file(email_file)
         interaction_data = parser.extract_interaction_data_from_email()
         assert interaction_data['sender'].email == expected_interaction_data['adviser_email']
-        contact_emails = {contact.email for contact in interaction_data['contacts']}
-        assert contact_emails == set(expected_interaction_data['contact_emails'])
+        contacts = interaction_data['contacts']
+        expected_contacts = expected_interaction_data['contact_details'][:]
+        for contact in contacts:
+            expected_contacts.remove((contact.email, contact.company.name))
+        assert len(expected_contacts) == 0
         secondary_adviser_emails = {
             adviser.email for adviser in interaction_data['secondary_advisers']
         }

--- a/datahub/interaction/test/email_processors/test_processors.py
+++ b/datahub/interaction/test/email_processors/test_processors.py
@@ -114,13 +114,12 @@ class TestCalendarInteractionEmailProcessor:
             **interaction_data_overrides,
         }
         email_parser_mock = self._get_email_parser_mock(interaction_data, monkeypatch)
-        assert not Interaction.objects.count()
 
         # Process the message and save a draft interaction
         processor = CalendarInteractionEmailProcessor()
         result, message = processor.process_email(mock.Mock())
         assert result is True
-        interaction = Interaction.objects.first()
+        interaction = Interaction.objects.get(source__meeting__id='12345')
         assert message == f'Successfully created interaction #{interaction.id}'
 
         # Verify dit_participants holds all of the advisers for the interaction


### PR DESCRIPTION
### Description of change
It turns out that the data quality for Contacts in production is not the best - we have a lot of instances where multiple Contact models (for different companies) share the same email address.  For the meeting invite ingestion feature, this is problematic as using the contact matching utility would fail to select a suitable Contact for a draft interaction.  

This would often mean that meeting emails were ignored as one suitable matching contact could not be found in Data Hub to attribute the interaction to.

As a quick fix, this PR ensures that in a situation where there are multiple matching contacts for an email address, the contact with the highest number of interactions attributed to it is selected.  This is not a perfect solution by any means - but it strives to ensure that we save a draft interaction in Data Hub when we can.

Once the email notification feature is in, advisers will be directed to the actual interaction that was saved for their meeting invite and they will have an opportunity to move it to the correct contact if the contact selected automatically was not right.

### Things of note

- I've adapted the contact matching utility to allow the use of different strategies - who's identifier can be specified in a kwarg.  This allows us to customise the matching logic used for finding contacts according to different business needs.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
