### PR TITLE
Add request times to Gunicorn log format

### DIFF
--- a/changelog/update-gunicorn-log-format.rst
+++ b/changelog/update-gunicorn-log-format.rst
@@ -1,0 +1,1 @@
+The Gunicorn log format was updated to include request times in seconds.

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -5,7 +5,7 @@ from psycogreen.gevent import patch_psycopg
 accesslog = os.environ.get('GUNICORN_ACCESSLOG', '-')
 access_log_format = os.environ.get(
     'GUNICORN_ACCESS_LOG_FORMAT',
-    '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %({X-Forwarded-For}i)s',
+    '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s %({X-Forwarded-For}i)s',
 )
 worker_class = os.environ.get('GUNICORN_WORKER_CLASS', 'gevent')
 worker_connections = os.environ.get('GUNICORN_WORKER_CONNECTIONS', '10')


### PR DESCRIPTION
### Description of change

This updates the Gunicorn access log format to include request times in seconds (with decimal places).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
