### PR TITLE
Hydrate DNB search API responses with Data Hub company data if it exists

### DIFF
--- a/changelog/company/dnb-search-hydration.api.rst
+++ b/changelog/company/dnb-search-hydration.api.rst
@@ -1,0 +1,16 @@
+``POST /v4/dnb/company-search``: This endpoint was modified to ensure that DNB
+results were hydrated with the corresponding Data Hub company, if it is present
+and can be matched (by duns number).
+
+The API response returns Data Hub companies alongside DNB data in the following format::
+
+    "datahub_company": {
+        "id": "0f5216e0-849f-11e6-ae22-56b6b6499611",
+        "latest_interaction": {
+            "id": "e8c3534f-4f60-4c93-9880-09c22e4fc011",
+            "created_on": "2018-04-08T14:00:00Z",
+            "date": "2018-06-06",
+            "subject": "Exported to Canada"
+        }
+    }
+

--- a/datahub/dnb_api/queryset.py
+++ b/datahub/dnb_api/queryset.py
@@ -1,0 +1,31 @@
+from django.db.models import F
+
+from datahub.company.models import Company
+from datahub.core.query_utils import get_top_related_expression_subquery
+from datahub.interaction.models import Interaction
+
+
+def get_company_queryset():
+    """
+    Returns an annotated query set used by DNBCompanySearchView.
+
+    The annotations are supported by an index on the Interaction model.
+
+    (Note that getting all four interaction fields in one expression currently is not easily
+    done with the Django ORM, hence four annotations are used.)
+    """
+    return Company.objects.annotate(
+        latest_interaction_id=_get_field_of_latest_interaction('pk'),
+        latest_interaction_created_on=_get_field_of_latest_interaction('created_on'),
+        latest_interaction_date=_get_field_of_latest_interaction('date'),
+        latest_interaction_subject=_get_field_of_latest_interaction('subject'),
+    )
+
+
+def _get_field_of_latest_interaction(field):
+    return get_top_related_expression_subquery(
+        Interaction.company.field,
+        F(field),
+        ('-date', '-created_on', 'pk'),
+        outer_field='id',
+    )

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from datahub.company.models import Company
+from datahub.interaction.models import InteractionPermission
 
 
 class DNBMatchedCompanySerializer(serializers.ModelSerializer):
@@ -15,6 +16,15 @@ class DNBMatchedCompanySerializer(serializers.ModelSerializer):
         Construct a latest interaction object from the latest_interaction_id,
         latest_interaction_date and latest_interaction_subject query set annotations.
         """
+        request = self.context.get('request', None)
+
+        # Ensure that we do not return any interaction details if the user
+        # does not have permission to view them
+        if request:
+            permission_codename = f'interaction.{InteractionPermission.view_all}'
+            if not request.user or not request.user.has_perm(permission_codename):
+                return None
+
         if not obj.latest_interaction_id:
             return None
 

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -1,10 +1,11 @@
 from rest_framework import serializers
 
 from datahub.company.models import Company
+from datahub.core.serializers import PermittedFieldsModelSerializer
 from datahub.interaction.models import InteractionPermission
 
 
-class DNBMatchedCompanySerializer(serializers.ModelSerializer):
+class DNBMatchedCompanySerializer(PermittedFieldsModelSerializer):
     """
     Serialiser for data hub companies matched with a DNB entry.
     """
@@ -16,15 +17,6 @@ class DNBMatchedCompanySerializer(serializers.ModelSerializer):
         Construct a latest interaction object from the latest_interaction_id,
         latest_interaction_date and latest_interaction_subject query set annotations.
         """
-        request = self.context.get('request', None)
-
-        # Ensure that we do not return any interaction details if the user
-        # does not have permission to view them
-        if request:
-            permission_codename = f'interaction.{InteractionPermission.view_all}'
-            if not request.user or not request.user.has_perm(permission_codename):
-                return None
-
         if not obj.latest_interaction_id:
             return None
 
@@ -43,3 +35,6 @@ class DNBMatchedCompanySerializer(serializers.ModelSerializer):
             'id',
             'latest_interaction',
         )
+        permissions = {
+            f'interaction.{InteractionPermission.view_all}': 'latest_interaction',
+        }

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -1,0 +1,35 @@
+from rest_framework import serializers
+
+from datahub.company.models import Company
+
+
+class DNBMatchedCompanySerializer(serializers.ModelSerializer):
+    """
+    Serialiser for data hub companies matched with a DNB entry.
+    """
+
+    latest_interaction = serializers.SerializerMethodField()
+
+    def get_latest_interaction(self, obj):
+        """
+        Construct a latest interaction object from the latest_interaction_id,
+        latest_interaction_date and latest_interaction_subject query set annotations.
+        """
+        if not obj.latest_interaction_id:
+            return None
+
+        return {
+            'id': obj.latest_interaction_id,
+            'created_on': obj.latest_interaction_created_on,
+            # For consistency with the main interaction API, only return the date part.
+            # See InteractionSerializer for more information
+            'date': obj.latest_interaction_date.date(),
+            'subject': obj.latest_interaction_subject,
+        }
+
+    class Meta:
+        model = Company
+        fields = (
+            'id',
+            'latest_interaction',
+        )

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1,13 +1,19 @@
+import datetime
+import json
+
 import pytest
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.test.utils import override_settings
+from django.utils.timezone import make_aware
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.company.test.factories import CompanyFactory
 from datahub.core.test_utils import APITestMixin
 from datahub.dnb_api.constants import FEATURE_FLAG_DNB_COMPANY_SEARCH
 from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.interaction.test.factories import CompanyInteractionFactory
 
 
 @pytest.fixture()
