### PR TITLE
Add endpoint for deleting company list contents

### DIFF
--- a/changelog/adviser/company-list-remove-item.api.rst
+++ b/changelog/adviser/company-list-remove-item.api.rst
@@ -1,0 +1,7 @@
+The following endpoint was added:
+
+  - ``DELETE /v4/company-list/<company list ID>/item/<company ID>``
+
+This removes a company from the user's own selected list of companies.
+
+If the operation is successful, a 204 status code will be returned. If there is no company list with specified company list ID or a list doesn't belong to the user, a 404 will be returned.

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -84,6 +84,10 @@ class CompanyListItemAPIPermissions(DjangoModelPermissions):
             f'company.{CompanyPermission.view_company}',
             f'company_list.{CompanyListItemPermissionCode.add_company_list_item}',
         ],
+        'DELETE': [
+            f'company.{CompanyPermission.view_company}',
+            f'company_list.{CompanyListItemPermissionCode.delete_company_list_item}',
+        ],
     }
 
 
@@ -164,6 +168,19 @@ class CompanyListItemAPIView(APIView):
                 'modified_by': adviser,
             },
         )
+
+        return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+    @method_decorator(transaction.non_atomic_requests)
+    def delete(self, request, company_list_pk, company_pk=None, format=None):
+        """
+        Delete a CompanyListItem for the selected list of authenticated user and
+        specified company if it exists.
+        """
+        company_list = get_object_or_404(CompanyList, pk=company_list_pk, adviser=request.user)
+        company = get_object_or_404(Company, pk=company_pk)
+
+        self.queryset.filter(list=company_list, company=company).delete()
 
         return Response(None, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
### Description of change

This add the following endpoint:

  - ``DELETE /v4/company-list/<company list ID>/item/<company ID>``

It removes a company from the user's own selected list of companies.

If the operation is successful, a 204 status code will be returned. If there is no company list with specified company list ID or a list doesn't belong to the user, a 404 will be returned.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
