### PR TITLE
Adjust OMIS to use notification app based on a feature flag

### DIFF
--- a/changelog/omis/notification-app-feature-flag.feature.rst
+++ b/changelog/omis/notification-app-feature-flag.feature.rst
@@ -1,0 +1,3 @@
+The notification logic in ``datahub.omis`` was adjusted to optionally use the
+``datahub.notification`` app for triggering GOVUK notifications. This 
+functionality can be switched on using a feature flag.

--- a/datahub/omis/notification/client.py
+++ b/datahub/omis/notification/client.py
@@ -7,8 +7,14 @@ from django.conf import settings
 from notifications_python_client.notifications import NotificationsAPIClient
 
 from datahub.core.thread_pool import submit_to_thread_pool
+from datahub.feature_flag.utils import is_feature_flag_active
+from datahub.notification.constants import NotifyServiceName
+from datahub.notification.notify import notify_by_email
 from datahub.omis.market.models import Market
-from datahub.omis.notification.constants import Template
+from datahub.omis.notification.constants import (
+    OMIS_USE_NOTIFICATION_APP_FEATURE_FLAG_NAME,
+    Template,
+)
 from datahub.omis.region.models import UKRegionalSettings
 
 
@@ -17,13 +23,7 @@ logger = getLogger(__name__)
 
 def send_email(client, **kwargs):
     """Send email and catch potential errors."""
-    data = dict(kwargs)
-
-    # override recipient if needed
-    if settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL:
-        data['email_address'] = settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL
-
-    client.send_email_notification(**data)
+    client.send_email_notification(**kwargs)
 
 
 class Notify:
@@ -55,9 +55,22 @@ class Notify:
                 stacklevel=2,
             )
 
-    def _send_email(self, **kwargs):
+    def _send_email(self, **data):
         """Send email in a separate thread."""
-        submit_to_thread_pool(send_email, self.client, **kwargs)
+        # override recipient if needed
+        if settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL:
+            data['email_address'] = settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL
+
+        use_notification_app = is_feature_flag_active(OMIS_USE_NOTIFICATION_APP_FEATURE_FLAG_NAME)
+        if use_notification_app:
+            notify_by_email(
+                data['email_address'],
+                data['template_id'],
+                data.get('personalisation'),
+                NotifyServiceName.omis,
+            )
+        else:
+            submit_to_thread_pool(send_email, self.client, **data)
 
     def _prepare_personalisation(self, order, data=None):
         """Prepare the personalisation data with common values."""

--- a/datahub/omis/notification/constants.py
+++ b/datahub/omis/notification/constants.py
@@ -23,3 +23,6 @@ class Template(Enum):
     quote_accepted_for_adviser = 'd7b7f327-f814-4eed-9130-0a2ef988691f'
     quote_cancelled_for_customer = '86dd03cd-53b6-41b2-9eed-c3d2f6a0fda1'
     quote_cancelled_for_adviser = 'a36fff71-e62b-4d51-a374-4cdf3e50ac47'
+
+
+OMIS_USE_NOTIFICATION_APP_FEATURE_FLAG_NAME = 'omis_use_notification_app'

--- a/datahub/omis/notification/test/conftest.py
+++ b/datahub/omis/notification/test/conftest.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+
+import pytest
+
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.notification import notify_gateway
+from datahub.omis.notification.client import notify
+from datahub.omis.notification.constants import OMIS_USE_NOTIFICATION_APP_FEATURE_FLAG_NAME
+
+
+@pytest.fixture(params=(True, False))
+def notify_client(request):
+    """
+    Get a reference to the correct notify client, depending on whether the
+    feature flag for using the notification app is active or not.
+
+    By using the pytest.fixture params kwarg, we ensure that every test case
+    using this fixture is run once with the feature flag active (using the
+    notification app) and once with the feature flag inactive (using omis' notify
+    client).
+    """
+    use_notification_app = request.param
+    if use_notification_app:
+        FeatureFlagFactory(code=OMIS_USE_NOTIFICATION_APP_FEATURE_FLAG_NAME)
+        client = notify_gateway.clients['omis']
+    else:
+        client = notify.client
+    if isinstance(client, Mock):
+        client.reset_mock()
+    return client

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.django_db
 class TestSendEmail:
     """Tests for errors with the internal send_email function."""
 
-    def test_override_recipient_email(self, settings, notify_client):
+    def test_override_recipient_email(self, settings, mocked_notify_client):
         """
         Test that if settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL is set,
         all the emails are sent to it.
@@ -39,13 +39,13 @@ class TestSendEmail:
             personalisation={},
         )
 
-        notify_client.send_email_notification.assert_called_with(
+        mocked_notify_client.send_email_notification.assert_called_with(
             email_address='different_email@example.com',
             template_id='foobar',
             personalisation={},
         )
 
-    def test_without_overriding_recipient_email(self, settings, notify_client):
+    def test_without_overriding_recipient_email(self, settings, mocked_notify_client):
         """
         Test that if settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL is not set,
         all the emails are sent to the intended recipient.
@@ -58,7 +58,7 @@ class TestSendEmail:
             personalisation={},
         )
 
-        notify_client.send_email_notification.assert_called_with(
+        mocked_notify_client.send_email_notification.assert_called_with(
             email_address='test@example.com',
             template_id='foobar',
             personalisation={},
@@ -69,7 +69,7 @@ class TestSendEmail:
 class TestNotifyOrderInfo:
     """Tests for generic notifications related to an order."""
 
-    def test_without_primary_market(self, notify_client):
+    def test_without_primary_market(self, mocked_notify_client):
         """
         Test that calling `order_info` without primary market
         (in case of some legacy orders), uses a placeholder for the market.
@@ -78,11 +78,11 @@ class TestNotifyOrderInfo:
 
         notify.order_info(order, what_happened='something happened', why='to inform you')
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['personalisation']['primary market'] == 'Unknown market'
 
-    def test_with_recipient_email_and_name(self, notify_client):
+    def test_with_recipient_email_and_name(self, mocked_notify_client):
         """
         Test that calling `order_info` with recipient email and name sends an email
         to the specified email addressed to the specified recipient name.
@@ -97,13 +97,13 @@ class TestNotifyOrderInfo:
             to_name='example name',
         )
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == 'example@example.com'
         assert call_args['template_id'] == Template.generic_order_info.value
         assert call_args['personalisation']['recipient name'] == 'example name'
 
-    def test_with_recipient_email_only(self, notify_client):
+    def test_with_recipient_email_only(self, mocked_notify_client):
         """
         Test that calling `order_info` with only recipient email sends an email
         to the specified email using the email as recipient name.
@@ -117,13 +117,13 @@ class TestNotifyOrderInfo:
             to_email='example@example.com',
         )
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == 'example@example.com'
         assert call_args['template_id'] == Template.generic_order_info.value
         assert call_args['personalisation']['recipient name'] == 'example@example.com'
 
-    def test_with_recipient_name_only(self, notify_client):
+    def test_with_recipient_name_only(self, mocked_notify_client):
         """
         Test that calling `order_info` with only the recipient name sends an email
         to the OMIS admin email addressed to the specified recipient name.
@@ -137,8 +137,8 @@ class TestNotifyOrderInfo:
             to_name='example name',
         )
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == settings.OMIS_NOTIFICATION_ADMIN_EMAIL
         assert call_args['template_id'] == Template.generic_order_info.value
         assert call_args['personalisation']['recipient name'] == 'example name'
@@ -148,7 +148,7 @@ class TestNotifyOrderInfo:
 class TestNotifyOrderCreated:
     """Tests for notifications sent when an order is created."""
 
