### PR TITLE
Correct schemas for various endpoints

### DIFF
--- a/changelog/schema-fixes.bugfix.rst
+++ b/changelog/schema-fixes.bugfix.rst
@@ -2,3 +2,5 @@ Schemas in the API documentation were corrected for the following endpoints:
 
 - all archive endpoints
 - all unarchive endpoints
+- the complete OMIS order endpoint
+- the cancel OMIS order endpoint

--- a/changelog/schema-fixes.bugfix.rst
+++ b/changelog/schema-fixes.bugfix.rst
@@ -1,0 +1,4 @@
+Schemas in the API documentation were corrected for the following endpoints:
+
+- all archive endpoints
+- all unarchive endpoints

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -27,13 +27,9 @@ company_timeline = CompanyTimelineViewSet.as_view({
     'get': 'list',
 })
 
-company_archive = CompanyViewSet.as_view({
-    'post': 'archive',
-})
+company_archive = CompanyViewSet.as_action_view('archive')
 
-company_unarchive = CompanyViewSet.as_view({
-    'post': 'unarchive',
-})
+company_unarchive = CompanyViewSet.as_action_view('unarchive')
 
 one_list_group_core_team = OneListGroupCoreTeamViewSet.as_view({
     'get': 'list',

--- a/datahub/company/urls/contact.py
+++ b/datahub/company/urls/contact.py
@@ -12,13 +12,9 @@ contact_item = ContactViewSet.as_view({
     'patch': 'partial_update',
 })
 
-contact_archive = ContactViewSet.as_view({
-    'post': 'archive',
-})
+contact_archive = ContactViewSet.as_action_view('archive')
 
-contact_unarchive = ContactViewSet.as_view({
-    'post': 'unarchive',
-})
+contact_unarchive = ContactViewSet.as_action_view('unarchive')
 
 contact_audit = ContactAuditViewSet.as_view({
     'get': 'list',

--- a/datahub/core/mixins.py
+++ b/datahub/core/mixins.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from datahub.core.schemas import ExplicitSerializerSchema
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
 
@@ -32,7 +33,11 @@ class ArchivableViewSetMixin:
     archive_validators = []
     unarchive_validators = []
 
-    @action(methods=['post'], detail=True)
+    @action(
+        methods=['post'],
+        detail=True,
+        schema=ExplicitSerializerSchema(ArchiveSerializer),
+    )
     def archive(self, request, pk):
         """Archive the object."""
         obj = self.get_object()
@@ -51,7 +56,11 @@ class ArchivableViewSetMixin:
         obj_serializer = self.get_serializer_class()(obj)
         return Response(data=obj_serializer.data)
 
-    @action(methods=['post'], detail=True)
+    @action(
+        methods=['post'],
+        detail=True,
+        schema=ExplicitSerializerSchema(UnarchiveSerializer),
+    )
     def unarchive(self, request, pk):
         """Unarchive the object."""
         obj = self.get_object()

--- a/datahub/core/schemas.py
+++ b/datahub/core/schemas.py
@@ -1,0 +1,58 @@
+import coreapi
+from rest_framework import serializers
+from rest_framework.schemas import AutoSchema
+from rest_framework.schemas.inspectors import field_to_schema
+
+
+class ExplicitSerializerSchema(AutoSchema):
+    """
+    Subclass of AutoSchema that explicitly takes a serializer rather than using the one defined
+    on the view set.
+
+    This is useful for extra routes added to view sets.
+
+    Note: This does not currently support ListSerializer.
+
+    Usage example:
+
+        from rest_framework.decorators import action
+
+        class MyViewSet(CoreViewSet):
+            @action(
+                methods=['post'],
+                detail=True,
+                schema=ExplicitSerializerSchema(ArchiveSerializer),
+            )
+            def archive(self, request, pk):
+                pass
+    """
+
+    def __init__(self, serializer_cls, *args, **kwargs):
+        """Initialise the schema with a serialiser."""
+        super().__init__(*args, **kwargs)
+
+        self.serializer_cls = serializer_cls
+
+    def get_serializer_fields(self, path, method):
+        """
+        Get the schema fields for self.serializer_cls.
+
+        This logic is based on the equivalent logic in AutoSchema.
+        """
+        serializer = self.serializer_cls()
+        is_partial = method == 'PATCH'
+
+        writable_fields = (
+            field for field in serializer.fields.values()
+            if not (field.read_only or isinstance(field, serializers.HiddenField))
+        )
+
+        return [
+            coreapi.Field(
+                name=field.field_name,
+                location='form',
+                required=field.required and not is_partial,
+                schema=field_to_schema(field),
+            )
+            for field in writable_fields
+        ]

--- a/datahub/core/schemas.py
+++ b/datahub/core/schemas.py
@@ -25,6 +25,9 @@ class ExplicitSerializerSchema(AutoSchema):
             )
             def archive(self, request, pk):
                 pass
+
+
+    See also: CoreViewSet.as_action_view
     """
 
     def __init__(self, serializer_cls, *args, **kwargs):

--- a/datahub/core/test/test_schemas.py
+++ b/datahub/core/test/test_schemas.py
@@ -1,0 +1,61 @@
+import coreapi
+import coreschema
+import pytest
+from rest_framework import serializers
+
+from datahub.core.schemas import ExplicitSerializerSchema
+
+
+class SimpleSerializer(serializers.Serializer):
+    """Example serializer used in the tests below."""
+
+    field_a = serializers.CharField(required=False)
+    field_b = serializers.IntegerField(required=True)
+
+
+class TestExplicitSerializerSchema:
+    """Tests for ExplicitSerializerSchema."""
+
+    @pytest.mark.parametrize(
+        'http_method,expected_fields',
+        (
+            pytest.param(
+                'POST',
+                [
+                    coreapi.Field(
+                        'field_a',
+                        False,
+                        'form',
+                        coreschema.String(title='Field a', description=''),
+                    ),
+                    coreapi.Field(
+                        'field_b',
+                        True,
+                        'form',
+                        coreschema.Integer(title='Field b', description=''),
+                    ),
+                ],
+            ),
+            pytest.param(
+                'PATCH',
+                [
+                    coreapi.Field(
+                        'field_a',
+                        False,
+                        'form',
+                        coreschema.String(title='Field a', description=''),
+                    ),
+                    coreapi.Field(
+                        'field_b',
+                        False,
+                        'form',
+                        coreschema.Integer(title='Field b', description=''),
+                    ),
+                ],
+            ),
+        ),
+    )
+    def test_get_serializer_fields(self, http_method, expected_fields):
+        """Test get_serializer_fields()."""
+        schema = ExplicitSerializerSchema(SimpleSerializer)
+        assert schema.get_serializer_fields('/path', http_method) == expected_fields

--- a/datahub/core/viewsets.py
+++ b/datahub/core/viewsets.py
@@ -25,6 +25,30 @@ class CoreViewSet(
 ):
     """Base class for view sets."""
 
+    @classmethod
+    def as_action_view(cls, action):
+        """
+        Creates a view for a method decorated with the @action decorator.
+
+        Usage example:
+
+            from rest_framework.decorators import action
+
+            class CompanyViewSet(CoreViewSet):
+                @action(methods=['post'], detail=True)
+                def archive(self, request, pk):
+                    pass
+
+            path(
+                'company/<uuid:pk>/archive',
+                CompanyViewSet.as_action_view('archive'),
+                name='archive',
+            )
+        """
+        method = getattr(cls, action)
+        mapping = dict(method.mapping)
+        return cls.as_view(mapping, **method.kwargs)
+
     def perform_create(self, serializer):
         """Custom logic for creating the model instance."""
         extra_data = self.get_additional_data(True)

--- a/datahub/interaction/urls.py
+++ b/datahub/interaction/urls.py
@@ -12,13 +12,9 @@ item = InteractionViewSet.as_view({
     'patch': 'partial_update',
 })
 
-archive_item = InteractionViewSet.as_view({
-    'post': 'archive',
-})
+archive_item = InteractionViewSet.as_action_view('archive')
 
-unarchive_item = InteractionViewSet.as_view({
-    'post': 'unarchive',
-})
+unarchive_item = InteractionViewSet.as_action_view('unarchive')
 
 urlpatterns = [
     path('interaction', collection, name='collection'),

--- a/datahub/investment/project/urls.py
+++ b/datahub/investment/project/urls.py
@@ -41,13 +41,9 @@ audit_item = IProjectAuditViewSet.as_view({
     'get': 'list',
 })
 
-archive_item = IProjectViewSet.as_view({
-    'post': 'archive',
-})
+archive_item = IProjectViewSet.as_action_view('archive')
 
-unarchive_item = IProjectViewSet.as_view({
-    'post': 'unarchive',
-})
+unarchive_item = IProjectViewSet.as_action_view('unarchive')
 
 
 urlpatterns = [

--- a/datahub/metadata/views.py
+++ b/datahub/metadata/views.py
@@ -7,6 +7,7 @@ from datahub.metadata.registry import registry
 
 def _create_metadata_view(mapping):
     has_filters = mapping.filterset_fields or mapping.filterset_class
+    model = mapping.queryset.model
 
     attrs = {
         'authentication_classes': (),
@@ -17,6 +18,7 @@ def _create_metadata_view(mapping):
         'permission_classes': (),
         'queryset': mapping.queryset,
         'serializer_class': mapping.serializer,
+        '__doc__': f'List all {model._meta.verbose_name_plural}.',
     }
 
     view_set = type(

--- a/datahub/omis/order/urls.py
+++ b/datahub/omis/order/urls.py
@@ -22,12 +22,12 @@ internal_frontend_urls = [
     ),
     path(
         'order/<uuid:pk>/complete',
-        OrderViewSet.as_view({'post': 'complete'}),
+        OrderViewSet.as_action_view('complete'),
         name='complete',
     ),
     path(
         'order/<uuid:pk>/cancel',
-        OrderViewSet.as_view({'post': 'cancel'}),
+        OrderViewSet.as_action_view('cancel'),
         name='cancel',
     ),
 

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -1,9 +1,11 @@
 from django.http import Http404
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
 from rest_framework import status
+from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from datahub.core.schemas import ExplicitSerializerSchema
 from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
 from datahub.omis.order.models import Order, OrderAssignee, OrderSubscriber
@@ -28,6 +30,11 @@ class OrderViewSet(CoreViewSet):
         'primary_market',
     )
 
+    @action(
+        methods=['post'],
+        detail=True,
+        schema=ExplicitSerializerSchema(CompleteOrderSerializer),
+    )
     def complete(self, request, *args, **kwargs):
         """Complete an order."""
         instance = self.get_object()
@@ -43,6 +50,11 @@ class OrderViewSet(CoreViewSet):
             status=status.HTTP_200_OK,
         )
 
+    @action(
+        methods=['post'],
+        detail=True,
+        schema=ExplicitSerializerSchema(CancelOrderSerializer),
+    )
     def cancel(self, request, *args, **kwargs):
         """Cancel an order."""
         instance = self.get_object()


### PR DESCRIPTION
## Description of change

This corrects the schemas for the following endpoints:

- all archive endpoints
- all unarchive endpoints
- the complete OMIS order endpoint
- the cancel OMIS order endpoint

It also adds (automatically-generated) docstrings for the metadata views so that they don't look so jarring in the UI.

Cleanly setting a custom schema for extra endpoints added to the generic view sets was a bit tricky (due to the way we register routes for views). 

I came up with a compromise solution with `CoreViewSet.as_action_view()` so that we can still set the schema where the view is defined. However, we may want to look to switching to a custom DRF router instead at some point.

I've added a news fragment for now but will remove it if this is merged before the previous PR is released as it doesn't make sense having both in the same release.

Possible points of discussion:

- the name of the `ExplicitSerializerSchema` class
- making `as_action_view` a standalone function instead of a method on `CoreViewSet`

## Screenshots

A few examples of the changes:

### `/v3/contact/{id}/archive`

#### Before

![image](https://user-images.githubusercontent.com/12693549/60902177-1d64fe80-a267-11e9-96d3-92dab37ac804.png)

#### After

![image](https://user-images.githubusercontent.com/12693549/60901690-49cc4b00-a266-11e9-99f5-bf7fd76e9895.png)

### `/metadata/administrative-area/`

#### Before

![image](https://user-images.githubusercontent.com/12693549/60902065-f5759b00-a266-11e9-9f90-e9ddbfc420ef.png)

#### After

![image](https://user-images.githubusercontent.com/12693549/60901831-88620580-a266-11e9-9f44-4523d3a22261.png)

### `/v3/omis/order/{id}/cancel`

#### Before

![image](https://user-images.githubusercontent.com/12693549/60902048-ed1d6000-a266-11e9-8f34-4e3f03beebb9.png)

#### After

![image](https://user-images.githubusercontent.com/12693549/60901918-ab8cb500-a266-11e9-910e-cefa25c906c6.png)

## Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
