### PR TITLE
Resolve schema introspection warnings for PropositionViewSet and EvidenceDocumentViewSet

### DIFF
--- a/datahub/investment/project/proposition/views.py
+++ b/datahub/investment/project/proposition/views.py
@@ -60,18 +60,26 @@ class PropositionViewSet(CoreViewSet):
     ordering_fields = ('deadline', 'created_on')
     ordering = ('-deadline', '-created_on')
 
-    def get_queryset(self):
-        """Filters the query set to the specified project."""
-        self._check_project_exists()
+    def initial(self, request, *args, **kwargs):
+        """
+        Raise an Http404 if there is no project corresponding to the project ID specified in
+        the URL path.
+        """
+        super().initial(request, *args, **kwargs)
 
-        return self.queryset.filter(
+        if not InvestmentProject.objects.filter(pk=self.kwargs['project_pk']).exists():
+            raise Http404(self.non_existent_project_error_message)
+
+    def filter_queryset(self, queryset):
+        """Filter the queryset to the project specified in the URL path."""
+        filtered_queryset = super().filter_queryset(queryset)
+
+        return filtered_queryset.filter(
             investment_project_id=self.kwargs['project_pk'],
         )
 
     def create(self, request, *args, **kwargs):
         """Creates proposition."""
-        self._check_project_exists()
-
         serializer = CreatePropositionSerializer(
             data=request.data,
             context=self.get_serializer_context(),
@@ -85,8 +93,6 @@ class PropositionViewSet(CoreViewSet):
 
     def _action(self, method, action_serializer, request, *args, **kwargs):
         """Invokes action for a proposition."""
-        self._check_project_exists()
-
         if method not in ('abandon', 'complete'):
             raise APIBadRequestException()
 
@@ -126,10 +132,6 @@ class PropositionViewSet(CoreViewSet):
         if create:
             data['investment_project_id'] = self.kwargs['project_pk']
         return data
-
-    def _check_project_exists(self):
-        if not InvestmentProject.objects.filter(pk=self.kwargs['project_pk']).exists():
-            raise Http404(self.non_existent_project_error_message)
 
 
 class PropositionDocumentViewSet(BaseEntityDocumentModelViewSet):


### PR DESCRIPTION
### Description of change

This resolves the following two warnings that were occurring when accessing `/docs` for the first time:

```
/<omitted>/lib/python3.7/site-packages/django_filters/rest_framework/backends.py:128: UserWarning: <class 'datahub.investment.project.proposition.views.PropositionViewSet'> is not compatible with schema generation
  "{} is not compatible with schema generation".format(view.__class__)

/<omitted>/lib/python3.7/site-packages/django_filters/rest_framework/backends.py:128: UserWarning: <class 'datahub.investment.project.evidence.views.EvidenceDocumentViewSet'> is not compatible with schema generation
  "{} is not compatible with schema generation".format(view.__class__)
```

These were occurring as we were depending on `self.kwargs` being populated in places that it isn't during schema introspection.

This was resolved for both view sets by simply moving the logic using `self.kwargs` elsewhere.

(There is a similar problem outstanding for `PropositionDocumentViewSet`, but I have left that to a separate PR as there are quite a few tests to add to make sure it returns 404s in various scenarios.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