-    def test_email_sent_to_managers(self, notify_client):
+    def test_email_sent_to_managers(self, mocked_notify_client):
         """
         Test that `.order_created` sends an email to
         - the overseas manager of the market related to the order
@@ -171,9 +171,9 @@ class TestNotifyOrderCreated:
 
         notify.order_created(order)
 
-        assert notify_client.send_email_notification.call_count == 3
+        assert mocked_notify_client.send_email_notification.call_count == 3
 
-        send_email_call_args_list = notify_client.send_email_notification.call_args_list
+        send_email_call_args_list = mocked_notify_client.send_email_notification.call_args_list
 
         # post manager notified
         call_args = send_email_call_args_list[0][1]
@@ -186,7 +186,7 @@ class TestNotifyOrderCreated:
             assert call_args['email_address'] == regional_manager_emails[index]
             assert call_args['template_id'] == Template.order_created_for_regional_manager.value
 
-    def test_email_sent_to_omis_admin_if_no_manager(self, notify_client):
+    def test_email_sent_to_omis_admin_if_no_manager(self, mocked_notify_client):
         """
         Test that `.order_created` sends an email to the OMIS admin email
         if the market related to the order just created doesn't have any overseas
@@ -200,12 +200,12 @@ class TestNotifyOrderCreated:
 
         notify.order_created(order)
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == settings.OMIS_NOTIFICATION_ADMIN_EMAIL
         assert call_args['template_id'] == Template.generic_order_info.value
 
-    def test_email_sent_to_omis_admin_if_no_market(self, notify_client):
+    def test_email_sent_to_omis_admin_if_no_market(self, mocked_notify_client):
         """
         Test that `.order_created` sends an email to the OMIS admin email
         if the market related to the order does not exist.
@@ -218,12 +218,12 @@ class TestNotifyOrderCreated:
 
         notify.order_created(order)
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == settings.OMIS_NOTIFICATION_ADMIN_EMAIL
         assert call_args['template_id'] == Template.generic_order_info.value
 
-    def test_no_email_sent_to_regions_if_region_is_null(self, notify_client):
+    def test_no_email_sent_to_regions_if_region_is_null(self, mocked_notify_client):
         """
         Test that if order.uk_region is null, the regional notification does not get
         triggered.
@@ -232,11 +232,11 @@ class TestNotifyOrderCreated:
 
         notify.order_created(order)
 
-        assert notify_client.send_email_notification.call_count == 1
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.call_count == 1
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['template_id'] != Template.order_created_for_regional_manager.value
 
-    def test_no_email_sent_to_regions_without_settings(self, notify_client):
+    def test_no_email_sent_to_regions_without_settings(self, mocked_notify_client):
         """
         Test that if there's no UKRegionalSettings record defined for order.uk_region,
         the regional notification does not get triggered.
@@ -246,11 +246,11 @@ class TestNotifyOrderCreated:
 
         notify.order_created(order)
 
-        assert notify_client.send_email_notification.call_count == 1
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.call_count == 1
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['template_id'] != Template.order_created_for_regional_manager.value
 
-    def test_no_email_sent_to_regions_if_no_manager_email_defined(self, notify_client):
+    def test_no_email_sent_to_regions_if_no_manager_email_defined(self, mocked_notify_client):
         """
         Test that if the UKRegionalSettings for the order.uk_region does not define any
         manager emails, the regional notification does not get triggered.
@@ -264,8 +264,8 @@ class TestNotifyOrderCreated:
 
         notify.order_created(order)
 
-        assert notify_client.send_email_notification.call_count == 1
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.call_count == 1
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['template_id'] != Template.order_created_for_regional_manager.value
 
 
@@ -273,7 +273,7 @@ class TestNotifyOrderCreated:
 class TestNotifyAdviserAdded:
     """Tests for the adviser_added logic."""
 
-    def test_adviser_notified(self, notify_client):
+    def test_adviser_notified(self, mocked_notify_client):
         """
         Test that calling `adviser_added` sends an email notifying the adviser that
         they have been added to the order.
@@ -289,8 +289,8 @@ class TestNotifyAdviserAdded:
             creation_date=dateutil_parse('2017-05-18'),
         )
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_added_for_adviser.value
 
@@ -303,7 +303,7 @@ class TestNotifyAdviserAdded:
 class TestNotifyAdviserRemoved:
     """Tests for the adviser_removed logic."""
 
-    def test_adviser_notified(self, notify_client):
+    def test_adviser_notified(self, mocked_notify_client):
         """
         Test that calling `adviser_removed` sends an email notifying the adviser that
         they have been removed from the order.
@@ -313,8 +313,8 @@ class TestNotifyAdviserRemoved:
 
         notify.adviser_removed(order=order, adviser=adviser)
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_removed_for_adviser.value
 
@@ -325,7 +325,7 @@ class TestNotifyAdviserRemoved:
 class TestNotifyOrderPaid:
     """Tests for the order_paid logic."""
 
-    def test_customer_notified(self, notify_client):
+    def test_customer_notified(self, mocked_notify_client):
         """
         Test that calling `order_paid` sends an email notifying the customer that
         the order has been marked as paid.
@@ -334,14 +334,14 @@ class TestNotifyOrderPaid:
 
         notify.order_paid(order)
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.order_paid_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self, notify_client):
+    def test_advisers_notified(self, mocked_notify_client):
         """
         Test that calling `order_paid` sends an email to all advisers notifying them that
         the order has been marked as paid.
@@ -352,16 +352,16 @@ class TestNotifyOrderPaid:
 
         notify.order_paid(order)
 
-        assert notify_client.send_email_notification.called
+        assert mocked_notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify_client.send_email_notification.call_args_list
+            for _, data in mocked_notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -374,7 +374,7 @@ class TestNotifyOrderPaid:
 class TestNotifyOrderCompleted:
     """Tests for the order_completed logic."""
 
-    def test_advisers_notified(self, notify_client):
+    def test_advisers_notified(self, mocked_notify_client):
         """
         Test that calling `order_completed` sends an email to all advisers
         notifying them that the order has been marked as completed.
@@ -385,16 +385,16 @@ class TestNotifyOrderCompleted:
 
         notify.order_completed(order)
 
-        assert notify_client.send_email_notification.called
+        assert mocked_notify_client.send_email_notification.called
         # 4 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == 4
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == 4
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify_client.send_email_notification.call_args_list
+            for _, data in mocked_notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -407,7 +407,7 @@ class TestNotifyOrderCompleted:
 class TestNotifyOrderCancelled:
     """Tests for the order_cancelled logic."""
 
-    def test_customer_notified(self, notify_client):
+    def test_customer_notified(self, mocked_notify_client):
         """
         Test that calling `order_cancelled` sends an email notifying the customer that
         the order has been cancelled.
@@ -416,14 +416,14 @@ class TestNotifyOrderCancelled:
 
         notify.order_cancelled(order)
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.order_cancelled_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self, notify_client):
+    def test_advisers_notified(self, mocked_notify_client):
         """
         Test that calling `order_cancelled` sends an email to all advisers notifying them that
         the order has been cancelled.
@@ -434,16 +434,16 @@ class TestNotifyOrderCancelled:
 
         notify.order_cancelled(order)
 
-        assert notify_client.send_email_notification.called
+        assert mocked_notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify_client.send_email_notification.call_args_list
+            for _, data in mocked_notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -456,7 +456,7 @@ class TestNotifyOrderCancelled:
 class TestNotifyQuoteGenerated:
     """Tests for the quote_generated logic."""
 
-    def test_customer_notified(self, notify_client):
+    def test_customer_notified(self, mocked_notify_client):
         """
         Test that calling `quote_generated` sends an email notifying the customer that
         they have to accept the quote.
@@ -465,14 +465,14 @@ class TestNotifyQuoteGenerated:
 
         notify.quote_generated(order)
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.quote_sent_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self, notify_client):
+    def test_advisers_notified(self, mocked_notify_client):
         """
         Test that calling `quote_generated` sends an email to all advisers notifying them that
         the quote has been sent.
@@ -483,16 +483,16 @@ class TestNotifyQuoteGenerated:
 
         notify.quote_generated(order)
 
-        assert notify_client.send_email_notification.called
+        assert mocked_notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify_client.send_email_notification.call_args_list
+            for _, data in mocked_notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -505,7 +505,7 @@ class TestNotifyQuoteGenerated:
 class TestNotifyQuoteAccepted:
     """Tests for the quote_accepted logic."""
 
-    def test_customer_notified(self, notify_client):
+    def test_customer_notified(self, mocked_notify_client):
         """
         Test that calling `quote_accepted` sends an email notifying the customer that
         they have accepted the quote.
