### PR TITLE
Adjust email ingestion to delete ingested emails

### DIFF
--- a/changelog/email-ingestion-delete.feature.rst
+++ b/changelog/email-ingestion-delete.feature.rst
@@ -1,0 +1,4 @@
+Email ingestion was adjusted so that emails are deleted after they are ingested.
+Previously, email ingestion would mark the emails as "seen" but now that we are
+out of the pilot for meeting invite ingestion we have switched to deletes as this
+is safer for data retention/protection reasons.

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -200,7 +200,7 @@ class Mailbox:
                     )
                     logger.exception(error_message)
                     # Just set the message to None so that we still mark it as
-                    # read later
+                    # deleted later
                     message = None
                 except EmailRetrievalError:
                     # We should fail and exit immediately in this case, as it's

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -172,9 +172,13 @@ class Mailbox:
 
     def get_new_mail(self):
         """
-        Generator method which gets new messages from the email inbox. After a
-        message has been yielded (or an error has been logged while parsing it),
-        it is flagged as DELETED on the inbox so that it will not be ingested again later.
+        Generator method which gets new messages from the email inbox.
+
+        After a message has been yielded (or an error has been logged while parsing it), it is
+        flagged as DELETED on the inbox. Finally, the function will call `expunge()` on the mailbox
+        (which will delete all messages marked for deletion) - this will be called after all unread
+        messages have been yielded by the generator.
+
         We only consider messages that have not been seen for ingestion.
 
         :yields: A mailparser.Message object for each parsed message.

--- a/datahub/email_ingestion/mailbox.py
+++ b/datahub/email_ingestion/mailbox.py
@@ -28,7 +28,7 @@ class Mailbox:
     them using associated processing classes.
 
     When an email is retrieved from the inbox successfully, it is marked as
-    SEEN on the upstream IMAP inbox.  This is the mechanism we use to ensure
+    DELETED on the upstream IMAP inbox.  This is the mechanism we use to ensure
     that emails are only ever processed once.
 
     The first processor to successfully consume and process the message will stop
@@ -174,7 +174,7 @@ class Mailbox:
         """
         Generator method which gets new messages from the email inbox. After a
         message has been yielded (or an error has been logged while parsing it),
-        it is flagged as SEEN on the inbox so that it will not be ingested again later.
+        it is flagged as DELETED on the inbox so that it will not be ingested again later.
         We only consider messages that have not been seen for ingestion.
 
         :yields: A mailparser.Message object for each parsed message.
@@ -209,8 +209,10 @@ class Mailbox:
                 if message:
                     yield message
 
-                # Mark the email as read in the inbox
-                connection.uid('store', uid, '+FLAGS', '(\\SEEN)')
+                # Mark the email for deletion in the inbox
+                connection.uid('store', uid, '+FLAGS', '(\\Deleted)')
+            # Delete the emails which were marked for deletion
+            connection.expunge()
 
     def process_new_mail(self):
         """

--- a/datahub/email_ingestion/test/test_mailbox.py
+++ b/datahub/email_ingestion/test/test_mailbox.py
@@ -126,14 +126,15 @@ class TestMailbox:
             expected_email_message = expected_email_messages[count]
             # Ensure that the messages our mailbox retrieves are those that we expect
             assert message == expected_email_message['message_content']
-            # Ensure that a call was made to mark each message retrieved as SEEN
+            # Ensure that a call was made to mark each message retrieved as Deleted
             mocked_imap.uid.assert_any_call(
                 'store',
                 expected_email_message['uid'],
                 '+FLAGS',
-                '(\\SEEN)',
+                '(\\Deleted)',
             )
         # Ensure that the imap connection was cleaned up
+        mocked_imap.expunge.assert_called_once()
         mocked_imap.close.assert_called_once()
         mocked_imap.logout.assert_called_once()
 
@@ -192,12 +193,12 @@ class TestMailbox:
             expected_email_message = expected_email_messages[count]
             # Ensure that the messages our mailbox retrieves are those that we expect
             assert message == expected_email_message['message_content']
-            # Ensure that a call was made to mark each message retrieved as SEEN
+            # Ensure that a call was made to mark each message retrieved as Deleted
             mocked_imap.uid.assert_any_call(
                 'store',
                 expected_email_message['uid'],
                 '+FLAGS',
-                '(\\SEEN)',
+                '(\\Deleted)',
             )
 
     @patch_imap(EXPECTED_EMAIL_MESSAGES)
@@ -235,12 +236,12 @@ class TestMailbox:
             expected_email_message = expected_email_messages[count]
             # Ensure that the messages our mailbox retrieves are those that we expect
             assert message == expected_email_message['message_content']
-            # Ensure that a call was made to mark each message retrieved as SEEN
+            # Ensure that a call was made to mark each message retrieved as Deleted
             mocked_imap.uid.assert_any_call(
                 'store',
                 expected_email_message['uid'],
                 '+FLAGS',
-                '(\\SEEN)',
+                '(\\Deleted)',
             )
         # Ensure that the imap connection was cleaned up
         mocked_imap.close.assert_called_once()


### PR DESCRIPTION
### Description of change

Email ingestion was adjusted so that emails are deleted after they are ingested. Previously, email ingestion would mark the emails as "seen" but now that we are out of the pilot for meeting invite ingestion we have switched to deletes as this is safer for data retention/protection reasons.

**NOTE** This should not be merged until we have agreed that the invite ingestion pilot is finished.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
