### PR TITLE
Add endpoint for deleting company list contents

### DIFF
--- a/changelog/adviser/company-list-add-item.api.rst
+++ b/changelog/adviser/company-list-add-item.api.rst
@@ -1,0 +1,15 @@
+The following endpoint was added:
+
+  - ``PUT /v4/company-list/<company list ID>/<company ID>``
+
+  This adds a company to the user's own selected list of companies.
+
+  If the operation is successful, a 2xx status code will be returned. If there is no company list with specified company list ID or company with the specified company ID, a 404 wil lbe returned.
+
+  If an archived company is specified, a 400 status code will be returned and response body will contain::
+
+      {
+          "non_field_errors": "An archived company can't be added to a company list."
+      }
+
+  Otherwise, the response body will be empty.

--- a/changelog/adviser/company-list-list-item.api.rst
+++ b/changelog/adviser/company-list-list-item.api.rst
@@ -1,0 +1,38 @@
+The following endpoint was added:
+
+``GET /v4/company-list/<company list ID>``
+
+It lists all the companies on the authenticated user's selected list, with responses in the following format::
+
+    {
+        "count": <int>,
+        "previous": <url>,
+        "next": <url>,
+        "results": [
+            {
+                "company": {
+                    "id": <string>,
+                    "archived": <boolean>,
+                    "name": <string>,
+                    "trading_names": [<string>, <string>, ...]
+                },
+                "created_on": <ISO timestamp>,
+                "latest_interaction": {
+                    "id": <string>,
+                    "created_on": <ISO timestamp>,
+                    "date": <ISO date>,
+                    "subject": <string>
+                }
+            },
+            ...
+        ]
+    }
+
+
+``latest_interaction`` may be ``null`` if the company has no interactions.
+
+Results are sorted by ``latest_interaction.date`` in reverse chronological order, with ``null`` values last.
+
+The endpoint has pagination in line with other endpoints; to retrieve all results pass a large value for the ``limit`` query parameter (e.g. ``?limit=1000``).
+
+If selected list does not exist, the endpoint will return 404 status code.

--- a/changelog/adviser/company-list-remove-item.api.rst
+++ b/changelog/adviser/company-list-remove-item.api.rst
@@ -1,0 +1,7 @@
+The following endpoint was added:
+
+  - ``DELETE /v4/company-list/<company list ID>/<company ID>``
+
+  This removes a company from the user's own selected list of companies.
+
+  If the operation is successful, a 2xx status code will be returned. If there is no company list with specified company list ID or company with the specified company ID, a 404 wil lbe returned.

--- a/datahub/user/company_list/legacy_views.py
+++ b/datahub/user/company_list/legacy_views.py
@@ -6,51 +6,26 @@ from django.utils.translation import gettext_lazy
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework import serializers, status
 from rest_framework.filters import OrderingFilter
-from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
-from datahub.company.models import Company, CompanyPermission
+from datahub.company.models import Company
 from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
 from datahub.user.company_list.models import (
     CompanyList,
     CompanyListItem,
-    CompanyListItemPermissionCode,
 )
 from datahub.user.company_list.queryset import get_company_list_item_queryset
 from datahub.user.company_list.serializers import CompanyListItemSerializer
-
+from datahub.user.company_list.views import CompanyListItemPermissions
 
 CANT_ADD_ARCHIVED_COMPANY_MESSAGE = gettext_lazy(
     "An archived company can't be added to a company list.",
 )
 
 DEFAULT_LEGACY_LIST_NAME = '1. My list'
