### PR TITLE
Add statsd monitoring for calendar invite ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `DATABASE_URL`  | Yes | PostgreSQL server URL (with embedded credentials). |
 | `DATAHUB_FRONTEND_BASE_URL`  | Yes | |
 | `DATAHUB_NOTIFICATION_API_KEY` | No | The GOVUK notify API key to use for the `datahub.notification` django app. |
+| `DATAHUB_SUPPORT_EMAIL_ADDRESS` | No | Email address for DataHub support team. |
 | `DEBUG`  | Yes | Whether Django's debug mode should be enabled. |
 | `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass\|spf:pass\|dkim:pass |
 | `DJANGO_SECRET_KEY`  | Yes | |
@@ -305,15 +306,13 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `RESTRICT_ADMIN` | No | Whether to restrict access to the admin site by IP address. |
 | `SENTRY_ENVIRONMENT`  | Yes | Value for the environment tag in Sentry. |
 | `SSO_ENABLED` | Yes | Whether single sign-on via RFC 7662 token introspection is enabled |
+| `STATSD_HOST` | No | StatsD host url. |
+| `STATSD_PORT` | No | StatsD port number. |
+| `STATSD_PREFIX` | No | Prefix for metrics being pushed to StatsD. |
 | `VCAP_SERVICES` | No | Set by GOV.UK PaaS when using their backing services. Contains connection details for Elasticsearch and Redis. |
 | `WEB_CONCURRENCY` | No | Number of Gunicorn workers (set automatically by Heroku, otherwise defaults to 1). |
 | `ENABLE_EMAIL_INGESTION` | No | True or False.  Whether or not to activate the celery beat task for ingesting emails |
-| `MAILBOX_MEETINGS_USERNAME` | No | Username of the inbox for ingesting meeting invites via IMAP (likely to be the same as the email for the mailbox) |
-| `MAILBOX_MEETINGS_PASSWORD` | No | Password for the inbox for ingesting meeting invites via IMAP |
-| `MAILBOX_MEETINGS_IMAP_DOMAIN` | No | IMAP domain for the inbox for ingesting meeting invites via IMAP |
-| `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass\|spf:pass\|dkim:pass |
 | `DATAHUB_NOTIFICATION_API_KEY` | No | The GOVUK notify API key to use for the `datahub.notification` django app. |
-| `DATAHUB_SUPPORT_EMAIL_ADDRESS` | No | Email address for DataHub support team. |
 
 
 ## Management commands