@@ -514,14 +514,14 @@ class TestNotifyQuoteAccepted:
 
         notify.quote_accepted(order)
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.quote_accepted_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self, notify_client):
+    def test_advisers_notified(self, mocked_notify_client):
         """
         Test that calling `quote_accepted` sends an email to all advisers notifying them that
         the quote has been accepted.
@@ -532,16 +532,16 @@ class TestNotifyQuoteAccepted:
 
         notify.quote_accepted(order)
 
-        assert notify_client.send_email_notification.called
+        assert mocked_notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify_client.send_email_notification.call_args_list
+            for _, data in mocked_notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -554,7 +554,7 @@ class TestNotifyQuoteAccepted:
 class TestNotifyQuoteCancelled:
     """Tests for the quote_cancelled logic."""
 
-    def test_customer_notified(self, notify_client):
+    def test_customer_notified(self, mocked_notify_client):
         """
         Test that calling `quote_cancelled` sends an email notifying the customer that
         the quote has been cancelled.
@@ -563,14 +563,14 @@ class TestNotifyQuoteCancelled:
 
         notify.quote_cancelled(order, by=AdviserFactory())
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.quote_cancelled_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self, notify_client):
+    def test_advisers_notified(self, mocked_notify_client):
         """
         Test that calling `quote_cancelled` sends an email to all advisers notifying them that
         the quote has been cancelled.
@@ -582,16 +582,16 @@ class TestNotifyQuoteCancelled:
 
         notify.quote_cancelled(order, by=canceller)
 
-        assert notify_client.send_email_notification.called
+        assert mocked_notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify_client.send_email_notification.call_args_list
+            for _, data in mocked_notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]

--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -1,5 +1,4 @@
 import itertools
-from unittest import mock
 
 import pytest
 from dateutil.parser import parse as dateutil_parse
@@ -8,7 +7,7 @@ from django.conf import settings
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import UKRegion
 from datahub.omis.market.models import Market
-from datahub.omis.notification.client import notify, send_email
+from datahub.omis.notification.client import notify
 from datahub.omis.notification.constants import Template
 from datahub.omis.order.test.factories import (
     OrderAssigneeCompleteFactory,
@@ -27,32 +26,42 @@ pytestmark = pytest.mark.django_db
 class TestSendEmail:
     """Tests for errors with the internal send_email function."""
 
-    def test_override_recipient_email(self, settings):
+    def test_override_recipient_email(self, settings, notify_client):
         """
         Test that if settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL is set,
         all the emails are sent to it.
         """
         settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL = 'different_email@example.com'
 
-        notify_client = mock.Mock()
-        send_email(notify_client, email_address='test@example.com')
+        notify._send_email(
+            email_address='test@example.com',
+            template_id='foobar',
+            personalisation={},
+        )
 
         notify_client.send_email_notification.assert_called_with(
             email_address='different_email@example.com',
+            template_id='foobar',
+            personalisation={},
         )
 
-    def test_without_overriding_recipient_email(self, settings):
+    def test_without_overriding_recipient_email(self, settings, notify_client):
         """
         Test that if settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL is not set,
         all the emails are sent to the intended recipient.
         """
         settings.OMIS_NOTIFICATION_OVERRIDE_RECIPIENT_EMAIL = ''
 
-        notify_client = mock.Mock()
-        send_email(notify_client, email_address='test@example.com')
+        notify._send_email(
+            email_address='test@example.com',
+            template_id='foobar',
+            personalisation={},
+        )
 
         notify_client.send_email_notification.assert_called_with(
             email_address='test@example.com',
+            template_id='foobar',
+            personalisation={},
         )
 
 
@@ -60,30 +69,26 @@ class TestSendEmail:
 class TestNotifyOrderInfo:
     """Tests for generic notifications related to an order."""
 
-    def test_without_primary_market(self):
+    def test_without_primary_market(self, notify_client):
         """
         Test that calling `order_info` without primary market
         (in case of some legacy orders), uses a placeholder for the market.
         """
         order = OrderFactory(primary_market_id=None)
 
-        notify.client.reset_mock()
-
         notify.order_info(order, what_happened='something happened', why='to inform you')
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['personalisation']['primary market'] == 'Unknown market'
 
-    def test_with_recipient_email_and_name(self):
+    def test_with_recipient_email_and_name(self, notify_client):
         """
         Test that calling `order_info` with recipient email and name sends an email
         to the specified email addressed to the specified recipient name.
         """
         order = OrderFactory()
 
-        notify.client.reset_mock()
-
         notify.order_info(
             order,
             what_happened='something happened',
@@ -92,21 +97,19 @@ class TestNotifyOrderInfo:
             to_name='example name',
         )
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == 'example@example.com'
         assert call_args['template_id'] == Template.generic_order_info.value
         assert call_args['personalisation']['recipient name'] == 'example name'
 
-    def test_with_recipient_email_only(self):
+    def test_with_recipient_email_only(self, notify_client):
         """
         Test that calling `order_info` with only recipient email sends an email
         to the specified email using the email as recipient name.
         """
         order = OrderFactory()
 
-        notify.client.reset_mock()
-
         notify.order_info(
             order,
             what_happened='something happened',
@@ -114,20 +117,18 @@ class TestNotifyOrderInfo:
             to_email='example@example.com',
         )
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == 'example@example.com'
         assert call_args['template_id'] == Template.generic_order_info.value
         assert call_args['personalisation']['recipient name'] == 'example@example.com'
 
-    def test_with_recipient_name_only(self):
+    def test_with_recipient_name_only(self, notify_client):
         """
         Test that calling `order_info` with only the recipient name sends an email
         to the OMIS admin email addressed to the specified recipient name.
         """
         order = OrderFactory()
-
-        notify.client.reset_mock()
 
         notify.order_info(
             order,
@@ -136,8 +137,8 @@ class TestNotifyOrderInfo:
             to_name='example name',
         )
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == settings.OMIS_NOTIFICATION_ADMIN_EMAIL
         assert call_args['template_id'] == Template.generic_order_info.value
         assert call_args['personalisation']['recipient name'] == 'example name'
@@ -147,7 +148,7 @@ class TestNotifyOrderInfo:
 class TestNotifyOrderCreated:
     """Tests for notifications sent when an order is created."""
 
-    def test_email_sent_to_managers(self):
+    def test_email_sent_to_managers(self, notify_client):
         """
         Test that `.order_created` sends an email to
         - the overseas manager of the market related to the order
@@ -168,13 +169,11 @@ class TestNotifyOrderCreated:
             uk_region_id=UKRegion.london.value.id,
         )
 
-        notify.client.reset_mock()
-
         notify.order_created(order)
 
-        assert notify.client.send_email_notification.call_count == 3
+        assert notify_client.send_email_notification.call_count == 3
 
-        send_email_call_args_list = notify.client.send_email_notification.call_args_list
+        send_email_call_args_list = notify_client.send_email_notification.call_args_list
 
         # post manager notified
         call_args = send_email_call_args_list[0][1]
@@ -187,7 +186,7 @@ class TestNotifyOrderCreated:
             assert call_args['email_address'] == regional_manager_emails[index]
             assert call_args['template_id'] == Template.order_created_for_regional_manager.value
 
