### PR TITLE
Tidy up investment project search model slightly

### DIFF
--- a/changelog/investment/investment-sortby.removal.rst
+++ b/changelog/investment/investment-sortby.removal.rst
@@ -1,0 +1,3 @@
+``POST /v3/search/investment_project``: The ``sortby`` value ``referral_source_adviser.name`` is no longer accepted.
+
+This ``sortby`` value was non-functional and was returning a 500 error if an attempt to use it was made.

--- a/datahub/search/fields.py
+++ b/datahub/search/fields.py
@@ -19,29 +19,6 @@ TextWithTrigram = partial(
 )
 
 
-class TextWithKeyword(Text):
-    """
-    Text field with keyword sub-field.
-
-    This definition is in line with the data type Elasticsearch uses for dynamically mapped text
-    fields, and is intended to be used to explicitly define fields that were previously
-    implicitly added to the ES mapping.
-    """
-
-    # The default value Elasticsearch uses for ignore_above when dynamically mapping text fields
-    ES_DEFAULT_IGNORE_ABOVE = 256
-
-    def __init__(self, *args, **kwargs):
-        """Initialises the field, creating a keyword sub-field."""
-        super().__init__(
-            *args,
-            **kwargs,
-            fields={
-                'keyword': Keyword(ignore_above=self.ES_DEFAULT_IGNORE_ABOVE),
-            },
-        )
-
-
 def contact_or_adviser_field(include_dit_team=False):
     """Object field for advisers and contacts."""
     props = {
@@ -169,11 +146,4 @@ def sector_field():
             'name': NormalizedKeyword(),
             'ancestors': ancestors,
         },
-    )
-
-
-def object_field(*fields):
-    """This is a mapping that reflects how Elasticsearch auto-creates mappings for objects."""
-    return Object(
-        properties={field: TextWithKeyword() for field in fields},
     )

--- a/datahub/search/investment/models.py
+++ b/datahub/search/investment/models.py
@@ -8,29 +8,6 @@ from datahub.search.models import BaseESModel
 DOC_TYPE = 'investment_project'
 
 
