### PR TITLE
Disable Celery conf inspect command

### DIFF
--- a/changelog/disable-celery-inspect-conf.internal.rst
+++ b/changelog/disable-celery-inspect-conf.internal.rst
@@ -1,0 +1,1 @@
+The Celery ``conf`` inspect command was disabled for security reasons.

--- a/config/celery.py
+++ b/config/celery.py
@@ -3,6 +3,8 @@ import os
 
 from celery import Celery
 from celery.signals import after_setup_logger
+from celery.utils.serialization import strtobool
+from celery.worker.control import inspect_command
 
 
 # set the default Django settings module for the 'celery' program.
@@ -25,3 +27,19 @@ def after_setup_logger_handler(**kwargs):
     """As the Elasticsearch module is noisy, set its log level to WARNING for Celery workers."""
     es_logger = logging.getLogger('elasticsearch')
     es_logger.setLevel(logging.WARNING)
+
+
+@inspect_command(
+    alias='dump_conf',
+    signature='[include_defaults=False]',
+    args=[('with_defaults', strtobool)],
+)
+def conf(state, with_defaults=False, **kwargs):
+    """
+    This overrides the default `conf` inspect command to effectively disable it.
+
+    This is to stop sensitive configuration information appearing in e.g. Flower.
+
+    (Celery makes an attempt to remove sensitive information, but it is not foolproof.)
+    """
+    return {'error': 'Config inspection has been disabled.'}


### PR DESCRIPTION
### Description of change

This disables the `conf` inspect command for security reasons.

The reason that it's problematic is that  sensitive configuration information can leak out through e.g. Flower with it enabled.

(Celery makes an attempt to remove sensitive information, but it's not foolproof.)

This was the best way I could find of doing this, and follows the suggestion in https://github.com/mher/flower/issues/340 (and example at https://celery.readthedocs.io/en/latest/userguide/workers.html#writing-your-own-remote-control-commands).

This can be tested locally by running Celery and then running `celery inspect -A config conf` separately. 'Config inspection has been disabled.' should be displayed.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
