### PR TITLE
Add view for deleting a company list

### DIFF
--- a/changelog/adviser/delete-company-list.api.rst
+++ b/changelog/adviser/delete-company-list.api.rst
@@ -1,0 +1,3 @@
+The following endpoint was added:
+
+- ``DELETE /v4/company-list/<list ID>``: Delete a company list and all its items.

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -21,6 +21,7 @@ urlpatterns = [
         'company-list/<uuid:pk>',
         CompanyListViewSet.as_view(
             {
+                'delete': 'destroy',
                 'patch': 'partial_update',
             },
         ),

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -1,5 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
+from rest_framework.mixins import DestroyModelMixin
 
 from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
@@ -7,11 +8,11 @@ from datahub.user.company_list.models import CompanyList
 from datahub.user.company_list.serializers import CompanyListSerializer
 
 
-class CompanyListViewSet(CoreViewSet):
+class CompanyListViewSet(CoreViewSet, DestroyModelMixin):
     """
     Views for managing the authenticated user's company lists.
 
-    This covers creating, updating (i.e. renaming) and listing lists.
+    This covers creating, updating (i.e. renaming), deleting and listing lists.
     """
 
     required_scopes = (Scope.internal_front_end,)


### PR DESCRIPTION
### Description of change

This adds a view at `DELETE /v4/company-list/<id>` for deleting a company list associated with the authenticated user (including all of the list's items).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
