### PR TITLE
Correct interaction services.

### DIFF
--- a/datahub/metadata/migrations/0033_update_services.py
+++ b/datahub/metadata/migrations/0033_update_services.py
@@ -1,0 +1,23 @@
+from pathlib import PurePath
+
+from django.db import migrations
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_services(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0033_update_services.yaml',
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('metadata', '0032_service_order'),
+    ]
+
+    operations = [
+        migrations.RunPython(load_services, migrations.RunPython.noop),
+    ]

--- a/datahub/metadata/migrations/0033_update_services.yaml
+++ b/datahub/metadata/migrations/0033_update_services.yaml
@@ -1,0 +1,16 @@
+- model: metadata.service
+  pk: 140e343e-b69c-4449-99df-bc6735498391
+  fields:
+    disabled_on:
+    name: 'A Specific Service : Great International Trade Campaign'
+    order: 660.0
+    contexts: ["event", "other_interaction", "other_service_delivery"]
+    requires_service_answers_flow_feature_flag: false
+- model: metadata.service
+  pk: 041e7ce1-9d5a-4ce6-b77c-088aef9d816b
+  fields:
+    disabled_on: null
+    name: 'Enquiry or Referral Received : General Export Enquiry'
+    order: 200.0
+    contexts: ["export_interaction"]
+    requires_service_answers_flow_feature_flag: false


### PR DESCRIPTION
### Description of change

This changes the context of two services that was incorrect. 

`A Specific Service : Great International Trade Campaign` is added to other interaction context.

`Enquiry or Referral Received : General Export Enquiry` has event context removed.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
