### PR TITLE
Add endpoint to check if a company is on a user's personal list

### DIFF
--- a/changelog/adviser/check-company-list-item.api.rst
+++ b/changelog/adviser/check-company-list-item.api.rst
@@ -1,0 +1,7 @@
+The following endpoint was added:
+
+- ``GET /v4/user/company-list/<company ID>``
+
+It checks if a company is on the authenticated user's personal list of companies.
+
+If the company is on the user's list, a 2xx status code will be returned. If it is not, a 404 will be returned.

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework import status
@@ -17,6 +18,14 @@ class CompanyListItemPermissions(DjangoModelPermissions):
         'DELETE': [
             f'company.{CompanyPermission.view_company}',
             f'company_list.{CompanyListItemPermissionCode.delete_company_list_item}',
+        ],
+        'GET': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{CompanyListItemPermissionCode.view_company_list_item}',
+        ],
+        'HEAD': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{CompanyListItemPermissionCode.view_company_list_item}',
         ],
         'PUT': [
             f'company.{CompanyPermission.view_company}',
@@ -44,6 +53,18 @@ class CompanyListItemView(APIView):
     )
     # Note: A query set is required for CompanyListItemPermissions
     queryset = CompanyListItem.objects.all()
+
+    def get(self, request, format=None, company_pk=None):
+        """Check if a CompanyListItem exists for the authenticated user and specified company."""
+        company_exists = CompanyListItem.objects.filter(
+            adviser=request.user.pk,
+            company_id=company_pk,
+        ).exists()
+
+        if not company_exists:
+            raise Http404()
+
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
 
     def put(self, request, format=None, company_pk=None):
         """


### PR DESCRIPTION
### Description of change

This adds an endpoint at `GET /v4/user/company-list/<company ID>` which checks if a specific company is on the authenticated user's personal list of companies.

(The endpoint should also support `HEAD` although we've seen some weirdness with it that's not in our control. Also note that `HEAD` is omitted from the docs generated by DRF.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
