### PR TITLE
Update Python to version 3.7.4 in deployed environments

### DIFF
--- a/changelog/python-3.7.4.internal.rst
+++ b/changelog/python-3.7.4.internal.rst
@@ -1,0 +1,1 @@
+Python was updated from version 3.7.3 to 3.7.4 in deployed environments.

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
-- buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.32
+- buildpack: https://github.com/cloudfoundry/python-buildpack.git#v1.6.35
   stack: cflinuxfs3

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.3
+python-3.7.4


### PR DESCRIPTION
### Description of change

This:

- updates Python to version 3.7.4 in deployed environments
- updates the build pack to version 1.6.35

Build pack release notes: https://github.com/cloudfoundry/python-buildpack/releases
Python 3.7.4 change log: https://docs.python.org/3.7/whatsnew/changelog.html#python-3-7-4-final

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
