### PR TITLE
Deprecate unused contact search sorting options

### DIFF
--- a/changelog/contact/contact-search-sortby.removal.rst
+++ b/changelog/contact/contact-search-sortby.removal.rst
@@ -1,0 +1,20 @@
+``POST /v3/search/contact``, ``POST /v3/search/contact/export`` the following ``sortby`` values are deprecated and will be removed on or after 12 September 2019:
+
+- ``accepts_dit_email_marketing``
+- ``address_county``
+- ``address_same_as_company``
+- ``address_town``
+- ``adviser.name``
+- ``archived``
+- ``archived_by.name``
+- ``archived_on``
+- ``company_sector.name``
+- ``email``
+- ``first_name``
+- ``id``
+- ``job_title``
+- ``name``
+- ``primary``
+- ``telephone_countrycode``
+- ``telephone_number``
+- ``title.name``

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -484,6 +484,26 @@ class TestSearch(APITestMixin):
             for contact in response.data['results']
         ]
 
+    def test_sort_by_deprecated_field_logs_error(self, setup_es, caplog):
+        """Test that sorting by a deprecated sorting option logs an error."""
+        caplog.set_level('ERROR')
+
+        url = reverse('api-v3:search:contact')
+        response = self.api_client.post(
+            url,
+            data={
+                'original_query': '',
+                'sortby': 'company_sector.name:desc',
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        expected_message = (
+            'The following deprecated contact search sortby field was used: company_sector.name'
+        )
+        assert expected_message in caplog.text
+
 
 class TestContactExportView(APITestMixin):
     """Tests the contact export view."""


### PR DESCRIPTION
### Description of change

This deprecates various sorting options for contact search that aren't being used by the front end.

This is so that we can simplify the code base and make future refactoring easier. It will also allow us to make the contact search model leaner.

Many of these sorting options were also untested.

Logging has been added to make sure we don't break things inadvertently.

The approach used is the same as in #1450.

[The options that are in use in the front end can be seen here.](https://github.com/uktrade/data-hub-frontend/blob/ebccec4a08ea01b50957a357c7b5d709f25f0583/src/apps/contacts/macros.js#L26-L34)

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
