### PR TITLE
Update Django Rest Framework and django-filter

### DIFF
--- a/changelog/update-drf.internal.rst
+++ b/changelog/update-drf.internal.rst
@@ -1,0 +1,1 @@
+Django Rest Framework was updated from version 3.9.4 to version 3.10.1.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -260,6 +260,7 @@ REST_FRAMEWORK = {
         'oauth2_provider.contrib.rest_framework.IsAuthenticatedOrTokenHasScope',
         'datahub.core.permissions.DjangoCrudPermission',
     ],
+    'DEFAULT_SCHEMA_CLASS': 'rest_framework.schemas.coreapi.AutoSchema',
     'DEFAULT_THROTTLE_RATES': {
         'payment_gateway_session.create': '5/min',
     },

--- a/datahub/core/schemas.py
+++ b/datahub/core/schemas.py
@@ -1,7 +1,6 @@
 import coreapi
 from rest_framework import serializers
-from rest_framework.schemas import AutoSchema
-from rest_framework.schemas.inspectors import field_to_schema
+from rest_framework.schemas.coreapi import AutoSchema, field_to_schema
 
 
 class ExplicitSerializerSchema(AutoSchema):

--- a/datahub/interaction/serializers.py
+++ b/datahub/interaction/serializers.py
@@ -44,16 +44,6 @@ class InteractionDITParticipantListSerializer(serializers.ListSerializer):
         ),
     }
 
