### PR TITLE
Explicitly order multi-value fields in search CSV exports

### DIFF
--- a/changelog/csv-multi-value-fields-order.bugfix.rst
+++ b/changelog/csv-multi-value-fields-order.bugfix.rst
@@ -1,0 +1,1 @@
+Comma- and semicolon-delimited values in CSV exports are now always sorted alphabetically. (Previously, they were in an unspecified order which could change between exports.)

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -33,18 +33,17 @@ def get_string_agg_subquery(model, expression, delimiter=', '):
 
     The passed model must be the model of the query set being annotated.
 
-    At present values are concatenated in an undefined order, however Django 2.2 added support for
-    providing an ordering.
-
-    TODO: However, the StringAgg ordering keyword argument is not currently used due to the
-     problem described in https://code.djangoproject.com/ticket/30315.
+    Values are sorted alphabetically before concatenation.
 
     Usage example:
         Company.objects.annotate(
             export_to_country_names=get_string_agg_subquery(Company, 'export_to_countries__name'),
         )
     """
-    return get_aggregate_subquery(model, StringAgg(expression, delimiter))
+    return get_aggregate_subquery(
+        model,
+        StringAgg(expression, delimiter, ordering=(expression,)),
+    )
 
 
 def get_aggregate_subquery(model, expression):

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -383,7 +383,7 @@ def join_attr_values(iterable, attr='name', separator=', '):
     attr can also be a dotted path (to specify sub-attributes).
     """
     getter = attrgetter(attr)
-    return separator.join(sorted(getter(value) for value in iterable))
+    return separator.join(getter(value) for value in iterable)
 
 
 def format_csv_data(rows):

--- a/datahub/search/interaction/tests/test_views.py
+++ b/datahub/search/interaction/tests/test_views.py
@@ -18,6 +18,7 @@ from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import CompanyFactory, ContactFactory
 from datahub.core import constants
+from datahub.core.query_utils import get_bracketed_concat_expression, get_full_name_expression
 from datahub.core.test_utils import (
     APITestMixin,
     create_test_user,
@@ -954,14 +955,22 @@ class TestInteractionExportView(APITestMixin):
                     'service_delivery_status.name',
                 ),
                 'Net company receipt': interaction.net_company_receipt,
-                'Policy issue types': join_attr_values(interaction.policy_issue_types.all()),
-                'Policy areas': join_attr_values(interaction.policy_areas.all(), separator='; '),
+                'Policy issue types': join_attr_values(
+                    interaction.policy_issue_types.order_by('name'),
+                ),
+                'Policy areas': join_attr_values(
+                    interaction.policy_areas.order_by('name'),
+                    separator='; ',
+                ),
                 'Policy feedback notes': interaction.policy_feedback_notes,
             }
             for interaction in sorted_interactions
         ]
 
-        actual_row_data = [_format_actual_csv_row(row) for row in reader]
+        # DictReader uses OrderedDicts, we convert them to normal dicts to get better errors
+        # when the assertion fails
+        actual_row_data = [dict(item) for item in reader]
+
         assert actual_row_data == format_csv_data(expected_row_data)
 
 
@@ -1074,10 +1083,13 @@ class TestInteractionBasicSearch(APITestMixin):
 
 
 def _format_expected_contacts(interaction):
