### PR TITLE
Remove interaction dit_adviser and dit_team fields from database

### DIFF
--- a/changelog/interaction/adviser-fields-from-db.removal.rst
+++ b/changelog/interaction/adviser-fields-from-db.removal.rst
@@ -1,0 +1,1 @@
+``interaction_interaction``: The deprecated ``dit_adviser_id`` and ``dit_team_id`` columns were removed. Please use the ``interaction_interactionditparticipant`` table instead.

--- a/datahub/interaction/migrations/0066_remove_dit_adviser_and_team_from_db.py
+++ b/datahub/interaction/migrations/0066_remove_dit_adviser_and_team_from_db.py
@@ -1,0 +1,48 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('interaction', '0065_remove_dit_adviser_and_team_from_state'),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name='interaction',
+                    name='dit_adviser',
+                    field=models.ForeignKey(
+                        help_text='This field is deprecated and has been replaced by DIT '
+                                  'participants.',
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='interactions',
+                        to=settings.AUTH_USER_MODEL
+                    ),
+                ),
+                migrations.AddField(
+                    model_name='interaction',
+                    name='dit_team',
+                    field=models.ForeignKey(
+                        help_text='This field is deprecated and has been replaced by DIT '
+                                  'participants.',
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        to='metadata.Team'
+                    ),
+                ),
+            ],
+        ),
+        migrations.RemoveField(
+            model_name='interaction',
+            name='dit_adviser',
+        ),
+        migrations.RemoveField(
+            model_name='interaction',
+            name='dit_team',
+        ),
+    ]


### PR DESCRIPTION
### Description of change

Dependent on https://github.com/uktrade/data-hub-leeloo/pull/1906 being released.

This removes the deprecated `dit_adviser` and `dit_team` interaction fields from the database.


### Migration SQL

```
BEGIN;
--
-- Custom state/database change combination
--
--
-- Remove field dit_adviser from interaction
--
SET CONSTRAINTS "interaction_interact_dit_adviser_id_73d9fa97_fk_company_a" IMMEDIATE; ALTER TABLE "interaction_interaction" DROP CONSTRAINT "interaction_interact_dit_adviser_id_73d9fa97_fk_company_a";
ALTER TABLE "interaction_interaction" DROP COLUMN "dit_adviser_id" CASCADE;
--
-- Remove field dit_team from interaction
--
SET CONSTRAINTS "interaction_interact_dit_team_id_f71bfd7b_fk_metadata_" IMMEDIATE; ALTER TABLE "interaction_interaction" DROP CONSTRAINT "interaction_interact_dit_team_id_f71bfd7b_fk_metadata_";
ALTER TABLE "interaction_interaction" DROP COLUMN "dit_team_id" CASCADE;
COMMIT;
```

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
