### PR TITLE
Use CREATE INDEX instead of CREATE INDEX CONCURRENTLY in migration

### DIFF
--- a/changelog/interaction/no-concurrently-index.internal.rst
+++ b/changelog/interaction/no-concurrently-index.internal.rst
@@ -1,0 +1,1 @@
+A migration was updated to not create a database index concurrently due to a problem encountered during deployment.

--- a/datahub/interaction/migrations/0063_add_index_for_company_list.py
+++ b/datahub/interaction/migrations/0063_add_index_for_company_list.py
@@ -2,32 +2,14 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-    # This is needed so that we can use CREATE INDEX CONCURRENTLY
-    atomic = False
-
     dependencies = [
         ('interaction', '0062_disable_making_introductions_serviceansweroptions'),
     ]
 
     operations = [
-        # Note that we are using SeparateDatabaseAndState only so that we can use
-        # CREATE INDEX CONCURRENTLY.
-        # After squashing, migrations.SeparateDatabaseAndState should be removed and
-        # just migrations.AddIndex used instead.
-        migrations.SeparateDatabaseAndState(
-            state_operations=[
-                migrations.AddIndex(
-                    model_name='interaction',
-                    index=models.Index(fields=['company', '-date', '-created_on', 'id'],
-                                       name='interaction_company_236ca9_idx'),
-                ),
-            ],
-            database_operations=[
-                migrations.RunSQL("""
-CREATE INDEX CONCURRENTLY "interaction_company_236ca9_idx"
-ON "interaction_interaction" ("company_id", "date"DESC, "created_on"DESC, "id");
-"""
-                )
-            ],
+        migrations.AddIndex(
+            model_name='interaction',
+            index=models.Index(fields=['company', '-date', '-created_on', 'id'],
+                               name='interaction_company_236ca9_idx'),
         ),
     ]


### PR DESCRIPTION
### Description of change

This updates a recent migration to use CREATE INDEX instead of CREATE INDEX CONCURRENTLY as we had a deadlock with the latter which needs further investigation.

For now, we will have to live with the temporary SHARE lock that CREATE INDEX obtains.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