@@ -18,30 +24,101 @@ def dnb_company_search_feature_flag():
     yield FeatureFlagFactory(code=FEATURE_FLAG_DNB_COMPANY_SEARCH)
 
 
+@pytest.fixture()
+def dnb_company_search_datahub_companies():
+    """
+    Creates Data Hub companies for hydrating DNB search results with.
+    """
+    # Company with no interactions
+    CompanyFactory(duns_number='1234567', id='6083b732-b07a-42d6-ada4-c8082293285b')
+    # Company with two interactions
+    company = CompanyFactory(duns_number='7654321', id='6083b732-b07a-42d6-ada4-c99999999999')
+
+    interaction_date = make_aware(
+        datetime.datetime(year=2019, month=8, day=1, hour=16, minute=0, second=0),
+    )
+    latest_interaction = CompanyInteractionFactory(
+        id='6083b732-b07a-42d6-ada4-222222222222',
+        date=interaction_date,
+        subject='Meeting with Joe Bloggs',
+        company=company,
+    )
+    latest_interaction.created_on = interaction_date
+    latest_interaction.save()
+
+    older_interaction_date = make_aware(datetime.datetime(year=2018, month=8, day=1))
+    older_interaction = CompanyInteractionFactory(
+        id='6083b732-b07a-42d6-ada4-111111111111',
+        date=older_interaction_date,
+        subject='Meeting with John Smith',
+        company=company,
+    )
+    older_interaction.created_on = older_interaction_date
+
+
 class TestDNBCompanySearchAPI(APITestMixin):
     """
     DNB Company Search view test case.
     """
 
     @pytest.mark.parametrize(
-        'request_data,response_status_code,response_content',
+        'request_data,response_status_code,upstream_response_content,response_data',
         (
             pytest.param(
                 b'{"arg": "value"}',
                 200,
-                b'{"took":27}',
-                id='successful call to proxied API',
+                b'{"results":[{"duns_number":"9999999"}]}',
+                {
+                    'results': [
+                        {
+                            'dnb_company': {'duns_number': '9999999'},
+                            'datahub_company': None,
+                        },
+                    ],
+                },
+                id='successful call to proxied API with company that cannot be hydrated',
+            ),
+            pytest.param(
+                b'{"arg": "value"}',
+                200,
+                b'{"results":[{"duns_number":"1234567"}, {"duns_number":"7654321"}]}',
+                {
+                    'results': [
+                        {
+                            'dnb_company': {'duns_number': '1234567'},
+                            'datahub_company': {
+                                'id': '6083b732-b07a-42d6-ada4-c8082293285b',
+                                'latest_interaction': None,
+                            },
+                        },
+                        {
+                            'dnb_company': {'duns_number': '7654321'},
+                            'datahub_company': {
+                                'id': '6083b732-b07a-42d6-ada4-c99999999999',
+                                'latest_interaction': {
+                                    'id': '6083b732-b07a-42d6-ada4-222222222222',
+                                    'date': '2019-08-01',
+                                    'created_on': '2019-08-01T16:00:00Z',
+                                    'subject': 'Meeting with Joe Bloggs',
+                                },
+                            },
+                        },
+                    ],
+                },
+                id='successful call to proxied API with company that can be hydrated',
             ),
             pytest.param(
                 b'{"arg": "value"}',
                 400,
                 b'{"error":"msg"}',
+                {'error': 'msg'},
                 id='proxied API returns a bad request',
             ),
             pytest.param(
                 b'{"arg": "value"}',
                 500,
                 b'{"error":"msg"}',
+                {'error': 'msg'},
                 id='proxied API returns a server error',
             ),
         ),
@@ -49,10 +126,12 @@ class TestDNBCompanySearchAPI(APITestMixin):
     def test_post(
         self,
         dnb_company_search_feature_flag,
+        dnb_company_search_datahub_companies,
         requests_mock,
         request_data,
         response_status_code,
-        response_content,
+        upstream_response_content,
+        response_data,
     ):
         """
         Test for POST proxy.
@@ -60,7 +139,7 @@ class TestDNBCompanySearchAPI(APITestMixin):
         requests_mock.post(
             settings.DNB_SERVICE_BASE_URL + 'companies/search/',
             status_code=response_status_code,
-            content=response_content,
+            content=upstream_response_content,
         )
 
         url = reverse('api-v4:dnb-api:company-search')
@@ -71,7 +150,7 @@ class TestDNBCompanySearchAPI(APITestMixin):
         )
 
         assert response.status_code == response_status_code
-        assert response.content == response_content
+        assert json.loads(response.content) == response_data
         assert requests_mock.last_request.body == request_data
 
     def test_post_no_feature_flag(self, requests_mock):
@@ -127,6 +206,7 @@ class TestDNBCompanySearchAPI(APITestMixin):
         requests_mock.post(
             settings.DNB_SERVICE_BASE_URL + 'companies/search/',
             status_code=status.HTTP_200_OK,
+            content=b'{"results":[]}',
         )
 
         url = reverse('api-v4:dnb-api:company-search')

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -253,13 +253,12 @@ class TestDNBCompanySearchAPI(APITestMixin):
                 b'{"results":[{"duns_number":"7654321"}]}',
                 {
                     'results': [
-                        # latest_interaction is None, because the user does not have permission
+                        # latest_interaction is omitted, because the user does not have permission
                         # to view interactions
                         {
                             'dnb_company': {'duns_number': '7654321'},
                             'datahub_company': {
                                 'id': '6083b732-b07a-42d6-ada4-c99999999999',
-                                'latest_interaction': None,
                             },
                         },
                     ],

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -1,3 +1,4 @@
+import json
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -5,11 +6,14 @@ from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponse
 from django.utils.decorators import method_decorator
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
+from rest_framework.renderers import JSONRenderer
 from rest_framework.views import APIView
 
 from datahub.core.api_client import APIClient, TokenAuth
 from datahub.core.view_utils import enforce_request_content_type
 from datahub.dnb_api.constants import FEATURE_FLAG_DNB_COMPANY_SEARCH
+from datahub.dnb_api.queryset import get_company_queryset
+from datahub.dnb_api.serializers import DNBMatchedCompanySerializer
 from datahub.feature_flag.utils import feature_flagged_view
 from datahub.oauth.scopes import Scope
 
@@ -26,14 +30,49 @@ class DNBCompanySearchView(APIView):
     @method_decorator(enforce_request_content_type('application/json'))
     def post(self, request):
         """
-        Proxy for POST requests.
+        Proxy to DNB search API for POST requests.  This will also hydrate results
+        with Data Hub company details if the company exists (and can be matched)
+        on Data Hub.
         """
         upstream_response = self._get_upstream_response(request)
+        response_body_text = upstream_response.text
+
+        if upstream_response.status_code == 200:
+            response_body = json.loads(upstream_response.text)
+            response_body['results'] = self._transpose_and_hydrate(response_body['results'])
+            response_body_text = JSONRenderer().render(response_body)
+
         return HttpResponse(
-            upstream_response.text,
+            response_body_text,
             status=upstream_response.status_code,
             content_type=upstream_response.headers.get('content-type'),
         )
+
+    def _transpose_and_hydrate(self, dnb_results):
+        """
+        Transpose each result from DNB such that there is a "dnb_company" key and
+        a "datahub_company" key.  The value for "datahub_company" represents
+        the corresponding Company entry on Data Hub for the DNB result, if it
+        exists.
+        """
+        duns_numbers = [result['duns_number'] for result in dnb_results]
+        matching_datahub_companies = get_company_queryset().filter(duns_number__in=duns_numbers)
+        datahub_companies_by_duns = {
+            company.duns_number: company for company in matching_datahub_companies
+        }
+
+        hydrated_results = []
+
+        for dnb_result in dnb_results:
+            duns_number = dnb_result['duns_number']
+            hydrated_result = {'dnb_company': dnb_result, 'datahub_company': None}
+            datahub_company = datahub_companies_by_duns.get(duns_number)
+            if datahub_company:
+                datahub_company_data = DNBMatchedCompanySerializer(datahub_company).data
+                hydrated_result['datahub_company'] = datahub_company_data
+            hydrated_results.append(hydrated_result)
+
+        return hydrated_results
 
     def _get_upstream_response(self, request):
 

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -65,8 +65,7 @@ class DNBCompanySearchView(APIView):
                 datahub_company,
                 context={'request': self.request},
             ).data
-        else:
-            return None
+        return None
 
     def _format_and_hydrate(self, dnb_results):
         """


### PR DESCRIPTION
### Description of change

This PR aims to give DNB search results some context for the user by hydrating the results with Data Hub company data. Search results will be hydrated if the corresponding Company exists on Data Hub and if it has a duns number which matches the DNB duns number.

We have a requirement for the last interaction to show against each matched search result in the frontend, so this data is exposed using @reupen's pattern for getting the latest related entity to a model from a one to many relationship.  It's possible that we will need other company/related data to be exposed later, but for now this gives us a basis to get started with.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
