### PR TITLE
Update indirect dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,20 +4,20 @@
 #
 #    pip-compile --output-file=requirements.txt requirements.in
 #
-amqp==2.5.0               # via kombu
+amqp==2.5.1               # via kombu
 apipkg==1.5               # via execnet
 argh==0.26.2              # via watchdog
 atomicwrites==1.3.0       # via pytest
-attrs==19.1.0             # via flake8-bugbear, pytest
+attrs==19.1.0             # via flake8-bugbear, packaging, pytest
 backcall==0.1.0           # via ipython
 billiard==3.6.1.0
 boto3==1.9.210
 botocore==1.12.210        # via boto3, s3transfer
 celery[redis]==4.3
-certifi==2019.3.9         # via requests, sentry-sdk
+certifi==2019.6.16        # via requests, sentry-sdk
 chardet==3.0.4
 click==7.0                # via pip-tools, towncrier
-coverage==4.5.3           # via pytest-cov
+coverage==4.5.4           # via pytest-cov
 cssselect==1.1.0
 decorator==4.4.0          # via ipython, traitlets
 django-admin-ip-restrictor==1.0.0
@@ -36,13 +36,13 @@ django-reversion==3.0.4
 django==2.2.4
 djangorestframework==3.10.2
 docopt==0.6.2             # via notifications-python-client
-docutils==0.14            # via botocore
+docutils==0.15.2          # via botocore
 elasticsearch-dsl==6.3.1
 elasticsearch==6.4.0
 entrypoints==0.3          # via flake8
-execnet==1.6.0            # via pytest-xdist
+execnet==1.7.0            # via pytest-xdist
 factory-boy==2.12.0
-faker==1.0.7              # via factory-boy
+faker==2.0.0              # via factory-boy
 flake8-blind-except==0.1.1
 flake8-bugbear==19.8.0
 flake8-commas==2.0.0
@@ -61,12 +61,12 @@ greenlet==0.4.15          # via gevent
 gunicorn==19.9.0
 icalendar==4.0.3
 idna==2.8                 # via requests
-importlib-metadata==0.17  # via pluggy, pytest
+importlib-metadata==0.19  # via pluggy, pytest
 incremental==17.5.0       # via towncrier
 ipaddress==1.0.22         # via mail-parser
 ipython-genutils==0.2.0   # via traitlets
 ipython==7.7.0
-jedi==0.13.3              # via ipython
+jedi==0.15.1              # via ipython
 jinja2==2.10.1            # via towncrier
 jmespath==0.9.4           # via boto3, botocore
 kombu==4.6.3
@@ -76,11 +76,11 @@ markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via flake8
 mohawk==1.0.0
 monotonic==1.5            # via notifications-python-client
-more-itertools==7.0.0     # via pytest
+more-itertools==7.2.0     # via pytest
 notifications-python-client==5.3.0
 oauthlib==2.1.0
-packaging==19.0           # via pytest, pytest-sugar
-parso==0.5.0              # via jedi
+packaging==19.1           # via pytest, pytest-sugar
+parso==0.5.1              # via jedi
 pathtools==0.1.2          # via watchdog
 pep8-naming==0.8.2
 pexpect==4.7.0            # via ipython
@@ -98,7 +98,7 @@ pydocstyle==4.0.1
 pyflakes==2.1.1           # via flake8
 pygments==2.4.2           # via ipython
 pyjwt==1.7.1              # via notifications-python-client
-pyparsing==2.4.0          # via packaging
+pyparsing==2.4.2          # via packaging
 pytest-cov==2.7.1
 pytest-django==3.5.1
 pytest-forked==1.0.2      # via pytest-xdist
@@ -106,18 +106,18 @@ pytest-sugar==0.9.2
 pytest-xdist==1.29.0
 pytest==5.1.0
 python-dateutil==2.8.0
-pytz==2019.1              # via celery, django, icalendar
+pytz==2019.2              # via celery, django, icalendar
 pyyaml==5.1.2
 redis==3.3.7
-requests-futures==0.9.9   # via piprot
+requests-futures==1.0.0   # via piprot
 requests-mock==1.6.0
 requests==2.22.0
 requests_toolbelt==0.9.1
-s3transfer==0.2.0         # via boto3
+s3transfer==0.2.1         # via boto3
 sentry_sdk==0.11.0
 simplejson==3.16.0        # via mail-parser
 six==1.12.0               # via django-extensions, elasticsearch-dsl, faker, flake8-print, freezegun, mail-parser, mohawk, packaging, pip-tools, piprot, prompt-toolkit, pytest-xdist, python-dateutil, requests-mock, traitlets
-snowballstemmer==1.2.1    # via pydocstyle
+snowballstemmer==1.9.0    # via pydocstyle
 sqlparse==0.3.0           # via django, django-debug-toolbar
 statsd==3.3.0
 termcolor==1.1.0          # via pytest-sugar
@@ -132,7 +132,7 @@ watchdog==0.9.0
 wcwidth==0.1.7            # via prompt-toolkit, pytest
 werkzeug==0.15.5
 whitenoise==4.1.3
-zipp==0.5.1               # via importlib-metadata
+zipp==0.5.2               # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools==41.1.0        # via flake8-blind-except, flake8-import-order, ipython


### PR DESCRIPTION
### Description of change

This does a one-off update of indirect dependencies (as we don't have dependabot configured to update them in the general case to avoid too much noise).

There seems to be little of note here. The change log for the Faker update is here: https://github.com/joke2k/faker/blob/master/CHANGELOG.rst

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
