### PR TITLE
Correct search view schemas

### DIFF
--- a/changelog/schema-fixes.bugfix.rst
+++ b/changelog/schema-fixes.bugfix.rst
@@ -4,3 +4,4 @@ Schemas in the API documentation were corrected for the following endpoints:
 - all unarchive endpoints
 - the complete OMIS order endpoint
 - the cancel OMIS order endpoint
+- all search endpoints

--- a/datahub/core/mixins.py
+++ b/datahub/core/mixins.py
@@ -36,7 +36,7 @@ class ArchivableViewSetMixin:
     @action(
         methods=['post'],
         detail=True,
-        schema=ExplicitSerializerSchema(ArchiveSerializer),
+        schema=ExplicitSerializerSchema(request_body_serializer=ArchiveSerializer()),
     )
     def archive(self, request, pk):
         """Archive the object."""
@@ -59,7 +59,7 @@ class ArchivableViewSetMixin:
     @action(
         methods=['post'],
         detail=True,
-        schema=ExplicitSerializerSchema(UnarchiveSerializer),
+        schema=ExplicitSerializerSchema(request_body_serializer=UnarchiveSerializer()),
     )
     def unarchive(self, request, pk):
         """Unarchive the object."""

--- a/datahub/core/schemas.py
+++ b/datahub/core/schemas.py
@@ -21,7 +21,7 @@ class ExplicitSerializerSchema(AutoSchema):
             @action(
                 methods=['post'],
                 detail=True,
-                schema=ExplicitSerializerSchema(ArchiveSerializer),
+                schema=ExplicitSerializerSchema(request_body_serializer=ArchiveSerializer()),
             )
             def archive(self, request, pk):
                 pass
