### PR TITLE
Add ability to filter company lists by a company ID

### DIFF
--- a/changelog/adviser/filter-company-lists.api.rst
+++ b/changelog/adviser/filter-company-lists.api.rst
@@ -1,0 +1,1 @@
+``GET /v4/company-list``: The ``items__company_id`` query parameter can now be used to get the authenticated user's lists that contain a particular company.

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -1,3 +1,4 @@
+from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
 
 from datahub.core.viewsets import CoreViewSet
@@ -16,7 +17,8 @@ class CompanyListViewSet(CoreViewSet):
     required_scopes = (Scope.internal_front_end,)
     queryset = CompanyList.objects.all()
     serializer_class = CompanyListSerializer
-    filter_backends = (OrderingFilter,)
+    filter_backends = (DjangoFilterBackend, OrderingFilter)
+    filterset_fields = ('items__company_id',)
     ordering = ('name', 'created_on', 'pk')
 
     def get_queryset(self):


### PR DESCRIPTION
### Description of change

This adds a `items__company_id` query parameter to `GET /v4/company-list` to get the authenticated user's company lists that contain a particular company.

This is so the front end can determine which lists a particular company is on.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