-
-
-class CompanyListItemPermissions(DjangoModelPermissions):
-    """DRF permissions class for the company list item view."""
-
-    perms_map = {
-        'DELETE': [
-            f'company.{CompanyPermission.view_company}',
-            f'company_list.{CompanyListItemPermissionCode.delete_company_list_item}',
-        ],
-        'GET': [
-            f'company.{CompanyPermission.view_company}',
-            f'company_list.{CompanyListItemPermissionCode.view_company_list_item}',
-        ],
-        'HEAD': [
-            f'company.{CompanyPermission.view_company}',
-            f'company_list.{CompanyListItemPermissionCode.view_company_list_item}',
-        ],
-        'PUT': [
-            f'company.{CompanyPermission.view_company}',
-            f'company_list.{CompanyListItemPermissionCode.add_company_list_item}',
-        ],
-    }
 
 
 class LegacyCompanyListViewSet(CoreViewSet):

--- a/datahub/user/company_list/queryset.py
+++ b/datahub/user/company_list/queryset.py
@@ -8,7 +8,7 @@ from datahub.user.company_list.models import CompanyListItem
 
 def get_company_list_item_queryset():
     """
-    Returns an annotated query set used by LegacyCompanyListViewSet.
+    Returns an annotated query set used by CompanyListViewSet and LegacyCompanyListViewSet.
 
     The annotations are supported by an index on the Interaction model.
 

--- a/datahub/user/company_list/tests/test_views.py
+++ b/datahub/user/company_list/tests/test_views.py
@@ -1,4 +1,6 @@
 from datetime import datetime
+from functools import partial
+from random import sample
 from uuid import uuid4
 
 import factory
@@ -10,7 +12,7 @@ from rest_framework.reverse import reverse
 from rest_framework.settings import api_settings
 
 from datahub.company.test.factories import ArchivedCompanyFactory, CompanyFactory
-from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
 from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.metadata.test.factories import TeamFactory
 from datahub.user.company_list.models import CompanyListItem
@@ -279,6 +281,224 @@ class TestCreateOrUpdateCompanyListItemAPIView(APITestMixin):
             list__adviser=self.user,
             company=company,
         ).exists()
+
+
+class TestCompanyListItemViewSet(APITestMixin):
+    """Tests for CompanyListItemViewSet."""
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned for an unauthenticated user."""
+        company_list = CompanyListFactory()
+        url = reverse(
+            'api-v4:company-list:list-collection',
+            kwargs={
+                'company_list_pk': company_list.pk,
+            },
+        )
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_returns_403_if_without_permissions(self, api_client):
+        """Test that a 403 is returned for a user with no permissions."""
+        user = create_test_user(dit_team=TeamFactory())
+        company_list = CompanyListFactory(adviser=user)
+
+        url = reverse(
+            'api-v4:company-list:list-collection',
+            kwargs={
+                'company_list_pk': company_list.pk,
+            },
+        )
+        api_client = self.create_api_client(user=user)
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_with_no_list_items(self):
+        """
+        Test that an empty list is returned if the user does not have any companies on their
+        list.
+        """
+        company_list = CompanyListFactory(adviser=self.user)
+        url = reverse(
+            'api-v4:company-list:list-collection',
+            kwargs={
+                'company_list_pk': company_list.pk,
+            },
+        )
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['results'] == []
+
+    def test_with_list_that_does_not_exist(self):
+        """
+        Test that an empty list is returned if the user does not have any companies on their
+        list.
+        """
+        url = reverse(
+            'api-v4:company-list:list-collection',
+            kwargs={
+                'company_list_pk': uuid4(),
+            },
+        )
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_with_only_items_on_other_users_list(self):
+        """
+        Test that an empty list is returned if the user has no companies on their list,
+        but other users have companies on theirs.
+        """
+        CompanyListItemFactory.create_batch(5)
+        company_list = CompanyListFactory(adviser=self.user)
+        url = reverse(
+            'api-v4:company-list:list-collection',
+            kwargs={
+                'company_list_pk': company_list.pk,
+            },
+        )
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['results'] == []
+
+    def test_with_multiple_user_lists(self):
+        """Test that user can list their own lists."""
+        creation_date = datetime(2018, 1, 2, tzinfo=utc)
+
+        # other items on other users lists, that shouldn't appear in results
+        CompanyListItemFactory.create_batch(10)
+
+        lists = CompanyListFactory.create_batch(5, adviser=self.user)
+
+        company_list_companies = {}
+
+        for company_list in lists:
+            companies = CompanyFactory.create_batch(5)
+            company_list_companies[company_list.pk] = companies
+
+            with freeze_time(creation_date):
+                CompanyListItemFactory.create_batch(
+                    len(companies),
+                    list=company_list,
+                    company=factory.Iterator(companies),
+                )
+
+        for company_list in lists:
+            url = reverse(
+                'api-v4:company-list:list-collection',
+                kwargs={
+                    'company_list_pk': company_list.pk,
+                },
+            )
+            response = self.api_client.get(url)
+
+            assert response.status_code == status.HTTP_200_OK
+            response_data = response.json()
+
+            result_company_ids = {result['company']['id'] for result in response_data['results']}
+            assert result_company_ids == {
+                str(company.id) for company in company_list_companies[company_list.pk]
+            }
+
+    @pytest.mark.parametrize(
+        'company_factory',
+        (
+            CompanyFactory,
+            ArchivedCompanyFactory,
+            partial(company_with_interactions_factory, 1),
+            partial(company_with_interactions_factory, 10),
+        ),
+    )
+    def test_with_item(self, company_factory):
+        """Test serialisation of various companies."""
+        company = company_factory()
+        list_item = CompanyListItemFactory(list__adviser=self.user, company=company)
+
+        latest_interaction = company.interactions.order_by('-date', '-created_by', 'pk').first()
+
+        url = reverse(
+            'api-v4:company-list:list-collection',
+            kwargs={
+                'company_list_pk': list_item.list.pk,
+            },
+        )
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['results'] == [
+            {
+                'company': {
+                    'id': str(company.pk),
+                    'archived': company.archived,
+                    'name': company.name,
+                    'trading_names': company.trading_names,
+                },
+                'created_on': format_date_or_datetime(list_item.created_on),
+                'latest_interaction': {
+                    'id': str(latest_interaction.pk),
+                    'created_on': format_date_or_datetime(latest_interaction.created_on),
+                    'date': format_date_or_datetime(latest_interaction.date.date()),
+                    'subject': latest_interaction.subject,
+                } if latest_interaction else None,
+            },
+        ]
+
+    def test_sorting(self):
+        """
+        Test that list items are sorted in reverse order of the date of the latest
+        interaction with the company.
+
+        Note that we want companies without any interactions to be sorted last.
+        """
+        # These dates are in the order we expect them to be returned
+        interaction_dates = [
+            datetime(2019, 10, 8, tzinfo=utc),
+            datetime(2016, 9, 7, tzinfo=utc),
+            datetime(2009, 5, 6, tzinfo=utc),
+            None,
+        ]
+        shuffled_dates = sample(interaction_dates, len(interaction_dates))
+        company_list = CompanyListFactory(adviser=self.user)
+        list_items = CompanyListItemFactory.create_batch(
+            len(interaction_dates),
+            list=company_list,
+        )
+
+        for interaction_date, list_item in zip(shuffled_dates, list_items):
+            if interaction_date:
+                CompanyInteractionFactory(date=interaction_date, company=list_item.company)
+
+        url = reverse(
+            'api-v4:company-list:list-collection',
+            kwargs={
+                'company_list_pk': company_list.pk,
+            },
+        )
+
+        # Make sure future interactions are also sorted correctly
+        with freeze_time('2017-12-11 09:00:00'):
+            response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()['results']
+        assert len(results) == len(interaction_dates)
+
+        actual_interaction_dates = [
+            result['latest_interaction']['date'] if result['latest_interaction'] else None
+            for result in results
+        ]
+        expected_interaction_dates = [
+            format_date_or_datetime(date_.date()) if date_ else None
+            for date_ in interaction_dates
+        ]
+        assert actual_interaction_dates == expected_interaction_dates
 
 
 def _get_queryset_for_list_adviser_and_company(company_list, adviser, company):

