### PR TITLE
Add endpoint to add company to user company lists

### DIFF
--- a/changelog/adviser/company-list-add-item.api.rst
+++ b/changelog/adviser/company-list-add-item.api.rst
@@ -1,0 +1,15 @@
+The following endpoint was added:
+
+  - ``PUT /v4/company-list/<company list ID>/item/<company ID>``
+
+  This adds a company to the user's own selected list of companies.
+
+  If the operation is successful, a 204 status code will be returned. If there is no company list with specified company list ID or company with the specified company ID, a 404 will be returned.
+
+  If an archived company is specified, a 400 status code will be returned and response body will contain::
+
+      {
+          "non_field_errors": "An archived company can't be added to a company list."
+      }
+
+  Otherwise, the response body will be empty.

--- a/datahub/user/company_list/legacy_views.py
+++ b/datahub/user/company_list/legacy_views.py
@@ -17,11 +17,10 @@ from datahub.oauth.scopes import Scope
 from datahub.user.company_list.models import (
     CompanyList,
     CompanyListItem,
-    CompanyListItemPermissionCode,
 )
+from datahub.user.company_list.models import CompanyListItemPermissionCode
 from datahub.user.company_list.queryset import get_company_list_item_queryset
 from datahub.user.company_list.serializers import CompanyListItemSerializer
