### PR TITLE
Add migration to create legacy company lists for existing list items

### DIFF
--- a/changelog/adviser/data-migration.internal.rst
+++ b/changelog/adviser/data-migration.internal.rst
@@ -1,0 +1,1 @@
+A data migration was added to associate all existing company list items with a default list for each user. This is in preparation for it being possible for users to have multiple company lists.

--- a/datahub/user/company_list/migrations/0005_populate_list_on_items.py
+++ b/datahub/user/company_list/migrations/0005_populate_list_on_items.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+
+DEFAULT_LEGACY_LIST_NAME = '1. My list'
+
+
+def get_default_list_for_user(apps, adviser_id):
+    company_list_model = apps.get_model('company_list', 'CompanyList')
+
+    company_list, _ = company_list_model.objects.get_or_create(
+        adviser_id=adviser_id,
+        is_legacy_default=True,
+        defaults={
+            'created_by_id': adviser_id,
+            'name': DEFAULT_LEGACY_LIST_NAME,
+            'modified_by_id': adviser_id,
+        },
+    )
+    return company_list
+
+
+def populate_list_field(apps, schema_editor):
+    company_list_item_model = apps.get_model('company_list', 'CompanyListItem')
+
+    for item in company_list_item_model.objects.filter(list__isnull=True):
+        item.list = get_default_list_for_user(apps, item.adviser_id)
+        item.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('company_list', '0004_update_company_list_item'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_list_field, migrations.RunPython.noop, elidable=True),
+    ]


### PR DESCRIPTION
### Description of change

This adds a migration to make sure all existing company list items are associated with a company list.

This migration should be quick in production as there will be no or few list items without an associated list.

~This is currently blocked as we need to release https://github.com/uktrade/data-hub-leeloo/pull/1946 first.~

Next steps:

1. Make `CompanyListItem.list` non-nullable.
1. Change the logic in the existing company list endpoints to use `CompanyListItem.list`, and to not use `CompanyListItem.adviser`
1. Release.
1. Tidy up.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
