### PR TITLE
Add `iso_alpha2_code` to country metadata api endpoint

### DIFF
--- a/changelog/metadata-country-iso-alpha2.api.rst
+++ b/changelog/metadata-country-iso-alpha2.api.rst
@@ -1,0 +1,26 @@
+A field ``iso_alpha2_code`` was added to the ``GET /metadata/country/`` API
+endpoint.
+
+This endpoint now returns results of the following format:
+
+```
+...
+{
+    "id": "80756b9a-5d95-e211-a939-e4115bead28a",
+    "name": "United Kingdom",
+    "disabled_on": null,
+    "overseas_region": null,
+    "iso_alpha2_code": "GB"
+},
+{
+    "id": "81756b9a-5d95-e211-a939-e4115bead28a",
+    "name": "United States",
+    "disabled_on": null,
+    "overseas_region": {
+        "name": "North America",
+        "id": "fdfbbc8d-0e8a-479a-b10f-4979d582ff87"
+    },
+    "iso_alpha2_code": "US"
+},
+...
+```

--- a/datahub/metadata/serializers.py
+++ b/datahub/metadata/serializers.py
@@ -34,6 +34,7 @@ class CountrySerializer(ConstantModelSerializer):
     """Country serializer."""
 
     overseas_region = NestedRelatedField(OverseasRegion, read_only=True)
+    iso_alpha2_code = serializers.ReadOnlyField()
 
 
 class ServiceAnswerOptionSerializer(serializers.ModelSerializer):

--- a/datahub/metadata/test/test_views.py
+++ b/datahub/metadata/test/test_views.py
@@ -145,6 +145,7 @@ def test_country_view(api_client):
             'name': country.overseas_region.name,
         },
         'disabled_on': format_date_or_datetime(country.disabled_on),
+        'iso_alpha2_code': country.iso_alpha2_code,
     }
 
 


### PR DESCRIPTION
### Description of change
Add `iso_alpha2_code` to country metadata api endpoint.

This ensures that the frontend has the iso_alpha2_code available when querying the DNB search API, which requires this format for filtering by country.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
