### PR TITLE
Adapt notification app to be able to use multiple notify API credentials

### DIFF
--- a/changelog/notification-multiple-api-keys.feature.rst
+++ b/changelog/notification-multiple-api-keys.feature.rst
@@ -1,0 +1,3 @@
+The `datahub.notification` app was adapted so that it can work with multiple
+GOVUK notify API keys - so that different apps can define their GOVUK notify
+templates on different notify service instances.

--- a/datahub/notification/__init__.py
+++ b/datahub/notification/__init__.py
@@ -1,3 +1,3 @@
-from datahub.notification.core import client
+from datahub.notification.core import notify_gateway
 
-__all__ = ('client',)
+__all__ = ('notify_gateway',)

--- a/datahub/notification/constants.py
+++ b/datahub/notification/constants.py
@@ -11,7 +11,7 @@ class NotifyServiceName(StrEnum):
 DEFAULT_SERVICE_NAME = NotifyServiceName.datahub
 
 # TODO: This module should not know or care about the specifics of our notify
-# service instances.  This should be moved up in to a setting.  To ensure easy
+# service instances. This should be moved up in to a setting. To ensure easy
 # rollback, we will turn this on once OMIS integration no longer uses a feature
 # flag.
 NOTIFY_KEYS = {

--- a/datahub/notification/constants.py
+++ b/datahub/notification/constants.py
@@ -1,13 +1,20 @@
-DATAHUB_SERVICE_NAME = 'datahub'
-OMIS_SERVICE_NAME = 'omis'
+from datahub.core.utils import StrEnum
 
-DEFAULT_SERVICE_NAME = DATAHUB_SERVICE_NAME
+
+class NotifyServiceName(StrEnum):
+    """Notify service name constants."""
+
+    datahub = 'datahub'
+    omis = 'omis'
+
+
+DEFAULT_SERVICE_NAME = NotifyServiceName.datahub
 
 # TODO: This module should not know or care about the specifics of our notify
 # service instances.  This should be moved up in to a setting.  To ensure easy
 # rollback, we will turn this on once OMIS integration no longer uses a feature
 # flag.
 NOTIFY_KEYS = {
-    DATAHUB_SERVICE_NAME: 'DATAHUB_NOTIFICATION_API_KEY',
-    OMIS_SERVICE_NAME: 'OMIS_NOTIFICATION_API_KEY',
+    NotifyServiceName.datahub: 'DATAHUB_NOTIFICATION_API_KEY',
+    NotifyServiceName.omis: 'OMIS_NOTIFICATION_API_KEY',
 }

--- a/datahub/notification/constants.py
+++ b/datahub/notification/constants.py
@@ -1,0 +1,13 @@
+DATAHUB_SERVICE_NAME = 'datahub'
+OMIS_SERVICE_NAME = 'omis'
+
+DEFAULT_SERVICE_NAME = DATAHUB_SERVICE_NAME
+
+# TODO: This module should not know or care about the specifics of our notify
+# service instances.  This should be moved up in to a setting.  To ensure easy
+# rollback, we will turn this on once OMIS integration no longer uses a feature
+# flag.
+NOTIFY_KEYS = {
+    DATAHUB_SERVICE_NAME: 'DATAHUB_NOTIFICATION_API_KEY',
+    OMIS_SERVICE_NAME: 'OMIS_NOTIFICATION_API_KEY',
+}

--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -25,6 +25,13 @@ class NotifyGateway:
             if api_key:
                 clients[service_name] = NotificationsAPIClient(api_key)
             else:
+                # Mocking the client when we don't have an API key set gives us a dummy client.
+                # It has some benefits:
+                # 1) It allows developers to use local copies without needing to find API
+                #    credentials.
+                # 2) It means we do not need to complicate the client and provide a separate
+                #    execution path when the API key is unset.
+
                 client = mock.Mock(spec_set=NotificationsAPIClient)
                 client.send_email_notification.return_value = {'id': 'abc123'}
                 clients[service_name] = client

--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -21,7 +21,7 @@ class NotifyGateway:
     def _initialise_clients(self):
         clients = {}
         for service_name, api_key_setting_name in NOTIFY_KEYS.items():
-            api_key = getattr(settings, api_key_setting_name, None)
+            api_key = getattr(settings, api_key_setting_name)
             if api_key:
                 clients[service_name] = NotificationsAPIClient(api_key)
             else:
@@ -48,7 +48,7 @@ class NotifyGateway:
         Send an email notification using the GOVUK notification service.
         """
         # TODO: the default notify service name should be in a setting, not a constant.
-        # This will be fixed when we fully move over omis notifications from its
+        # This will be fixed when we fully move over OMIS notifications from its
         # own notification package to this app
         if not notify_service_name:
             notify_service_name = DEFAULT_SERVICE_NAME

--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -4,46 +4,63 @@ from unittest import mock
 from django.conf import settings
 from notifications_python_client.notifications import NotificationsAPIClient
 
+from datahub.notification.constants import DEFAULT_SERVICE_NAME, NOTIFY_KEYS
 
-class NotificationClient:
+
+class NotifyGateway:
     """
     For accessing underlying GOVUK notification service.
     """
 
     def __init__(self):
-        """Init underlying notification client."""
-        if settings.DATAHUB_NOTIFICATION_API_KEY:
-            self.client = NotificationsAPIClient(
-                settings.DATAHUB_NOTIFICATION_API_KEY,
-            )
-        else:
-            self.client = mock.Mock(spec_set=NotificationsAPIClient)
-            self.client.send_email_notification.return_value = {'id': 'abc123'}
-            warnings.warn(
-                '`settings.DATAHUB_NOTIFICATION_API_KEY` not specified therefore all '
-                'Data Hub notifications will be mocked. '
-                "You might want to change this if it's not a "
-                'testing or development environment.',
-                RuntimeWarning,
-                stacklevel=2,
-            )
+        """
+        Init underlying notification client(s).
+        """
+        self._initialise_clients()
+
+    def _initialise_clients(self):
+        clients = {}
+        for service_name, api_key_setting_name in NOTIFY_KEYS.items():
+            api_key = getattr(settings, api_key_setting_name, None)
+            if api_key:
+                clients[service_name] = NotificationsAPIClient(api_key)
+            else:
+                client = mock.Mock(spec_set=NotificationsAPIClient)
+                client.send_email_notification.return_value = {'id': 'abc123'}
+                clients[service_name] = client
+                warnings.warn(
+                    f'`settings.{api_key_setting_name}` not specified therefore '
+                    'notifications will be mocked. '
+                    "You might want to change this if it's not a "
+                    'testing or development environment.',
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+        self.clients = clients
 
     def send_email_notification(
         self,
         recipient_email,
         template_identifier,
         context=None,
+        notify_service_name=None,
     ):
         """
         Send an email notification using the GOVUK notification service.
         """
+        # TODO: the default notify service name should be in a setting, not a constant.
+        # This will be fixed when we fully move over omis notifications from its
+        # own notification package to this app
+        if not notify_service_name:
+            notify_service_name = DEFAULT_SERVICE_NAME
+        client = self.clients[notify_service_name]
         if not context:
             context = {}
-        return self.client.send_email_notification(
+        return client.send_email_notification(
             email_address=recipient_email,
             template_id=template_identifier,
             personalisation=context,
         )
 
 
-client = NotificationClient()
+notify_gateway = NotifyGateway()

--- a/datahub/notification/core.py
+++ b/datahub/notification/core.py
@@ -29,10 +29,9 @@ class NotifyGateway:
                 client.send_email_notification.return_value = {'id': 'abc123'}
                 clients[service_name] = client
                 warnings.warn(
-                    f'`settings.{api_key_setting_name}` not specified therefore '
-                    'notifications will be mocked. '
-                    "You might want to change this if it's not a "
-                    'testing or development environment.',
+                    f'`settings.{api_key_setting_name}` not specified therefore notifications '
+                    "will be mocked. You might want to change this if it's not a testing or "
+                    'development environment.',
                     RuntimeWarning,
                     stacklevel=2,
                 )

--- a/datahub/notification/notify.py
+++ b/datahub/notification/notify.py
@@ -23,7 +23,12 @@ def notify_by_email(email_address, template_identifier, context, notify_service_
     Notify an email address, using a GOVUK notify template and some template
     context.
     """
+    kwargs = {'context': context}
+    # TODO: Remove this check when we can assume that all celery workers will
+    # accept a notify_service_name kwarg - after this has been released.
+    if notify_service_name:
+        kwargs['notify_service_name'] = notify_service_name
     send_email_notification.apply_async(
         args=(email_address, template_identifier),
-        kwargs={'context': context, 'notify_service_name': notify_service_name},
+        kwargs=kwargs,
     )

--- a/datahub/notification/notify.py
+++ b/datahub/notification/notify.py
@@ -1,24 +1,29 @@
 from datahub.notification.tasks import send_email_notification
 
 
-def notify_adviser_by_email(adviser, template_identifier, context):
+def notify_adviser_by_email(adviser, template_identifier, context, notify_service_name=None):
     """
     Notify an adviser by email, using a GOVUK notify template and some template
     context.
     """
     email_address = adviser.get_current_email()
-    send_email_notification.apply_async(
-        args=(email_address, template_identifier),
-        kwargs={'context': context},
-    )
+    notify_by_email(email_address, template_identifier, context, notify_service_name)
 
 
-def notify_contact_by_email(contact, template_identifier, context):
+def notify_contact_by_email(contact, template_identifier, context, notify_service_name=None):
     """
     Notify a contact by email, using a GOVUK notify template and some template
     context.
     """
+    notify_by_email(contact.email, template_identifier, context, notify_service_name)
+
+
+def notify_by_email(email_address, template_identifier, context, notify_service_name=None):
+    """
+    Notify an email address, using a GOVUK notify template and some template
+    context.
+    """
     send_email_notification.apply_async(
-        args=(contact.email, template_identifier),
-        kwargs={'context': context},
+        args=(email_address, template_identifier),
+        kwargs={'context': context, 'notify_service_name': notify_service_name},
     )

--- a/datahub/notification/tasks.py
+++ b/datahub/notification/tasks.py
@@ -1,6 +1,6 @@
 from celery import shared_task
 
-from datahub.notification.core import client
+from datahub.notification.core import notify_gateway
 
 
 @shared_task(
@@ -14,10 +14,16 @@ def send_email_notification(
     recipient_email,
     template_identifier,
     context=None,
+    notify_service_name=None,
 ):
     """
     Celery task to call the notify API to send a templated email notification
     to an email address.
     """
-    response = client.send_email_notification(recipient_email, template_identifier, context)
+    response = notify_gateway.send_email_notification(
+        recipient_email,
+        template_identifier,
+        context,
+        notify_service_name,
+    )
     return response['id']

--- a/datahub/notification/test/test_core.py
+++ b/datahub/notification/test/test_core.py
@@ -1,7 +1,7 @@
 import pytest
 
 from datahub.notification import notify_gateway
-from datahub.notification.constants import DEFAULT_SERVICE_NAME, OMIS_SERVICE_NAME
+from datahub.notification.constants import DEFAULT_SERVICE_NAME, NotifyServiceName
 
 
 @pytest.mark.parametrize(
@@ -9,7 +9,7 @@ from datahub.notification.constants import DEFAULT_SERVICE_NAME, OMIS_SERVICE_NA
     (
         (None, None),
         ({'foo': 'bar'}, None),
-        ({'foo': 'bar'}, OMIS_SERVICE_NAME),
+        ({'foo': 'bar'}, NotifyServiceName.omis),
     ),
 )
 def test_send_email_notification(context, service_name):

--- a/datahub/notification/test/test_core.py
+++ b/datahub/notification/test/test_core.py
@@ -1,24 +1,32 @@
 import pytest
 
-from datahub.notification import client
+from datahub.notification import notify_gateway
+from datahub.notification.constants import DEFAULT_SERVICE_NAME, OMIS_SERVICE_NAME
 
 
 @pytest.mark.parametrize(
-    'context',
+    'context,service_name',
     (
-        (None,),
-        ({'foo': 'bar'},),
+        (None, None),
+        ({'foo': 'bar'}, None),
+        ({'foo': 'bar'}, OMIS_SERVICE_NAME),
     ),
 )
-def test_send_email_notification(context):
+def test_send_email_notification(context, service_name):
     """
     Test that NotificationClient.send_email_notification method
     works calls through
     to the underlying notify library as expected.
     """
-    client.send_email_notification('john.smith@example.net', 'foobar', context)
+    notify_gateway.send_email_notification(
+        'john.smith@example.net',
+        'foobar',
+        context,
+        service_name,
+    )
     expected_context = context or {}
-    notification_api_client = client.client
+    expected_service_name = service_name or DEFAULT_SERVICE_NAME
+    notification_api_client = notify_gateway.clients[expected_service_name]
     notification_api_client.send_email_notification.assert_called_with(
         email_address='john.smith@example.net',
         template_id='foobar',

--- a/datahub/notification/test/test_notify.py
+++ b/datahub/notification/test/test_notify.py
@@ -1,28 +1,31 @@
 import pytest
 
 from datahub.company.test.factories import AdviserFactory, ContactFactory
-from datahub.notification import client
+from datahub.notification import notify_gateway
+from datahub.notification.constants import DEFAULT_SERVICE_NAME, OMIS_SERVICE_NAME
 from datahub.notification.notify import (
     notify_adviser_by_email,
+    notify_by_email,
     notify_contact_by_email,
 )
 
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    'adviser_data',
+    'adviser_data,notify_service_name',
     (
-        ({'contact_email': ''}),
-        ({}),
+        ({'contact_email': ''}, None),
+        ({}, OMIS_SERVICE_NAME),
     ),
 )
-def test_notify_adviser_by_email(adviser_data):
+def test_notify_adviser_by_email(adviser_data, notify_service_name):
     """
     Test the notify_adviser_by_email utility.
     """
-    notification_api_client = client.client
+    expected_notify_service_name = notify_service_name or DEFAULT_SERVICE_NAME
+    notification_api_client = notify_gateway.clients[expected_notify_service_name]
     adviser = AdviserFactory(**adviser_data)
-    notify_adviser_by_email(adviser, 'foobar', {'abc': '123'})
+    notify_adviser_by_email(adviser, 'foobar', {'abc': '123'}, notify_service_name)
     notification_api_client.send_email_notification.assert_called_with(
         email_address=adviser.contact_email or adviser.email,
         template_id='foobar',
@@ -31,15 +34,46 @@ def test_notify_adviser_by_email(adviser_data):
 
 
 @pytest.mark.django_db
-def test_notify_contact_by_email():
+@pytest.mark.parametrize(
+    'notify_service_name',
+    (
+        None,
+        OMIS_SERVICE_NAME,
+    ),
+)
+def test_notify_contact_by_email(notify_service_name):
     """
     Test the notify_contact_by_email utility.
     """
-    notification_api_client = client.client
+    expected_notify_service_name = notify_service_name or DEFAULT_SERVICE_NAME
+    notification_api_client = notify_gateway.clients[expected_notify_service_name]
     contact = ContactFactory()
-    notify_contact_by_email(contact, 'foobar', {'abc': '123'})
+    notify_contact_by_email(contact, 'foobar', {'abc': '123'}, notify_service_name)
     notification_api_client.send_email_notification.assert_called_with(
         email_address=contact.email,
+        template_id='foobar',
+        personalisation={'abc': '123'},
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'notify_service_name',
+    (
+        None,
+        OMIS_SERVICE_NAME,
+    ),
+)
+def test_notify_by_email(notify_service_name):
+    """
+    Test the notify_by_email utility.
+    """
+    expected_notify_service_name = notify_service_name or DEFAULT_SERVICE_NAME
+    notification_api_client = notify_gateway.clients[expected_notify_service_name]
+    email_address = 'foo@example.net'
+    notify_by_email(email_address, 'foobar', {'abc': '123'}, notify_service_name)
+    notification_api_client.send_email_notification.assert_called_with(
+        email_address=email_address,
         template_id='foobar',
         personalisation={'abc': '123'},
     )

--- a/datahub/notification/test/test_notify.py
+++ b/datahub/notification/test/test_notify.py
@@ -2,7 +2,7 @@ import pytest
 
 from datahub.company.test.factories import AdviserFactory, ContactFactory
 from datahub.notification import notify_gateway
-from datahub.notification.constants import DEFAULT_SERVICE_NAME, OMIS_SERVICE_NAME
+from datahub.notification.constants import DEFAULT_SERVICE_NAME, NotifyServiceName
 from datahub.notification.notify import (
     notify_adviser_by_email,
     notify_by_email,
@@ -15,7 +15,7 @@ from datahub.notification.notify import (
     'adviser_data,notify_service_name',
     (
         ({'contact_email': ''}, None),
-        ({}, OMIS_SERVICE_NAME),
+        ({}, NotifyServiceName.omis),
     ),
 )
 def test_notify_adviser_by_email(adviser_data, notify_service_name):
@@ -38,7 +38,7 @@ def test_notify_adviser_by_email(adviser_data, notify_service_name):
     'notify_service_name',
     (
         None,
-        OMIS_SERVICE_NAME,
+        NotifyServiceName.omis,
     ),
 )
 def test_notify_contact_by_email(notify_service_name):
@@ -61,7 +61,7 @@ def test_notify_contact_by_email(notify_service_name):
     'notify_service_name',
     (
         None,
-        OMIS_SERVICE_NAME,
+        NotifyServiceName.omis,
     ),
 )
 def test_notify_by_email(notify_service_name):

--- a/datahub/notification/test/test_tasks.py
+++ b/datahub/notification/test/test_tasks.py
@@ -1,20 +1,35 @@
 import pytest
 
-from datahub.notification import client
+from datahub.notification import notify_gateway
+from datahub.notification.constants import DEFAULT_SERVICE_NAME, OMIS_SERVICE_NAME
 from datahub.notification.tasks import send_email_notification
 
 
 @pytest.mark.django_db
-def test_send_email_notification():
+@pytest.mark.parametrize(
+    'context,service_name',
+    (
+        (None, None),
+        ({'foo': 'bar'}, None),
+        ({'foo': 'bar'}, OMIS_SERVICE_NAME),
+    ),
+)
+def test_send_email_notification(context, service_name):
     """
     Test the send_email_notification utility.
     """
-    notification_api_client = client.client
+    expected_service_name = service_name or DEFAULT_SERVICE_NAME
+    notification_api_client = notify_gateway.clients[expected_service_name]
     notification_api_client.send_email_notification.return_value = {'id': 'someid'}
-    notification_id = send_email_notification('foobar@example.net', 'abcdefg')
+    notification_id = send_email_notification(
+        'foobar@example.net',
+        'abcdefg',
+        context,
+        service_name,
+    )
     assert notification_id == 'someid'
     notification_api_client.send_email_notification.assert_called_with(
         email_address='foobar@example.net',
         template_id='abcdefg',
-        personalisation={},
+        personalisation=context or {},
     )

--- a/datahub/notification/test/test_tasks.py
+++ b/datahub/notification/test/test_tasks.py
@@ -1,7 +1,7 @@
 import pytest
 
 from datahub.notification import notify_gateway
-from datahub.notification.constants import DEFAULT_SERVICE_NAME, OMIS_SERVICE_NAME
+from datahub.notification.constants import DEFAULT_SERVICE_NAME, NotifyServiceName
 from datahub.notification.tasks import send_email_notification
 
 
@@ -11,7 +11,7 @@ from datahub.notification.tasks import send_email_notification
     (
         (None, None),
         ({'foo': 'bar'}, None),
-        ({'foo': 'bar'}, OMIS_SERVICE_NAME),
+        ({'foo': 'bar'}, NotifyServiceName.omis),
     ),
 )
 def test_send_email_notification(context, service_name):


### PR DESCRIPTION
### Description of change

This lays the initial groundwork to allow us to refactor the `datahub.omis` app to use our new `datahub.notification` app for sending GOVUK notify notifications.

Specifically, this makes the `datahub.notification` app able to work with multiple GOVUK notify API keys.  This will allow us to use the functions defined in `datahub/notification/notify.py` with multiple different notify credentials which are identified by a `notify_service_name` keyword argument.

For now the different notify service names/API keys are collated in `datahub/notification/constants.py` under the `NOTIFY_KEYS` variable.  The ambition is to move this in to a django setting rather than using the current `DATAHUB_NOTIFICATION_API_KEY` and `OMIS_NOTIFICATION_API_KEY` settings.

I didn't want this groundwork to change any settings for the project as I want to keep this light touch until we have proven that the new notification app works for omis with functionality switched between the new app and omis' notification package with a feature flag.

### Rollout plan

- This work to allow the notification app to work with multiple notify API keys.
- Deploy.
- Switch omis to optionally use `datahub.notification` under the hood for sending notifications - functionality determined by feature flag.
- Deploy. Activate feature flag progressively across environments and test.
- Refactor omis' notification integration to exclusively use `datahub.notification` including cleanup and decoupling.  Remove feature flag.
- Deploy.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