-    def test_email_sent_to_omis_admin_if_no_manager(self):
+    def test_email_sent_to_omis_admin_if_no_manager(self, notify_client):
         """
         Test that `.order_created` sends an email to the OMIS admin email
         if the market related to the order just created doesn't have any overseas
@@ -199,16 +198,14 @@ class TestNotifyOrderCreated:
 
         order = OrderFactory(primary_market_id=market.country.id)
 
-        notify.client.reset_mock()
-
         notify.order_created(order)
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == settings.OMIS_NOTIFICATION_ADMIN_EMAIL
         assert call_args['template_id'] == Template.generic_order_info.value
 
-    def test_email_sent_to_omis_admin_if_no_market(self):
+    def test_email_sent_to_omis_admin_if_no_market(self, notify_client):
         """
         Test that `.order_created` sends an email to the OMIS admin email
         if the market related to the order does not exist.
@@ -219,30 +216,27 @@ class TestNotifyOrderCreated:
 
         order = OrderFactory(primary_market_id=country.id)
 
-        notify.client.reset_mock()
-
         notify.order_created(order)
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == settings.OMIS_NOTIFICATION_ADMIN_EMAIL
         assert call_args['template_id'] == Template.generic_order_info.value
 
-    def test_no_email_sent_to_regions_if_region_is_null(self):
+    def test_no_email_sent_to_regions_if_region_is_null(self, notify_client):
         """
         Test that if order.uk_region is null, the regional notification does not get
         triggered.
         """
         order = OrderFactory(uk_region_id=None)
 
-        notify.client.reset_mock()
         notify.order_created(order)
 
-        assert notify.client.send_email_notification.call_count == 1
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.call_count == 1
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['template_id'] != Template.order_created_for_regional_manager.value
 
-    def test_no_email_sent_to_regions_without_settings(self):
+    def test_no_email_sent_to_regions_without_settings(self, notify_client):
         """
         Test that if there's no UKRegionalSettings record defined for order.uk_region,
         the regional notification does not get triggered.
@@ -250,14 +244,13 @@ class TestNotifyOrderCreated:
         assert not UKRegionalSettings.objects.count()
         order = OrderFactory(uk_region_id=UKRegion.london.value.id)
 
-        notify.client.reset_mock()
         notify.order_created(order)
 
-        assert notify.client.send_email_notification.call_count == 1
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.call_count == 1
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['template_id'] != Template.order_created_for_regional_manager.value
 
-    def test_no_email_sent_to_regions_if_no_manager_email_defined(self):
+    def test_no_email_sent_to_regions_if_no_manager_email_defined(self, notify_client):
         """
         Test that if the UKRegionalSettings for the order.uk_region does not define any
         manager emails, the regional notification does not get triggered.
@@ -269,11 +262,10 @@ class TestNotifyOrderCreated:
 
         order = OrderFactory(uk_region_id=UKRegion.london.value.id)
 
-        notify.client.reset_mock()
         notify.order_created(order)
 
-        assert notify.client.send_email_notification.call_count == 1
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.call_count == 1
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['template_id'] != Template.order_created_for_regional_manager.value
 
 
@@ -281,7 +273,7 @@ class TestNotifyOrderCreated:
 class TestNotifyAdviserAdded:
     """Tests for the adviser_added logic."""
 
-    def test_adviser_notified(self):
+    def test_adviser_notified(self, notify_client):
         """
         Test that calling `adviser_added` sends an email notifying the adviser that
         they have been added to the order.
@@ -290,8 +282,6 @@ class TestNotifyAdviserAdded:
         adviser = AdviserFactory()
         creator = AdviserFactory()
 
-        notify.client.reset_mock()
-
         notify.adviser_added(
             order=order,
             adviser=adviser,
@@ -299,8 +289,8 @@ class TestNotifyAdviserAdded:
             creation_date=dateutil_parse('2017-05-18'),
         )
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_added_for_adviser.value
 
@@ -313,7 +303,7 @@ class TestNotifyAdviserAdded:
 class TestNotifyAdviserRemoved:
     """Tests for the adviser_removed logic."""
 
-    def test_adviser_notified(self):
+    def test_adviser_notified(self, notify_client):
         """
         Test that calling `adviser_removed` sends an email notifying the adviser that
         they have been removed from the order.
@@ -321,12 +311,10 @@ class TestNotifyAdviserRemoved:
         order = OrderFactory()
         adviser = AdviserFactory()
 
-        notify.client.reset_mock()
-
         notify.adviser_removed(order=order, adviser=adviser)
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_removed_for_adviser.value
 
@@ -337,25 +325,23 @@ class TestNotifyAdviserRemoved:
 class TestNotifyOrderPaid:
     """Tests for the order_paid logic."""
 
-    def test_customer_notified(self):
+    def test_customer_notified(self, notify_client):
         """
         Test that calling `order_paid` sends an email notifying the customer that
         the order has been marked as paid.
         """
         order = OrderPaidFactory()
 
-        notify.client.reset_mock()
-
         notify.order_paid(order)
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.order_paid_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self):
+    def test_advisers_notified(self, notify_client):
         """
         Test that calling `order_paid` sends an email to all advisers notifying them that
         the order has been marked as paid.
@@ -364,20 +350,18 @@ class TestNotifyOrderPaid:
         assignees = OrderAssigneeFactory.create_batch(2, order=order)
         subscribers = OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
-
         notify.order_paid(order)
 
-        assert notify.client.send_email_notification.called
+        assert notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify.client.send_email_notification.call_args_list
+            for _, data in notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -390,7 +374,7 @@ class TestNotifyOrderPaid:
 class TestNotifyOrderCompleted:
     """Tests for the order_completed logic."""
 
-    def test_advisers_notified(self):
+    def test_advisers_notified(self, notify_client):
         """
         Test that calling `order_completed` sends an email to all advisers
         notifying them that the order has been marked as completed.
@@ -399,20 +383,18 @@ class TestNotifyOrderCompleted:
         assignees = OrderAssigneeCompleteFactory.create_batch(2, order=order)
         subscribers = OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
-
         notify.order_completed(order)
 
-        assert notify.client.send_email_notification.called
+        assert notify_client.send_email_notification.called
         # 4 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == 4
+        assert len(notify_client.send_email_notification.call_args_list) == 4
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify.client.send_email_notification.call_args_list
+            for _, data in notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -425,25 +407,23 @@ class TestNotifyOrderCompleted:
 class TestNotifyOrderCancelled:
     """Tests for the order_cancelled logic."""
 
-    def test_customer_notified(self):
+    def test_customer_notified(self, notify_client):
         """
         Test that calling `order_cancelled` sends an email notifying the customer that
         the order has been cancelled.
         """
         order = OrderWithOpenQuoteFactory()
 
-        notify.client.reset_mock()
-
         notify.order_cancelled(order)
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.order_cancelled_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self):
+    def test_advisers_notified(self, notify_client):
         """
         Test that calling `order_cancelled` sends an email to all advisers notifying them that
         the order has been cancelled.
@@ -452,20 +432,18 @@ class TestNotifyOrderCancelled:
         assignees = OrderAssigneeFactory.create_batch(2, order=order)
         subscribers = OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
-
         notify.order_cancelled(order)
 
-        assert notify.client.send_email_notification.called
+        assert notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify.client.send_email_notification.call_args_list
+            for _, data in notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -478,25 +456,23 @@ class TestNotifyOrderCancelled:
 class TestNotifyQuoteGenerated:
     """Tests for the quote_generated logic."""
 
-    def test_customer_notified(self):
+    def test_customer_notified(self, notify_client):
         """
         Test that calling `quote_generated` sends an email notifying the customer that
         they have to accept the quote.
         """
         order = OrderWithOpenQuoteFactory()
 
-        notify.client.reset_mock()
-
         notify.quote_generated(order)
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.quote_sent_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self):
+    def test_advisers_notified(self, notify_client):
         """
         Test that calling `quote_generated` sends an email to all advisers notifying them that
         the quote has been sent.
@@ -505,20 +481,18 @@ class TestNotifyQuoteGenerated:
         assignees = OrderAssigneeFactory.create_batch(2, order=order)
         subscribers = OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
-
         notify.quote_generated(order)
 
