### PR TITLE
Revert "Bump sentry-sdk from 0.9.5 to 0.10.0"

### DIFF
--- a/changelog/revert-sentry-sdk.bugfix.rst
+++ b/changelog/revert-sentry-sdk.bugfix.rst
@@ -1,0 +1,2 @@
+An upgrade to sentry-sdk was reverted due to an `observed memory leak
+<https://github.com/getsentry/sentry-python/issues/419>`_.

--- a/requirements.in
+++ b/requirements.in
@@ -84,4 +84,4 @@ gevent==1.4.0
 mohawk==1.0.0
 requests==2.22.0
 requests_toolbelt==0.9.1
-sentry_sdk==0.10.0
+sentry_sdk==0.9.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -118,7 +118,7 @@ requests-mock==1.6.0
 requests==2.22.0
 requests_toolbelt==0.9.1
 s3transfer==0.2.0         # via boto3
-sentry_sdk==0.10.0
+sentry_sdk==0.9.5
 simplejson==3.16.0        # via mail-parser
 six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mail-parser, mohawk, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest-xdist, python-dateutil, requests-mock, traitlets
 snowballstemmer==1.2.1    # via pydocstyle


### PR DESCRIPTION
Reverts uktrade/data-hub-leeloo#1839

We are seeing a [significant memory leak](https://github.com/getsentry/sentry-python/issues/419) and things at least looked better with the older version of sentry-sdk.