### PR TITLE
Add additional Elasticsearch sub-fields to mapping types

### DIFF
--- a/changelog/search-multi-fields.internal.rst
+++ b/changelog/search-multi-fields.internal.rst
@@ -1,0 +1,1 @@
+Various sub-fields were added to all Elasticsearch mapping types as replacements for the few remaining uses of the ``copy_to`` mapping parameter.

--- a/datahub/search/companieshousecompany/models.py
+++ b/datahub/search/companieshousecompany/models.py
@@ -30,7 +30,10 @@ class CompaniesHouseCompany(BaseESModel):
     registered_address_2 = Text()
     registered_address_town = fields.NormalizedKeyword()
     registered_address_county = Text()
-    registered_address_postcode = Text(copy_to='registered_address_postcode_trigram')
+    # TODO: Remove registered_address_postcode_trigram
+    registered_address_postcode = fields.Text(
+        copy_to='registered_address_postcode_trigram',
+    )
     registered_address_postcode_trigram = fields.TrigramText()
     registered_address_country = fields.id_name_field()
 

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -94,7 +94,9 @@ class Company(BaseESModel):
     sector = fields.sector_field()
     address = fields.address_field()
     registered_address = fields.address_field()
-    trading_names = Text(
+    # TODO: Update queries to use the trigram sub-field (once indexed) and remove
+    #  trading_names_trigram
+    trading_names = fields.TextWithTrigram(
         copy_to=['trading_names_trigram'],
     )
     trading_names_trigram = fields.TrigramText()

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -245,6 +245,12 @@ def test_mapping(setup_es):
                 'trading_names': {
                     'copy_to': ['trading_names_trigram'],
                     'type': 'text',
+                    'fields': {
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'trading_names_trigram': {
                     'analyzer': 'trigram_analyzer',

--- a/datahub/search/event/models.py
+++ b/datahub/search/event/models.py
@@ -15,7 +15,9 @@ class Event(BaseESModel):
     address_2 = Text()
     address_town = fields.NormalizedKeyword()
     address_county = fields.NormalizedKeyword()
-    address_postcode = Text(copy_to='address_postcode_trigram')
+    # TODO: Update queries to use the trigram sub-field (once indexed) and remove
+    #  address_postcode_trigram
+    address_postcode = fields.TextWithTrigram(copy_to='address_postcode_trigram')
     address_postcode_trigram = fields.TrigramText()
     address_country = fields.id_name_partial_field()
     created_on = Date()

--- a/datahub/search/event/tests/test_elasticsearch.py
+++ b/datahub/search/event/tests/test_elasticsearch.py
@@ -44,6 +44,12 @@ def test_mapping(setup_es):
                         'address_postcode_trigram',
                     ],
                     'type': 'text',
+                    'fields': {
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'address_postcode_trigram': {
                     'analyzer': 'trigram_analyzer',

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -11,6 +11,12 @@ NormalizedKeyword = partial(
 )
 TrigramText = partial(Text, analyzer='trigram_analyzer')
 EnglishText = partial(Text, analyzer='english_analyzer')
+TextWithTrigram = partial(
+    Text,
+    fields={
+        'trigram': TrigramText(),
+    },
+)
 
 
 class TextWithKeyword(Text):
@@ -102,11 +108,7 @@ def company_field():
                     'keyword': NormalizedKeyword(),
                 },
             ),
-            'trading_names': Text(
-                fields={
-                    'trigram': TrigramText(),
-                },
-            ),
+            'trading_names': TextWithTrigram(),
         },
     )
 
@@ -116,11 +118,7 @@ def country_field():
     return Object(
         properties={
             'id': Keyword(),
-            'name': Text(
-                fields={
-                    'trigram': TrigramText(),
-                },
-            ),
+            'name': TextWithTrigram(),
         },
     )
 
@@ -143,11 +141,7 @@ def address_field(index_country=True):
             'line_2': Text(index=False),
             'town': Text(index=False),
             'county': Text(index=False),
-            'postcode': Text(
-                fields={
-                    'trigram': TrigramText(),
-                },
-            ),
+            'postcode': TextWithTrigram(),
             'country': nested_country_field,
         },
     )

--- a/datahub/search/inner_docs.py
+++ b/datahub/search/inner_docs.py
@@ -1,6 +1,6 @@
 from elasticsearch_dsl import InnerDoc, Keyword, Text
 
-from datahub.search.fields import TrigramText
+from datahub.search.fields import TextWithTrigram
 
 
 class Person(InnerDoc):
@@ -9,19 +9,11 @@ class Person(InnerDoc):
     id = Keyword()
     first_name = Text(index=False)
     last_name = Text(index=False)
-    name = Text(
-        fields={
-            'trigram': TrigramText(),
-        },
-    )
+    name = TextWithTrigram()
 
 
 class IDNameTrigram(InnerDoc):
     """Inner doc for a named object, with a trigram sub-field on name."""
 
     id = Keyword()
-    name = Text(
-        fields={
-            'trigram': TrigramText(),
-        },
-    )
+    name = TextWithTrigram()

