### PR TITLE
Move DNB serializers to `dnb_api` package.

### DIFF
--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -3,7 +3,6 @@ from operator import not_
 from uuid import UUID
 
 from django.conf import settings
-from django.core.validators import integer_validator
 from django.db import models
 from django.utils.translation import gettext_lazy
 from rest_framework import serializers
@@ -573,81 +572,3 @@ class OneListCoreTeamMemberSerializer(serializers.Serializer):
 
     adviser = NestedAdviserWithTeamGeographyField()
     is_global_account_manager = serializers.BooleanField()
-
-
-class DNBCompanySerializer(CompanySerializer):
-    """
-    For creating a company from DNB data.
-
-    Essentially makes the DNB fields writable and removes the validators
-    that make: sector, business_type and uk_region fields required.
-
-    TODO: The validators would be put back in when we have done the work for
-    unpacking these fields from the DNB payload so this particular change
-    is temporary.
-    """
-
-    class Meta(CompanySerializer.Meta):
-        read_only_fields = []
-        dnb_read_only_fields = []
-        validators = (
-            RulesBasedValidator(
-                ValidationRule(
-                    'required',
-                    OperatorRule('company_number', bool),
-                    when=EqualsRule(
-                        'business_type',
-                        BusinessTypeConstant.uk_establishment.value.id,
-                    ),
-                ),
-                ValidationRule(
-                    'invalid_uk_establishment_number_characters',
-                    OperatorRule('company_number', has_no_invalid_company_number_characters),
-                    when=EqualsRule(
-                        'business_type',
-                        BusinessTypeConstant.uk_establishment.value.id,
-                    ),
-                ),
-                ValidationRule(
-                    'invalid_uk_establishment_number_prefix',
-                    OperatorRule('company_number', has_uk_establishment_number_prefix),
-                    when=EqualsRule(
-                        'business_type',
-                        BusinessTypeConstant.uk_establishment.value.id,
-                    ),
-                ),
-            ),
-            RulesBasedValidator(
-                ValidationRule(
-                    'uk_establishment_not_in_uk',
-                    EqualsRule('address_country', Country.united_kingdom.value.id),
-                    when=EqualsRule(
-                        'business_type',
-                        BusinessTypeConstant.uk_establishment.value.id,
-                    ),
-                ),
-            ),
-        )
-
-
-class DUNSNumberSerializer(serializers.Serializer):
-    """
-    Parses duns_number from request body and validates format.
-    """
-
-    duns_number = serializers.CharField(
-        write_only=True,
-        max_length=9,
-        min_length=9,
-        validators=(integer_validator,),
-    )
-
-    def validate_duns_number(self, duns_number):
-        """
-        Check if the duns
-        """
-        if Company.objects.filter(duns_number=duns_number).exists():
-            raise serializers.ValidationError(
-                f'Company with duns_number: {duns_number} already exists in DataHub.',
-            )
-        return duns_number

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -1,7 +1,16 @@
+from django.core.validators import integer_validator
 from rest_framework import serializers
 
+from datahub.company.constants import BusinessTypeConstant
 from datahub.company.models import Company
+from datahub.company.serializers import CompanySerializer
+from datahub.company.validators import (
+    has_no_invalid_company_number_characters,
+    has_uk_establishment_number_prefix,
+)
+from datahub.core.constants import Country
 from datahub.core.serializers import PermittedFieldsModelSerializer
+from datahub.core.validators import EqualsRule, OperatorRule, RulesBasedValidator, ValidationRule
 from datahub.interaction.models import InteractionPermission
 
 
@@ -38,3 +47,81 @@ class DNBMatchedCompanySerializer(PermittedFieldsModelSerializer):
         permissions = {
             f'interaction.{InteractionPermission.view_all}': 'latest_interaction',
         }
+
+
+class DNBCompanySerializer(CompanySerializer):
+    """
+    For creating a company from DNB data.
+
+    Essentially makes the DNB fields writable and removes the validators
+    that make: sector, business_type and uk_region fields required.
+
+    TODO: The validators would be put back in when we have done the work for
+    unpacking these fields from the DNB payload so this particular change
+    is temporary.
+    """
+
+    class Meta(CompanySerializer.Meta):
+        read_only_fields = []
+        dnb_read_only_fields = []
+        validators = (
+            RulesBasedValidator(
+                ValidationRule(
+                    'required',
+                    OperatorRule('company_number', bool),
+                    when=EqualsRule(
+                        'business_type',
+                        BusinessTypeConstant.uk_establishment.value.id,
+                    ),
+                ),
+                ValidationRule(
+                    'invalid_uk_establishment_number_characters',
+                    OperatorRule('company_number', has_no_invalid_company_number_characters),
+                    when=EqualsRule(
+                        'business_type',
+                        BusinessTypeConstant.uk_establishment.value.id,
+                    ),
+                ),
+                ValidationRule(
+                    'invalid_uk_establishment_number_prefix',
+                    OperatorRule('company_number', has_uk_establishment_number_prefix),
+                    when=EqualsRule(
+                        'business_type',
+                        BusinessTypeConstant.uk_establishment.value.id,
+                    ),
+                ),
+            ),
+            RulesBasedValidator(
+                ValidationRule(
+                    'uk_establishment_not_in_uk',
+                    EqualsRule('address_country', Country.united_kingdom.value.id),
+                    when=EqualsRule(
+                        'business_type',
+                        BusinessTypeConstant.uk_establishment.value.id,
+                    ),
+                ),
+            ),
+        )
+
+
+class DUNSNumberSerializer(serializers.Serializer):
+    """
+    Parses duns_number from request body and validates format.
+    """
+
+    duns_number = serializers.CharField(
+        write_only=True,
+        max_length=9,
+        min_length=9,
+        validators=(integer_validator,),
+    )
+
+    def validate_duns_number(self, duns_number):
+        """
+        Check if the duns
+        """
+        if Company.objects.filter(duns_number=duns_number).exists():
+            raise serializers.ValidationError(
+                f'Company with duns_number: {duns_number} already exists in DataHub.',
+            )
+        return duns_number

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -8,13 +8,16 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from datahub.company.models import CompanyPermission
-from datahub.company.serializers import DNBCompanySerializer, DUNSNumberSerializer
 from datahub.core.exceptions import APIBadRequestException, APIUpstreamException
 from datahub.core.permissions import HasPermissions
 from datahub.core.view_utils import enforce_request_content_type
 from datahub.dnb_api.constants import FEATURE_FLAG_DNB_COMPANY_SEARCH
 from datahub.dnb_api.queryset import get_company_queryset
-from datahub.dnb_api.serializers import DNBMatchedCompanySerializer
+from datahub.dnb_api.serializers import (
+    DNBCompanySerializer,
+    DNBMatchedCompanySerializer,
+    DUNSNumberSerializer,
+)
 from datahub.dnb_api.utils import format_dnb_company, search_dnb
 from datahub.feature_flag.utils import feature_flagged_view
 from datahub.oauth.scopes import Scope


### PR DESCRIPTION
### Description of change

Moving the `DNBCompanySerializer` and `DUNSNumberSerializer` to the `dab_api` package.   


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
