### PR TITLE
Correct 404 handling in investment proposition document views

### DIFF
--- a/changelog/investment/proposition-document-404.api.rst
+++ b/changelog/investment/proposition-document-404.api.rst
@@ -1,0 +1,8 @@
+The following endpoints were corrected to return a 404 when a non-existent investment project or proposition was specified:
+
+- ``GET,POST /v3/investment/{project_pk}/proposition/{proposition_pk}/document``
+- ``GET,DELETE /v3/investment/{project_pk}/proposition/{proposition_pk}/document/{entity_document_pk}``
+- ``GET /v3/investment/{project_pk}/proposition/{proposition_pk}/document/{entity_document_pk}/download``
+- ``POST /v3/investment/{project_pk}/proposition/{proposition_pk}/document/{entity_document_pk}/upload-callback``
+
+(Previously, they would only return a 404 in some of the possible cases.)

--- a/datahub/investment/project/proposition/test/test_views.py
+++ b/datahub/investment/project/proposition/test/test_views.py
@@ -1515,6 +1515,164 @@ class TestAbandonProposition(APITestMixin):
         assert proposition.status == PropositionStatus.ongoing
 
 
+@pytest.mark.parametrize('http_method', ('get', 'post'))
+class TestPropositionDocumentCollectionView404Handling(APITestMixin):
+    """Tests for 404-handling in the proposition document collection view."""
+
+    def test_returns_404_for_non_existent_project(self, http_method):
+        """Test that a 404 is returned if an non-existent project is specified."""
+        proposition = PropositionFactory()
+
+        url = reverse(
+            'api-v3:investment:proposition:document-collection',
+            kwargs={
+                'project_pk': uuid.uuid4(),
+                'proposition_pk': proposition.pk,
+            },
+        )
+        response = self.api_client.generic(http_method, url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_for_non_existent_proposition(self, http_method):
+        """Test that a 404 is returned if an non-existent proposition is specified."""
+        project = InvestmentProjectFactory()
+
+        url = reverse(
+            'api-v3:investment:proposition:document-collection',
+            kwargs={
+                'project_pk': project.pk,
+                'proposition_pk': uuid.uuid4(),
+            },
+        )
+        response = self.api_client.generic(http_method, url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_for_mismatched_proposition_and_project(self, http_method):
+        """Test that a 404 is returned if an unrelated project and proposition are specified."""
+        proposition = PropositionFactory()
+        project = InvestmentProjectFactory()
+
+        url = reverse(
+            'api-v3:investment:proposition:document-collection',
+            kwargs={
+                'project_pk': project.pk,
+                'proposition_pk': proposition.pk,
+            },
+        )
+        response = self.api_client.generic(http_method, url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+@pytest.mark.parametrize(
+    'urlname,http_method',
+    (
+        ('api-v3:investment:proposition:document-item', 'get'),
+        ('api-v3:investment:proposition:document-item', 'delete'),
+        ('api-v3:investment:proposition:document-item-callback', 'post'),
+        ('api-v3:investment:proposition:document-item-download', 'get'),
+    ),
+)
+class TestPropositionDocumentItemViews404Handling(APITestMixin):
+    """Tests for 404-handling in all proposition document item views."""
+
+    def test_returns_404_for_non_existent_project(self, urlname, http_method):
+        """Test that a 404 is returned if a non-existent project is specified."""
+        proposition = PropositionFactory()
+        entity_document = PropositionDocument.objects.create(
+            proposition_id=proposition.pk,
+            original_filename='test.txt',
+            created_by=self.user,
+        )
+
+        url = reverse(
+            urlname,
+            kwargs={
+                'project_pk': uuid.uuid4(),
+                'proposition_pk': proposition.pk,
+                'entity_document_pk': entity_document.pk,
+            },
+        )
+        response = self.api_client.generic(http_method, url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_for_non_existent_proposition(self, urlname, http_method):
+        """Test that a 404 is returned if a non-existent proposition is specified."""
+        proposition = PropositionFactory()
+        entity_document = PropositionDocument.objects.create(
+            proposition_id=proposition.pk,
+            original_filename='test.txt',
+            created_by=self.user,
+        )
+
+        url = reverse(
+            urlname,
+            kwargs={
+                'project_pk': proposition.investment_project.pk,
+                'proposition_pk': uuid.uuid4(),
+                'entity_document_pk': entity_document.pk,
+            },
+        )
+        response = self.api_client.generic(http_method, url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_for_non_existent_document(self, urlname, http_method):
+        """Test that a 404 is returned if a non-existent document is specified."""
+        proposition = PropositionFactory()
+
+        url = reverse(
+            urlname,
+            kwargs={
+                'project_pk': proposition.investment_project.pk,
+                'proposition_pk': proposition.pk,
+                'entity_document_pk': uuid.uuid4(),
+            },
+        )
+        response = self.api_client.generic(http_method, url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_for_unrelated_project(self, urlname, http_method):
+        """Test that a 404 is returned if an unrelated project is specified."""
+        unrelated_project = InvestmentProjectFactory()
+        proposition = PropositionFactory()
+        entity_document = PropositionDocument.objects.create(
+            proposition_id=proposition.pk,
+            original_filename='test.txt',
+            created_by=self.user,
+        )
+
+        url = reverse(
+            urlname,
+            kwargs={
+                'project_pk': unrelated_project.pk,
+                'proposition_pk': proposition.pk,
+                'entity_document_pk': entity_document.pk,
+            },
+        )
+        response = self.api_client.generic(http_method, url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_for_unrelated_proposition(self, urlname, http_method):
+        """Test that a 404 is returned if an unrelated proposition is specified."""
+        proposition = PropositionFactory()
+        unrelated_proposition = PropositionFactory()
+        entity_document = PropositionDocument.objects.create(
+            proposition_id=proposition.pk,
+            original_filename='test.txt',
+            created_by=self.user,
+        )
+
+        url = reverse(
+            urlname,
+            kwargs={
+                'project_pk': proposition.investment_project.pk,
+                'proposition_pk': unrelated_proposition.pk,
+                'entity_document_pk': entity_document.pk,
+            },
+        )
+        response = self.api_client.generic(http_method, url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
 class TestPropositionDocumentViews(APITestMixin):
     """Tests for the proposition document views."""
 
@@ -1657,29 +1815,6 @@ class TestPropositionDocumentViews(APITestMixin):
         assert response.data == {
             'detail': 'You do not have permission to perform this action.',
         }
-
-    def test_cannot_create_document_for_non_existent_proposition(self):
-        """Test that user cannot create document for non existent proposition."""
-        investment_project = InvestmentProjectFactory()
-
-        url = reverse(
-            'api-v3:investment:proposition:document-collection',
-            kwargs={
-                'proposition_pk': uuid.uuid4(),
-                'project_pk': investment_project.pk,
-            },
-        )
-
-        user = create_test_user(permission_codenames=(PropositionDocumentPermission.add_all,))
-        api_client = self.create_api_client(user=user)
-
-        response = api_client.post(
-            url,
-            data={
-                'original_filename': 'test.txt',
-            },
-        )
-        assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.parametrize('permissions', NON_RESTRICTED_VIEW_PERMISSIONS)
     def test_documents_list(self, permissions):

--- a/datahub/investment/project/proposition/test/test_views.py
+++ b/datahub/investment/project/proposition/test/test_views.py
@@ -2310,6 +2310,10 @@ class TestPropositionDocumentViews(APITestMixin):
     @patch('datahub.documents.tasks.delete_document.apply_async')
     def test_document_delete_without_permission(self, delete_document):
         """Tests user can't delete document without permissions."""
+        user = create_test_user(
+            permission_codenames=(),
+            dit_team=TeamFactory(),
+        )
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk, original_filename='test.txt',
@@ -2325,7 +2329,8 @@ class TestPropositionDocumentViews(APITestMixin):
                 'entity_document_pk': entity_document.pk,
             },
         )
-        response = self.api_client.delete(url)
+        api_client = self.create_api_client(user=user)
+        response = api_client.delete(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
         assert delete_document.called is False
 
@@ -2415,6 +2420,10 @@ class TestPropositionDocumentViews(APITestMixin):
 
     def test_document_upload_status_no_status_without_permission(self):
         """Tests user without permission can't call upload status endpoint."""
+        user = create_test_user(
+            permission_codenames=(),
+            dit_team=TeamFactory(),
+        )
         proposition = PropositionFactory()
         entity_document = PropositionDocument.objects.create(
             proposition_id=proposition.pk, original_filename='test.txt',
@@ -2429,7 +2438,8 @@ class TestPropositionDocumentViews(APITestMixin):
             },
         )
 
-        response = self.api_client.post(url, data={})
+        api_client = self.create_api_client(user=user)
+        response = api_client.post(url, data={})
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
 

--- a/datahub/investment/project/proposition/views.py
+++ b/datahub/investment/project/proposition/views.py
@@ -146,21 +146,34 @@ class PropositionDocumentViewSet(BaseEntityDocumentModelViewSet):
         IsAssociatedToInvestmentProjectPropositionDocumentPermission,
     )
     serializer_class = PropositionDocumentSerializer
+    queryset = PropositionDocument.objects.select_related(
+        'proposition__investment_project',
+    )
 
     filter_backends = (
         DjangoFilterBackend,
     )
 
-    def create(self, request, *args, **kwargs):
-        """Creates proposition document."""
-        self._check_proposition_exists()
-        return super().create(request, *args, **kwargs)
+    def initial(self, request, *args, **kwargs):
+        """
+        Raise an Http404 if there is no project or proposition corresponding to the IDs
+        specified in the URL path.
+        """
+        super().initial(request, *args, **kwargs)
 
-    def get_queryset(self):
-        """Returns proposition documents queryset."""
-        return PropositionDocument.objects.select_related(
-            'proposition__investment_project',
-        ).filter(
+        proposition_queryset = Proposition.objects.filter(
+            pk=self.kwargs['proposition_pk'],
+            investment_project_id=self.kwargs['project_pk'],
+        )
+
+        if not proposition_queryset.exists():
+            raise Http404(self.non_existent_proposition_error_message)
+
+    def filter_queryset(self, queryset):
+        """Filter the queryset to the project and proposition specified in the URL path."""
+        filtered_queryset = super().filter_queryset(queryset)
+
+        return filtered_queryset.filter(
             proposition_id=self.kwargs['proposition_pk'],
             proposition__investment_project_id=self.kwargs['project_pk'],
         )
@@ -176,7 +189,3 @@ class PropositionDocumentViewSet(BaseEntityDocumentModelViewSet):
         data['proposition_id'] = entity_document.proposition_id
         record_user_event(request, USER_EVENT_TYPES.proposition_document_delete, data=data)
         return super().destroy(request, *args, **kwargs)
-
-    def _check_proposition_exists(self):
-        if not Proposition.objects.filter(pk=self.kwargs['proposition_pk']).exists():
-            raise Http404(self.non_existent_proposition_error_message)

--- a/fixtures/metadata/teams.yaml
+++ b/fixtures/metadata/teams.yaml
@@ -53,6 +53,18 @@
     - - view_associated_proposition
       - proposition
       - proposition
+    - - add_associated_propositiondocument
+      - proposition
+      - propositiondocument
+    - - change_associated_propositiondocument
+      - proposition
+      - propositiondocument
+    - - view_associated_propositiondocument
+      - proposition
+      - propositiondocument
+    - - delete_associated_propositiondocument
+      - proposition
+      - propositiondocument
     - - add_associated_evidencedocument
       - evidence
       - evidencedocument
@@ -186,6 +198,18 @@
     - - view_associated_proposition
       - proposition
       - proposition
+    - - add_associated_propositiondocument
+      - proposition
+      - propositiondocument
+    - - change_associated_propositiondocument
+      - proposition
+      - propositiondocument
+    - - view_associated_propositiondocument
+      - proposition
+      - propositiondocument
+    - - delete_associated_propositiondocument
+      - proposition
+      - propositiondocument
     - - add_associated_evidencedocument
       - evidence
       - evidencedocument
@@ -289,6 +313,18 @@
     - - view_all_proposition
       - proposition
       - proposition
+    - - add_all_propositiondocument
+      - proposition
+      - propositiondocument
+    - - change_all_propositiondocument
+      - proposition
+      - propositiondocument
+    - - view_all_propositiondocument
+      - proposition
+      - propositiondocument
+    - - delete_all_propositiondocument
+      - proposition
+      - propositiondocument
     - - add_all_evidencedocument
       - evidence
       - evidencedocument


### PR DESCRIPTION
### Description of change

This corrects various missed cases in the investment proposition documents views so that they return a 404 if a non-existent investment project or proposition is specified in the URL.

It also resolves the following warning that was happening during DRF schema introspection:

```
/<omitted>/python3.7/site-packages/django_filters/rest_framework/backends.py:128: UserWarning: <class 'datahub.investment.project.proposition.views.PropositionDocumentViewSet'> is not compatible with schema generation
  "{} is not compatible with schema generation".format(view.__class__)
```

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