--- a/datahub/user/company_list/tests/test_views.py
+++ b/datahub/user/company_list/tests/test_views.py
@@ -1,0 +1,289 @@
+from datetime import datetime
+from uuid import uuid4
+
+import factory
+import pytest
+from django.utils.timezone import utc
+from freezegun import freeze_time
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.settings import api_settings
+
+from datahub.company.test.factories import ArchivedCompanyFactory, CompanyFactory
+from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.interaction.test.factories import CompanyInteractionFactory
+from datahub.metadata.test.factories import TeamFactory
+from datahub.user.company_list.models import CompanyListItem
+from datahub.user.company_list.tests.factories import (
+    CompanyListFactory,
+    CompanyListItemFactory,
+)
+from datahub.user.company_list.views import (
+    CANT_ADD_ARCHIVED_COMPANY_MESSAGE,
+)
+
+
+def company_with_interactions_factory(num_interactions):
+    """Factory for a company with interactions."""
+    company = CompanyFactory()
+    CompanyInteractionFactory.create_batch(num_interactions, company=company)
+    return company
+
+
+@pytest.mark.parametrize('http_method', ('delete', 'get', 'head', 'put'))
+class TestCompanyListItemAuth(APITestMixin):
+    """Tests authentication and authorisation for the company list item views."""
+
+    def test_returns_401_if_unauthenticated(self, api_client, http_method):
+        """Test that a 401 is returned for an unauthenticated user."""
+        company = CompanyFactory()
+        company_list = CompanyListFactory()
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': company_list.pk,
+                'company_pk': company.pk,
+            },
+        )
+        response = api_client.generic(http_method, url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_returns_403_if_without_permissions(self, api_client, http_method):
+        """Test that a 403 is returned for a user with no permissions."""
+        company = CompanyFactory()
+        user = create_test_user(dit_team=TeamFactory())
+        company_list = CompanyListFactory(adviser=user)
+
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': company_list.pk,
+                'company_pk': company.pk,
+            },
+        )
+        api_client = self.create_api_client(user=user)
+        response = api_client.generic(http_method, url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestCreateOrUpdateCompanyListItemAPIView(APITestMixin):
+    """Tests for the PUT method in CompanyListItemAPIView."""
+
+    def test_creates_new_items(self):
+        """Test that a company can be added to the authenticated user's list."""
+        company = CompanyFactory()
+        company_list = CompanyListFactory(adviser=self.user)
+
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': company_list.pk,
+                'company_pk': company.pk,
+            },
+        )
+
+        response = self.api_client.put(url)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert response.content == b''
+
+        list_item = _get_queryset_for_list_adviser_and_company(
+            company_list,
+            self.user,
+            company,
+        ).first()
+
+        assert list_item
+        assert list_item.list.adviser == self.user
+        assert list_item.created_by == self.user
+        assert list_item.modified_by == self.user
+
+    def test_does_not_overwrite_other_items(self):
+        """Test that adding an item does not overwrite other (unrelated) items."""
+        existing_companies = CompanyFactory.create_batch(5)
+        company_list = CompanyListFactory(adviser=self.user)
+        CompanyListItemFactory.create_batch(
+            5,
+            list=company_list,
+            company=factory.Iterator(existing_companies),
+        )
+        company_to_add = CompanyFactory()
+
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': company_list.pk,
+                'company_pk': company_to_add.pk,
+            },
+        )
+        response = self.api_client.put(url)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        list_item_queryset = CompanyListItem.objects.filter(
+            list=company_list,
+            list__adviser=self.user,
+        )
+        companies_after = {item.company for item in list_item_queryset}
+        assert companies_after == {*existing_companies, company_to_add}
+
+    def test_two_advisers_can_have_the_same_company(self):
+        """Test that two advisers can have the same company on their list."""
+        other_user_item = CompanyListItemFactory()
+        other_user = other_user_item.list.adviser
+        company = other_user_item.company
+
+        company_list = CompanyListFactory(adviser=self.user)
+
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': company_list.pk,
+                'company_pk': company.pk,
+            },
+        )
+        response = self.api_client.put(url)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        assert _get_queryset_for_list_adviser_and_company(
+            other_user_item.list,
+            other_user,
+            company,
+        ).exists()
+        assert _get_queryset_for_list_adviser_and_company(
+            company_list,
+            self.user,
+            company,
+        ).exists()
+
+    def test_adviser_can_have_the_same_company_on_multiple_lists(self):
+        """Tests that adviser can have the same company on multiple lists."""
+        company = CompanyFactory()
+        lists = CompanyListFactory.create_batch(5, adviser=self.user)
+        for company_list in lists:
+            other_companies = CompanyFactory.create_batch(5)
+
+            CompanyListItemFactory.create_batch(
+                len(other_companies),
+                list=company_list,
+                company=factory.Iterator(other_companies),
+            )
+
+        for company_list in lists:
+            url = reverse(
+                'api-v4:company-list:list-item',
+                kwargs={
+                    'company_list_pk': company_list.pk,
+                    'company_pk': company.pk,
+                },
+            )
+            response = self.api_client.put(url)
+            assert response.status_code == status.HTTP_204_NO_CONTENT
+            assert response.content == b''
+
+        assert CompanyListItem.objects.filter(
+            list__adviser=self.user,
+            list__in=lists,
+            company=company,
+        ).count() == 5
+
+    def test_with_existing_item(self):
+        """
+        Test that no error is returned if the specified company is already on the
+        authenticated user's list.
+        """
+        creation_date = datetime(2018, 1, 2, tzinfo=utc)
+        modified_date = datetime(2018, 1, 2, tzinfo=utc)
+        company = CompanyFactory()
+
+        company_list = CompanyListFactory(adviser=self.user)
+
+        with freeze_time(creation_date):
+            CompanyListItemFactory(
+                list=company_list,
+                list__adviser=self.user,
+                company=company,
+            )
+
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': company_list.pk,
+                'company_pk': company.pk,
+            },
+        )
+
+        with freeze_time(modified_date):
+            response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert response.content == b''
+
+        company_list_item = _get_queryset_for_list_adviser_and_company(
+            company_list,
+            self.user,
+            company,
+        ).first()
+
+        assert company_list_item.created_on == creation_date
+        assert company_list_item.modified_on == modified_date
+
+    def test_with_archived_company(self):
+        """Test that an archived company can't be added to the authenticated user's list."""
+        company_list = CompanyListItemFactory(adviser=self.user)
+        company = ArchivedCompanyFactory()
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': company_list.pk,
+                'company_pk': company.pk,
+            },
+        )
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            api_settings.NON_FIELD_ERRORS_KEY: CANT_ADD_ARCHIVED_COMPANY_MESSAGE,
+        }
+
+    def test_with_non_existent_company(self):
+        """Test that a 404 is returned if the specified company ID is invalid."""
+        company_list = CompanyListFactory(adviser=self.user)
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': company_list.pk,
+                'company_pk': uuid4(),
+            },
+        )
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_with_non_existent_list(self):
+        """Test that you cannot add an item to a list that does not exist."""
+        # Existing company lists for other users should not matter
+        CompanyListFactory.create_batch(5)
+        company = CompanyFactory()
+
+        url = reverse(
+            'api-v4:company-list:list-item',
+            kwargs={
+                'company_list_pk': uuid4(),
+                'company_pk': company.pk,
+            },
+        )
+        response = self.api_client.put(url)
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert not CompanyListItem.objects.filter(
+            list__adviser=self.user,
+            company=company,
+        ).exists()
+
+
+def _get_queryset_for_list_adviser_and_company(company_list, adviser, company):
+    return CompanyListItem.objects.filter(
+        list=company_list,
+        list__adviser=adviser,
+        company=company,
+    )

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -4,8 +4,15 @@ from datahub.user.company_list.legacy_views import (
     LegacyCompanyListItemView,
     LegacyCompanyListViewSet,
 )
