### PR TITLE
Add item count to company list responses

### DIFF
--- a/changelog/adviser/company-list-item-counts.api.rst
+++ b/changelog/adviser/company-list-item-counts.api.rst
@@ -1,0 +1,1 @@
+``GET /v4/company-list``, ``PATCH /v4/company-list/<id>``: An ``item_count`` field was added to response items containing the count of items in the list.

--- a/datahub/user/company_list/serializers.py
+++ b/datahub/user/company_list/serializers.py
@@ -8,10 +8,14 @@ from datahub.user.company_list.models import CompanyList, CompanyListItem
 class CompanyListSerializer(serializers.ModelSerializer):
     """Serialiser for a company list."""
 
+    # This is an annotation on the query set
+    item_count = serializers.ReadOnlyField()
+
     class Meta:
         model = CompanyList
         fields = (
             'id',
+            'item_count',
             'name',
             'created_on',
         )

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -1,7 +1,9 @@
+from django.db.models import Count
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.filters import OrderingFilter
 from rest_framework.mixins import DestroyModelMixin
 
+from datahub.core.query_utils import get_aggregate_subquery
 from datahub.core.viewsets import CoreViewSet
 from datahub.oauth.scopes import Scope
 from datahub.user.company_list.models import CompanyList
@@ -16,7 +18,9 @@ class CompanyListViewSet(CoreViewSet, DestroyModelMixin):
     """
 
     required_scopes = (Scope.internal_front_end,)
-    queryset = CompanyList.objects.all()
+    queryset = CompanyList.objects.annotate(
+        item_count=get_aggregate_subquery(CompanyList, Count('items')),
+    )
     serializer_class = CompanyListSerializer
     filter_backends = (DjangoFilterBackend, OrderingFilter)
     filterset_fields = ('items__company_id',)


### PR DESCRIPTION
### Description of change

This adds an `item_count` field to the responses of the following company list endpoints:

- `GET /v4/company-list`
- `PATCH /v4/company-list/<id>`

This field contains the count of items contained in the company list.

(It does not get added to the POST response, because the created model object doesn't have the annotation.)

This is being added for the 'Edit lists' page in the front end where an item count is displayed for each list.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
