### PR TITLE
Remove deprecated contact search sorting options

### DIFF
--- a/changelog/contact/search-sort-by.api.rst
+++ b/changelog/contact/search-sort-by.api.rst
@@ -1,0 +1,20 @@
+``POST /v3/search/contact``, ``POST /v3/search/contact/export`` the following deprecated ``sortby`` values were removed:
+
+- ``accepts_dit_email_marketing``
+- ``address_county``
+- ``address_same_as_company``
+- ``address_town``
+- ``adviser.name``
+- ``archived``
+- ``archived_by.name``
+- ``archived_on``
+- ``company_sector.name``
+- ``email``
+- ``first_name``
+- ``id``
+- ``job_title``
+- ``name``
+- ``primary``
+- ``telephone_countrycode``
+- ``telephone_number``
+- ``title.name``

--- a/changelog/contact/search-sort-by.removal.rst
+++ b/changelog/contact/search-sort-by.removal.rst
@@ -1,0 +1,1 @@
+``POST /v3/search/contact``, ``POST /v3/search/contact/export`` various deprecated ``sortby`` values were removed. See the API section for more details.

--- a/datahub/search/contact/serializers.py
+++ b/datahub/search/contact/serializers.py
@@ -26,48 +26,10 @@ class SearchContactQuerySerializer(EntitySearchQuerySerializer):
     created_by = SingleOrListField(child=StringUUIDField(), required=False)
     created_on_exists = serializers.BooleanField(required=False)
 
-    # Deprecated sorting options
-    # TODO: Remove following deprecation period.
-    deprecated_sortby_fields = {
-        'accepts_dit_email_marketing',
-        'address_county',
-        'address_same_as_company',
-        'address_town',
-        'adviser.name',
-        'archived',
-        'archived_by.name',
-        'archived_on',
-        'company_sector.name',
-        'email',
-        'first_name',
-        'id',
-        'job_title',
-        'name',
-        'primary',
-        'telephone_countrycode',
-        'telephone_number',
-        'title.name',
-    }
-
     SORT_BY_FIELDS = (
         'address_country.name',
         'company.name',
         'created_on',
         'last_name',
         'modified_on',
-        *deprecated_sortby_fields,
     )
-
-    def validate(self, data):
-        """
-        Log all uses of deprecated sorting options as an extra check to make sure that they
-        aren't being used before we get rid of them.
-
-        TODO: Remove following deprecation period.
-        """
-        sortby = data.get('sortby')
-        if sortby and sortby.field in self.deprecated_sortby_fields:
-            logger.error(
-                f'The following deprecated contact search sortby field was used: {sortby.field}',
-            )
-        return super().validate(data)

--- a/datahub/search/contact/views.py
+++ b/datahub/search/contact/views.py
@@ -25,12 +25,8 @@ class SearchContactAPIViewMixin:
     search_app = ContactSearchApp
     serializer_class = SearchContactQuerySerializer
     es_sort_by_remappings = {
-        'adviser.name': 'adviser.name.keyword',
-        'archived_by.name': 'archived_by.name.keyword',
         'company.name': 'company.name.keyword',
-        'first_name': 'first_name.keyword',
         'last_name': 'last_name.keyword',
-        'name': 'name.keyword',
     }
 
     FILTER_FIELDS = (


### PR DESCRIPTION
### Description of change

This removes various deprecated sorting options from contact search (affecting the`POST /v3/search/contact` and `POST /v3/search/contact/export` endpoints).

These were previously deprecated in #2032.

This is blocked until 12 September 2019 (when the deprecation period has passed).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
