### PR TITLE
Add service_answers support to interaction upload tool

### DIFF
--- a/changelog/interaction/interaction-upload-tool.feature.rst
+++ b/changelog/interaction/interaction-upload-tool.feature.rst
@@ -1,0 +1,1 @@
+It is now possible to upload interactions with service answers using the interaction upload tool in the Django admin.

--- a/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_preview.html
@@ -41,6 +41,7 @@
         <th>{% trans 'Date' %}</th>
         <th>{% trans 'Advisers' %}</th>
         <th>{% trans 'Service' %}</th>
+        <th>{% trans 'Service answer' %}</th>
         <th>{% trans 'Contact' %}</th>
         <th>{% trans 'Company' %}</th>
         <th>{% trans 'Communication channel' %}</th>
@@ -61,6 +62,7 @@
         {% endfor %}
       </td>
       <td>{{ row.service }}</td>
+      <td>{{ row.service_answer }}</td>
       <td>
         {% for contact in row.contacts %}
           {% if not forloop.first %}<br>{%  endif %}

--- a/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
+++ b/datahub/interaction/templates/admin/interaction/interaction/import_select_file.html
@@ -41,6 +41,11 @@
       <td>{% trans 'The name of the service of the interaction e.g. <code>Account Management</code>' %}</td>
     </tr>
     <tr>
+      <td><code>{% trans 'service_answer' %}</code></td>
+      <td>{% trans 'If selected service requires an answer' %}</td>
+      <td>{% trans 'The name of the service answer e.g. <code>Banking & Funding</code>' %}</td>
+    </tr>
+    <tr>
       <td><code>{% trans 'contact_email' %}</code></td>
       <td>{{ yes }}</td>
       <td>{% trans 'The email address of the contact the interaction was with' %}</td>

--- a/datahub/interaction/test/views/constants.py
+++ b/datahub/interaction/test/views/constants.py
@@ -10,7 +10,7 @@ class ServiceQuestionID(Enum):
     making_export_introductions = '054b29fe-c14b-463d-8177-c378d3a819aa'
 
 
-class ServiceAnswerID(Enum):
+class ServiceAnswerOptionID(Enum):
     """ServiceAnswerOption."""
 
     # providing_investment_advice_and_information

--- a/datahub/interaction/test/views/test_service_answers.py
+++ b/datahub/interaction/test/views/test_service_answers.py
@@ -20,7 +20,7 @@ from datahub.interaction.test.permissions import (
     NON_RESTRICTED_ADD_PERMISSIONS,
     NON_RESTRICTED_VIEW_PERMISSIONS,
 )
-from datahub.interaction.test.views.constants import ServiceAnswerID, ServiceQuestionID
+from datahub.interaction.test.views.constants import ServiceAnswerOptionID, ServiceQuestionID
 from datahub.interaction.test.views.utils import resolve_data
 from datahub.metadata.models import Service
 from datahub.metadata.test.factories import TeamFactory
@@ -59,7 +59,7 @@ class TestServiceAnswers(APITestMixin):
             'service': service.pk,
             'service_answers': {
                 ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                    ServiceAnswerID.piai_banking_and_funding.value: {},
+                    ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                 },
             },
         }
@@ -95,7 +95,7 @@ class TestServiceAnswers(APITestMixin):
                 {
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -109,7 +109,7 @@ class TestServiceAnswers(APITestMixin):
                 {
                     'service_answers': {
                         ServiceQuestionID.making_export_introductions.value: {
-                            ServiceAnswerID.making_export_introductions_customers.value: {},
+                            ServiceAnswerOptionID.making_export_introductions_customers.value: {},
                         },
                     },
                 },
@@ -142,12 +142,12 @@ class TestServiceAnswers(APITestMixin):
                 {
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.making_export_introductions_customers.value,
+                            ServiceAnswerOptionID.making_export_introductions_customers.value,
                         },
                     },
                 },
                 {
-                    ServiceAnswerID.making_export_introductions_customers.value: [
+                    ServiceAnswerOptionID.making_export_introductions_customers.value: [
                         'The selected answer option is not valid for this question.',
                     ],
                 },
@@ -158,9 +158,8 @@ class TestServiceAnswers(APITestMixin):
                 {
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
-                            ServiceAnswerID.piai_dit_or_government_services.value: {
-                            },
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_dit_or_government_services.value: {},
                         },
                     },
                 },
@@ -212,7 +211,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -221,7 +220,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_dit_or_government_services.value: {},
+                            ServiceAnswerOptionID.piai_dit_or_government_services.value: {},
                         },
                     },
                 },
@@ -233,7 +232,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -242,7 +241,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.making_export_introductions.value.id,
                     'service_answers': {
                         ServiceQuestionID.making_export_introductions.value: {
-                            ServiceAnswerID.making_export_introductions_customers.value: {},
+                            ServiceAnswerOptionID.making_export_introductions_customers.value: {},
                         },
                     },
                 },
@@ -273,7 +272,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -282,7 +281,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.account_management.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -299,7 +298,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -308,7 +307,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.making_export_introductions.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -328,7 +327,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -352,7 +351,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_dit_or_government_services.value: {},
+                            ServiceAnswerOptionID.piai_dit_or_government_services.value: {},
                         },
                     },
                 },
@@ -361,12 +360,12 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.making_export_introductions_customers.value: {},
+                            ServiceAnswerOptionID.making_export_introductions_customers.value: {},
                         },
                     },
                 },
                 {
-                    ServiceAnswerID.making_export_introductions_customers.value: [
+                    ServiceAnswerOptionID.making_export_introductions_customers.value: [
                         'The selected answer option is not valid for this question.',
                     ],
                 },
@@ -378,7 +377,7 @@ class TestServiceAnswers(APITestMixin):
                         ServiceConstant.providing_investment_advice_and_information.value.id,
                     'service_answers': {
                         ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                            ServiceAnswerID.piai_banking_and_funding.value: {},
+                            ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                         },
                     },
                 },
@@ -417,7 +416,7 @@ class TestServiceAnswers(APITestMixin):
             'service_id': ServiceConstant.providing_investment_advice_and_information.value.id,
             'service_answers': {
                 ServiceQuestionID.piai_what_did_you_give_advice_about.value: {
-                    ServiceAnswerID.piai_banking_and_funding.value: {},
+                    ServiceAnswerOptionID.piai_banking_and_funding.value: {},
                 },
             },
         }


### PR DESCRIPTION
### Description of change

This adds support of `service_answers` field for interaction upload tool.

At the moment we only have one question at most that requires only one answer, so that this can be provided with a `service_answer` column in the spreadsheet.

If we get to have more questions, we could extend this to have `service_answer_1`, `service_answer_2` and so on. 

If the service answer is not found, we should get an error `A service answer could not be found with the specified name and service.`.

Service answer is only required when a service that has questions is provided in the CSV file.

Provided answer once found valid it is then transformed into a dictionary like below:

```
{
  <question_id_str>: {
    <answer_id_str>: {}
  }
}
```

the above dictionary is then stored in the Interaction's JSONField `service_answers`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [x] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
