### PR TITLE
Feature/fix dnb company create tests

### DIFF
--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -61,6 +61,12 @@ class DNBCompanySerializer(CompanySerializer):
     is temporary.
     """
 
+    duns_number = serializers.CharField(
+        max_length=9,
+        min_length=9,
+        validators=(integer_validator,),
+    )
+
     class Meta(CompanySerializer.Meta):
         read_only_fields = []
         dnb_read_only_fields = []


### PR DESCRIPTION
### Description of change

Some tests in `api-v4:dnb-api:company-create` we missing asserts. This PR adds them and deals with a couple of issues exposed.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?