### PR TITLE
Add list company lists view

### DIFF
--- a/changelog/adviser/list-company-lists.api.rst
+++ b/changelog/adviser/list-company-lists.api.rst
@@ -1,0 +1,11 @@
+The following endpoint was added:
+
+- ``GET /v4/company-list``: Lists the authenticated user's company lists.
+
+  This is a paginated endpoint. Items are sorted by name, and are in the following format::
+
+    {
+      "id": "string",
+      "name": "string",
+      "created_on": "ISO timestamp"
+    }

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -2,7 +2,19 @@ from rest_framework import serializers
 
 from datahub.company.models import Company
 from datahub.core.serializers import NestedRelatedField
-from datahub.user.company_list.models import CompanyListItem
+from datahub.user.company_list.models import CompanyList, CompanyListItem
+
+
+class CompanyListSerializer(serializers.ModelSerializer):
+    """Serialiser for a company list."""
+
+    class Meta:
+        model = CompanyList
+        fields = (
+            'id',
+            'name',
+            'created_on',
+        )
 
 
 class CompanyListItemSerializer(serializers.ModelSerializer):

--- a/datahub/user/company_list/tests/test_views.py
+++ b/datahub/user/company_list/tests/test_views.py
@@ -1,0 +1,87 @@
+from random import sample
+
+import factory
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+
+from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
+from datahub.user.company_list.tests.factories import CompanyListFactory
+
+
+list_collection_url = reverse('api-v4:company-list:list-collection')
+
+
+class TestListCompanyListsView(APITestMixin):
+    """Tests for listing a user's company lists."""
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if the user is unauthenticated."""
+        response = api_client.get(list_collection_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames,expected_status',
+        (
+            ([], status.HTTP_403_FORBIDDEN),
+            (['view_companylist'], status.HTTP_200_OK),
+        ),
+    )
+    def test_permission_checking(self, permission_codenames, expected_status, api_client):
+        """Test that the expected status is returned for various user permissions."""
+        user = create_test_user(permission_codenames=permission_codenames, dit_team=None)
+        api_client = self.create_api_client(user=user)
+        response = api_client.get(list_collection_url)
+        assert response.status_code == expected_status
+
+    def test_returns_empty_list_when_no_lists(self):
+        """Test that no results are returned when the user has no company lists."""
+        response = self.api_client.get(list_collection_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['results'] == []
+
+    def test_doesnt_return_other_users_lists(self):
+        """Test that other users' company lists are not returned."""
+        # Create some lists belonging to other users
+        CompanyListFactory.create_batch(5)
+
+        response = self.api_client.get(list_collection_url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['results'] == []
+
+    def test_returns_items_in_expected_format(self):
+        """Test that a user's list is returned in the expected format."""
+        company_list = CompanyListFactory(adviser=self.user)
+
+        response = self.api_client.get(list_collection_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        results = response.json()['results']
+        assert len(results) == 1
+        assert results[0] == {
+            'id': str(company_list.pk),
+            'name': company_list.name,
+            'created_on': format_date_or_datetime(company_list.created_on),
+        }
+
+    def test_lists_are_sorted_by_name(self):
+        """Test that returned lists are sorted by name."""
+        expected_list_names = ['A list', 'B list', 'C list', 'D list']
+
+        shuffled_list_names = sample(expected_list_names, len(expected_list_names))
+        CompanyListFactory.create_batch(
+            len(expected_list_names),
+            adviser=self.user,
+            name=factory.Iterator(shuffled_list_names),
+        )
+
+        response = self.api_client.get(list_collection_url)
+        assert response.status_code == status.HTTP_200_OK
+
+        response_data = response.json()
+        actual_list_names = [result['name'] for result in response_data['results']]
+        assert actual_list_names == expected_list_names

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -4,8 +4,18 @@ from datahub.user.company_list.legacy_views import (
     LegacyCompanyListItemView,
     LegacyCompanyListViewSet,
 )
+from datahub.user.company_list.views import CompanyListViewSet
 
 urlpatterns = [
+    path(
+        'company-list',
+        CompanyListViewSet.as_view(
+            {
+                'get': 'list',
+            },
+        ),
+        name='list-collection',
+    ),
     path(
         'user/company-list',
         LegacyCompanyListViewSet.as_view(

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -1,0 +1,24 @@
+from rest_framework.filters import OrderingFilter
+
+from datahub.core.viewsets import CoreViewSet
+from datahub.oauth.scopes import Scope
+from datahub.user.company_list.models import CompanyList
+from datahub.user.company_list.serializers import CompanyListSerializer
+
+
+class CompanyListViewSet(CoreViewSet):
+    """
+    Views for managing the authenticated user's company lists.
+
+    Currently, this covers listing lists only.
+    """
+
+    required_scopes = (Scope.internal_front_end,)
+    queryset = CompanyList.objects.all()
+    serializer_class = CompanyListSerializer
+    filter_backends = (OrderingFilter,)
+    ordering = ('name', 'created_on', 'pk')
+
+    def get_queryset(self):
+        """Get a query set filtered to the authenticated user's lists."""
+        return super().get_queryset().filter(adviser=self.request.user)


### PR DESCRIPTION
### Description of change

[This follows on from previous company list PRs](https://github.com/uktrade/data-hub-leeloo/pulls?q=is%3Apr+is%3Aclosed+author%3Areupen+label%3A%22company+lists%22
).

This adds a view at `GET /v4/company-list` for listing the authenticated user's company lists.

Results are sorted by name.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [x] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
