### PR TITLE
Add view for creating a company list

### DIFF
--- a/changelog/adviser/create-company-list.api.rst
+++ b/changelog/adviser/create-company-list.api.rst
@@ -1,0 +1,9 @@
+The following endpoint was added:
+
+- ``POST /v4/company-list``: Create a company list for the authenticated user.
+
+  The request body must be in following format::
+
+    {
+      "name": "string"
+    }

--- a/datahub/user/company_list/tests/test_views.py
+++ b/datahub/user/company_list/tests/test_views.py
@@ -2,10 +2,12 @@ from random import sample
 
 import factory
 import pytest
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
+from datahub.user.company_list.models import CompanyList
 from datahub.user.company_list.tests.factories import CompanyListFactory
 
 
@@ -85,3 +87,95 @@ class TestListCompanyListsView(APITestMixin):
         response_data = response.json()
         actual_list_names = [result['name'] for result in response_data['results']]
         assert actual_list_names == expected_list_names
+
+
+class TestAddCompanyListView(APITestMixin):
+    """Tests for adding a company list."""
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if the user is unauthenticated."""
+        response = api_client.post(list_collection_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames,expected_status',
+        (
+            ([], status.HTTP_403_FORBIDDEN),
+            (['add_companylist'], status.HTTP_201_CREATED),
+        ),
+    )
+    def test_permission_checking(self, permission_codenames, expected_status, api_client):
+        """Test that the expected status is returned for various user permissions."""
+        user = create_test_user(permission_codenames=permission_codenames, dit_team=None)
+        api_client = self.create_api_client(user=user)
+        response = api_client.post(
+            list_collection_url,
+            data={
+                'name': 'test list',
+            },
+        )
+        assert response.status_code == expected_status
+
+    @pytest.mark.parametrize(
+        'request_data,expected_errors',
+        (
+            pytest.param(
+                {},
+                {
+                    'name': ['This field is required.'],
+                },
+                id='name omitted',
+            ),
+            pytest.param(
+                {
+                    'name': None,
+                },
+                {
+                    'name': ['This field may not be null.'],
+                },
+                id='name is null',
+            ),
+            pytest.param(
+                {
+                    'name': '',
+                },
+                {
+                    'name': ['This field may not be blank.'],
+                },
+                id='name is empty string',
+            ),
+        ),
+    )
+    def test_validation(self, request_data, expected_errors):
+        """Test validation."""
+        response = self.api_client.post(list_collection_url, data=request_data)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_errors
+
+    @freeze_time('2017-04-19 15:25:30.986208')
+    def test_successfully_create_a_list(self):
+        """Test that a list can be created."""
+        name = 'list a'
+        response = self.api_client.post(
+            list_collection_url,
+            data={
+                'name': name,
+            },
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        response_data = response.json()
+        assert response_data == {
+            'id': response_data['id'],
+            'name': name,
+            'created_on': '2017-04-19T15:25:30.986208Z',
+        }
+
+        company_list = CompanyList.objects.get(pk=response_data['id'])
+
+        # adviser should be set to the authenticated user
+        assert company_list.adviser == self.user
+        assert company_list.created_by == self.user
+        assert company_list.modified_by == self.user

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -12,6 +12,7 @@ urlpatterns = [
         CompanyListViewSet.as_view(
             {
                 'get': 'list',
+                'post': 'create',
             },
         ),
         name='list-collection',

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -10,7 +10,7 @@ class CompanyListViewSet(CoreViewSet):
     """
     Views for managing the authenticated user's company lists.
 
-    Currently, this covers listing lists only.
+    This covers creating and listing lists.
     """
 
     required_scopes = (Scope.internal_front_end,)
@@ -22,3 +22,20 @@ class CompanyListViewSet(CoreViewSet):
     def get_queryset(self):
         """Get a query set filtered to the authenticated user's lists."""
         return super().get_queryset().filter(adviser=self.request.user)
+
+    def get_additional_data(self, create):
+        """
+        Set additional data for when serializer.save() is called.
+
+        This makes sure that adviser is set to self.request.user when a list is created
+        (in the same way created_by and modified_by are).
+
+        TODO: When we have support for updating (i.e. renaming) lists, change this to not overwrite
+         adviser when create=False.
+        """
+        additional_data = super().get_additional_data(create)
+
+        return {
+            **additional_data,
+            'adviser': self.request.user,
+        }


### PR DESCRIPTION
### Description of change

[This follows on from previous company list PRs](https://github.com/uktrade/data-hub-leeloo/pulls?q=is%3Apr+is%3Aclosed+author%3Areupen+label%3A%22company+lists%22
).

This adds a view at `POST /v4/company-list` for creating a company list associated with the authenticated user.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
