### PR TITLE
Add endpoint for listing company list contents

### DIFF
--- a/changelog/adviser/company-list-list-item.api.rst
+++ b/changelog/adviser/company-list-list-item.api.rst
@@ -1,0 +1,38 @@
+The following endpoint was added:
+
+``GET /v4/company-list/<company list ID>/item``
+
+It lists all the companies on the authenticated user's selected list, with responses in the following format::
+
+    {
+        "count": <int>,
+        "previous": <url>,
+        "next": <url>,
+        "results": [
+            {
+                "company": {
+                    "id": <string>,
+                    "archived": <boolean>,
+                    "name": <string>,
+                    "trading_names": [<string>, <string>, ...]
+                },
+                "created_on": <ISO timestamp>,
+                "latest_interaction": {
+                    "id": <string>,
+                    "created_on": <ISO timestamp>,
+                    "date": <ISO date>,
+                    "subject": <string>
+                }
+            },
+            ...
+        ]
+    }
+
+
+``latest_interaction`` may be ``null`` if the company has no interactions.
+
+Results are sorted by ``latest_interaction.date`` in reverse chronological order, with ``null`` values last.
+
+The endpoint has pagination in line with other endpoints; to retrieve all results pass a large value for the ``limit`` query parameter (e.g. ``?limit=1000``).
+
+If selected list does not exist, the endpoint will return 404 status code.

--- a/datahub/user/company_list/queryset.py
+++ b/datahub/user/company_list/queryset.py
@@ -8,7 +8,7 @@ from datahub.user.company_list.models import CompanyListItem
 
 def get_company_list_item_queryset():
     """
-    Returns an annotated query set used by LegacyCompanyListViewSet.
+    Returns an annotated query set used by CompanyListItemViewSet and LegacyCompanyListViewSet.
 
     The annotations are supported by an index on the Interaction model.
 

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -4,7 +4,11 @@ from datahub.user.company_list.legacy_views import (
     LegacyCompanyListItemView,
     LegacyCompanyListViewSet,
 )
-from datahub.user.company_list.views import CompanyListItemAPIView, CompanyListViewSet
+from datahub.user.company_list.views import (
+    CompanyListItemAPIView,
+    CompanyListItemViewSet,
+    CompanyListViewSet,
+)
 
 urlpatterns = [
     path(
@@ -26,6 +30,15 @@ urlpatterns = [
             },
         ),
         name='list-detail',
+    ),
+    path(
+        'company-list/<uuid:company_list_pk>/item',
+        CompanyListItemViewSet.as_view(
+            {
+                'get': 'list',
+            },
+        ),
+        name='item-collection',
     ),
     path(
         'company-list/<uuid:company_list_pk>/item/<uuid:company_pk>',


### PR DESCRIPTION
### Description of change

This adds an endpoint for getting contents of user's multiple company lists. The work is based on a legacy implementation done by @reupen for a single list per user.

``GET /v4/company-list/<company list ID>/item``

It lists all the companies on the authenticated user's selected list, with responses in the following format::

    {
        "count": <int>,
        "previous": <url>,
        "next": <url>,
        "results": [
            {
                "company": {
                    "id": <string>,
                    "archived": <boolean>,
                    "name": <string>,
                    "trading_names": [<string>, <string>, ...]
                },
                "created_on": <ISO timestamp>,
                "latest_interaction": {
                    "id": <string>,
                    "created_on": <ISO timestamp>,
                    "date": <ISO date>,
                    "subject": <string>
                }
            },
            ...
        ]
    }


``latest_interaction`` may be ``null`` if the company has no interactions.

Results are sorted by ``latest_interaction.date`` in reverse chronological order, with ``null`` values last.

The endpoint has pagination in line with other endpoints; to retrieve all results pass a large value for the ``limit`` query parameter (e.g. ``?limit=1000``).

If selected list does not exist, the endpoint will return 404 status code.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