@@ -30,32 +30,67 @@ class ExplicitSerializerSchema(AutoSchema):
     See also: CoreViewSet.as_action_view
     """
 
-    def __init__(self, serializer_cls, *args, **kwargs):
+    def __init__(
+        self,
+        request_body_serializer=None,
+        *args,
+        **kwargs,
+    ):
         """Initialise the schema with a serialiser."""
         super().__init__(*args, **kwargs)
 
-        self.serializer_cls = serializer_cls
+        self.request_body_serializer = request_body_serializer
+
+    def get_request_body_serializer(self):
+        """Get an instance of self.serializer_cls."""
+        return self.request_body_serializer
+
+    def get_serializer_configs(self, method):
+        """
+        Get a list of (serializer instance, is_partial, location) tuples.
+
+        See `get_fields_for_serializer` for the meaning of is_partial and location.
+        """
+        serializer_configs = []
+
+        request_body_serializer = self.get_request_body_serializer()
+
+        if request_body_serializer:
+            serializer_configs.append((request_body_serializer, method == 'PATCH', 'form'))
+
+        return serializer_configs
 
     def get_serializer_fields(self, path, method):
-        """
-        Get the schema fields for self.serializer_cls.
-
-        This logic is based on the equivalent logic in AutoSchema.
-        """
-        serializer = self.serializer_cls()
-        is_partial = method == 'PATCH'
-
-        writable_fields = (
-            field for field in serializer.fields.values()
-            if not (field.read_only or isinstance(field, serializers.HiddenField))
-        )
+        """Get schema fields for the serializers returned by get_serializer_configs()."""
+        serializer_configs = self.get_serializer_configs(method)
 
         return [
-            coreapi.Field(
-                name=field.field_name,
-                location='form',
-                required=field.required and not is_partial,
-                schema=field_to_schema(field),
-            )
-            for field in writable_fields
+            field
+            for serializer, is_partial, location in serializer_configs
+            for field in get_fields_for_serializer(serializer, is_partial, location)
         ]
+
+
+def get_fields_for_serializer(serializer, is_partial, location):
+    """
+    Generate a list of schema fields for a serializer.
+
+    :param serializer: a serializer instance
+    :param is_partial: whether this is a partial update (e.g. a PATCH request)
+    :param location: location of the generated fields
+        (valid values include 'form' for the request body and 'query' for the query string)
+    """
+    writable_fields = (
+        field for field in serializer.fields.values()
+        if not (field.read_only or isinstance(field, serializers.HiddenField))
+    )
+
+    return [
+        coreapi.Field(
+            name=field.field_name,
+            location=location,
+            required=field.required and not is_partial,
+            schema=field_to_schema(field),
+        )
+        for field in writable_fields
+    ]

--- a/datahub/core/schemas.py
+++ b/datahub/core/schemas.py
@@ -32,17 +32,23 @@ class ExplicitSerializerSchema(AutoSchema):
 
     def __init__(
         self,
+        query_string_serializer=None,
         request_body_serializer=None,
         *args,
         **kwargs,
     ):
-        """Initialise the schema with a serialiser."""
+        """Initialise the schema with query string and request body serialisers."""
         super().__init__(*args, **kwargs)
 
+        self.query_string_serializer = query_string_serializer
         self.request_body_serializer = request_body_serializer
 
+    def get_query_string_serializer(self):
+        """Get an instance of the serializer used for the query string."""
+        return self.query_string_serializer
+
     def get_request_body_serializer(self):
-        """Get an instance of self.serializer_cls."""
+        """Get an instance of the serializer used for the request body."""
         return self.request_body_serializer
 
     def get_serializer_configs(self, method):
@@ -57,6 +63,11 @@ class ExplicitSerializerSchema(AutoSchema):
 
         if request_body_serializer:
             serializer_configs.append((request_body_serializer, method == 'PATCH', 'form'))
+
+        query_string_serializer = self.get_query_string_serializer()
+
+        if query_string_serializer:
+            serializer_configs.append((query_string_serializer, False, 'query'))
 
         return serializer_configs
 

--- a/datahub/core/test/test_schemas.py
+++ b/datahub/core/test/test_schemas.py
@@ -17,9 +17,10 @@ class TestExplicitSerializerSchema:
     """Tests for ExplicitSerializerSchema."""
 
     @pytest.mark.parametrize(
-        'http_method,expected_fields',
+        'initkwargs,http_method,expected_fields',
         (
             pytest.param(
+                {'request_body_serializer': SimpleSerializer()},
                 'POST',
                 [
                     coreapi.Field(
@@ -35,8 +36,10 @@ class TestExplicitSerializerSchema:
                         coreschema.Integer(title='Field b', description=''),
                     ),
                 ],
+                id='request body, POST',
             ),
             pytest.param(
+                {'request_body_serializer': SimpleSerializer()},
                 'PATCH',
                 [
                     coreapi.Field(
@@ -52,10 +55,30 @@ class TestExplicitSerializerSchema:
                         coreschema.Integer(title='Field b', description=''),
                     ),
                 ],
+                id='request body, PATCH',
+            ),
+            pytest.param(
+                {'query_string_serializer': SimpleSerializer()},
+                'PATCH',
+                [
+                    coreapi.Field(
+                        'field_a',
+                        False,
+                        'query',
+                        coreschema.String(title='Field a', description=''),
+                    ),
+                    coreapi.Field(
+                        'field_b',
+                        True,
+                        'query',
+                        coreschema.Integer(title='Field b', description=''),
+                    ),
+                ],
+                id='query string',
             ),
         ),
     )
-    def test_get_serializer_fields(self, http_method, expected_fields):
+    def test_get_serializer_fields(self, initkwargs, http_method, expected_fields):
         """Test get_serializer_fields()."""
-        schema = ExplicitSerializerSchema(request_body_serializer=SimpleSerializer())
+        schema = ExplicitSerializerSchema(**initkwargs)
         assert schema.get_serializer_fields('/path', http_method) == expected_fields

--- a/datahub/core/test/test_schemas.py
+++ b/datahub/core/test/test_schemas.py
@@ -57,5 +57,5 @@ class TestExplicitSerializerSchema:
     )
     def test_get_serializer_fields(self, http_method, expected_fields):
         """Test get_serializer_fields()."""
-        schema = ExplicitSerializerSchema(SimpleSerializer)
+        schema = ExplicitSerializerSchema(request_body_serializer=SimpleSerializer())
         assert schema.get_serializer_fields('/path', http_method) == expected_fields

--- a/datahub/omis/order/views.py
+++ b/datahub/omis/order/views.py
@@ -33,7 +33,7 @@ class OrderViewSet(CoreViewSet):
     @action(
         methods=['post'],
         detail=True,
-        schema=ExplicitSerializerSchema(CompleteOrderSerializer),
+        schema=ExplicitSerializerSchema(request_body_serializer=CompleteOrderSerializer()),
     )
     def complete(self, request, *args, **kwargs):
         """Complete an order."""
@@ -53,7 +53,7 @@ class OrderViewSet(CoreViewSet):
     @action(
         methods=['post'],
         detail=True,
-        schema=ExplicitSerializerSchema(CancelOrderSerializer),
+        schema=ExplicitSerializerSchema(request_body_serializer=CancelOrderSerializer()),
     )
     def cancel(self, request, *args, **kwargs):
         """Cancel an order."""

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -45,6 +45,7 @@ v4_view_registry = {}
 class SearchBasicAPIView(APIView):
     """Aggregate all entities search view."""
 
+    schema = ExplicitSerializerSchema(query_string_serializer=BasicSearchQuerySerializer())
     permission_classes = (IsAuthenticatedOrTokenHasScope,)
 
     required_scopes = (Scope.internal_front_end,)

--- a/datahub/search/views.py
+++ b/datahub/search/views.py
@@ -13,6 +13,7 @@ from rest_framework.views import APIView
 
 from datahub.core.csv import create_csv_response
 from datahub.core.exceptions import DataHubException
+from datahub.core.schemas import ExplicitSerializerSchema
 from datahub.oauth.scopes import Scope
 from datahub.search.apps import get_search_apps
 from datahub.search.execute_query import execute_autocomplete_query, execute_search_query
@@ -90,8 +91,18 @@ def _get_permission_filters(request):
         yield (app.es_model._doc_type.name, filter_args)
 
 
+class SearchAPIViewSchema(ExplicitSerializerSchema):
+    """Schema used for views based on SearchAPIView."""
+
+    def get_request_body_serializer(self):
+        """Get a serializer instance using the serializer_class attribute on the view."""
+        return self.view.serializer_class()
+
+
 class SearchAPIView(APIView):
     """Filtered search view."""
+
+    schema = SearchAPIViewSchema()
 
     search_app = None
     permission_classes = (IsAuthenticatedOrTokenHasScope, SearchPermissions)


### PR DESCRIPTION
# Description of change

This corrects the schemas for the following endpoints:

- `GET /v3/search`
- `POST /v3/search/<model>`
- `POST /v3/search/<model>/export`
- `POST /v4/search/<model>`
- `POST /v4/search/<model>/export`
- `POST /v4/public/search/company`

`ExplicitSerializerSchema` was enhanced slightly so that a query string serializer can be specified, and also so that the request body serializer can be dynamically specified.

# Screenshots

## `GET /v3/search`

### Before

![image](https://user-images.githubusercontent.com/12693549/61209200-f8eaa580-a6f0-11e9-90dc-6f8478e2d60d.png)

### After

![image](https://user-images.githubusercontent.com/12693549/61209090-baed8180-a6f0-11e9-9aca-4fa780a3ed5d.png)

## `POST /v3/search/contact`

### Before

![image](https://user-images.githubusercontent.com/12693549/61209207-ff791d00-a6f0-11e9-819f-31161ee7c7f1.png)

### After

![image](https://user-images.githubusercontent.com/12693549/61209111-c640ad00-a6f0-11e9-82c9-15bcbf546529.png)

# Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
