### PR TITLE
Fix bug preventing multiple companies being added to company lists

### DIFF
--- a/changelog/adviser/add-to-company-list.rst.bugfix.rst
+++ b/changelog/adviser/add-to-company-list.rst.bugfix.rst
@@ -1,0 +1,1 @@
+``PUT /v4/user/company-list/<company ID>``: A bug was fixed where multiple companies could not be added to a company list.

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -126,12 +126,7 @@ class CompanyListItemView(APIView):
 
         # update_or_create() is used to avoid an error if there is an existing
         # CompanyListItem for this adviser and company
-        self.queryset.update_or_create(
-            defaults={
-                'adviser': request.user,
-                'company': company,
-            },
-        )
+        self.queryset.update_or_create(adviser=request.user, company=company)
 
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
### Description of change

This fixes an unfortunate bug that was preventing multiple companies being added to a company list.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
