### PR TITLE
Add API documentation maintenance details

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,6 +5,7 @@
 ### Checklist
 
 * [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
+* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
 * [ ] Have any relevant search models been updated?
 * [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
 * [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?

--- a/README.md
+++ b/README.md
@@ -170,6 +170,10 @@ Dependencies:
     `-O fair --prefetch-multiplier 1` arguments for better fairness when long-running tasks
     are running or pending execution.
 
+## API documentation
+
+Automatically-generated API documentation is served at `/docs` (requires admin site credentials). 
+
 ## Local development
 
 If using Docker, prefix these commands with `docker-compose run leeloo`.

--- a/docs/Maintaining the API documentation.md
+++ b/docs/Maintaining the API documentation.md
@@ -1,0 +1,32 @@
+# Maintaining the API documentation
+
+We make use of the built-in OpenAPI schema generation feature of Django Rest Framework. The feature is described in the following articles:
+
+- https://www.django-rest-framework.org/topics/documenting-your-api/
+- https://www.django-rest-framework.org/api-guide/schemas/
+
+Swagger UI is served at ``/docs`` and a JSON OpenAPI schema at ``/docs/schema``.  
+
+## Things to look out for when writing API views
+
+The feature in DRF largely works by trying to introspect views. There are a few things to be aware of:
+
+1. During introspection, generic view sets (in our code base, usually inheriting from `CoreViewSet`) will have their `get_serializer()` method (and, hence, `get_serializer_context()`) called without `self.kwargs` being populated. 
+   
+1. Where action methods are added to a generic view set (e.g. the `archive` and `unarchive` methods on many of our view sets), DRF will assume that the view set’s serializer is used for requests and responses.
+    
+    If this is wrong, the simplest thing to do is use the `datahub.core.schemas.StubSchema` to suppress request and response schema generation. See `datahub.omis.order.views.OrderViewSet` for an example.
+
+1. [Generic view sets must specify a serializer class.](https://github.com/encode/django-rest-framework/issues/6535)
+    
+    If the view doesn’t, it’s not a generic view set and so you should use `APIView` instead. 
+
+## Known limitations
+
+1. `NestedRelatedField` is currently rendered as a string. Currently, all the logic pertaining to particular fields lies in DRF’s `AutoSchema` so this can’t be changed without replacing `AutoSchema`.
+
+1. Pagination properties are missing from responses. This is a DRF limitation. 
+
+1. Endpoints using `StubSchema` or `APIView` will be missing request and response schemas (where they have them).
+      
+   This could be overcome with [custom `AutoSchema` subclasses](https://www.django-rest-framework.org/api-guide/schemas/#per-view-customization). These could, for example, allow serializers to be explicitly specified or allow a schema in OpenAPI format to be explicitly specified (depending on the use case).

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This page contains a non-exhaustive list of documents related to specific develo
 * [Code Review guidelines](./Code&#32;review&#32;guidelines.md)
 * [Incremental Pull Requests](./Incremental&#32;Pull&#32;Requests.md)
 * [Managing dependencies](./Managing&#32;dependencies.md)
+* [Maintaining the API documentation](./Maintaining&#32;the&#32;API&#32;documentation.md)
 * [Document upload architectural design](./Document&#32;upload.md)
 * [How elasticsearch mapping migration works and how to use it](./Elasticsearch&#32;migrations.md)
 * [How to prepare a release](./How&#32;to&#32;prepare&#32;a&#32;release.md)


### PR DESCRIPTION
### Description of change

This adds a few notes about the API documentation and schema generation in DRF.

(I've left the wording of the PR checklist item a bit loose as we know the generated documentation isn't perfect.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