-def _referral_source_adviser_mapping():
-    """
-    Mapping for referral_source_adviser.
-
-    referral_source_adviser is not using contact_or_adviser_mapping because the mapping for it
-    was not explicitly defined, and so was implicitly auto-created.
-
-    The mapping here reflects how it has been auto-created. Further down the line, this mapping
-    and contact_or_adviser_mapping will be harmonised.
-    """
-    return fields.object_field('id', 'first_name', 'last_name', 'name')
-
-
-def _country_lost_to_mapping():
-    """
-    Mapping for country_lost_to.
-
-    The mapping for country_lost_to was implicitly auto-created. This reflects how it was
-    auto-created so that we can explicitly define it in the model.
-    """
-    return fields.object_field('id', 'name')
-
-
 def _related_investment_project_field():
     """Field for a related investment project."""
     return Object(properties={
@@ -70,10 +47,15 @@ class InvestmentProject(BaseESModel):
     client_cannot_provide_total_investment = Boolean()
     client_contacts = fields.contact_or_adviser_field()
     client_relationship_manager = fields.contact_or_adviser_field(include_dit_team=True)
-    client_requirements = fields.TextWithKeyword()
+    client_requirements = Text(index=False)
     comments = fields.EnglishText()
     country_investment_originates_from = fields.id_name_field()
-    country_lost_to = _country_lost_to_mapping()
+    country_lost_to = Object(
+        properties={
+            'id': Keyword(index=False),
+            'name': Text(index=False),
+        },
+    )
     created_on = Date()
     created_by = fields.contact_or_adviser_field(include_dit_team=True)
     date_abandoned = Date()
@@ -117,17 +99,24 @@ class InvestmentProject(BaseESModel):
     )
     project_code_trigram = fields.TrigramText()
     proposal_deadline = Date()
-    other_business_activity = fields.TextWithKeyword()
+    other_business_activity = Text(index=False)
     quotable_as_public_case_study = Boolean()
     r_and_d_budget = Boolean()
-    reason_abandoned = fields.TextWithKeyword()
-    reason_delayed = fields.TextWithKeyword()
-    reason_lost = fields.TextWithKeyword()
+    reason_abandoned = Text(index=False)
+    reason_delayed = Text(index=False)
+    reason_lost = Text(index=False)
     referral_source_activity = fields.id_name_field()
     referral_source_activity_event = fields.NormalizedKeyword()
     referral_source_activity_marketing = fields.id_name_field()
     referral_source_activity_website = fields.id_name_field()
-    referral_source_adviser = _referral_source_adviser_mapping()
+    referral_source_adviser = Object(
+        properties={
+            'id': Keyword(index=False),
+            'first_name': Text(index=False),
+            'last_name': Text(index=False),
+            'name': Text(index=False),
+        },
+    )
     sector = fields.sector_field()
     site_decided = Boolean()
     some_new_jobs = Boolean()

--- a/datahub/search/investment/serializers.py
+++ b/datahub/search/investment/serializers.py
@@ -78,7 +78,6 @@ class SearchInvestmentProjectQuerySerializer(EntitySearchQuerySerializer):
         'referral_source_activity_event',
         'referral_source_activity_marketing.name',
         'referral_source_activity_website.name',
-        'referral_source_adviser.name',
         'sector.name',
         'site_decided',
         'stage.name',

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -186,13 +186,8 @@ def test_mapping(setup_es):
                     'type': 'object',
                 },
                 'client_requirements': {
-                    'fields': {
-                        'keyword': {
-                            'ignore_above': 256,
-                            'type': 'keyword',
-                        },
-                    },
                     'type': 'text',
+                    'index': False,
                 },
                 'comments': {
                     'analyzer': 'english_analyzer',
@@ -211,22 +206,12 @@ def test_mapping(setup_es):
                 'country_lost_to': {
                     'properties': {
                         'id': {
-                            'fields': {
-                                'keyword': {
-                                    'ignore_above': 256,
-                                    'type': 'keyword',
-                                },
-                            },
-                            'type': 'text',
+                            'type': 'keyword',
+                            'index': False,
                         },
                         'name': {
-                            'fields': {
-                                'keyword': {
-                                    'ignore_above': 256,
-                                    'type': 'keyword',
-                                },
-                            },
                             'type': 'text',
+                            'index': False,
                         },
                     },
                     'type': 'object',
@@ -410,13 +395,8 @@ def test_mapping(setup_es):
                 'number_new_jobs': {'type': 'integer'},
                 'number_safeguarded_jobs': {'type': 'long'},
                 'other_business_activity': {
-                    'fields': {
-                        'keyword': {
-                            'ignore_above': 256,
-                            'type': 'keyword',
-                        },
-                    },
                     'type': 'text',
+                    'index': False,
                 },
                 'project_arrived_in_triage_on': {'type': 'date'},
                 'project_assurance_adviser': {
@@ -512,31 +492,16 @@ def test_mapping(setup_es):
                 'quotable_as_public_case_study': {'type': 'boolean'},
                 'r_and_d_budget': {'type': 'boolean'},
                 'reason_abandoned': {
-                    'fields': {
-                        'keyword': {
-                            'ignore_above': 256,
-                            'type': 'keyword',
-                        },
-                    },
                     'type': 'text',
+                    'index': False,
                 },
                 'reason_delayed': {
-                    'fields': {
-                        'keyword': {
-                            'ignore_above': 256,
-                            'type': 'keyword',
-                        },
-                    },
                     'type': 'text',
+                    'index': False,
                 },
                 'reason_lost': {
-                    'fields': {
-                        'keyword': {
-                            'ignore_above': 256,
-                            'type': 'keyword',
-                        },
-                    },
                     'type': 'text',
+                    'index': False,
                 },
                 'referral_source_activity': {
                     'properties': {
@@ -575,40 +540,20 @@ def test_mapping(setup_es):
                 'referral_source_adviser': {
                     'properties': {
                         'first_name': {
-                            'fields': {
-                                'keyword': {
-                                    'ignore_above': 256,
-                                    'type': 'keyword',
-                                },
-                            },
                             'type': 'text',
+                            'index': False,
                         },
                         'id': {
-                            'fields': {
-                                'keyword': {
-                                    'ignore_above': 256,
-                                    'type': 'keyword',
-                                },
-                            },
-                            'type': 'text',
+                            'type': 'keyword',
+                            'index': False,
                         },
                         'last_name': {
-                            'fields': {
-                                'keyword': {
-                                    'ignore_above': 256,
-                                    'type': 'keyword',
-                                },
-                            },
                             'type': 'text',
+                            'index': False,
                         },
                         'name': {
-                            'fields': {
-                                'keyword': {
-                                    'ignore_above': 256,
-                                    'type': 'keyword',
-                                },
-                            },
                             'type': 'text',
+                            'index': False,
                         },
                     },
                     'type': 'object',


### PR DESCRIPTION
### Description of change

Originally, we left [dynamic field mapping](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/dynamic-field-mapping.html) on in Elasticsearch. This resulted in a few fields being unintentionally added to the investment project mapping type.

Later on, we turned off dynamic field mapping and explicitly added the fields that we had accidentally indexed to the mapping type.

This PR makes an effort to tidy things up slightly by turning indexing off on those fields (as they are not used in searches). The field definitions have also been simplified as a result.

The fields have still been kept in the mapping type for now to avoid changing API responses.

In one case, one of the fields had been added as a sorting option. However, it was non-functional as it is not possible to sort on `text` fields. Hence, I've removed that field from the allowed sorting options.

### To manually test

1. Run `./manage.py migrate_es` (with Celery running)
2. Test the investment project collection page in the front end. There should be no errors when using the filters or sorting
3. Test global search for investment projects

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [x] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