--- a/datahub/search/interaction/models.py
+++ b/datahub/search/interaction/models.py
@@ -65,8 +65,13 @@ class Interaction(BaseESModel):
     policy_issue_types = fields.id_unindexed_name_field()
     service = fields.id_name_field()
     service_delivery_status = fields.id_name_field()
+    # TODO: Update queries to use the english sub-field (once indexed) and remove
+    #  subject_english
     subject = fields.NormalizedKeyword(
         copy_to=['subject_english'],
+        fields={
+            'english': fields.EnglishText(),
+        },
     )
     subject_english = fields.EnglishText()
     was_policy_feedback_provided = Boolean()

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -107,7 +107,14 @@ class InvestmentProject(BaseESModel):
     number_safeguarded_jobs = Long()
     modified_on = Date()
     project_arrived_in_triage_on = Date()
-    project_code = fields.NormalizedKeyword(copy_to='project_code_trigram')
+    # TODO: Update queries to use the trigram sub-field (once indexed) and remove
+    #  project_code_trigram
+    project_code = fields.NormalizedKeyword(
+        copy_to='project_code_trigram',
+        fields={
+            'trigram': fields.TrigramText(),
+        },
+    )
     project_code_trigram = fields.TrigramText()
     proposal_deadline = Date()
     other_business_activity = fields.TextWithKeyword()

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -460,6 +460,12 @@ def test_mapping(setup_es):
                     'normalizer': 'lowercase_asciifolding_normalizer',
                     'copy_to': ['project_code_trigram'],
                     'type': 'keyword',
+                    'fields': {
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'project_code_trigram': {
                     'analyzer': 'trigram_analyzer',

--- a/datahub/search/omis/models.py
+++ b/datahub/search/omis/models.py
@@ -12,7 +12,13 @@ class Order(BaseESModel):
     """Elasticsearch representation of Order model."""
 
     id = Keyword()
-    reference = fields.NormalizedKeyword(copy_to=['reference_trigram'])
+    # TODO: Update queries to use the trigram sub-field (once indexed) and remove copy_to field
+    reference = fields.NormalizedKeyword(
+        copy_to=['reference_trigram'],
+        fields={
+            'trigram': fields.TrigramText(),
+        },
+    )
     reference_trigram = fields.TrigramText()
     status = fields.NormalizedKeyword()
     company = fields.company_field()
@@ -40,10 +46,24 @@ class Order(BaseESModel):
     vat_verified = Boolean(index=False)
     net_cost = Integer(index=False)
     subtotal_cost_string = Keyword()
-    subtotal_cost = Integer(copy_to=['subtotal_cost_string'])
+    # TODO: Update queries to use the keyword sub-field (once indexed) and remove
+    #  subtotal_cost_string
+    subtotal_cost = Integer(
+        copy_to=['subtotal_cost_string'],
+        fields={
+            'keyword': Keyword(),
+        },
+    )
     vat_cost = Integer(index=False)
     total_cost_string = Keyword()
-    total_cost = Integer(copy_to=['total_cost_string'])
+    # TODO: Update queries to use the keyword sub-field (once indexed) and remove
+    #  total_cost_string
+    total_cost = Integer(
+        copy_to=['total_cost_string'],
+        fields={
+            'keyword': Keyword(),
+        },
+    )
     payment_due_date = Date()
     paid_on = Date()
     completed_by = fields.contact_or_adviser_field()

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -350,6 +350,12 @@ def test_mapping(setup_es):
                     'copy_to': ['reference_trigram'],
                     'normalizer': 'lowercase_asciifolding_normalizer',
                     'type': 'keyword',
+                    'fields': {
+                        'trigram': {
+                            'analyzer': 'trigram_analyzer',
+                            'type': 'text',
+                        },
+                    },
                 },
                 'reference_trigram': {
                     'analyzer': 'trigram_analyzer',
@@ -447,6 +453,11 @@ def test_mapping(setup_es):
                 'subtotal_cost': {
                     'copy_to': ['subtotal_cost_string'],
                     'type': 'integer',
+                    'fields': {
+                        'keyword': {
+                            'type': 'keyword',
+                        },
+                    },
                 },
                 'subtotal_cost_string': {
                     'type': 'keyword',
@@ -454,6 +465,11 @@ def test_mapping(setup_es):
                 'total_cost': {
                     'copy_to': ['total_cost_string'],
                     'type': 'integer',
+                    'fields': {
+                        'keyword': {
+                            'type': 'keyword',
+                        },
+                    },
                 },
                 'total_cost_string': {
                     'type': 'keyword',


### PR DESCRIPTION
### Description of change

This adds additional sub-fields to our Elasticsearch mapping types. This is part of the migration away from (unnecessarily) using the `copy_to` mapping parameter (and [using multi-fields instead](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/multi-fields.html)) that was started some time ago.

These fields represent the last few places `copy_to` was still being used. Once all environments have been migrated to the new mapping types, we can update search queries to use the new sub-fields and remove the `copy_to` usage and target fields.

This is the most recent similar PR: https://github.com/uktrade/data-hub-leeloo/pull/1595

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
