### PR TITLE
Add view for retrieving a single company list

### DIFF
--- a/changelog/adviser/get-single-company-list.api.rst
+++ b/changelog/adviser/get-single-company-list.api.rst
@@ -1,0 +1,12 @@
+The following endpoint was added:
+
+- ``GET /v4/company-list/<id>``: Gets details of a single company list belonging to the authenticated user.
+
+Responses are in the following format::
+
+  {
+    "id": "string",
+    "name": "string",
+    "item_count": integer,
+    "created_on": "ISO timestamp"
+  }

--- a/datahub/user/company_list/urls.py
+++ b/datahub/user/company_list/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
         CompanyListViewSet.as_view(
             {
                 'delete': 'destroy',
+                'get': 'retrieve',
                 'patch': 'partial_update',
             },
         ),

--- a/datahub/user/company_list/views.py
+++ b/datahub/user/company_list/views.py
@@ -36,7 +36,13 @@ class CompanyListViewSet(CoreViewSet, DestroyModelMixin):
     """
     Views for managing the authenticated user's company lists.
 
-    This covers creating, updating (i.e. renaming), deleting and listing lists.
+    This covers:
+
+    - creating a list
+    - updating (i.e. renaming) a list
+    - deleting a list
+    - listing lists
+    - retrieving details of a single list
     """
 
     required_scopes = (Scope.internal_front_end,)


### PR DESCRIPTION
### Description of change

This adds a view at `GET /v4/company-list/<id>` for retrieving details of a single company list belonging to the authenticated user.

This is required for certain pages in the front end pertaining to a single list (e.g. the page to delete a list).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