-    formatted_contact_names = sorted(
-        [_format_expected_contact_name(contact) for contact in interaction.contacts.all()],
+    queryset = interaction.contacts.order_by(
+        get_full_name_expression(bracketed_field_name='job_title'),
     )
-    return ', '.join(formatted_contact_names)
+
+    return ', '.join(
+        _format_expected_contact_name(contact) for contact in queryset
+    )
 
 
 def _format_expected_contact_name(contact):
@@ -1088,41 +1100,20 @@ def _format_expected_contact_name(contact):
 
 
 def _format_expected_advisers(interaction):
-    formatted_contact_names = sorted(
-        _format_expected_adviser_name(dit_participant)
-        for dit_participant in interaction.dit_participants.all()
+    queryset = interaction.dit_participants.order_by(
+        get_bracketed_concat_expression(
+            'adviser__first_name',
+            'adviser__last_name',
+            expression_to_bracket='team__name',
+        ),
     )
-    return ', '.join(formatted_contact_names)
+
+    return ', '.join(
+        _format_expected_adviser_name(dit_participant) for dit_participant in queryset
+    )
 
 
 def _format_expected_adviser_name(dit_participant):
     adviser_name = dit_participant.adviser.name if dit_participant.adviser else ''
     team_name = f'({dit_participant.team.name})' if dit_participant.team else ''
     return join_truthy_strings(adviser_name, team_name)
-
-
-def _format_actual_csv_row(row):
-    return {key: _format_actual_csv_value(key, value) for key, value in row.items()}
-
-
-def _format_actual_csv_value(key, value):
-    """
-    Sorts the value of multi-value fields for a row alphabetically as they are unordered at
-    present.
-
-    TODO Django 2.2 added ordering support to StringAgg, which will remove the need for this.
-     However, it is not currently used due to https://code.djangoproject.com/ticket/30315.
-    """
-    multi_value_fields_and_separators = {
-        'Advisers': ', ',
-        'Contacts': ', ',
-        'Policy areas': '; ',
-        'Policy issue types': ', ',
-    }
-
-    if key in multi_value_fields_and_separators:
-        separator = multi_value_fields_and_separators[key]
-        sorted_split_values = sorted(value.split(separator))
-        return separator.join(sorted_split_values)
-
-    return value

--- a/datahub/search/large_investor_profile/test/test_views.py
+++ b/datahub/search/large_investor_profile/test/test_views.py
@@ -2,7 +2,6 @@ from cgi import parse_header
 from collections import Counter
 from csv import DictReader
 from io import StringIO
-from itertools import chain
 
 import pytest
 from django.conf import settings
@@ -692,36 +691,36 @@ class TestLargeInvestorProfileExportView(APITestMixin):
                 ),
                 'Date last modified': profile.modified_on,
                 'UK regions of interest': join_attr_values(
-                    profile.uk_region_locations.all(),
+                    profile.uk_region_locations.order_by('name'),
                 ),
                 'Restrictions': join_attr_values(
-                    profile.restrictions.all(),
+                    profile.restrictions.order_by('name'),
                 ),
                 'Time horizons': join_attr_values(
-                    profile.time_horizons.all(),
+                    profile.time_horizons.order_by('name'),
                 ),
                 'Investment types': join_attr_values(
-                    profile.investment_types.all(),
+                    profile.investment_types.order_by('name'),
                 ),
                 'Deal ticket sizes': join_attr_values(
-                    profile.deal_ticket_sizes.all(),
+                    profile.deal_ticket_sizes.order_by('name'),
                 ),
                 'Desired deal roles': join_attr_values(
-                    profile.desired_deal_roles.all(),
+                    profile.desired_deal_roles.order_by('name'),
                 ),
                 'Required checks conducted by': get_attr_or_none(
                     profile, 'required_checks_conducted_by.name',
                 ),
                 'Required checks conducted on': profile.required_checks_conducted_on,
                 'Other countries being considered': join_attr_values(
-                    profile.other_countries_being_considered.all(),
+                    profile.other_countries_being_considered.order_by('name'),
                 ),
                 'Construction risks': join_attr_values(
-                    profile.construction_risks.all(),
+                    profile.construction_risks.order_by('name'),
                 ),
                 'Data Hub profile reference': str(profile.pk),
                 'Asset classes of interest': join_attr_values(
-                    profile.asset_classes_of_interest.all(),
+                    profile.asset_classes_of_interest.order_by('name'),
                 ),
                 'Data Hub link': (
                     f'{settings.DATAHUB_FRONTEND_URL_PREFIXES["company"]}'
@@ -736,25 +735,5 @@ class TestLargeInvestorProfileExportView(APITestMixin):
         # item is an ordered dict so is cast to a dict to make the comparison easier to
         # interpret in the event of the assert actual_rows == expected_rows failing.
         actual_rows = [dict(item) for item in reader]
-
-        # Support for ordering was added to StringAgg in Django 2.2. However, it is not
-        # currently used due to https://code.djangoproject.com/ticket/30315. While that
-        # remains the case, our StringAgg fields are unordered and we use this workaround to
-        # compare them.
-        unordered_fields = [
-            'Asset classes of interest',
-            'Construction risks',
-            'Deal ticket sizes',
-            'Desired deal roles',
-            'Investment types',
-            'Other countries being considered',
-            'Restrictions',
-            'Time horizons',
-            'UK regions of interest',
-        ]
-
-        for row in chain(actual_rows, expected_rows):
-            for field in unordered_fields:
-                row[field] = frozenset(row[field].split(', '))
 
         assert actual_rows == expected_rows


### PR DESCRIPTION
### Description of change

This sets StringAgg orderings in CSV export query sets now that https://code.djangoproject.com/ticket/30315 has been fixed.

The ordering used is alphabetical as this is the only real ordering available.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
