### PR TITLE
Add Gunicorn StatsD configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `GUNICORN_ACCESSLOG`  | No | File to direct Gunicorn logs to (default=stdout). |
 | `GUNICORN_ACCESS_LOG_FORMAT`  | No |  |
 | `GUNICORN_ENABLE_ASYNC_PSYCOPG2` | No | Whether to enable asynchronous psycopg2 when the worker class is 'gevent' (default=True). |
+| `GUNICORN_ENABLE_STATSD` | No | Whether to enable Gunicorn StatD instrumentation (default=False). |
 | `GUNICORN_WORKER_CLASS`  | No | [Type of Gunicorn worker.](http://docs.gunicorn.org/en/stable/settings.html#worker-class) Uses async workers via gevent by default. |
 | `GUNICORN_WORKER_CONNECTIONS`  | No | Maximum no. of connections for async workers (default=10). |
 | `HAWK_RECEIVER_IP_WHITELIST` | No | IP addresses (comma-separated) that can access the Hawk-authenticated endpoints. |

--- a/changelog/gunicorn-statsd.feature.rst
+++ b/changelog/gunicorn-statsd.feature.rst
@@ -1,0 +1,1 @@
+It's now possible to configure Gunicorn to `emit monitoring metrics <http://docs.gunicorn.org/en/stable/instrumentation.html>`_ to a StatsD host.

--- a/config/gunicorn.py
+++ b/config/gunicorn.py
@@ -1,12 +1,40 @@
 import os
+import platform
 
 from psycogreen.gevent import patch_psycopg
+
+# Access log settings
 
 accesslog = os.environ.get('GUNICORN_ACCESSLOG', '-')
 access_log_format = os.environ.get(
     'GUNICORN_ACCESS_LOG_FORMAT',
     '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(L)s %({X-Forwarded-For}i)s',
 )
+
+# StatsD settings
+
+# Note: Gunicorn logs warnings if it can't connect to the StatsD server, so an explicit
+# opt-in is preferable
+_enable_statsd = os.environ.get('GUNICORN_ENABLE_STATSD', 'false').lower() in ('true', '1')
+
+if _enable_statsd:
+    _statsd_host = os.environ.get('STATSD_HOST', 'localhost')
+    _statsd_port = os.environ.get('STATSD_PORT', '9125')
+    _statsd_prefix = os.environ.get('STATSD_PREFIX', 'datahub-api')
+    _instance_index = os.environ.get('CF_INSTANCE_INDEX', '0')
+
+    # Instance index is not always unique (blue-green deployment, across process types etc.)
+    # so the instance GUID is added as well so we can always disambiguate.
+    #
+    # platform.node() is used as a fallback (it usually returns the host name, and it is
+    # portable and never fails)
+    _instance_id = os.environ.get('CF_INSTANCE_GUID', platform.node() or 'undefined')
+
+    statsd_host = f'{_statsd_host}:{_statsd_port}'
+    statsd_prefix = f'{_statsd_prefix}.{_instance_index}.{_instance_id}'
+
+# Worker class and gevent set-up
+
 worker_class = os.environ.get('GUNICORN_WORKER_CLASS', 'gevent')
 worker_connections = os.environ.get('GUNICORN_WORKER_CONNECTIONS', '10')
 


### PR DESCRIPTION
### Description of change

This (optionally) enables StatsD instrumentation for Gunicorn.

Both the Cloud Foundry instance index and GUID are included in the metric prefix so that metrics for different instances can never overwrite each other. We should be able to aggregate them in Grafana as needed.

A new environment variable has been added to control whether this is enabled. This is so we can opt in to it as wanted, and also because Gunicorn logs warnings if it can't connect to the StatsD server.

For details of the metrics that Gunicorn provides, see http://docs.gunicorn.org/en/stable/instrumentation.html (and also the source code at https://github.com/benoitc/gunicorn/blob/master/gunicorn/instrument/statsd.py).

### To test

1. Create a StatsD mapping file with file name `statsd_mapping.yml`:
    
    You can use the following example:
    
    <details>
    <summary>statsd_mapping.yml</summary>

    ```yaml
    mappings:
    - match: "*.*.calendar-invite-ingest.*.*"
    name: "calendar_invite_ingest_total"
    labels:
        app: "$1"
        source: "$2"
        result: "$3"
        domain: "$4"
        job: "calendar-invite-ingest"
    - match: "*.*.*.gunicorn.requests"
    name: "gunicorn_request_total"
    labels:
        app: "$1"
        source: "gunicorn"
        instance_index: "$2"
        instance_id: "$3"
    - match: "*.*.*.gunicorn.request.status.*"
    name: "gunicorn_request_status_total"
    labels:
        app: "$1"
        source: "gunicorn"
        instance_index: "$2"
        instance_id: "$3"
        status: "$4"
    - match: "*.*.*.gunicorn.request.duration"
    name: "gunicorn_request_duration"
    labels:
        app: "$1"
        source: "gunicorn"
        instance_index: "$2"
        instance_id: "$3"
    - match: "*.*.*.gunicorn.workers"
    name: "gunicorn_workers_total"
    labels:
        app: "$1"
        source: "gunicorn"
        instance_index: "$2"
        instance_id: "$3"
    - match: "*.*.*.gunicorn.log.*"
    name: "gunicorn_log_event_total"
    labels:
        app: "$1"
        source: "gunicorn"
        instance_index: "$2"
        instance_id: "$3"
        level: "$4"
    ```
    </details>

2. Run the StatsD exporter:

```
docker run -p 9102:9102 -p 9125:9125 -p 9125:9125/udp -v $PWD/statsd_mapping.yml:/tmp/statsd_mapping.yml prom/statsd-exporter --statsd.mapping-config=/tmp/statsd_mapping.yml
```

3. Run Gunicorn:

```bash
GUNICORN_ENABLE_STATSD=True DEBUG=False gunicorn config.wsgi --config config/gunicorn.py
```

4. Make some requests to `http://localhost:8000` for various paths.

5. Have a look at http://localhost:9102/metrics.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