-    def bind(self, field_name, parent):
-        """
-        Overridden to set self.partial to False as otherwise allow_empty=False does not behave
-        correctly.
-
-        See https://github.com/encode/django-rest-framework/issues/6509.
-        """
-        super().bind(field_name, parent)
-        self.partial = False
-
     def run_validation(self, data=serializers.empty):
         """
         Validates that there are no duplicate advisers.

--- a/datahub/investment/project/test/test_signals.py
+++ b/datahub/investment/project/test/test_signals.py
@@ -1,0 +1,66 @@
+from unittest.mock import Mock
+
+import pytest
+
+from datahub.core.test_utils import random_obj_for_model
+from datahub.investment.project.test.factories import InvestmentProjectFactory
+from datahub.metadata.models import InvestmentBusinessActivity
+
+
+@pytest.mark.django_db
+class TestUpdateGVAOnBusinessActivitiesM2MChanged:
+    """
+    Tests for the update_gross_value_added_on_project_business_activities_m2m_changed
+    signal receiver.
+    """
+
+    def test_add(self, monkeypatch):
+        """
+        Test that the GVA of a project is updated when a business activity is added to the
+        project.
+        """
+        project = InvestmentProjectFactory()
+
+        set_gross_value_added_for_investment_project_mock = Mock()
+        monkeypatch.setattr(
+            'datahub.investment.project.signals.set_gross_value_added_for_investment_project',
+            set_gross_value_added_for_investment_project_mock,
+        )
+
+        business_activity = random_obj_for_model(InvestmentBusinessActivity)
+        project.business_activities.add(business_activity)
+
+        set_gross_value_added_for_investment_project_mock.assert_called_once_with(project)
+
+    def test_remove(self, monkeypatch):
+        """
+        Test that the GVA of a project is updated when a business activity is removed from
+        the project.
+        """
+        business_activity = random_obj_for_model(InvestmentBusinessActivity)
+        project = InvestmentProjectFactory(business_activities=[business_activity])
+
+        set_gross_value_added_for_investment_project_mock = Mock()
+        monkeypatch.setattr(
+            'datahub.investment.project.signals.set_gross_value_added_for_investment_project',
+            set_gross_value_added_for_investment_project_mock,
+        )
+
+        project.business_activities.remove(business_activity)
+
+        set_gross_value_added_for_investment_project_mock.assert_called_once_with(project)
+
+    def test_clear(self, monkeypatch):
+        """Test that the GVA of a project is updated when its business activities are cleared."""
+        business_activity = random_obj_for_model(InvestmentBusinessActivity)
+        project = InvestmentProjectFactory(business_activities=[business_activity])
+
+        set_gross_value_added_for_investment_project_mock = Mock()
+        monkeypatch.setattr(
+            'datahub.investment.project.signals.set_gross_value_added_for_investment_project',
+            set_gross_value_added_for_investment_project_mock,
+        )
+
+        project.business_activities.clear()
+
+        set_gross_value_added_for_investment_project_mock.assert_called_once_with(project)

--- a/datahub/investment/project/test/test_views.py
+++ b/datahub/investment/project/test/test_views.py
@@ -471,8 +471,8 @@ class TestCreateView(APITestMixin):
             response_data['project_manager_request_status']['id']
             == str(project_manager_request_status_id)
         )
-        # GVA Multiplier - Transportation & storage - 2019 - 0.0621 * 1000
-        assert response_data['gross_value_added'] == '62'
+        # GVA Multiplier for Retail & wholesale trade - 2019 - 0.0581 * 1000
+        assert response_data['gross_value_added'] == '58'
 
     def test_create_project_fail(self):
         """Test creating a project with missing required values."""
@@ -1128,6 +1128,11 @@ class TestPartialUpdateView(APITestMixin):
         response_data = response.json()
         assert str(response_data['foreign_equity_investment']) == '100000'
         assert response_data['gross_value_added'] == expected_gross_value_added
+
+        # Make sure the GVA was actually saved (and an unsaved investment project wasn't
+        # serialised)
+        project.refresh_from_db()
+        assert project.gross_value_added == Decimal(expected_gross_value_added)
 
     def test_patch_project_conditional_failure(self):
         """Test updating a project w/ missing conditionally required value."""

--- a/requirements.in
+++ b/requirements.in
@@ -4,11 +4,11 @@ cssselect==1.0.3
 
 # Django and django related
 Django==2.2.3
-djangorestframework==3.9.4
+djangorestframework==3.10.1
 django-admin-ip-restrictor==1.0.0
 django-environ==0.4.5
 django-extensions==2.1.9
-django-filter==2.1.0
+django-filter==2.2.0
 django-reversion==3.0.4
 django-pglocks==1.0.2
 django-model-utils==3.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ django-admin-ip-restrictor==1.0.0
 django-debug-toolbar==2.0
 django-environ==0.4.5
 django-extensions==2.1.9
-django-filter==2.1.0
+django-filter==2.2.0
 django-ipware==2.1.0      # via django-admin-ip-restrictor
 django-js-asset==1.2.2    # via django-mptt
 django-model-utils==3.2.0
@@ -36,7 +36,7 @@ django-pglocks==1.0.2
 django-redis==4.10.0
 django-reversion==3.0.4
 django==2.2.3
-djangorestframework==3.9.4
+djangorestframework==3.10.1
 docopt==0.6.2             # via notifications-python-client
 docutils==0.14            # via botocore
 elasticsearch-dsl==6.3.1


### PR DESCRIPTION
### Description of change

This updates Django Rest Framework to version 3.10.1 and django-filter to version 2.2.0.

Release notes:

- DRF 3.10.0: https://www.django-rest-framework.org/community/3.10-announcement/
- django-filter 2.2.0: https://github.com/carltongibson/django-filter/blob/master/CHANGES.rst#version-22-2019-7-16

This keeps using the Core API schema features of DRF (rather than switching to OpenAPI schema generation). Switching to OpenAPI will be tackled separately.

There [was a slight change to the order DRF saves fields during updates](https://github.com/encode/django-rest-framework/pull/6752). Previously, it saved to-one and to-many fields in a somewhat arbitrary order. Now, it consistently saves to-many fields last. 

That change revealed a problem with the investment project GVA updates. One of the investment project GVA tests was failing after the DRF update as there was an assumption that the business activities to-many field would be saved before the model object.

This has been fixed by adding an additional signal receiver that specifically monitors changes to the `business_activities` many-to-many field.

A workaround for encode/django-rest-framework#6509 has also been removed as that bug has now been fixed.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
