### PR TITLE
Deprecate company timeline endpoint

### DIFF
--- a/changelog/company/timeline-deprecation.removal.rst
+++ b/changelog/company/timeline-deprecation.removal.rst
@@ -1,0 +1,1 @@
+``GET /v4/company/<id>>/timeline``: This endpoint is deprecated and will be removed on or after 9 September 2019. Please use ``/v4/activity-feed`` instead.


### PR DESCRIPTION
### Description of change

This deprecates company timeline functionality as is no longer in use as it was replaced by the activity feed.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
