### PR TITLE
Block adding archived companies to a user's company list

### DIFF
--- a/changelog/adviser/block-add-archived-company-list-item.api.rst
+++ b/changelog/adviser/block-add-archived-company-list-item.api.rst
@@ -1,0 +1,9 @@
+``PUT /v4/user/company-list/<company ID>``: A 400 is now returned if an archived company is specified.
+
+In this case, the response body will contain::
+
+    {
+        "non_field_errors": "An archived company can't be added to a company list."
+    }
+
+(Note that it is still possible to remove archived companies from a user's company list.)


### PR DESCRIPTION
### Description of change

This amends `PUT /v4/user/company-list/<company ID>` so that it's not possible to add archived companies to a user's company list.

(It's still possible to remove archived companies from a user's list, in case they become archived after they are added to a user's list.)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