-
 
 CANT_ADD_ARCHIVED_COMPANY_MESSAGE = gettext_lazy(
     "An archived company can't be added to a company list.",

--- a/datahub/user/company_list/test/test_views.py
+++ b/datahub/user/company_list/test/test_views.py
@@ -1,18 +1,26 @@
+from datetime import datetime
 from random import sample
 from uuid import uuid4
 
 import factory
 import pytest
+from django.utils.timezone import utc
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
+from rest_framework.settings import api_settings
 
 from datahub.company.models import Company
-from datahub.company.test.factories import CompanyFactory
-from datahub.core.test_utils import APITestMixin, create_test_user, format_date_or_datetime
-from datahub.user.company_list.models import CompanyList, CompanyListItem
+from datahub.company.test.factories import ArchivedCompanyFactory, CompanyFactory
+from datahub.core.test_utils import APITestMixin, create_test_user
+from datahub.core.test_utils import format_date_or_datetime
+from datahub.metadata.test.factories import TeamFactory
+from datahub.user.company_list.models import CompanyList
+from datahub.user.company_list.models import CompanyListItem
 from datahub.user.company_list.test.factories import CompanyListFactory, CompanyListItemFactory
-
+from datahub.user.company_list.views import (
+    CANT_ADD_ARCHIVED_COMPANY_MESSAGE,
+)
 
 list_collection_url = reverse('api-v4:company-list:list-collection')
 
@@ -463,3 +471,188 @@ class TestDeleteCompanyListView(APITestMixin):
 
         response = self.api_client.delete(url)
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+class TestCompanyListItemAuth(APITestMixin):
+    """Tests authentication and authorisation for the company list item views."""
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned for an unauthenticated user."""
+        company = CompanyFactory()
+        company_list = CompanyListFactory()
+
+        url = _get_list_item_url(company_list.pk, company.pk)
+        response = api_client.put(url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_returns_403_if_without_permissions(self, api_client):
+        """Test that a 403 is returned for a user with no permissions."""
+        company = CompanyFactory()
+        user = create_test_user(dit_team=TeamFactory())
+        company_list = CompanyListFactory(adviser=user)
+
+        url = _get_list_item_url(company_list.pk, company.pk)
+        api_client = self.create_api_client(user=user)
+
+        response = api_client.put(url)
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+class TestCreateOrUpdateCompanyListItemAPIView(APITestMixin):
+    """Tests for the PUT method in CompanyListItemAPIView."""
+
+    def test_creates_new_items(self):
+        """Test that a company can be added to the authenticated user's list."""
+        company = CompanyFactory()
+        company_list = CompanyListFactory(adviser=self.user)
+
+        url = _get_list_item_url(company_list.pk, company.pk)
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert response.content == b''
+
+        list_item = _get_queryset_for_list_and_company(company_list, company).first()
+
+        assert list_item
+        assert list_item.list == company_list
+        assert list_item.created_by == self.user
+        assert list_item.modified_by == self.user
+
+    def test_does_not_overwrite_other_items(self):
+        """Test that adding an item does not overwrite other (unrelated) items."""
+        existing_companies = CompanyFactory.create_batch(5)
+        company_list = CompanyListFactory(adviser=self.user)
+        CompanyListItemFactory.create_batch(
+            5,
+            list=company_list,
+            company=factory.Iterator(existing_companies),
+        )
+        company_to_add = CompanyFactory()
+
+        url = _get_list_item_url(company_list.pk, company_to_add.pk)
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        list_item_queryset = CompanyListItem.objects.filter(list=company_list)
+        companies_after = {item.company for item in list_item_queryset}
+        assert companies_after == {*existing_companies, company_to_add}
+
+    def test_two_advisers_can_have_the_same_company(self):
+        """Test that two advisers can have the same company on their list."""
+        other_user_item = CompanyListItemFactory()
+        company = other_user_item.company
+
+        company_list = CompanyListFactory(adviser=self.user)
+
+        url = _get_list_item_url(company_list.pk, company.pk)
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        assert _get_queryset_for_list_and_company(other_user_item.list, company).exists()
+        assert _get_queryset_for_list_and_company(company_list, company).exists()
+
+    def test_adviser_can_have_the_same_company_on_multiple_lists(self):
+        """Tests that adviser can have the same company on multiple lists."""
+        company = CompanyFactory()
+
+        other_list = CompanyListFactory(adviser=self.user)
+        CompanyListItemFactory(list=other_list, company=company)
+
+        company_list = CompanyListFactory(adviser=self.user)
+
+        url = _get_list_item_url(company_list.pk, company.pk)
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert response.content == b''
+
+        assert CompanyListItem.objects.filter(
+            list__in=(other_list, company_list),
+            company=company,
+        ).count() == 2
+
+    def test_with_existing_item(self):
+        """
+        Test that no error is returned if the specified company is already on the
+        authenticated user's list.
+        """
+        creation_date = datetime(2018, 1, 2, tzinfo=utc)
+        modified_date = datetime(2018, 1, 5, tzinfo=utc)
+        company = CompanyFactory()
+
+        company_list = CompanyListFactory(adviser=self.user)
+
+        with freeze_time(creation_date):
+            CompanyListItemFactory(list=company_list, company=company)
+
+        url = _get_list_item_url(company_list.pk, company.pk)
+
+        with freeze_time(modified_date):
+            response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert response.content == b''
+
+        company_list_item = _get_queryset_for_list_and_company(
+            company_list,
+            company,
+        ).first()
+
+        assert company_list_item.created_on == creation_date
+        assert company_list_item.modified_on == creation_date
+
+    def test_with_archived_company(self):
+        """Test that an archived company can't be added to the authenticated user's list."""
+        company_list = CompanyListFactory(adviser=self.user)
+        company = ArchivedCompanyFactory()
+
+        url = _get_list_item_url(company_list.pk, company.pk)
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {
+            api_settings.NON_FIELD_ERRORS_KEY: CANT_ADD_ARCHIVED_COMPANY_MESSAGE,
+        }
+
+    def test_with_non_existent_company(self):
+        """Test that a 404 is returned if the specified company ID is invalid."""
+        company_list = CompanyListFactory(adviser=self.user)
+
+        url = _get_list_item_url(company_list.pk, uuid4())
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_with_non_existent_list(self):
+        """Test that you cannot add an item to a list that does not exist."""
+        # Existing company lists for other users should not matter
+        CompanyListFactory.create_batch(5)
+        company = CompanyFactory()
+
+        url = _get_list_item_url(uuid4(), company.pk)
+        response = self.api_client.put(url)
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert not CompanyListItem.objects.filter(
+            list__adviser=self.user,
+            company=company,
+        ).exists()
+
+
+def _get_queryset_for_list_and_company(company_list, company):
+    return CompanyListItem.objects.filter(list=company_list, company=company)
+
+
+def _get_list_item_url(company_list_pk, company_pk):
+    return reverse(
+        'api-v4:company-list:item-detail',
+        kwargs={
+            'company_list_pk': company_list_pk,
+            'company_pk': company_pk,
+        },
+    )

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -4,7 +4,7 @@ from datahub.user.company_list.legacy_views import (
     LegacyCompanyListItemView,
     LegacyCompanyListViewSet,
 )
-from datahub.user.company_list.views import CompanyListViewSet
+from datahub.user.company_list.views import CompanyListItemAPIView, CompanyListViewSet
 
 urlpatterns = [
     path(
@@ -26,6 +26,11 @@ urlpatterns = [
             },
         ),
         name='list-detail',
+    ),
+    path(
+        'company-list/<uuid:company_list_pk>/item/<uuid:company_pk>',
+        CompanyListItemAPIView.as_view(),
+        name='item-detail',
     ),
     path(
         'user/company-list',

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -1,13 +1,33 @@
+from django.db import transaction
 from django.db.models import Count
+from django.shortcuts import get_object_or_404
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
 from django_filters.rest_framework import DjangoFilterBackend
+from oauth2_provider.contrib.rest_framework import IsAuthenticatedOrTokenHasScope
+from rest_framework import serializers, status
 from rest_framework.filters import OrderingFilter
 from rest_framework.mixins import DestroyModelMixin
+from rest_framework.permissions import DjangoModelPermissions
+from rest_framework.response import Response
+from rest_framework.settings import api_settings
+from rest_framework.views import APIView
 
+from datahub.company.models import Company, CompanyPermission
 from datahub.core.query_utils import get_aggregate_subquery
 from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
-from datahub.user.company_list.models import CompanyList
+from datahub.user.company_list.models import (
+    CompanyList,
+    CompanyListItem,
+    CompanyListItemPermissionCode,
+)
+from datahub.user.company_list.serializers import CompanyListItemSerializer
 from datahub.user.company_list.serializers import CompanyListSerializer
+
+CANT_ADD_ARCHIVED_COMPANY_MESSAGE = gettext_lazy(
+    "An archived company can't be added to a company list.",
+)
 
 
 class CompanyListViewSet(CoreViewSet, DestroyModelMixin):
@@ -48,3 +68,65 @@ class CompanyListViewSet(CoreViewSet, DestroyModelMixin):
             **additional_data,
             'adviser': self.request.user,
         }
+
+
+class CompanyListItemAPIPermissions(DjangoModelPermissions):
+    """DRF permissions class for the company list item view."""
+
+    perms_map = {
+        'PUT': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{CompanyListItemPermissionCode.add_company_list_item}',
+        ],
+    }
+
+
+class CompanyListItemAPIView(APIView):
+    """
+    A view for adding a company to a selected list of companies that belongs to a user.
+    """
+
+    required_scopes = (Scope.internal_front_end,)
+    permission_classes = (
+        IsAuthenticatedOrTokenHasScope,
+        CompanyListItemAPIPermissions,
+    )
+    # Note: A query set is required for CompanyListItemPermissions
+    queryset = CompanyListItem.objects.all()
+    serializer_class = CompanyListItemSerializer
+
+    @method_decorator(transaction.non_atomic_requests)
+    def put(self, request, company_list_pk, company_pk, format=None):
+        """Add company to a list."""
+        company_list = self._get_company_list_or_404(request, company_list_pk)
+
+        company = get_object_or_404(Company, pk=company_pk)
+        if company.archived:
+            errors = {
+                api_settings.NON_FIELD_ERRORS_KEY: CANT_ADD_ARCHIVED_COMPANY_MESSAGE,
+            }
+            raise serializers.ValidationError(errors)
+
+        adviser = request.user
+
+        # get_or_create() is used to avoid an error if there is an existing
+        # CompanyListItem for this adviser and company
+        self.queryset.get_or_create(
+            company=company,
+            list=company_list,
+            defaults={
+                'created_by': adviser,
+                'modified_by': adviser,
+            },
+        )
+
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    def _get_company_list_or_404(self, request, company_list_pk):
+        obj = get_object_or_404(
+            CompanyList,
+            adviser=request.user,
+            pk=company_list_pk,
+        )
+        self.check_object_permissions(request, obj)
+        return obj


### PR DESCRIPTION
### Description of change

This adds an endpoint for adding a company to user's multiple company lists. 
The work is based on a legacy implementation done by @reupen for a single list per user.

 ``PUT /v4/company-list/<company list ID>/item/<company ID>``

  This adds a company to the user's own selected list of companies.

  If the operation is successful, a 204 status code will be returned. If there is no company list with specified company list ID or company with the specified company ID, a 404 will be returned.

  If an archived company is specified, a 400 status code will be returned and response body will contain::

      {
          "non_field_errors": "An archived company can't be added to a company list."
      }

  Otherwise, the response body will be empty.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
