### PR TITLE
Correct investment document upload callback view schemas

### DIFF
--- a/changelog/investment/schema-fixes.bugfix.rst
+++ b/changelog/investment/schema-fixes.bugfix.rst
@@ -1,0 +1,1 @@
+The schema in the API documentation was corrected for all investment document upload callback endpoints.

--- a/datahub/documents/views.py
+++ b/datahub/documents/views.py
@@ -1,6 +1,8 @@
 """Document views."""
 from django.core.exceptions import PermissionDenied
+from rest_framework.decorators import action
 
+from datahub.core.schemas import ExplicitSerializerSchema
 from datahub.core.viewsets import CoreViewSet
 from datahub.documents.exceptions import TemporarilyUnavailableException
 from datahub.documents.tasks import delete_document
@@ -19,12 +21,14 @@ class BaseEntityDocumentModelViewSet(CoreViewSet):
 
         return response
 
+    @action(methods=['post'], detail=True, schema=ExplicitSerializerSchema())
     def upload_complete_callback(self, request, *args, **kwargs):
         """File upload done callback."""
         entity_document = self.get_object()
         entity_document.document.schedule_av_scan()
         return self.retrieve(request)
 
+    @action(methods=['get'], detail=True, schema=ExplicitSerializerSchema())
     def download(self, request, *args, **kwargs):
         """Provides download information."""
         entity_document = self.get_object()

--- a/datahub/investment/project/evidence/urls.py
+++ b/datahub/investment/project/evidence/urls.py
@@ -14,14 +14,6 @@ evidence_document_item = EvidenceDocumentViewSet.as_view({
     'delete': 'destroy',
 })
 
-evidence_document_callback = EvidenceDocumentViewSet.as_view({
-    'post': 'upload_complete_callback',
-})
-
-evidence_document_download = EvidenceDocumentViewSet.as_view({
-    'get': 'download',
-})
-
 urlpatterns = [
     path(
         'evidence-document',
@@ -35,12 +27,12 @@ urlpatterns = [
     ),
     path(
         'evidence-document/<uuid:entity_document_pk>/upload-callback',
-        evidence_document_callback,
+        EvidenceDocumentViewSet.as_action_view('upload_complete_callback'),
         name='document-item-callback',
     ),
     path(
         'evidence-document/<uuid:entity_document_pk>/download',
-        evidence_document_download,
+        EvidenceDocumentViewSet.as_action_view('download'),
         name='document-item-download',
     ),
 ]

--- a/datahub/investment/project/proposition/urls.py
+++ b/datahub/investment/project/proposition/urls.py
@@ -34,13 +34,11 @@ proposition_document_item = PropositionDocumentViewSet.as_view({
     'delete': 'destroy',
 })
 
-proposition_document_callback = PropositionDocumentViewSet.as_view({
-    'post': 'upload_complete_callback',
-})
+proposition_document_callback = PropositionDocumentViewSet.as_action_view(
+    'upload_complete_callback',
+)
 
-proposition_document_download = PropositionDocumentViewSet.as_view({
-    'get': 'download',
-})
+proposition_document_download = PropositionDocumentViewSet.as_action_view('download')
 
 urlpatterns = [
     path('proposition', proposition_collection, name='collection'),


### PR DESCRIPTION
# Description of change

This corrects the schema for:

- `/v3/investment/{project_pk}/evidence-document/{entity_document_pk}/upload-callback`
- `/v3/investment/{project_pk}/proposition/{proposition_pk}/document/{entity_document_pk}/upload-callback`

Previously, they were showing a request body, which was incorrect. As these are extra actions on a generic API view set they need a schema to be explicitly set.

# Screenshots

## `/v3/investment/{project_pk}/evidence-document/{entity_document_pk}/upload-callback`

### Before

![image](https://user-images.githubusercontent.com/12693549/61299210-91f3ec00-a7d7-11e9-877c-c9c469384e3c.png)

### After

![image](https://user-images.githubusercontent.com/12693549/61299036-44777f00-a7d7-11e9-9366-ac1c84b56e52.png)

# Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
