### PR TITLE
Replace email ingest whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `DATA_HUB_FRONTEND_SECRET_ACCESS_KEY` | If `DATA_HUB_FRONTEND_ACCESS_KEY_ID` is set | A secret key, corresponding to `METADATA_ACCESS_KEY_ID`. The holder of this key can access the metadata endpoints by Hawk authentication. | 
 | `DEBUG`  | Yes | Whether Django's debug mode should be enabled. |
 | `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass\|spf:pass\|dkim:pass |
+| `DIT_EMAIL_INGEST_BLACKLIST` | No | A list of emails for which email ingestion is prohibited. |
 | `DJANGO_SECRET_KEY`  | Yes | |
 | `DJANGO_SENTRY_DSN`  | Yes | |
 | `DJANGO_SETTINGS_MODULE`  | Yes | |

--- a/changelog/email-ingestion-blacklist.feature.rst
+++ b/changelog/email-ingestion-blacklist.feature.rst
@@ -1,0 +1,2 @@
+A configurable blacklist was added so that we can specifically prohibit certain
+email addresses from the email ingestion feature.

--- a/changelog/email-ingestion-replace-whitelist.feature.rst
+++ b/changelog/email-ingestion-replace-whitelist.feature.rst
@@ -1,0 +1,7 @@
+The email ingestion whitelist was removed so that email ingestion is open to
+all DIT advisers.  
+The email domain that a DIT adviser uses to send an email to Data Hub must be 
+known to Data Hub through a ``DIT_EMAIL_DOMAIN_<domain>`` django setting -
+there is no longer a default domain authentication value. This ensures that 
+email ingestion is locked down to domains that we know the authentication
+signature for.

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -568,6 +568,8 @@ MAILBOXES = {
     },
 }
 
+DIT_EMAIL_INGEST_BLACKLIST = [email.lower() for email in env.list('DIT_EMAIL_INGEST_BLACKLIST', default=[])]
+
 DIT_EMAIL_DOMAINS = {}
 domain_environ_names = [
     environ_name

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -568,8 +568,6 @@ MAILBOXES = {
     },
 }
 
-# TODO: Remove this setting once we are past the pilot period for email ingestion
-DIT_EMAIL_INGEST_WHITELIST = env.list('DIT_EMAIL_INGEST_WHITELIST', default=[])
 DIT_EMAIL_DOMAINS = {}
 domain_environ_names = [
     environ_name

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -110,17 +110,6 @@ DOCUMENT_BUCKETS = {
     }
 }
 
-# TODO: Remove this setting once we are past the pilot period for email ingestion
-DIT_EMAIL_INGEST_WHITELIST = [
-    'bill.adama@digital.trade.gov.uk',
-    'bill.adama@other.trade.gov.uk',
-    'bill.adama@trade.gov.uk',
-    'adviser1@trade.gov.uk',
-    'adviser2@digital.trade.gov.uk',
-    'adviser3@digital.trade.gov.uk',
-    'correspondence3@digital.trade.gov.uk',
-    'unknown@trade.gov.uk',
-]
 DIT_EMAIL_DOMAINS = {
     'trade.gov.uk': [['exempt']],
     'digital.trade.gov.uk': [['spf', 'pass'], ['dmarc', 'bestguesspass'], ['dkim', 'pass']],

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -113,7 +113,6 @@ DOCUMENT_BUCKETS = {
 DIT_EMAIL_DOMAINS = {
     'trade.gov.uk': [['exempt']],
     'digital.trade.gov.uk': [['spf', 'pass'], ['dmarc', 'bestguesspass'], ['dkim', 'pass']],
-    'other.trade.gov.uk': [],
 }
 
 ACTIVITY_STREAM_OUTGOING_URL = 'http://activity.stream/'

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -110,6 +110,10 @@ DOCUMENT_BUCKETS = {
     }
 }
 
+DIT_EMAIL_INGEST_BLACKLIST = [
+    'blacklisted@trade.gov.uk',
+]
+
 DIT_EMAIL_DOMAINS = {
     'trade.gov.uk': [['exempt']],
     'digital.trade.gov.uk': [['spf', 'pass'], ['dmarc', 'bestguesspass'], ['dkim', 'pass']],

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -39,8 +39,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) header.from=gmail.com',
                 'compauth=pass (reason=109)',
             ]),
-            # TODO: Will need review as we adjust domain verification during trial
-            False,
+            True,
         ),
         # Invalid authentication results - dkim
         (

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -150,6 +150,13 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'dmarc=pass spf=pass'
             ),
         ),
+        # Blacklisted email
+        (
+            'blacklisted@trade.gov.uk',
+            None,
+            False,
+            None,
+        ),
     ),
 )
 def test_email_sent_by_dit(

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -1,3 +1,4 @@
+import logging
 from unittest import mock
 
 import pytest
@@ -6,13 +7,14 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
 
 
 @pytest.mark.parametrize(
-    'email,authentication_results,expected_result',
+    'email,authentication_results,expected_result,expected_warning',
     (
         # Valid trade.gov.uk email - authentication exempt
         (
             'bill.adama@trade.gov.uk',
             None,
             True,
+            None,
         ),
         # Valid digital.trade.gov.uk email, ensure whitelist is case insensitive
         (
@@ -27,19 +29,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'compauth=pass (reason=109)',
             ]),
             True,
-        ),
-        # Invalid domain - not on DIT adviser whitelist
-        (
-            'bill.adama@gmail.com',
-            '\n'.join([
-                'mx.google.com;',
-                'dkim=pass header.i=@gmail.com header.s=selector1 header.b=foobar;',
-                'spf=pass (google.com: domain of bill.adama@gmail.com designates '
-                'XX.XXX.XX.XX as permitted sender) smtp.mailfrom=bill.adama@gmail.com;',
-                'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) header.from=gmail.com',
-                'compauth=pass (reason=109)',
-            ]),
-            True,
+            None,
         ),
         # Invalid authentication results - dkim
         (
@@ -56,6 +46,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'compauth=pass (reason=109)',
             ]),
             False,
+            None,
         ),
         # Invalid authentication results - spf
         (
@@ -72,6 +63,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'compauth=pass (reason=109)',
             ]),
             False,
+            None,
         ),
         # Invalid authentication results - dmarc
         (
@@ -88,6 +80,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'compauth=pass (reason=109)',
             ]),
             False,
+            None,
         ),
         # Missing authentication results for spf
         (
@@ -102,6 +95,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'compauth=pass (reason=109)',
             ]),
             False,
+            None,
         ),
         # Extra unknown auth method - still passes
         (
@@ -117,32 +111,70 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
                 'compauth=pass (reason=109)',
             ]),
             True,
+            None,
         ),
-        # Domain with no auth methods set, uses default methods and fails
+        # Domain which is not on DIT_EMAIL_DOMAINS setting, fails validation
         (
             'bill.adama@other.trade.gov.uk',
             '\n'.join([
                 'mx.google.com;',
-                'dkim=fail header.i=@digital.trade.gov.uk header.s=selector1 header.b=foobar;',
-                'spf=fail (google.com: domain of bill.adama@digital.trade.gov.uk designates '
+                'dkim=pass header.i=@digital.trade.gov.uk header.s=selector1 header.b=foobar;',
+                'spf=pass (google.com: domain of bill.adama@digital.trade.gov.uk designates '
                 'XX.XXX.XX.XX as permitted sender) smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
                 'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
                 'header.from=digital.trade.gov.uk;',
                 'compauth=pass (reason=109)',
             ]),
             False,
+            (
+                'Domain "other.trade.gov.uk" not present in DIT_EMAIL_DOMAINS setting. '
+                'This email had the following authentication results: compauth=pass dkim=pass '
+                'dmarc=pass spf=pass'
+            ),
+        ),
+        # Domain which is not on DIT_EMAIL_DOMAINS setting, fails validation
+        (
+            'joe.bloggs@gmail.com',
+            '\n'.join([
+                'mx.google.com;',
+                'dkim=pass header.i=@gmail.com header.s=selector1 header.b=foobar;',
+                'spf=pass (google.com: domain of joe.bloggs@gmail.com designates '
+                'XX.XXX.XX.XX as permitted sender) smtp.mailfrom=bill.adama@digital.trade.gov.uk;',
+                'dmarc=pass (p=QUARANTINE sp=QUARANTINE dis=NONE) '
+                'header.from=digital.trade.gov.uk;',
+            ]),
+            False,
+            (
+                'Domain "gmail.com" not present in DIT_EMAIL_DOMAINS setting. '
+                'This email had the following authentication results: dkim=pass '
+                'dmarc=pass spf=pass'
+            ),
         ),
     ),
 )
-def test_email_sent_by_dit(email, authentication_results, expected_result):
+def test_email_sent_by_dit(
+    caplog,
+    email,
+    authentication_results,
+    expected_result,
+    expected_warning,
+):
     """
     Tests for was_email_sent_by_dit validator.
     """
+    caplog.set_level(logging.WARNING)
     message = mock.Mock()
     message.from_ = [['Bill Adama', email]]
     message.authentication_results = authentication_results
     result = was_email_sent_by_dit(message)
     assert result == expected_result
+    if expected_warning:
+        expected_log = (
+            'datahub.email_ingestion.validation',
+            30,
+            expected_warning,
+        )
+        assert expected_log in caplog.record_tuples
 
 
 def test_bad_from_returns_false():

--- a/datahub/email_ingestion/validation.py
+++ b/datahub/email_ingestion/validation.py
@@ -70,6 +70,9 @@ def was_email_sent_by_dit(message):
     except IndexError:
         return False
 
+    if from_email.lower() in settings.DIT_EMAIL_INGEST_BLACKLIST:
+        return False
+
     try:
         domain_auth_methods = settings.DIT_EMAIL_DOMAINS[from_domain]
     except KeyError:

--- a/datahub/email_ingestion/validation.py
+++ b/datahub/email_ingestion/validation.py
@@ -51,10 +51,6 @@ def was_email_sent_by_dit(message):
     except IndexError:
         return False
 
-    # TODO: Remove this logic once we are past the pilot period for email ingestion
-    if from_email.lower() not in settings.DIT_EMAIL_INGEST_WHITELIST:
-        return False
-
     try:
         domain_auth_methods = settings.DIT_EMAIL_DOMAINS[from_domain]
     except KeyError:


### PR DESCRIPTION
### Description of change

This PR does the following:
- Removes the email ingestion whitelist so that any DIT advisers that are known by Data Hub can send calendar invites to Data Hub.
- Removes the default value for domain authentication.  This means that for every DIT adviser email domain, we must have a django setting `DIT_EMAIL_DOMAIN_<domain>` which details the expected levels of authentication that emails from this domain should adhere to.  The code will log a warning message if an authentication value for the domain cannot be found.
- Adds an email ingestion blacklist - a list of email address to ignore for email ingestion.

**NOTE** This PR should not be merged until the business has agreed that email ingestion has progressed past the pilot stage.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
