### PR TITLE
Update contact search CSV export for multiple interaction advisers

### DIFF
--- a/changelog/contact/search-csv-export-multiple-interaction-teams.feature.rst
+++ b/changelog/contact/search-csv-export-multiple-interaction-teams.feature.rst
@@ -1,0 +1,1 @@
+The search CSV export was updated to handle interactions with multiple teams in the 'Team of latest interaction' column. Multiple team names are separated by commas, and duplicate teams are omitted. The column was accordingly renamed 'Teams of latest interaction'.

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -27,7 +27,7 @@ class PreferNullConcat(Func):
     arg_joiner = ' || '
 
 
-def get_string_agg_subquery(model, expression, delimiter=', '):
+def get_string_agg_subquery(model, expression, delimiter=', ', distinct=False):
     """
     Gets a subquery that uses string_agg to concatenate values in a to-many field.
 
@@ -42,7 +42,7 @@ def get_string_agg_subquery(model, expression, delimiter=', '):
     """
     return get_aggregate_subquery(
         model,
-        StringAgg(expression, delimiter, ordering=(expression,)),
+        StringAgg(expression, delimiter, ordering=(expression,), distinct=distinct),
     )
 
 

--- a/datahub/core/test/test_query_utils.py
+++ b/datahub/core/test/test_query_utils.py
@@ -1,5 +1,5 @@
 from datetime import date
-from random import shuffle
+from random import sample, shuffle
 
 import factory
 import pytest
@@ -19,28 +19,48 @@ from datahub.core.query_utils import (
 )
 from datahub.core.test.support.factories import BookFactory, PersonFactory, PersonListItemFactory
 from datahub.core.test.support.models import Book, Person, PersonListItem
-from datahub.core.test_utils import join_attr_values
 
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize('num_authors', range(3))
-def test_get_string_agg_subquery(num_authors):
-    """
-    Test that get_string_agg_subquery() can be used to concatenate the first names of
-    all authors for each book into one field.
-    """
-    authors = PersonFactory.create_batch(num_authors)
-    book = BookFactory(authors=authors)
-    queryset = Book.objects.annotate(
-        author_names=get_string_agg_subquery(Book, 'authors__first_name'),
+class TestGetStringAggSubquery:
+    """Tests for get_string_agg_subquery()."""
+
+    @pytest.mark.parametrize(
+        'names,distinct,expected_result',
+        (
+            ([], False, None),
+            (['Barbara'], False, 'Barbara'),
+            (['Barbara', 'Claire'], False, 'Barbara, Claire'),
+            (['Barbara', 'Claire', 'John'], False, 'Barbara, Claire, John'),
+            (['Barbara', 'Claire', 'Claire'], False, 'Barbara, Claire, Claire'),
+            ([], True, None),
+            (['Barbara', 'Claire', 'John'], True, 'Barbara, Claire, John'),
+            (['Barbara', 'Claire', 'Claire'], True, 'Barbara, Claire'),
+            (
+                ['Barbara', 'Barbara', 'Claire', 'John', 'John', 'John', 'Samantha'],
+                True,
+                'Barbara, Claire, John, Samantha',
+            ),
+        ),
     )
-    actual_author_names = queryset.first().author_names or ''
-    expected_author_names = join_attr_values(
-        book.authors.order_by('first_name'),
-        'first_name',
-    )
-    assert actual_author_names == expected_author_names
+    def test_can_annotate_queryset(self, names, distinct, expected_result):
+        """
+        Test that the first names of all authors for each book can be concatenated into
+        one field as a query set annotation for various cases.
+        """
+        authors = PersonFactory.create_batch(
+            len(names),
+            first_name=factory.Iterator(
+                sample(names, len(names)),
+            ),
+        )
+        BookFactory(authors=authors)
+        queryset = Book.objects.annotate(
+            author_names=get_string_agg_subquery(Book, 'authors__first_name', distinct=distinct),
+        )
+        actual_author_names = queryset.first().author_names
+        assert actual_author_names == expected_result
 
 
 class TestGetAggregateSubquery:

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -1,4 +1,4 @@
-from django.db.models import Case, F, Max, Value, When
+from django.db.models import Case, Max, Value, When
 from django.db.models.functions import NullIf
 
 from datahub.company.models import Contact as DBContact
@@ -7,6 +7,7 @@ from datahub.core.query_utils import (
     get_aggregate_subquery,
     get_front_end_url_expression,
     get_full_name_expression,
+    get_string_agg_subquery,
     get_top_related_expression_subquery,
 )
 from datahub.interaction.models import Interaction as DBInteraction
@@ -105,9 +106,9 @@ class SearchContactExportAPIView(SearchContactAPIViewMixin, SearchExportAPIView)
             DBContact,
             Max('interactions__date'),
         ),
-        team_of_latest_interaction=get_top_related_expression_subquery(
+        teams_of_latest_interaction=get_top_related_expression_subquery(
             DBInteraction.contacts.field,
-            F('dit_team__name'),
+            get_string_agg_subquery(DBInteraction, 'dit_participants__team__name', distinct=True),
             ('-date',),
         ),
     )
@@ -127,6 +128,6 @@ class SearchContactExportAPIView(SearchContactAPIViewMixin, SearchExportAPIView)
         'email': 'Email address',
         'accepts_dit_email_marketing': 'Accepts DIT email marketing',
         'date_of_latest_interaction': 'Date of latest interaction',
-        'team_of_latest_interaction': 'Team of latest interaction',
+        'teams_of_latest_interaction': 'Teams of latest interaction',
         'created_by__dit_team__name': 'Created by team',
     }


### PR DESCRIPTION
### Description of change

Dependent on https://github.com/uktrade/data-hub-leeloo/pull/1900.

This updates the 'Team of latest interaction' field in the contact search CSV export to use `Interaction.dit_participants` instead of the old `Interaction.dit_team` field.

As a result, it now can contain multiple (comma-separated) values and the output column has been renamed 'Teams of latest interaction'.

Only unique values are included (as one team could be on an interaction multiple times if multiple advisers from the team were added to the interaction).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