+from datahub.user.company_list.views import CompanyListItemAPIView
+
 
 urlpatterns = [
+    path(
+        'company-list/<uuid:company_list_pk>/<uuid:company_pk>',
+        CompanyListItemAPIView.as_view(),
+        name='list-item',
+    ),
     path(
         'user/company-list',
         LegacyCompanyListViewSet.as_view(

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -4,7 +4,10 @@ from datahub.user.company_list.legacy_views import (
     LegacyCompanyListItemView,
     LegacyCompanyListViewSet,
 )
-from datahub.user.company_list.views import CompanyListItemAPIView
+from datahub.user.company_list.views import (
+    CompanyListItemAPIView,
+    CompanyListItemViewSet,
+)
 
 
 urlpatterns = [
@@ -12,6 +15,15 @@ urlpatterns = [
         'company-list/<uuid:company_list_pk>/<uuid:company_pk>',
         CompanyListItemAPIView.as_view(),
         name='list-item',
+    ),
+    path(
+        'company-list/<uuid:company_list_pk>',
+        CompanyListItemViewSet.as_view(
+            {
+                'get': 'list',
+            },
+        ),
+        name='list-collection',
     ),
     path(
         'user/company-list',

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -1,0 +1,97 @@
+from django.db import transaction
+from django.shortcuts import get_object_or_404
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
+from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
+from rest_framework import serializers, status
+from rest_framework.permissions import DjangoModelPermissions
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+from rest_framework.views import APIView
+
+from datahub.company.models import Company, CompanyPermission
+from datahub.oauth.scopes import Scope
+from datahub.user.company_list.models import (
+    CompanyList,
+    CompanyListItem,
+    CompanyListItemPermissionCode,
+)
+from datahub.user.company_list.serializers import CompanyListItemSerializer
+
+CANT_ADD_ARCHIVED_COMPANY_MESSAGE = gettext_lazy(
+    "An archived company can't be added to a company list.",
+)
+
+
+class CompanyListItemPermissions(DjangoModelPermissions):
+    """DRF permissions class for the company list item view."""
+
+    perms_map = {
+        'DELETE': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{CompanyListItemPermissionCode.delete_company_list_item}',
+        ],
+        'GET': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{CompanyListItemPermissionCode.view_company_list_item}',
+        ],
+        'HEAD': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{CompanyListItemPermissionCode.view_company_list_item}',
+        ],
+        'PUT': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{CompanyListItemPermissionCode.add_company_list_item}',
+        ],
+    }
+
+
+class CompanyListItemAPIView(APIView):
+    """
+    A view for adding and removing a company to and from a selected list of companies
+    that belongs to a user.
+    """
+
+    required_scopes = (Scope.internal_front_end,)
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        CompanyListItemPermissions,
+    )
+    # Note: A query set is required for CompanyListItemPermissions
+    queryset = CompanyListItem.objects.all()
+    serializer_class = CompanyListItemSerializer
+
+    @method_decorator(transaction.non_atomic_requests)
+    def put(self, request, company_list_pk, company_pk, format=None):
+        """Add company to a list."""
+        company = get_object_or_404(Company, pk=company_pk)
+        if company.archived:
+            errors = {
+                api_settings.NON_FIELD_ERRORS_KEY: CANT_ADD_ARCHIVED_COMPANY_MESSAGE,
+            }
+            raise serializers.ValidationError(errors)
+
+        adviser = request.user
+        company_list = self._get_company_list(request, company_list_pk)
+
+        # get_or_create() is used to avoid an error if there is an existing
+        # CompanyListItem for this adviser and company
+        self.queryset.get_or_create(
+            company=company,
+            list=company_list,
+            defaults={
+                'created_by': adviser,
+                'modified_by': adviser,
+            },
+        )
+
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    def _get_company_list(self, request, company_list_pk):
+        obj = get_object_or_404(
+            CompanyList,
+            adviser=request.user,
+            pk=company_list_pk,
+        )
+        self.check_object_permissions(request, obj)
+        return obj

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -1,21 +1,25 @@
 from django.db import transaction
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy
 from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
 from rest_framework import serializers, status