-        assert notify.client.send_email_notification.called
+        assert notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify.client.send_email_notification.call_args_list
+            for _, data in notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -531,25 +505,23 @@ class TestNotifyQuoteGenerated:
 class TestNotifyQuoteAccepted:
     """Tests for the quote_accepted logic."""
 
-    def test_customer_notified(self):
+    def test_customer_notified(self, notify_client):
         """
         Test that calling `quote_accepted` sends an email notifying the customer that
         they have accepted the quote.
         """
         order = OrderPaidFactory()
 
-        notify.client.reset_mock()
-
         notify.quote_accepted(order)
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.quote_accepted_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self):
+    def test_advisers_notified(self, notify_client):
         """
         Test that calling `quote_accepted` sends an email to all advisers notifying them that
         the quote has been accepted.
@@ -558,20 +530,18 @@ class TestNotifyQuoteAccepted:
         assignees = OrderAssigneeFactory.create_batch(2, order=order)
         subscribers = OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
-
         notify.quote_accepted(order)
 
-        assert notify.client.send_email_notification.called
+        assert notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify.client.send_email_notification.call_args_list
+            for _, data in notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]
@@ -584,25 +554,23 @@ class TestNotifyQuoteAccepted:
 class TestNotifyQuoteCancelled:
     """Tests for the quote_cancelled logic."""
 
-    def test_customer_notified(self):
+    def test_customer_notified(self, notify_client):
         """
         Test that calling `quote_cancelled` sends an email notifying the customer that
         the quote has been cancelled.
         """
         order = OrderFactory()
 
-        notify.client.reset_mock()
-
         notify.quote_cancelled(order, by=AdviserFactory())
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == order.get_current_contact_email()
         assert call_args['template_id'] == Template.quote_cancelled_for_customer.value
         assert call_args['personalisation']['recipient name'] == order.contact.name
         assert call_args['personalisation']['embedded link'] == order.get_public_facing_url()
 
-    def test_advisers_notified(self):
+    def test_advisers_notified(self, notify_client):
         """
         Test that calling `quote_cancelled` sends an email to all advisers notifying them that
         the quote has been cancelled.
@@ -612,20 +580,18 @@ class TestNotifyQuoteCancelled:
         subscribers = OrderSubscriberFactory.create_batch(2, order=order)
         canceller = AdviserFactory()
 
-        notify.client.reset_mock()
-
         notify.quote_cancelled(order, by=canceller)
 
-        assert notify.client.send_email_notification.called
+        assert notify_client.send_email_notification.called
         # 1 = customer, 4 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (4 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (4 + 1)
 
         calls_by_email = {
             data['email_address']: {
                 'template_id': data['template_id'],
                 'personalisation': data['personalisation'],
             }
-            for _, data in notify.client.send_email_notification.call_args_list
+            for _, data in notify_client.send_email_notification.call_args_list
         }
         for item in itertools.chain(assignees, subscribers):
             call = calls_by_email[item.adviser.get_current_email()]

--- a/datahub/omis/notification/test/test_signal_receivers.py
+++ b/datahub/omis/notification/test/test_signal_receivers.py
@@ -21,53 +21,53 @@ pytestmark = pytest.mark.django_db
 class TestNotifyPostSaveOrder:
     """Tests for notifications sent when an order is saved/updated."""
 
-    def test_notification_on_order_created(self, notify_client):
+    def test_notification_on_order_created(self, mocked_notify_client):
         """Test that a notification is triggered when an order is created."""
         OrderFactory()
 
-        assert notify_client.send_email_notification.called
+        assert mocked_notify_client.send_email_notification.called
 
-    def test_no_notification_on_order_updated(self, notify_client):
+    def test_no_notification_on_order_updated(self, mocked_notify_client):
         """Test that no notification is triggered when saving an order."""
         order = OrderFactory()
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.description = 'new description'
         order.save()
 
-        assert not notify_client.send_email_notification.called
+        assert not mocked_notify_client.send_email_notification.called
 
 
 @pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNofityPostSaveOrderAdviser:
     """Tests for notifications sent when an adviser is added to an order."""
 
-    def test_notify_on_order_assignee_added(self, notify_client):
+    def test_notify_on_order_assignee_added(self, mocked_notify_client):
         """
         Test that a notification is sent to the adviser when they get assigned to an order.
         """
         order = OrderFactory(assignees=[])
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         assignee = OrderAssigneeFactory(order=order)
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == assignee.adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_added_for_adviser.value
 
-    def test_notify_on_order_subscriber_added(self, notify_client):
+    def test_notify_on_order_subscriber_added(self, mocked_notify_client):
         """
         Test that a notification is sent to the adviser when they get subscribed to an order.
         """
         order = OrderFactory(assignees=[])
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         subscriber = OrderSubscriberFactory(order=order)
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == subscriber.adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_added_for_adviser.value
 
@@ -76,35 +76,35 @@ class TestNofityPostSaveOrderAdviser:
 class TestNofityPostDeleteOrderAdviser:
     """Tests for notifications sent when an adviser is removed from an order."""
 
-    def test_notify_on_order_assignee_deleted(self, notify_client):
+    def test_notify_on_order_assignee_deleted(self, mocked_notify_client):
         """
         Test that a notification is sent to the adviser when they get removed from an order.
         """
         order = OrderFactory(assignees=[])
         assignee = OrderAssigneeFactory(order=order)
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.assignees.all().delete()
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == assignee.adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_removed_for_adviser.value
 
-    def test_notify_on_order_subscriber_deleted(self, notify_client):
+    def test_notify_on_order_subscriber_deleted(self, mocked_notify_client):
         """
         Test that a notification is sent to the adviser when they get removed from an order.
         """
         order = OrderFactory(assignees=[])
         subscriber = OrderSubscriberFactory(order=order)
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.subscribers.all().delete()
 
-        assert notify_client.send_email_notification.called
-        call_args = notify_client.send_email_notification.call_args_list[0][1]
+        assert mocked_notify_client.send_email_notification.called
+        call_args = mocked_notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == subscriber.adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_removed_for_adviser.value
 
@@ -113,13 +113,13 @@ class TestNofityPostDeleteOrderAdviser:
 class TestNofityPostOrderPaid:
     """Tests for notifications sent when an order is marked as paid."""
 
-    def test_notify_on_order_paid(self, notify_client):
+    def test_notify_on_order_paid(self, mocked_notify_client):
         """Test that a notification is triggered when an order is marked as paid."""
         order = OrderWithAcceptedQuoteFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.mark_as_paid(
             by=AdviserFactory(),
@@ -132,11 +132,11 @@ class TestNofityPostOrderPaid:
         )
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify_client.send_email_notification.call_args_list
+            for data in mocked_notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.order_paid_for_customer.value,
@@ -150,22 +150,22 @@ class TestNofityPostOrderPaid:
 class TestNotifyPostOrderCompleted:
     """Tests for notifications sent when an order marked as completed."""
 
-    def test_notify_on_order_completed(self, notify_client):
+    def test_notify_on_order_completed(self, mocked_notify_client):
         """Test that a notification is triggered when an order is marked as completed."""
         order = OrderPaidFactory(assignees=[])
         OrderAssigneeCompleteFactory.create_batch(1, order=order, is_lead=True)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.complete(by=None)
 
         #  3 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == 3
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == 3
 
         templates_called = [
             data[1]['template_id']
-            for data in notify_client.send_email_notification.call_args_list
+            for data in mocked_notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.order_completed_for_adviser.value,
@@ -178,22 +178,22 @@ class TestNotifyPostOrderCompleted:
 class TestNofityPostOrderCancelled:
     """Tests for notifications sent when an order is cancelled."""
 
-    def test_notify_on_order_cancelled(self, notify_client):
+    def test_notify_on_order_cancelled(self, mocked_notify_client):
         """Test that a notification is triggered when an order is cancelled."""
         order = OrderFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order, is_lead=True)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.cancel(by=AdviserFactory(), reason=CancellationReason.objects.first())
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify_client.send_email_notification.call_args_list
+            for data in mocked_notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.order_cancelled_for_customer.value,
@@ -207,22 +207,22 @@ class TestNofityPostOrderCancelled:
 class TestNotifyPostQuoteGenerated:
     """Tests for notifications sent when a quote is generated."""
 
