### PR TITLE
Add a validator to restrict unarchiving companies with certain archive reasons

### DIFF
--- a/datahub/company/validators.py
+++ b/datahub/company/validators.py
@@ -27,6 +27,33 @@ class NotATransferredCompanyValidator:
             )
 
 
+class ArchiveReasonRestrictedValidator:
+    """
+    Validates that an archived company does not have an archive reason which
+    restricts unarchiving it.
+    """
+
+    RESTRICTED_REASONS = (
+        'Not a valid company',
+    )
+
+    def __init__(self):
+        """Initialises the validator."""
+        self.instance = None
+
+    def set_context(self, serializer):
+        """Saves a reference to the model object."""
+        self.instance = serializer.instance
+
+    def __call__(self, data):
+        """Performs validation."""
+        if self.instance.archived_reason in self.RESTRICTED_REASONS:
+            raise ValidationError(
+                'Records that have been archived with the reason '
+                f'"{self.instance.archived_reason}" cannot be unarchived.',
+            )
+
+
 def has_uk_establishment_number_prefix(value):
     """Checks if a UK establishment number has the correct (BR) prefix."""
     return not value or value.startswith('BR')

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -23,7 +23,10 @@ from datahub.company.serializers import (
     OneListCoreTeamMemberSerializer,
     PublicCompanySerializer,
 )
-from datahub.company.validators import NotATransferredCompanyValidator
+from datahub.company.validators import (
+    ArchiveReasonRestrictedValidator,
+    NotATransferredCompanyValidator,
+)
 from datahub.core.audit import AuditViewSet
 from datahub.core.hawk_receiver import (
     HawkAuthentication,
@@ -41,7 +44,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
 
     serializer_class = CompanySerializer
     required_scopes = (Scope.internal_front_end,)
-    unarchive_validators = (NotATransferredCompanyValidator(),)
+    unarchive_validators = (ArchiveReasonRestrictedValidator(), NotATransferredCompanyValidator())
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filterset_fields = ('global_headquarters_id',)
     ordering_fields = ('name', 'created_on')


### PR DESCRIPTION
# Description of change

This adds an `unarchive_validator` to the Company viewset which prevents unarchiving companies that were archived with a specific reason.

The business case here is to ensure that a company record which was determined to be invalid (and so archived by DH support) after a DNB investigation cannot be subsequently unarchived by Data Hub users.

I believe we would add to the canned archive reasons shown on the frontend here:
![archive](https://user-images.githubusercontent.com/3239148/63934873-39f60980-ca54-11e9-82bd-bdd48df334fc.png)

### Things of note
- It would be good to have some discussion around this approach - I'm a little uncomfortable about the approach of checking whether `archived_reason in RESTRICTED_REASONS`.  Especially since `RESTRICTED_REASONS` just consists of raw strings and that a reason is a user friendly string which could be liable to change in future.  This is complicated in that the canned reasons available on the frontend do not appear to be driven by backend data.
- The string for the restricted reason is not final.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
