### PR TITLE
Associate items added to company lists with a default list

### DIFF
--- a/changelog/adviser/add-to-list-default-list.internal.rst
+++ b/changelog/adviser/add-to-list-default-list.internal.rst
@@ -1,0 +1,1 @@
+Items added to company lists are now internally associated with a default list for each user. This is in preparation for it being possible for users to have multiple company lists.


### PR DESCRIPTION
### Description of change

This makes sure that any new items added to a company list are associated with a default list for each user. This list is created if it does not already exist.

This is in preparation for there being multiple company lists per user.

The next steps will be:

1. Do a release.
2. Add a data migration to populate `CompanyListItem.list` for the remaining objects that don't have it set and make `CompanyListItem.list` non-nullable.
3. Change the logic in the existing company list endpoints to use `CompanyListItem.list`, and to not use `CompanyListItem.adviser` when filtering
4. Another release.
5. Tidy up.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
