### PR TITLE
Update deprecation docs to separate removal and deprecation

### DIFF
--- a/docs/How to deprecate a field.md
+++ b/docs/How to deprecate a field.md
@@ -14,7 +14,7 @@ This is currently done by creating [newsfragments](../changelog/) with details o
 
 To do that:
 
-* Create an `.api `, `.removal` and, if necessary, a `.db` newsfragment announcing the change. See [example](https://github.com/uktrade/data-hub-leeloo/pull/1082/files).
+* Create an `.api `, `.deprecation` and, if necessary, a `.db` newsfragment announcing the change. See [example](https://github.com/uktrade/data-hub-leeloo/commit/ff5484b4331cd8a42dfd962d00438274d9edc6a6).
 * Open a PR and merge it into develop after it's been approved.
 * Wait for the next release; your changes will appear in the release notes.
 


### PR DESCRIPTION
### Description of change

Update deprecation docs to separate removal and deprecation.  Also link to a more recent/representative example commit.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
