### PR TITLE
Split removal and deprecation sections in changelog

### DIFF
--- a/changelog/README.rst
+++ b/changelog/README.rst
@@ -20,10 +20,11 @@ and should not contain any full stops. A good candidate would be your branch nam
 
 * ``feature``: new features or changes.
 * ``bugfix``: fixes a bug.
-* ``removal``: feature deprecation or removal. API related news should also have an equivalent .api entry.
-  Include upcoming changes when possible.
+* ``removal``: removal of deprecated feature. API related news should also have an equivalent .api entry.
+* ``deprecation``: feature deprecation. API related news should also have an equivalent .api entry. Include an
+  earliest date for the actual removal of the feature when possible, and details of any other relevant upcoming changes.
 * ``internal``: internal changes e.g. dependencies updated, test data updated etc.
-* ``api``: any changes to the API. Removal/deprecations should also have an equivalent .removal entry.
+* ``api``: any changes to the API. Removals and deprecations should also have an equivalent .removal or .deprecation entry.
   Include upcoming changes when possible.
 * ``db``: any changes to the database schema.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@
 
     [[tool.towncrier.type]]
         directory = "removal"
-        name = "Deprecations and removals"
+        name = "Removals"
+        showcontent = true
+
+    [[tool.towncrier.type]]
+        directory = "deprecation"
+        name = "Deprecations"
         showcontent = true
 
     [[tool.towncrier.type]]


### PR DESCRIPTION
### Description of change

This updates the towncrier configuration so that `removal` and `deprecation` are separate news fragment types (and hence separate sections in the changelog).

This is to improve clarity (as opposed to mixing the two things under one heading).

This was discussed some time ago, but we didn't get round to making the change until now.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