-    def test_notify_on_quote_generated(self, notify_client):
+    def test_notify_on_quote_generated(self, mocked_notify_client):
         """Test that a notification is triggered when a quote is generated."""
         order = OrderFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order, is_lead=True)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.generate_quote(by=None)
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify_client.send_email_notification.call_args_list
+            for data in mocked_notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.quote_sent_for_customer.value,
@@ -236,22 +236,22 @@ class TestNotifyPostQuoteGenerated:
 class TestNotifyPostQuoteAccepted:
     """Tests for notifications sent when a quote is accepted."""
 
-    def test_notify_on_quote_accepted(self, notify_client):
+    def test_notify_on_quote_accepted(self, mocked_notify_client):
         """Test that a notification is triggered when a quote is accepted."""
         order = OrderWithOpenQuoteFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order, is_lead=True)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.accept_quote(by=None)
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify_client.send_email_notification.call_args_list
+            for data in mocked_notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.quote_accepted_for_customer.value,
@@ -265,22 +265,22 @@ class TestNotifyPostQuoteAccepted:
 class TestNotifyPostQuoteCancelled:
     """Tests for notifications sent when a quote is cancelled."""
 
-    def test_notify_on_quote_cancelled(self, notify_client):
+    def test_notify_on_quote_cancelled(self, mocked_notify_client):
         """Test that a notification is triggered when a quote is cancelled."""
         order = OrderWithOpenQuoteFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify_client.reset_mock()
+        mocked_notify_client.reset_mock()
 
         order.reopen(by=AdviserFactory())
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(mocked_notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify_client.send_email_notification.call_args_list
+            for data in mocked_notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.quote_cancelled_for_customer.value,

--- a/datahub/omis/notification/test/test_signal_receivers.py
+++ b/datahub/omis/notification/test/test_signal_receivers.py
@@ -2,7 +2,6 @@ import pytest
 from dateutil.parser import parse as dateutil_parse
 
 from datahub.company.test.factories import AdviserFactory
-from datahub.omis.notification.client import notify
 from datahub.omis.notification.constants import Template
 from datahub.omis.order.models import CancellationReason
 from datahub.omis.order.test.factories import (
@@ -22,55 +21,53 @@ pytestmark = pytest.mark.django_db
 class TestNotifyPostSaveOrder:
     """Tests for notifications sent when an order is saved/updated."""
 
-    def test_notification_on_order_created(self):
+    def test_notification_on_order_created(self, notify_client):
         """Test that a notification is triggered when an order is created."""
-        notify.client.reset_mock()
-
         OrderFactory()
 
-        assert notify.client.send_email_notification.called
+        assert notify_client.send_email_notification.called
 
-    def test_no_notification_on_order_updated(self):
+    def test_no_notification_on_order_updated(self, notify_client):
         """Test that no notification is triggered when saving an order."""
         order = OrderFactory()
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.description = 'new description'
         order.save()
 
-        assert not notify.client.send_email_notification.called
+        assert not notify_client.send_email_notification.called
 
 
 @pytest.mark.usefixtures('synchronous_thread_pool', 'synchronous_on_commit')
 class TestNofityPostSaveOrderAdviser:
     """Tests for notifications sent when an adviser is added to an order."""
 
-    def test_notify_on_order_assignee_added(self):
+    def test_notify_on_order_assignee_added(self, notify_client):
         """
         Test that a notification is sent to the adviser when they get assigned to an order.
         """
         order = OrderFactory(assignees=[])
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         assignee = OrderAssigneeFactory(order=order)
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == assignee.adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_added_for_adviser.value
 
-    def test_notify_on_order_subscriber_added(self):
+    def test_notify_on_order_subscriber_added(self, notify_client):
         """
         Test that a notification is sent to the adviser when they get subscribed to an order.
         """
         order = OrderFactory(assignees=[])
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         subscriber = OrderSubscriberFactory(order=order)
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == subscriber.adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_added_for_adviser.value
 
@@ -79,35 +76,35 @@ class TestNofityPostSaveOrderAdviser:
 class TestNofityPostDeleteOrderAdviser:
     """Tests for notifications sent when an adviser is removed from an order."""
 
-    def test_notify_on_order_assignee_deleted(self):
+    def test_notify_on_order_assignee_deleted(self, notify_client):
         """
         Test that a notification is sent to the adviser when they get removed from an order.
         """
         order = OrderFactory(assignees=[])
         assignee = OrderAssigneeFactory(order=order)
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.assignees.all().delete()
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == assignee.adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_removed_for_adviser.value
 
-    def test_notify_on_order_subscriber_deleted(self):
+    def test_notify_on_order_subscriber_deleted(self, notify_client):
         """
         Test that a notification is sent to the adviser when they get removed from an order.
         """
         order = OrderFactory(assignees=[])
         subscriber = OrderSubscriberFactory(order=order)
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.subscribers.all().delete()
 
-        assert notify.client.send_email_notification.called
-        call_args = notify.client.send_email_notification.call_args_list[0][1]
+        assert notify_client.send_email_notification.called
+        call_args = notify_client.send_email_notification.call_args_list[0][1]
         assert call_args['email_address'] == subscriber.adviser.contact_email
         assert call_args['template_id'] == Template.you_have_been_removed_for_adviser.value
 
@@ -116,13 +113,13 @@ class TestNofityPostDeleteOrderAdviser:
 class TestNofityPostOrderPaid:
     """Tests for notifications sent when an order is marked as paid."""
 
-    def test_notify_on_order_paid(self):
+    def test_notify_on_order_paid(self, notify_client):
         """Test that a notification is triggered when an order is marked as paid."""
         order = OrderWithAcceptedQuoteFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.mark_as_paid(
             by=AdviserFactory(),
@@ -135,11 +132,11 @@ class TestNofityPostOrderPaid:
         )
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify.client.send_email_notification.call_args_list
+            for data in notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.order_paid_for_customer.value,
@@ -153,22 +150,22 @@ class TestNofityPostOrderPaid:
 class TestNotifyPostOrderCompleted:
     """Tests for notifications sent when an order marked as completed."""
 
-    def test_notify_on_order_completed(self):
+    def test_notify_on_order_completed(self, notify_client):
         """Test that a notification is triggered when an order is marked as completed."""
         order = OrderPaidFactory(assignees=[])
         OrderAssigneeCompleteFactory.create_batch(1, order=order, is_lead=True)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.complete(by=None)
 
         #  3 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == 3
+        assert len(notify_client.send_email_notification.call_args_list) == 3
 
         templates_called = [
             data[1]['template_id']
-            for data in notify.client.send_email_notification.call_args_list
+            for data in notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.order_completed_for_adviser.value,
@@ -181,22 +178,22 @@ class TestNotifyPostOrderCompleted:
 class TestNofityPostOrderCancelled:
     """Tests for notifications sent when an order is cancelled."""
 
-    def test_notify_on_order_cancelled(self):
+    def test_notify_on_order_cancelled(self, notify_client):
         """Test that a notification is triggered when an order is cancelled."""
         order = OrderFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order, is_lead=True)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.cancel(by=AdviserFactory(), reason=CancellationReason.objects.first())
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify.client.send_email_notification.call_args_list
+            for data in notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.order_cancelled_for_customer.value,
@@ -210,22 +207,22 @@ class TestNofityPostOrderCancelled:
 class TestNotifyPostQuoteGenerated:
     """Tests for notifications sent when a quote is generated."""
 
-    def test_notify_on_quote_generated(self):
+    def test_notify_on_quote_generated(self, notify_client):
         """Test that a notification is triggered when a quote is generated."""
         order = OrderFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order, is_lead=True)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.generate_quote(by=None)
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify.client.send_email_notification.call_args_list
+            for data in notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.quote_sent_for_customer.value,
@@ -239,22 +236,22 @@ class TestNotifyPostQuoteGenerated:
 class TestNotifyPostQuoteAccepted:
     """Tests for notifications sent when a quote is accepted."""
 
-    def test_notify_on_quote_accepted(self):
+    def test_notify_on_quote_accepted(self, notify_client):
         """Test that a notification is triggered when a quote is accepted."""
         order = OrderWithOpenQuoteFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order, is_lead=True)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.accept_quote(by=None)
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify.client.send_email_notification.call_args_list
+            for data in notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.quote_accepted_for_customer.value,
@@ -268,22 +265,22 @@ class TestNotifyPostQuoteAccepted:
 class TestNotifyPostQuoteCancelled:
     """Tests for notifications sent when a quote is cancelled."""
 
