### PR TITLE
Fix random failure of delete_old_records test

### DIFF
--- a/datahub/cleanup/test/commands/test_delete_old_records.py
+++ b/datahub/cleanup/test/commands/test_delete_old_records.py
@@ -492,6 +492,7 @@ MAPPING = {
                     {
                         'created_on': ORDER_DELETE_BEFORE_DATETIME - relativedelta(days=1),
                         'modified_on': ORDER_MODIFIED_ON_CUT_OFF - relativedelta(days=1),
+                        'level2_approved_on': None,
                     },
                 ],
                 'unexpired_objects_kwargs': [


### PR DESCRIPTION
### Description of change

This corrects one of the `delete_old_records` OMIS order test parametrisations where a value for one of the datetime fields was not being explicitly specified.

The value was intended to be `None`, but it was picking up a random datetime which was sometimes not before the cut-off date for deleting old records.

This was causing this failure: https://circleci.com/gh/uktrade/data-hub-leeloo/12389

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
