### PR TITLE
Change sync_es management command to use Celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Dependencies:
     ```shell
     ./manage.py loaddata fixtures/test_data.yaml
 
-    ./manage.py sync_es
+    ./manage.py sync_es --foreground
     ```
 
 13. Create a superuser:
@@ -362,10 +362,16 @@ Create the Elasticsearch index (if it doesn't exist) and update the mapping:
 ./manage.py init_es
 ```
 
-Resync all Elasticsearch records:
+Resync all Elasticsearch records (using Celery):
 
 ```shell
 ./manage.py sync_es
+```
+
+Resync all Elasticsearch records synchronously (without Celery running):
+
+```shell
+./manage.py sync_es --foreground
 ```
 
 You can resync only specific models by using the `--model=` argument.

--- a/changelog/sync-es-celery.internal.rst
+++ b/changelog/sync-es-celery.internal.rst
@@ -1,0 +1,3 @@
+The ``sync_es`` management command was updated to use Celery.
+
+The ``--batch_size`` argument was removed as it is rarely used and isn't currently supported by the Celery task.

--- a/changelog/sync-es-celery.internal.rst
+++ b/changelog/sync-es-celery.internal.rst
@@ -1,3 +1,5 @@
 The ``sync_es`` management command was updated to use Celery.
 
+By default, the Celery task runs asynchronously. ``--foreground`` can be passed to run the Celery task synchronously (without Celery running).
+
 The ``--batch_size`` argument was removed as it is rarely used and isn't currently supported by the Celery task.

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -19,6 +19,12 @@ class Command(BaseCommand):
             choices=[search_app.name for search_app in get_search_apps()],
             help='Search model to import. If empty, it imports all',
         )
+        parser.add_argument(
+            '--foreground',
+            action='store_true',
+            help='If specified, the command runs in the foreground without needing Celery '
+                 'running. (By default, it runs asynchronously using Celery.)',
+        )
 
     def handle(self, *args, **options):
         """Handle."""
@@ -33,6 +39,11 @@ class Command(BaseCommand):
             )
 
         for app in apps:
-            sync_model.apply(args=(app.name,), throw=True)
+            task_args = (app.name,)
+
+            if options['foreground']:
+                sync_model.apply(args=task_args, throw=True)
+            else:
+                sync_model.apply_async(args=task_args)
 
         logger.info('Elasticsearch sync complete!')

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -3,17 +3,9 @@ from logging import getLogger, WARNING
 from django.core.management.base import BaseCommand, CommandError
 
 from datahub.search.apps import are_apps_initialised, get_search_apps, get_search_apps_by_name
-from datahub.search.bulk_sync import sync_app
+from datahub.search.tasks import sync_model
 
 logger = getLogger(__name__)
-
-
-def sync_es(batch_size, search_apps):
-    """Sends data to Elasticsearch."""
-    for app in search_apps:
-        sync_app(app, batch_size=batch_size)
-
-    logger.info('Elasticsearch sync complete!')
 
 
 class Command(BaseCommand):
@@ -21,12 +13,6 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         """Handle arguments."""
-        parser.add_argument(
-            '--batch_size',
-            type=int,
-            help='Batch size - number of rows processed at a time (defaults to per-model '
-                 'defaults)',
-        )
         parser.add_argument(
             '--model',
             action='append',
@@ -46,7 +32,7 @@ class Command(BaseCommand):
                 f'Index and mapping not initialised, please run `init_es` first.',
             )
 
-        sync_es(
-            batch_size=options['batch_size'],
-            search_apps=apps,
-        )
+        for app in apps:
+            sync_model.apply(args=(app.name,), throw=True)
+
+        logger.info('Elasticsearch sync complete!')

--- a/datahub/search/management/commands/sync_es.py
+++ b/datahub/search/management/commands/sync_es.py
@@ -13,6 +13,8 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         """Handle arguments."""
+        # TODO: This argument is actually the search app name, not the model name, and
+        #  the argument should therefore be renamed
         parser.add_argument(
             '--model',
             action='append',

--- a/datahub/search/test/commands/test_sync_es.py
+++ b/datahub/search/test/commands/test_sync_es.py
@@ -18,64 +18,47 @@ def test_fails_if_index_doesnt_exist():
         management.call_command(sync_es.Command())
 
 
-@mock.patch('datahub.search.management.commands.sync_es.sync_es')
-@mock.patch('datahub.search.management.commands.sync_es.get_search_apps_by_name')
-@mock.patch(
-    'datahub.search.apps.index_exists',
-    mock.Mock(return_value=True),
-)
-@pytest.mark.django_db
-def test_sync_es(get_search_apps_by_name_mock, sync_es_mock):
-    """Tests syncing app to Elasticsearch."""
-    management.call_command(sync_es.Command(), batch_size=1)
-
-    sync_es_mock.assert_called_once_with(
-        batch_size=1,
-        search_apps=get_search_apps_by_name_mock.return_value,
-    )
-
-
 @pytest.mark.parametrize(
     'search_model',
     (app.name for app in get_search_apps()),
 )
-@mock.patch('datahub.search.management.commands.sync_es.sync_app')
+@mock.patch('datahub.search.management.commands.sync_es.sync_model')
 @mock.patch(
     'datahub.search.apps.index_exists',
     mock.Mock(return_value=True),
 )
-def test_sync_one_model(sync_app_mock, search_model):
+def test_sync_one_model(sync_model_mock, search_model):
     """
-    Test that --model can be used to specify what we weant to sync.
+    Test that --model can be used to specify what we want to sync.
     """
     management.call_command(sync_es.Command(), model=[search_model])
 
-    assert sync_app_mock.call_count == 1
+    assert sync_model_mock.apply.call_count == 1
 
 
-@mock.patch('datahub.search.management.commands.sync_es.sync_app')
+@mock.patch('datahub.search.management.commands.sync_es.sync_model')
 @mock.patch(
     'datahub.search.apps.index_exists',
     mock.Mock(return_value=True),
 )
-def test_sync_all_models(sync_app_mock):
+def test_sync_all_models(sync_model_mock):
     """
     Test that if --model is not used, all the search apps are synced.
     """
     management.call_command(sync_es.Command())
 
-    assert sync_app_mock.call_count == len(get_search_apps())
+    assert sync_model_mock.apply.call_count == len(get_search_apps())
 
 
-@mock.patch('datahub.search.management.commands.sync_es.sync_app')
+@mock.patch('datahub.search.management.commands.sync_es.sync_model')
 @mock.patch(
     'datahub.search.apps.index_exists',
     mock.Mock(return_value=True),
 )
-def test_sync_invalid_model(sync_app_mock):
+def test_sync_invalid_model(sync_model_mock):
     """
     Test that if an invalid value is used with --model, nothing gets synced.
     """
     management.call_command(sync_es.Command(), model='invalid')
 
-    assert sync_app_mock.call_count == 0
+    assert sync_model_mock.apply.call_count == 0

--- a/setup-uat.sh
+++ b/setup-uat.sh
@@ -68,6 +68,6 @@ AccessToken.objects.create(
 python /app/manage.py loaddata /app/fixtures/test_ch_data.yaml
 python /app/manage.py loaddata /app/fixtures/test_data.yaml
 python /app/manage.py createinitialrevisions
-python /app/manage.py sync_es
+python /app/manage.py sync_es --foreground
 python /app/manage.py collectstatic --noinput
 DEBUG=False gunicorn config.wsgi --config config/gunicorn.py -b 0.0.0.0


### PR DESCRIPTION
### Description of change

This makes some changes to the `sync_es` management command. It:

- makes the task run asynchronously by default (using Celery)
- removes the `--batch_size` argument as it's not really used
- adds a `--foreground` argument for running it synchronously (mainly for convenience)

The reason for this change is to make things more consistent, and also as syncing (asynchronously) using Celery is generally faster due to parallelism. (This change will also benefit the staging refresh job.)

`--foreground` is similar to running `CELERY_TASK_ALWAYS_EAGER=True ./manage.py sync_es` so we could potentially not bother adding `--sync`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