+from rest_framework.filters import OrderingFilter
 from rest_framework.permissions import DjangoModelPermissions
 from rest_framework.response import Response
 from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from datahub.company.models import Company, CompanyPermission
+from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
 from datahub.user.company_list.models import (
     CompanyList,
     CompanyListItem,
     CompanyListItemPermissionCode,
 )
+from datahub.user.company_list.queryset import get_company_list_item_queryset
 from datahub.user.company_list.serializers import CompanyListItemSerializer
 
 CANT_ADD_ARCHIVED_COMPANY_MESSAGE = gettext_lazy(
@@ -95,3 +99,42 @@ class CompanyListItemAPIView(APIView):
         )
         self.check_object_permissions(request, obj)
         return obj
+
+
+class CompanyListItemViewSet(CoreViewSet):
+    """A view set for returning the contents of a company list."""
+
+    required_scopes = (Scope.internal_front_end,)
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        CompanyListItemPermissions,
+    )
+    serializer_class = CompanyListItemSerializer
+    filter_backends = (OrderingFilter,)
+    # Note that we want null to be treated as the oldest value when sorting by
+    # how long ago the interaction happened. This happens automatically when sorting by
+    # latest_interaction_time_ago (as opposed to sorting by latest_interaction_date in
+    # descending order)
+    ordering = (
+        'latest_interaction_time_ago',
+        '-latest_interaction_created_on',
+        'latest_interaction_id',
+    )
+    queryset = get_company_list_item_queryset()
+
+    def initial(self, request, *args, **kwargs):
+        """
+        Raise an Http404 if company list specified in the URL path does not exist.
+        """
+        super().initial(request, *args, **kwargs)
+
+        if not CompanyList.objects.filter(pk=self.kwargs['company_list_pk']).exists():
+            raise Http404
+
+    def filter_queryset(self, queryset):
+        """Filter the query set to the items relating to the authenticated users."""
+        queryset = super().filter_queryset(queryset)
+        return queryset.filter(
+            list__adviser=self.request.user,
+            list__pk=self.request.parser_context['kwargs']['company_list_pk'],
+        )

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -91,6 +91,26 @@ class CompanyListItemAPIView(APIView):
 
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 
+    def delete(self, request, company_list_pk, company_pk=None, format=None):
+        """
+        Delete a CompanyListItem for the selected list of authenticated user and
+        specified company if it exists.
+        """
+        company = get_object_or_404(Company, pk=company_pk)
+
+        to_delete_qs = self.queryset.filter(
+            list_id=company_list_pk,
+            list__adviser_id=request.user.pk,
+            company=company,
+        )
+
+        if not to_delete_qs.exists():
+            raise Http404
+
+        to_delete_qs.delete()
+
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
     def _get_company_list(self, request, company_list_pk):
         obj = get_object_or_404(
             CompanyList,


### PR DESCRIPTION
### Description of change

This add the following endpoint:

  - ``DELETE /v4/company-list/<company list ID>/<company ID>``

It removes a company from the user's own selected list of companies.

If the operation is successful, a 2xx status code will be returned. If there is no company list with specified company list ID or company with the specified company ID, a 404 wil lbe returned.

This is branched off https://github.com/uktrade/data-hub-leeloo/pull/2017

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
