### PR TITLE
Add view for updating a company list

### DIFF
--- a/changelog/adviser/update-company-list.api.rst
+++ b/changelog/adviser/update-company-list.api.rst
@@ -1,0 +1,9 @@
+The following endpoint was added:
+
+- ``PATCH /v4/company-list/<list ID>``: Rename a company list.
+
+  The request body must be in following format::
+
+    {
+      "name": "string"
+    }

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -18,6 +18,15 @@ urlpatterns = [
         name='list-collection',
     ),
     path(
+        'company-list/<uuid:pk>',
+        CompanyListViewSet.as_view(
+            {
+                'patch': 'partial_update',
+            },
+        ),
+        name='list-detail',
+    ),
+    path(
         'user/company-list',
         LegacyCompanyListViewSet.as_view(
             {

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -10,7 +10,7 @@ class CompanyListViewSet(CoreViewSet):
     """
     Views for managing the authenticated user's company lists.
 
-    This covers creating and listing lists.
+    This covers creating, updating (i.e. renaming) and listing lists.
     """
 
     required_scopes = (Scope.internal_front_end,)
@@ -29,11 +29,13 @@ class CompanyListViewSet(CoreViewSet):
 
         This makes sure that adviser is set to self.request.user when a list is created
         (in the same way created_by and modified_by are).
-
-        TODO: When we have support for updating (i.e. renaming) lists, change this to not overwrite
-         adviser when create=False.
         """
         additional_data = super().get_additional_data(create)
+
+        if not create:
+            # A list is being updated rather than created, so leave the adviser field unchanged
+            # (as there is no reason to change it)
+            return additional_data
 
         return {
             **additional_data,


### PR DESCRIPTION
### Description of change

[This follows on from previous company list PRs](https://github.com/uktrade/data-hub-leeloo/pulls?q=is%3Apr+is%3Aclosed+author%3Areupen+label%3A%22company+lists%22
).

This adds a view at `PATCH /v4/company-list<id>` for renaming a company list that is associated with the authenticated user.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
