### PR TITLE
Add a configurable blacklist to prohibit certain email addresses using email ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `DATAHUB_SUPPORT_EMAIL_ADDRESS` | No | Email address for DataHub support team. |
 | `DEBUG`  | Yes | Whether Django's debug mode should be enabled. |
 | `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass\|spf:pass\|dkim:pass |
+| `DIT_EMAIL_INGEST_WHITELIST` | No | A list of emails that email ingestion is allowed to ingest emails from. |
+| `DIT_EMAIL_INGEST_BLACKLIST` | No | A list of emails for which email ingestion is prohibited. |
 | `DJANGO_SECRET_KEY`  | Yes | |
 | `DJANGO_SENTRY_DSN`  | Yes | |
 | `DJANGO_SETTINGS_MODULE`  | Yes | |

--- a/changelog/email-ingestion-blacklist.feature.rst
+++ b/changelog/email-ingestion-blacklist.feature.rst
@@ -1,0 +1,2 @@
+A configurable blacklist was added so that we can specifically prohibit certain
+email addresses from the email ingestion feature.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -566,7 +566,9 @@ MAILBOXES = {
 }
 
 # TODO: Remove this setting once we are past the pilot period for email ingestion
-DIT_EMAIL_INGEST_WHITELIST = env.list('DIT_EMAIL_INGEST_WHITELIST', default=[])
+DIT_EMAIL_INGEST_WHITELIST = [email.lower() for email in env.list('DIT_EMAIL_INGEST_WHITELIST', default=[])]
+DIT_EMAIL_INGEST_BLACKLIST = [email.lower() for email in env.list('DIT_EMAIL_INGEST_BLACKLIST', default=[])]
+
 DIT_EMAIL_DOMAINS = {}
 domain_environ_names = [
     environ_name

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -110,6 +110,9 @@ DIT_EMAIL_INGEST_WHITELIST = [
     'correspondence3@digital.trade.gov.uk',
     'unknown@trade.gov.uk',
 ]
+DIT_EMAIL_INGEST_BLACKLIST = [
+    'blacklisted@trade.gov.uk',
+]
 DIT_EMAIL_DOMAINS = {
     'trade.gov.uk': [['exempt']],
     'digital.trade.gov.uk': [['spf', 'pass'], ['dmarc', 'bestguesspass'], ['dkim', 'pass']],

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -109,6 +109,9 @@ DIT_EMAIL_INGEST_WHITELIST = [
     'adviser3@digital.trade.gov.uk',
     'correspondence3@digital.trade.gov.uk',
     'unknown@trade.gov.uk',
+    # This needs to be on the whitelist so that the blacklist logic can trigger.
+    # The whitelist will eventually be removed
+    'blacklisted@trade.gov.uk',
 ]
 DIT_EMAIL_INGEST_BLACKLIST = [
     'blacklisted@trade.gov.uk',

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -133,6 +133,12 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
             ]),
             False,
         ),
+        # Blacklisted email
+        (
+            'blacklisted@trade.gov.uk',
+            None,
+            False,
+        ),
     ),
 )
 def test_email_sent_by_dit(email, authentication_results, expected_result):

--- a/datahub/email_ingestion/validation.py
+++ b/datahub/email_ingestion/validation.py
@@ -55,6 +55,9 @@ def was_email_sent_by_dit(message):
     if from_email.lower() not in settings.DIT_EMAIL_INGEST_WHITELIST:
         return False
 
+    if from_email.lower() in settings.DIT_EMAIL_INGEST_BLACKLIST:
+        return False
+
     try:
         domain_auth_methods = settings.DIT_EMAIL_DOMAINS[from_domain]
     except KeyError:


### PR DESCRIPTION
### Description of change

It was agreed in a meeting about securing the email ingestion feature that we should have a configurable blacklist of emails that are prohibited from using email ingestion.  This has been implemented as a new setting `DIT_EMAIL_INGEST_BLACKLIST`.  

It's possible that we may want to add some logging in the future, but for right now a simple blacklist lookup is good enough to satisfy the business requirements.


### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
