### PR TITLE
Enable the use of TAP fields for interaction.

### DIFF
--- a/changelog/interaction/interaction-tap-validation.api.rst
+++ b/changelog/interaction/interaction-tap-validation.api.rst
@@ -1,0 +1,1 @@
+``POST /v3/interaction`` now accepts TAP related fields ``grant_amount_offered`` and ``net_company_receipt`` for interaction.

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -415,8 +415,6 @@ class InteractionSerializer(serializers.ModelSerializer):
                     OperatorRule('is_event', is_blank),
                     OperatorRule('event', is_blank),
                     OperatorRule('service_delivery_status', is_blank),
-                    OperatorRule('grant_amount_offered', is_blank),
-                    OperatorRule('net_company_receipt', is_blank),
                     when=EqualsRule('kind', Interaction.KINDS.interaction),
                 ),
                 ValidationRule(

--- a/datahub/interaction/test/views/test_interaction.py
+++ b/datahub/interaction/test/views/test_interaction.py
@@ -323,6 +323,8 @@ class TestAddInteraction(APITestMixin):
                     'service': Service.inbound_referral.value.id,
                     'communication_channel': partial(random_obj_for_model, CommunicationChannel),
                     'was_policy_feedback_provided': False,
+                    'grant_amount_offered': '1111.11',
+                    'net_company_receipt': '8888.11',
 
                     # fields not allowed
                     'is_event': True,
@@ -330,8 +332,6 @@ class TestAddInteraction(APITestMixin):
                     'service_delivery_status': partial(
                         random_obj_for_model, ServiceDeliveryStatus,
                     ),
-                    'grant_amount_offered': '1111.11',
-                    'net_company_receipt': '8888.11',
                     'policy_areas': [partial(random_obj_for_model, PolicyArea)],
                     'policy_feedback_notes': 'Policy feedback notes.',
                     'policy_issue_types': [partial(random_obj_for_model, PolicyIssueType)],
@@ -342,8 +342,6 @@ class TestAddInteraction(APITestMixin):
                     'service_delivery_status': [
                         'This field is only valid for service deliveries.',
                     ],
-                    'grant_amount_offered': ['This field is only valid for service deliveries.'],
-                    'net_company_receipt': ['This field is only valid for service deliveries.'],
                     'policy_areas': [
                         'This field is only valid when policy feedback has been provided.',
                     ],


### PR DESCRIPTION
### Description of change

This change removes validation of TAP fields so that they can be accepted when creating an interaction (before the change, these fields were only allowed for service delivery).

This is branched off `feature/service-order`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
