### PR TITLE
Fix high memory usage with blank contact email addresses in import interaction tools

### DIFF
--- a/changelog/interaction/fix-oom-interactions-import-blank-contact-email.bugfix.rst
+++ b/changelog/interaction/fix-oom-interactions-import-blank-contact-email.bugfix.rst
@@ -1,0 +1,3 @@
+An out-of-memory crash when trying to import a CSV file with blank ``contact_email`` values was fixed.
+
+(This would only have happened if there were a large number of active contacts in the database with blank email addresses.)

--- a/datahub/company/contact_matching.py
+++ b/datahub/company/contact_matching.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 from django.db.models import Count
 
 from datahub.company.models import Contact
+from datahub.core.query_utils import get_queryset_object
 
 # NOTE: We may want to review our approach with this utility mechanism if we
 # need to add further strategies.  It could be that a better approach is to move
@@ -21,7 +22,7 @@ def _match_contact(filter_criteria):
     """
     contact = None
     try:
-        contact = Contact.objects.get(**filter_criteria)
+        contact = get_queryset_object(Contact.objects.all(), **filter_criteria)
         contact_matching_status = ContactMatchingStatus.matched
     except Contact.DoesNotExist:
         contact_matching_status = ContactMatchingStatus.unmatched

--- a/datahub/core/query_utils.py
+++ b/datahub/core/query_utils.py
@@ -229,3 +229,21 @@ def get_front_end_url_expression(model_name, pk_expression, url_suffix=''):
         pk_expression,
         Value(url_suffix),
     )
+
+
+def get_queryset_object(queryset, **filters):
+    """
+    Safer version of QuerySet.get() that avoids loading all objects into memory when there
+    are multiple results.
+
+    (When there are multiple results, QuerySet.get() loads all of them into memory even though
+    it raises an exception when multiple matches are found. This can lead to out-of-memory
+    situations when there are a very large number of matches. This function avoids that by
+    applying a LIMIT to the query.)
+
+    TODO: This will be fixed in Django 3.0 and we should be able to remove this function once
+    Django 3.0 has been released and we have updated to it.
+
+    See https://code.djangoproject.com/ticket/6785 for more information.
+    """
+    return queryset.filter(**filters)[:2].get()

--- a/datahub/interaction/admin_csv_import/row_form.py
+++ b/datahub/interaction/admin_csv_import/row_form.py
@@ -214,10 +214,7 @@ class InteractionCSVRowForm(forms.Form):
         if not subject and service:
             data['subject'] = service.name
 
-        # Attempt to look up the contact
-        data['contact'], data['contact_matching_status'] = find_active_contact_by_email_address(
-            data.get('contact_email'),
-        )
+        self._populate_contact(data)
 
         self._validate_not_duplicate_of_prior_row(data)
         self._validate_not_duplicate_of_existing_interaction(data)
@@ -298,6 +295,20 @@ class InteractionCSVRowForm(forms.Form):
             )
         except ValidationError as exc:
             self.add_error(adviser_field, exc)
+
+    @staticmethod
+    def _populate_contact(data):
+        """Attempt to look up the contact using the provided email address."""
+        contact_email = data.get('contact_email')
+
+        if not contact_email:
+            # No contact email address was provided, or it did not pass validation.
+            # Skip the look-up in this case.
+            return
+
+        data['contact'], data['contact_matching_status'] = find_active_contact_by_email_address(
+            contact_email,
+        )
 
     def _check_adviser_1_and_2_are_different(self, data):
         adviser_1 = data.get('adviser_1')


### PR DESCRIPTION
### Description of change

This fixes a problem that arose in non-development environments when using the import interactions admin site tool.

This occurred when the `contact_email` field was left blank in the CSV file being imported and there are a large number of contacts without email addresses in the database (despite it being a mandatory field).

The problem was twofold:

- the tool was attempting to look up contacts when the `contact_email` was blank
- `QuerySet.get()` was being used to look up contacts and it loads all results into memory despite it raising an exception when multiple matches are found

This fixes the problem at both points of failure so it should not be possible for a similar problem to reoccur in this scenario.

I also added a utility function, `get_queryset_object()` in case we need to do similar query set look-ups elsewhere in a safe fashion, and also as it's a bit easier to check that it's behaving correctly that way. However, the function could be removed (and the code inlined) if we don't think it's adding much.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