-    def test_notify_on_quote_cancelled(self):
+    def test_notify_on_quote_cancelled(self, notify_client):
         """Test that a notification is triggered when a quote is cancelled."""
         order = OrderWithOpenQuoteFactory(assignees=[])
         OrderAssigneeFactory.create_batch(1, order=order)
         OrderSubscriberFactory.create_batch(2, order=order)
 
-        notify.client.reset_mock()
+        notify_client.reset_mock()
 
         order.reopen(by=AdviserFactory())
 
         #  1 = customer, 3 = assignees/subscribers
-        assert len(notify.client.send_email_notification.call_args_list) == (3 + 1)
+        assert len(notify_client.send_email_notification.call_args_list) == (3 + 1)
 
         templates_called = [
             data[1]['template_id']
-            for data in notify.client.send_email_notification.call_args_list
+            for data in notify_client.send_email_notification.call_args_list
         ]
         assert templates_called == [
             Template.quote_cancelled_for_customer.value,

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -1,11 +1,16 @@
 import pytest
 from dateutil.parser import parse as dateutil_parse
 from django.conf import settings
+from django.test.utils import override_settings
 
 from datahub.company.test.factories import AdviserFactory
 from datahub.core.constants import UKRegion
+from datahub.feature_flag.test.factories import FeatureFlagFactory
+from datahub.notification.core import NotifyGateway
+from datahub.notification.tasks import send_email_notification
 from datahub.omis.market.models import Market
 from datahub.omis.notification.client import Notify
+from datahub.omis.notification.constants import OMIS_USE_NOTIFICATION_APP_FEATURE_FLAG_NAME
 from datahub.omis.order.test.factories import (
     OrderCompleteFactory,
     OrderFactory,
@@ -18,6 +23,34 @@ from datahub.omis.region.models import UKRegionalSettings
 pytestmark = pytest.mark.django_db
 
 
+@pytest.fixture
+def notify_task_return_value_tracker(track_return_values):
+    """
+    Attaches and returns a return value tracker for send email notification
+    tasks.
+    """
+    return track_return_values(send_email_notification, 'apply_async')
+
+
+@pytest.fixture
+def end_to_end_notify(monkeypatch, settings):
+    """
+    A fixture for a notify client which uses the new datahub.notification app
+    under the hood and calls through to the GOVUK notify service (with
+    settings.OMIS_NOTIFICATION_TEST_API_KEY).
+
+    By contrast, our other test cases will use mocked clients so that no actual
+    web requests are made to GOVUK notify.
+    """
+    with override_settings(OMIS_NOTIFICATION_API_KEY=settings.OMIS_NOTIFICATION_TEST_API_KEY):
+        monkeypatch.setattr(
+            'datahub.notification.tasks.notify_gateway',
+            NotifyGateway(),
+        )
+        FeatureFlagFactory(code=OMIS_USE_NOTIFICATION_APP_FEATURE_FLAG_NAME)
+        yield Notify()
+
+
 @pytest.mark.skipif(
     not settings.OMIS_NOTIFICATION_TEST_API_KEY,
     reason='`settings.OMIS_NOTIFICATION_TEST_API_KEY` not set (optional).',
@@ -28,12 +61,171 @@ class TestTemplates:
     These tests are going to be run only if `OMIS_NOTIFICATION_TEST_API_KEY` is set
     and it's meant to check that the templates in GOV.UK notifications have not been
     changed.
-
     If `OMIS_NOTIFICATION_TEST_API_KEY` is not set they will not run as they are
     not strictly mandatory.
     """
 
-    def test_order_info(self, settings, notify_client):
+    def _assert_tasks_successful(self, task_count, return_value_tracker):
+        task_results = return_value_tracker.return_values
+        assert len(task_results) == task_count
+        for task_result in task_results:
+            try:
+                task_result.get()
+            except Exception as exc:
+                pytest.fail(f'Notify task raised an exception {exc}')
+
+    def test_order_info(self, end_to_end_notify, notify_task_return_value_tracker):
+        """
+        Test the order info template.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        end_to_end_notify.order_info(OrderFactory(), what_happened='', why='')
+        self._assert_tasks_successful(1, notify_task_return_value_tracker)
+
+    def test_order_created(self, end_to_end_notify, notify_task_return_value_tracker):
+        """
+        Test the order created template.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        market = Market.objects.first()
+        market.manager_email = 'test@test.com'
+        market.save()
+
+        UKRegionalSettings.objects.create(
+            uk_region_id=UKRegion.london.value.id,
+            manager_emails=['reg_test@test.com'],
+        )
+
+        order = OrderFactory(
+            primary_market_id=market.country.pk,
+            uk_region_id=UKRegion.london.value.id,
+        )
+
+        end_to_end_notify.order_created(order)
+        self._assert_tasks_successful(2, notify_task_return_value_tracker)
+
+    def test_you_have_been_added_for_adviser(
+        self,
+        end_to_end_notify,
+        notify_task_return_value_tracker,
+    ):
+        """
+        Test the notification for when an adviser is added to an order.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        order = OrderFactory()
+
+        end_to_end_notify.adviser_added(
+            order=order,
+            adviser=AdviserFactory(),
+            by=AdviserFactory(),
+            creation_date=dateutil_parse('2017-05-18'),
+        )
+        self._assert_tasks_successful(1, notify_task_return_value_tracker)
+
+    def test_you_have_been_removed_for_adviser(
+        self,
+        end_to_end_notify,
+        notify_task_return_value_tracker,
+    ):
+        """
+        Test the notification for when an adviser is removed from an order.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        order = OrderFactory()
+
+        end_to_end_notify.adviser_removed(order=order, adviser=AdviserFactory())
+        self._assert_tasks_successful(1, notify_task_return_value_tracker)
+
+    def test_order_paid(self, end_to_end_notify, notify_task_return_value_tracker):
+        """
+        Test templates of order paid for customer and advisers.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        order = OrderPaidFactory()
+
+        end_to_end_notify.order_paid(order)
+        self._assert_tasks_successful(2, notify_task_return_value_tracker)
+
+    def test_order_completed(self, end_to_end_notify, notify_task_return_value_tracker):
+        """
+        Test templates of order completed for advisers.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        order = OrderCompleteFactory()
+
+        end_to_end_notify.order_completed(order)
+        self._assert_tasks_successful(1, notify_task_return_value_tracker)
+
+    def test_order_cancelled(self, end_to_end_notify, notify_task_return_value_tracker):
+        """
+        Test templates of order cancelled for customer and advisers.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        order = OrderWithOpenQuoteFactory()
+
+        end_to_end_notify.order_cancelled(order)
+        self._assert_tasks_successful(2, notify_task_return_value_tracker)
+
+    def test_quote_sent(self, end_to_end_notify, notify_task_return_value_tracker):
+        """
+        Test templates of quote sent for customer and advisers.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        order = OrderWithOpenQuoteFactory()
+
+        end_to_end_notify.quote_generated(order)
+        self._assert_tasks_successful(2, notify_task_return_value_tracker)
+
+    def test_quote_accepted(self, end_to_end_notify, notify_task_return_value_tracker):
+        """
+        Test templates of quote accepted for customer and advisers.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        order = OrderPaidFactory()
+
+        end_to_end_notify.quote_accepted(order)
+        self._assert_tasks_successful(2, notify_task_return_value_tracker)
+
+    def test_quote_cancelled(self, end_to_end_notify, notify_task_return_value_tracker):
+        """
+        Test templates of quote cancelled for customer and advisers.
+        If the template variables have been changed in GOV.UK notifications the
+        celery task will be unsuccessful.
+        """
+        order = OrderWithOpenQuoteFactory()
+
+        end_to_end_notify.quote_cancelled(order, by=AdviserFactory())
+        self._assert_tasks_successful(2, notify_task_return_value_tracker)
+
+
+@pytest.mark.skipif(
+    not settings.OMIS_NOTIFICATION_TEST_API_KEY,
+    reason='`settings.OMIS_NOTIFICATION_TEST_API_KEY` not set (optional).',
+)
+@pytest.mark.usefixtures('synchronous_thread_pool')
+class TestTemplatesLegacyOMISNotification:
+    """
+    TODO: This will need removing when we switch over fully to using the
+    datahub.notification app.
+
+    These tests are going to be run only if `OMIS_NOTIFICATION_TEST_API_KEY` is set
+    and it's meant to check that the templates in GOV.UK notifications have not been
+    changed.
+    If `OMIS_NOTIFICATION_TEST_API_KEY` is not set they will not run as they are
+    not strictly mandatory.
+    """
+
+    def test_order_info(self, settings):
         """
         Test the order info template.
         If the template variables have been changed in GOV.UK notifications this
@@ -44,7 +236,7 @@ class TestTemplates:
 
         notify.order_info(OrderFactory(), what_happened='', why='')
 
-    def test_order_created(self, settings, notify_client):
+    def test_order_created(self, settings):
         """
         Test the order created template.
         If the template variables have been changed in GOV.UK notifications this
@@ -69,7 +261,7 @@ class TestTemplates:
 
         notify.order_created(order)
 
-    def test_you_have_been_added_for_adviser(self, settings, notify_client):
+    def test_you_have_been_added_for_adviser(self, settings):
         """
         Test the notification for when an adviser is added to an order.
         If the template variables have been changed in GOV.UK notifications this
@@ -87,7 +279,7 @@ class TestTemplates:
             creation_date=dateutil_parse('2017-05-18'),
         )
 
-    def test_you_have_been_removed_for_adviser(self, settings, notify_client):
+    def test_you_have_been_removed_for_adviser(self, settings):
         """
         Test the notification for when an adviser is removed from an order.
         If the template variables have been changed in GOV.UK notifications this
@@ -100,7 +292,7 @@ class TestTemplates:
 
         notify.adviser_removed(order=order, adviser=AdviserFactory())
 
-    def test_order_paid(self, settings, notify_client):
+    def test_order_paid(self, settings):
         """
         Test templates of order paid for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -113,7 +305,7 @@ class TestTemplates:
 
         notify.order_paid(order)
 
-    def test_order_completed(self, settings, notify_client):
+    def test_order_completed(self, settings):
         """
         Test templates of order completed for advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -126,7 +318,7 @@ class TestTemplates:
 
         notify.order_completed(order)
 
-    def test_order_cancelled(self, settings, notify_client):
+    def test_order_cancelled(self, settings):
         """
         Test templates of order cancelled for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -139,7 +331,7 @@ class TestTemplates:
 
         notify.order_cancelled(order)
 
-    def test_quote_sent(self, settings, notify_client):
+    def test_quote_sent(self, settings):
         """
         Test templates of quote sent for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -152,7 +344,7 @@ class TestTemplates:
 
         notify.quote_generated(order)
 
-    def test_quote_accepted(self, settings, notify_client):
+    def test_quote_accepted(self, settings):
         """
         Test templates of quote accepted for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -165,7 +357,7 @@ class TestTemplates:
 
         notify.quote_accepted(order)
 
-    def test_quote_cancelled(self, settings, notify_client):
+    def test_quote_cancelled(self, settings):
         """
         Test templates of quote cancelled for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this

--- a/datahub/omis/notification/test/test_templates.py
+++ b/datahub/omis/notification/test/test_templates.py
@@ -33,7 +33,7 @@ class TestTemplates:
     not strictly mandatory.
     """
 
-    def test_order_info(self, settings):
+    def test_order_info(self, settings, notify_client):
         """
         Test the order info template.
         If the template variables have been changed in GOV.UK notifications this
@@ -44,7 +44,7 @@ class TestTemplates:
 
         notify.order_info(OrderFactory(), what_happened='', why='')
 
-    def test_order_created(self, settings):
+    def test_order_created(self, settings, notify_client):
         """
         Test the order created template.
         If the template variables have been changed in GOV.UK notifications this
@@ -69,7 +69,7 @@ class TestTemplates:
 
         notify.order_created(order)
 
-    def test_you_have_been_added_for_adviser(self, settings):
+    def test_you_have_been_added_for_adviser(self, settings, notify_client):
         """
         Test the notification for when an adviser is added to an order.
         If the template variables have been changed in GOV.UK notifications this
@@ -87,7 +87,7 @@ class TestTemplates:
             creation_date=dateutil_parse('2017-05-18'),
         )
 
-    def test_you_have_been_removed_for_adviser(self, settings):
+    def test_you_have_been_removed_for_adviser(self, settings, notify_client):
         """
         Test the notification for when an adviser is removed from an order.
         If the template variables have been changed in GOV.UK notifications this
@@ -100,7 +100,7 @@ class TestTemplates:
 
         notify.adviser_removed(order=order, adviser=AdviserFactory())
 
-    def test_order_paid(self, settings):
+    def test_order_paid(self, settings, notify_client):
         """
         Test templates of order paid for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -113,7 +113,7 @@ class TestTemplates:
 
         notify.order_paid(order)
 
-    def test_order_completed(self, settings):
+    def test_order_completed(self, settings, notify_client):
         """
         Test templates of order completed for advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -126,7 +126,7 @@ class TestTemplates:
 
         notify.order_completed(order)
 
-    def test_order_cancelled(self, settings):
+    def test_order_cancelled(self, settings, notify_client):
         """
         Test templates of order cancelled for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -139,7 +139,7 @@ class TestTemplates:
 
         notify.order_cancelled(order)
 
-    def test_quote_sent(self, settings):
+    def test_quote_sent(self, settings, notify_client):
         """
         Test templates of quote sent for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -152,7 +152,7 @@ class TestTemplates:
 
         notify.quote_generated(order)
 
-    def test_quote_accepted(self, settings):
+    def test_quote_accepted(self, settings, notify_client):
         """
         Test templates of quote accepted for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this
@@ -165,7 +165,7 @@ class TestTemplates:
 
         notify.quote_accepted(order)
 
-    def test_quote_cancelled(self, settings):
+    def test_quote_cancelled(self, settings, notify_client):
         """
         Test templates of quote cancelled for customer and advisers.
         If the template variables have been changed in GOV.UK notifications this


### PR DESCRIPTION
### Description of change

This allows us to switch OMIS notifications to be sent through the new `datahub.notification` app by activating a feature flag.  It allows us to switch over to the new app in a way that is low risk - as we can easily switch back to the existing implementation if there are any problems.

Due to the nature of making this switch achievable with a feature flag, the logic which triggers omis notifications has gotten a little ugly.  Once we have successfully switched to the `datahub.notification` app, a PR will follow which cleans up `datahub.omis.notification`.  There's some easy refactors that can be made to make this much cleaner.

This follows on from previous work to allow `datahub.notification` to work with multiple API keys/client instances. https://github.com/uktrade/data-hub-leeloo/pull/1948

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