--- a/changelog/interaction/statsd-email-monitoring.feature.rst
+++ b/changelog/interaction/statsd-email-monitoring.feature.rst
@@ -1,0 +1,1 @@
+It is now possible to monitor the number of failed and successful calendar invites being ingested in DataHub using StatsD.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -567,13 +567,13 @@ MAILBOXES = {
 DIT_EMAIL_INGEST_WHITELIST = env.list('DIT_EMAIL_INGEST_WHITELIST', default=[])
 DIT_EMAIL_DOMAINS = {}
 domain_environ_names = [
-    environ_name 
+    environ_name
     for environ_name in env.ENVIRON.keys()
     if environ_name.startswith('DIT_EMAIL_DOMAIN_')
 ]
 
 # Go through all DIT_EMAIL_DOMAIN_* environment variables and extract
-# dictionary with key email domain and value consisting of 
+# dictionary with key email domain and value consisting of
 # authentication method/minimum pass result pairs e.g.
 # example.com=dmarc:pass|spf:pass|dkim:pass becomes
 # {'example.com': [['dmarc', 'pass'], ['spf', 'pass'], ['dkim', 'pass']]}
@@ -592,3 +592,7 @@ DNB_SERVICE_BASE_URL = env('DNB_SERVICE_BASE_URL', default=None)
 DNB_SERVICE_TOKEN = env('DNB_SERVICE_TOKEN', default=None)
 
 DATAHUB_SUPPORT_EMAIL_ADDRESS = env('DATAHUB_SUPPORT_EMAIL_ADDRESS', default=None)
+
+STATSD_HOST = env('STATSD_HOST', default='localhost')
+STATSD_PORT = env('STATSD_PORT', default='9125')
+STATSD_PREFIX = env('STATSD_PREFIX', default='datahub-api')

--- a/datahub/company/models/adviser.py
+++ b/datahub/company/models/adviser.py
@@ -121,6 +121,17 @@ class Advisor(AbstractBaseUser, PermissionsMixin):
         """
         return self.contact_email or self.email
 
+    def get_email_domain(self):
+        """
+        :returns: Domain for adviser's current email.
+        """
+        email = self.get_current_email()
+        try:
+            _, domain = email.rsplit('@', maxsplit=1)
+        except ValueError:
+            return None
+        return domain.lower()
+
     class Meta:
         indexes = [
             models.Index(fields=['first_name', 'last_name']),

--- a/datahub/company/test/models/test_adviser.py
+++ b/datahub/company/test/models/test_adviser.py
@@ -1,0 +1,27 @@
+import pytest
+
+from datahub.company.test.factories import AdviserFactory
+
+
+@pytest.mark.parametrize(
+    'email, domain',
+    (
+        ('adviser@dit.gov.uk', 'dit.gov.uk'),
+        # Emails can have @ if in quotes
+        ('"adviser@dit"@dit.gov.uk', 'dit.gov.uk'),
+        # Domain may not have a .
+        ('adviser@dit', 'dit'),
+        # Domain may have different case
+        ('adviser@Dit.gov.uk', 'dit.gov.uk'),
+        ('adviser@DIT.GOV.UK', 'dit.gov.uk'),
+        # Invalid email
+        ('adviser', None),
+    ),
+)
+def test_get_email_domain(email, domain, db):
+    """
+    Test that the `Adviser.get_email_domain` method
+    returns the domain for the given adviser's email.
+    """
+    adviser = AdviserFactory(email=email, contact_email=email)
+    assert adviser.get_email_domain() == domain

--- a/datahub/interaction/email_processors/notify.py
+++ b/datahub/interaction/email_processors/notify.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
+from statsd.defaults.django import statsd
 
 from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.interaction import INTERACTION_EMAIL_NOTIFICATION_FEATURE_FLAG_NAME
@@ -20,11 +21,21 @@ class Template(Enum):
     meeting_ingest_success = '47418011-3f53-4b39-860a-30969b29781b'
 
 
+def get_domain_label(domain):
+    """
+    "." is not a valid character in a prometheus label and the recommended
+    practice is to replace it with an "_".
+    """
+    return domain.replace('.', '_')
+
+
 def notify_meeting_ingest_failure(adviser, errors, recipients):
     """
     Notify an adviser that a meeting ingest has failed - including error
     details and intended recipients.
     """
+    domain_label = get_domain_label(adviser.get_email_domain())
+    statsd.incr(f'celery.calendar-invite-ingest.failure.{domain_label}')
     if not is_feature_flag_active(INTERACTION_EMAIL_NOTIFICATION_FEATURE_FLAG_NAME):
         logger.info(
             f'Feature flag "{INTERACTION_EMAIL_NOTIFICATION_FEATURE_FLAG_NAME}" is not active, '
@@ -49,6 +60,8 @@ def notify_meeting_ingest_success(adviser, interaction, recipients):
     Notify an adviser that a meeting ingest has succeeeded - including a link
     to the interaction and intended recipients.
     """
+    domain_label = get_domain_label(adviser.get_email_domain())
+    statsd.incr(f'celery.calendar-invite-ingest.success.{domain_label}')
     if not is_feature_flag_active(INTERACTION_EMAIL_NOTIFICATION_FEATURE_FLAG_NAME):
         logger.info(
             f'Feature flag "{INTERACTION_EMAIL_NOTIFICATION_FEATURE_FLAG_NAME}" is not active, '

--- a/datahub/interaction/test/email_processors/test_notify.py
+++ b/datahub/interaction/test/email_processors/test_notify.py
@@ -1,0 +1,64 @@
+from unittest.mock import Mock
+
+import pytest
+
+from datahub.company.test.factories import AdviserFactory
+from datahub.interaction.email_processors.notify import (
+    get_domain_label,
+    notify_meeting_ingest_failure,
+    notify_meeting_ingest_success,
+)
+
+
+@pytest.fixture
+def mock_statsd(monkeypatch):
+    """
+    Returns a mock statsd client instance.
+    """
+    mock_statsd = Mock()
+    monkeypatch.setattr(
+        'datahub.interaction.email_processors.notify.statsd',
+        mock_statsd,
+    )
+    return mock_statsd
+
+
+@pytest.mark.parametrize(
+    'domain, label',
+    (
+        ('dit.gov.uk', 'dit_gov_uk'),
+    ),
+)
+def test_get_domain_label(domain, label):
+    """
+    Test if the `get_domain_label` function converts
+    a given domain (with "." characters) to a Prometheus
+    label (without "." characters).
+    """
+    assert get_domain_label(domain) == label
+
+
+@pytest.mark.django_db
+def test_notify_email_ingest_failure(mock_statsd):
+    """
+    Test that the `notify_email_ingest_failure` fucntion increments the
+    right counters in StatsD.
+    """
+    adviser = AdviserFactory(contact_email='adviser@dit.gov.uk')
+    notify_meeting_ingest_failure(adviser, (), ())
+    mock_statsd.incr.assert_called_once_with(
+        f'celery.calendar-invite-ingest.failure.dit_gov_uk',
+    )
+
+
+@pytest.mark.django_db
+def test_notify_email_ingest_success(mock_statsd):
+    """
+    Test that the `notify_email_ingest_failure` fucntion increments the
+    right counters in StatsD.
+    """
+    adviser = AdviserFactory(contact_email='adviser@dit.gov.uk')
+    notify_meeting_ingest_success(adviser, Mock(), ())
+    mock_statsd.incr.assert_called_once_with(
+        f'celery.calendar-invite-ingest.success.dit_gov_uk',
+    )

--- a/requirements.in
+++ b/requirements.in
@@ -30,6 +30,9 @@ boto3==1.9.200
 
 notifications-python-client==5.3.0
 
+# Prometheus
+statsd==3.3.0
+
 # Email
 mail-parser==3.9.3
 icalendar==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -120,6 +120,7 @@ simplejson==3.16.0        # via mail-parser
 six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mail-parser, mohawk, packaging, pip-tools, piprot, prompt-toolkit, pydocstyle, pytest-xdist, python-dateutil, requests-mock, traitlets
 snowballstemmer==1.2.1    # via pydocstyle
 sqlparse==0.3.0           # via django, django-debug-toolbar
+statsd==3.3.0
 termcolor==1.1.0          # via pytest-sugar
 text-unidecode==1.2       # via faker
 toml==0.10.0              # via towncrier

--- a/statsd_mapping.yml
+++ b/statsd_mapping.yml
@@ -1,0 +1,8 @@
+mappings:
+- match: "datahub.*.calendar-invite-ingest.*.*"
+  name: "calendar_invite_ingest_total"
+  labels:
+    source: "$1"
+    result: "$2"
+    domain: "$3"
+    job: "calendar-invite-ingest"


### PR DESCRIPTION
### Description of change

This puts in the minimal code required to send metrics to `statsd` or specifically [statsd_exporter](https://github.com/prometheus/statsd_exporter). 

There are a few caveats around the DSL used by `statsd_exporter` to map metrics. Happy to hear ideas for how to solve this more elegantly.

To run this, you can do something along the following lines:

```
$ docker run -d -p 9102:9102 -p 9125:9125 -p 9125:9125/udp \
-v $PWD/statsd_mapping.yml:/tmp/statsd_mapping.yml \
prom/statsd-exporter --statsd.mapping-config=/tmp/statsd_mapping.yml

$ pytest datahub/interaction/test/email_processors/test_processors.py

$ curl localhost:9102/metrics

💰 
```


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
