### PR TITLE
Fix minor invite notify issues

### DIFF
--- a/changelog/interaction/meeting-invite-notification-fixes.bugfix.rst
+++ b/changelog/interaction/meeting-invite-notification-fixes.bugfix.rst
@@ -1,0 +1,5 @@
+Meeting invite ingestion was adjusted so that users do not get error 
+notifications when they send a meeting cancellation.
+
+The notification celery task was modified so that 400/403 level responses do not
+have automatic retries.

--- a/datahub/interaction/email_processors/exceptions.py
+++ b/datahub/interaction/email_processors/exceptions.py
@@ -16,6 +16,12 @@ class SenderUnverifiedError(InvalidInviteError):
     """
 
 
+class UnconfirmedCalendarInviteError(InvalidInviteError):
+    """
+    Exception for when the calendar invite was not confirmed.
+    """
+
+
 class BadCalendarInviteError(InvalidInviteError):
     """
     Exception for when the calendar invite was bad.

--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -15,6 +15,7 @@ from datahub.interaction.email_processors.exceptions import (
     MalformedEmailError,
     NoContactsError,
     SenderUnverifiedError,
+    UnconfirmedCalendarInviteError,
 )
 from datahub.interaction.email_processors.utils import (
     get_all_recipients,
@@ -185,7 +186,7 @@ class CalendarInteractionEmailParser:
 
         meeting_confirmed = calendar_event['status'] == CALENDAR_STATUS_CONFIRMED
         if not meeting_confirmed:
-            raise BadCalendarInviteError(
+            raise UnconfirmedCalendarInviteError(
                 f'The calendar event was not status: {CALENDAR_STATUS_CONFIRMED}.',
             )
 

--- a/datahub/interaction/email_processors/parsers.py
+++ b/datahub/interaction/email_processors/parsers.py
@@ -186,6 +186,8 @@ class CalendarInteractionEmailParser:
 
         meeting_confirmed = calendar_event['status'] == CALENDAR_STATUS_CONFIRMED
         if not meeting_confirmed:
+            # This will not send a notification as it is not in
+            # processors.EXCEPTION_NOTIFY_MESSAGES
             raise UnconfirmedCalendarInviteError(
                 f'The calendar event was not status: {CALENDAR_STATUS_CONFIRMED}.',
             )

--- a/datahub/interaction/test/email_processors/test_parsers.py
+++ b/datahub/interaction/test/email_processors/test_parsers.py
@@ -10,6 +10,7 @@ from datahub.interaction.email_processors.exceptions import (
     MalformedEmailError,
     NoContactsError,
     SenderUnverifiedError,
+    UnconfirmedCalendarInviteError,
 )
 from datahub.interaction.email_processors.parsers import CalendarInteractionEmailParser
 
@@ -261,7 +262,7 @@ class TestCalendarInteractionEmailParser:
             ),
             (
                 'email_samples/invalid/calendar_event_unconfirmed.eml',
-                BadCalendarInviteError(
+                UnconfirmedCalendarInviteError(
                     'The calendar event was not status: CONFIRMED.',
                 ),
             ),

--- a/datahub/interaction/test/email_processors/test_processors.py
+++ b/datahub/interaction/test/email_processors/test_processors.py
@@ -15,6 +15,7 @@ from datahub.interaction.email_processors.exceptions import (
     MalformedEmailError,
     NoContactsError,
     SenderUnverifiedError,
+    UnconfirmedCalendarInviteError,
 )
 from datahub.interaction.email_processors.notify import Template
 from datahub.interaction.email_processors.processors import (
@@ -261,6 +262,10 @@ class TestCalendarInteractionEmailProcessor:
             ),
             (
                 MalformedEmailError,
+                False,
+            ),
+            (
+                UnconfirmedCalendarInviteError,
                 False,
             ),
         ),

--- a/datahub/notification/tasks.py
+++ b/datahub/notification/tasks.py
@@ -1,16 +1,16 @@
 from celery import shared_task
+from notifications_python_client.errors import HTTPError
 
 from datahub.notification.core import notify_gateway
 
 
 @shared_task(
+    bind=True,
     acks_late=True,
     priority=9,
-    max_retries=5,
-    autoretry_for=(Exception,),
-    retry_backoff=60,
 )
 def send_email_notification(
+    self,
     recipient_email,
     template_identifier,
     context=None,
@@ -20,10 +20,16 @@ def send_email_notification(
     Celery task to call the notify API to send a templated email notification
     to an email address.
     """
-    response = notify_gateway.send_email_notification(
-        recipient_email,
-        template_identifier,
-        context,
-        notify_service_name,
-    )
+    try:
+        response = notify_gateway.send_email_notification(
+            recipient_email,
+            template_identifier,
+            context,
+            notify_service_name,
+        )
+    except HTTPError as exc:
+        # Raise 400/403 responses without retry
+        if exc.status_code in (400, 403):
+            raise exc
+        raise self.retry(exc=exc, max_retries=5, countdown=60)
     return response['id']

--- a/datahub/notification/tasks.py
+++ b/datahub/notification/tasks.py
@@ -8,6 +8,7 @@ from datahub.notification.core import notify_gateway
     bind=True,
     acks_late=True,
     priority=9,
+    max_retries=5,
 )
 def send_email_notification(
     self,
@@ -28,8 +29,10 @@ def send_email_notification(
             notify_service_name,
         )
     except HTTPError as exc:
-        # Raise 400/403 responses without retry
+        # Raise 400/403 responses without retry - these are problems with the
+        # way we are calling the notify service and retries will not result in
+        # a successful outcome.
         if exc.status_code in (400, 403):
-            raise exc
-        raise self.retry(exc=exc, max_retries=5, countdown=60)
+            raise
+        raise self.retry(exc=exc, countdown=60)
     return response['id']

--- a/datahub/notification/test/test_tasks.py
+++ b/datahub/notification/test/test_tasks.py
@@ -1,11 +1,14 @@
+from unittest import mock
+
 import pytest
+from celery.exceptions import Retry
+from notifications_python_client.errors import HTTPError
 
 from datahub.notification import notify_gateway
 from datahub.notification.constants import DEFAULT_SERVICE_NAME, NotifyServiceName
 from datahub.notification.tasks import send_email_notification
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     'context,service_name',
     (
@@ -33,3 +36,37 @@ def test_send_email_notification(context, service_name):
         template_id='abcdefg',
         personalisation=context or {},
     )
+
+
+@pytest.mark.parametrize(
+    'error_status_code,expect_retry',
+    (
+        (503, True),
+        (500, True),
+        (403, False),
+        (400, False),
+    ),
+)
+def test_send_email_notification_retries_errors(monkeypatch, error_status_code, expect_retry):
+    """
+    Test the send_email_notification utility.
+    """
+    notification_api_client = notify_gateway.clients[DEFAULT_SERVICE_NAME]
+    # Set up an HTTPError with the parametrized status code
+    mock_response = mock.Mock()
+    mock_response.status_code = error_status_code
+    mock_response.json.return_value = {}
+    error = HTTPError(mock_response)
+    notification_api_client.send_email_notification.side_effect = error
+
+    # Mock the task's retry method
+    retry_mock = mock.Mock(side_effect=Retry())
+    monkeypatch.setattr('datahub.notification.tasks.send_email_notification.retry', retry_mock)
+
+    if expect_retry:
+        expected_exception_class = Retry
+    else:
+        expected_exception_class = HTTPError
+
+    with pytest.raises(expected_exception_class):
+        send_email_notification('foobar@example.net', 'abcdefg')


### PR DESCRIPTION
### Description of change

This PR does the following:
- Stops the meeting invite processing logic from sending error notifications when a meeting is cancelled.  This was some unexpected behaviour as most clients send cancellations in iCalendar format and the processing logic was handling this as if it was a new meeting request.
This was achieved by adding a new exception `UnconfirmedCalendarInviteError` - since this is not present in `NOTIFY_EXCEPTIONS`, advisers will not be notified about it.
- Prevents the notification celery task from retrying API calls that came back with a 400/403 error - these are raised as exceptions immediately.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
