### PR TITLE
Add Hawk authorization to metadata endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Leeloo can run on any Heroku-style platform. Configuration is performed via the 
 | `DATAHUB_FRONTEND_BASE_URL`  | Yes | |
 | `DATAHUB_NOTIFICATION_API_KEY` | No | The GOVUK notify API key to use for the `datahub.notification` django app. |
 | `DATAHUB_SUPPORT_EMAIL_ADDRESS` | No | Email address for DataHub support team. |
+| `DATA_HUB_FRONTEND_ACCESS_KEY_ID` | No | A non-secret access key ID, corresponding to `DATA_HUB_FRONTEND_SECRET_ACCESS_KEY`. The holder of the secret key can access the metadata endpoints by Hawk authentication. |
+| `DATA_HUB_FRONTEND_SECRET_ACCESS_KEY` | If `DATA_HUB_FRONTEND_ACCESS_KEY_ID` is set | A secret key, corresponding to `METADATA_ACCESS_KEY_ID`. The holder of this key can access the metadata endpoints by Hawk authentication. | 
 | `DEBUG`  | Yes | Whether Django's debug mode should be enabled. |
 | `DIT_EMAIL_DOMAIN_*` | No | An allowable DIT email domain for email ingestion along with it's allowed email authentication methods. Django-environ dict format e.g. example.com=dmarc:pass\|spf:pass\|dkim:pass |
 | `DJANGO_SECRET_KEY`  | Yes | |

--- a/changelog/metadata-public-api.api.rst
+++ b/changelog/metadata-public-api.api.rst
@@ -1,0 +1,1 @@
+All ``/metadata/*`` endpoints are deprecated and will be removed on or after 15th October 2019. Please use corresponding ``/v4/metadata`` endpoints instead.

--- a/changelog/metadata-public-api.removal.rst
+++ b/changelog/metadata-public-api.removal.rst
@@ -1,0 +1,1 @@
+All ``/metadata/*`` endpoints are deprecated and will be removed on or after 17th October 2019. Please use corresponding ``/v4/metadata`` endpoints instead.

--- a/changelog/metadata.api.rst
+++ b/changelog/metadata.api.rst
@@ -1,0 +1,59 @@
+Following endpoints were added to replace existing ``/metadata`` endpoint:
+
+``GET /v4/metadata/administrative-area``
+``GET /v4/metadata/business-type``
+``GET /v4/metadata/capital-investment/asset-class-interest``
+``GET /v4/metadata/capital-investment/construction-risk``
+``GET /v4/metadata/capital-investment/deal-ticket-size``
+``GET /v4/metadata/capital-investment/desired-deal-role``
+``GET /v4/metadata/capital-investment/equity-percentage``
+``GET /v4/metadata/capital-investment/investor-type``
+``GET /v4/metadata/capital-investment/large-capital-investment-type``
+``GET /v4/metadata/capital-investment/required-checks-conducted``
+``GET /v4/metadata/capital-investment/restriction``
+``GET /v4/metadata/capital-investment/return-rate``
+``GET /v4/metadata/capital-investment/time-horizon``
+``GET /v4/metadata/communication-channel``
+``GET /v4/metadata/country``
+``GET /v4/metadata/employee-range``
+``GET /v4/metadata/event-type``
+``GET /v4/metadata/evidence-tag``
+``GET /v4/metadata/export-experience-category``
+``GET /v4/metadata/fdi-type``
+``GET /v4/metadata/fdi-value``
+``GET /v4/metadata/headquarter-type``
+``GET /v4/metadata/investment-activity-type``
+``GET /v4/metadata/investment-business-activity``
+``GET /v4/metadata/investment-delivery-partner``
+``GET /v4/metadata/investment-investor-type``
+``GET /v4/metadata/investment-involvement``
+``GET /v4/metadata/investment-project-stage``
+``GET /v4/metadata/investment-specific-programme``
+``GET /v4/metadata/investment-strategic-driver``
+``GET /v4/metadata/investment-type``
+``GET /v4/metadata/likelihood-to-land``
+``GET /v4/metadata/location-type``
+``GET /v4/metadata/omis-market``
+``GET /v4/metadata/order-cancellation-reason``
+``GET /v4/metadata/order-service-type``
+``GET /v4/metadata/overseas-region``
+``GET /v4/metadata/policy-area``
+``GET /v4/metadata/policy-issue-type``
+``GET /v4/metadata/programme``
+``GET /v4/metadata/project-manager-request-status``
+``GET /v4/metadata/referral-source-activity``
+``GET /v4/metadata/referral-source-marketing``
+``GET /v4/metadata/referral-source-website``
+``GET /v4/metadata/salary-range``
+``GET /v4/metadata/sector``
+``GET /v4/metadata/service-delivery-status``
+``GET /v4/metadata/service``
+``GET /v4/metadata/team-role``
+``GET /v4/metadata/team``
+``GET /v4/metadata/title``
+``GET /v4/metadata/turnover``
+``GET /v4/metadata/uk-region``
+
+The responses are exactly the same as their corresponding ``/metadata`` endpoints.
+
+New endpoints use Hawk authentication.

--- a/config/api_urls.py
+++ b/config/api_urls.py
@@ -17,10 +17,10 @@ from datahub.feature_flag import urls as feature_flag_urls
 from datahub.interaction import urls as interaction_urls
 from datahub.investment.investor_profile import urls as investor_profile_urls
 from datahub.investment.project import urls as investment_urls
+from datahub.metadata import urls as metadata_urls
 from datahub.omis import urls as omis_urls
 from datahub.search import urls as search_urls
 from datahub.user.company_list import urls as company_list_urls
-
 
 # API V1
 
@@ -75,4 +75,5 @@ v4_urls = [
     path('', include((activity_feed_urls, 'activity-feed'), namespace='activity-feed')),
     path('', include((company_list_urls, 'company-list'), namespace='company-list')),
     path('dataset/', include((dataset_urls, 'dataset'), namespace='dataset')),
+    path('metadata/', include((metadata_urls, 'metadata'), namespace='metadata')),
 ]

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -490,7 +490,7 @@ HAWK_RECEIVER_NONCE_EXPIRY_SECONDS = 60
 HAWK_RECEIVER_CREDENTIALS = {}
 
 
-def _add_hawk_credentials(id_env_name, key_env_name, scope):
+def _add_hawk_credentials(id_env_name, key_env_name, scopes):
     id_ = env(id_env_name, default=None)
 
     if not id_:
@@ -503,26 +503,32 @@ def _add_hawk_credentials(id_env_name, key_env_name, scope):
 
     HAWK_RECEIVER_CREDENTIALS[id_] = {
         'key': env(key_env_name),
-        'scope': scope,
+        'scopes': scopes,
     }
 
 
 _add_hawk_credentials(
     'ACTIVITY_STREAM_ACCESS_KEY_ID',
     'ACTIVITY_STREAM_SECRET_ACCESS_KEY',
-    HawkScope.activity_stream,
+    (HawkScope.activity_stream, ),
 )
 
 _add_hawk_credentials(
     'MARKET_ACCESS_ACCESS_KEY_ID',
     'MARKET_ACCESS_SECRET_ACCESS_KEY',
-    HawkScope.public_company,
+    (HawkScope.public_company, HawkScope.metadata, ),
 )
 
 _add_hawk_credentials(
     'DATA_FLOW_API_ACCESS_KEY_ID',
     'DATA_FLOW_API_SECRET_ACCESS_KEY',
-    HawkScope.data_flow_api,
+    (HawkScope.data_flow_api, ),
+)
+
+_add_hawk_credentials(
+    'DATA_HUB_FRONTEND_ACCESS_KEY_ID',
+    'DATA_HUB_FRONTEND_ACCESS_KEY',
+    (HawkScope.metadata, ),
 )
 
 # To read data from Activity Stream

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -1,5 +1,6 @@
 import environ
 
+
 environ.Env.read_env()  # reads the .env file
 env = environ.Env()
 
@@ -58,23 +59,31 @@ HAWK_RECEIVER_IP_WHITELIST = ['1.2.3.4']
 HAWK_RECEIVER_CREDENTIALS = {
     'some-id': {
         'key': 'some-secret',
-        'scope': HawkScope.activity_stream,
+        'scopes': (HawkScope.activity_stream, ),
     },
     'test-id-with-scope': {
         'key': 'test-key-with-scope',
-        'scope': next(iter(HawkScope.__members__.values())),
+        'scopes': (next(iter(HawkScope.__members__.values())), ),
     },
     'test-id-without-scope': {
         'key': 'test-key-without-scope',
-        'scope': object(),
+        'scopes': (),
+    },
+    'test-id-with-multiple-scopes': {
+        'key': 'test-key-with-multiple-scopes',
+        'scopes': list(HawkScope.__members__.values())[:2],
+    },
+    'test-id-with-metadata-scope': {
+        'key': 'test-key-with-metadata-scope',
+        'scopes': (HawkScope.metadata, ),
     },
     'public-company-id': {
         'key': 'public-company-key',
-        'scope': HawkScope.public_company,
+        'scopes': (HawkScope.public_company, ),
     },
     'data-flow-api-id': {
         'key': 'data-flow-api-key',
-        'scope': HawkScope.data_flow_api,
+        'scopes': (HawkScope.data_flow_api, ),
     },
 }
 

--- a/config/settings/types.py
+++ b/config/settings/types.py
@@ -13,3 +13,4 @@ class HawkScope(Enum):
     activity_stream = auto()
     public_company = auto()
     data_flow_api = auto()
+    metadata = auto()

--- a/config/urls.py
+++ b/config/urls.py
@@ -5,16 +5,17 @@ from oauth2_provider.views import TokenView
 
 from config import api_urls
 from config.api_docs_urls import api_docs_urls
+from datahub.metadata.urls import legacy_urlpatterns as metadata_legacy_urlpatterns
 from datahub.ping.views import ping
 from datahub.user.views import who_am_i
-
 
 unversioned_urls = [
     path('admin/', admin.site.urls),
     path('', include('datahub.admin_report.urls')),
     path('', include('datahub.investment.project.report.urls')),
     path('ping.xml', ping, name='ping'),
-    path('metadata/', include('datahub.metadata.urls')),
+    # TODO: `metadata/` should be removed after deprecation period
+    path('metadata/', include(metadata_legacy_urlpatterns)),
     path('token/', TokenView.as_view(), name='token'),
     path('whoami/', who_am_i, name='who_am_i'),
     path(

--- a/datahub/core/hawk_receiver.py
+++ b/datahub/core/hawk_receiver.py
@@ -128,7 +128,7 @@ class HawkScopePermission(BasePermission):
         if not isinstance(request.successful_authenticator, HawkAuthentication):
             return False
 
-        return required_hawk_scope == request.auth.resource.credentials['scope']
+        return required_hawk_scope in request.auth.resource.credentials['scopes']
 
 
 def _lookup_credentials(access_key_id):

--- a/datahub/core/test/test_hawk_receiver.py
+++ b/datahub/core/test/test_hawk_receiver.py
@@ -410,3 +410,23 @@ class TestHawkScopePermission:
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json() == {'content': 'hawk-test-view-with-scope'}
+
+    def test_authorises_when_with_one_of_the_required_scopes(self, api_client):
+        """
+        Test that a 200 is returned if the request is Hawk authenticated and the client has
+        one of the required scope.
+        """
+        sender = _auth_sender(
+            key_id='test-id-with-multiple-scopes',
+            secret_key='test-key-with-multiple-scopes',
+            url=_url_with_scope,
+        )
+        response = api_client.get(
+            _url_with_scope(),
+            content_type='',
+            HTTP_AUTHORIZATION=sender.request_header,
+            HTTP_X_FORWARDED_FOR='1.2.3.4, 123.123.123.123',
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {'content': 'hawk-test-view-with-scope'}

--- a/datahub/core/test_utils.py
+++ b/datahub/core/test_utils.py
@@ -51,6 +51,14 @@ class HawkAPITestClient:
         """Make a POST request with a JSON body."""
         return self.request('post', path, json_=json_)
 
+    def put(self, path, json_):
+        """Make a PUT request with a JSON body."""
+        return self.request('put', path, json_=json_)
+
+    def patch(self, path, json_):
+        """Make a PATCH request with a JSON body."""
+        return self.request('patch', path, json_=json_)
+
     def request(self, method, path, params=None, json_=unset, content_type=''):
         """Make a request with a specified HTTP method."""
         params = urlencode(params) if params else ''

--- a/datahub/metadata/urls.py
+++ b/datahub/metadata/urls.py
@@ -2,4 +2,7 @@ from django.urls import path
 
 from datahub.metadata import views
 
+# TODO: this should be removed after the deprecation period
+legacy_urlpatterns = [path(*args, **kwargs) for args, kwargs in views.legacy_urls_args]
+
 urlpatterns = [path(*args, **kwargs) for args, kwargs in views.urls_args]

--- a/datahub/metadata/views.py
+++ b/datahub/metadata/views.py
@@ -2,28 +2,34 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.mixins import ListModelMixin
 from rest_framework.viewsets import GenericViewSet
 
+from config.settings.types import HawkScope
+from datahub.core.hawk_receiver import (
+    HawkAuthentication,
+    HawkResponseSigningMixin,
+    HawkScopePermission,
+)
 from datahub.metadata.registry import registry
 
 
-def _create_metadata_view(mapping):
+# TODO: remove function parameters once legacy views have been removed after deprecation period
+def _create_metadata_view(mapping, view_set_types=None, auth_attributes=None):
     has_filters = mapping.filterset_fields or mapping.filterset_class
     model = mapping.queryset.model
 
     attrs = {
-        'authentication_classes': (),
         'filter_backends': (DjangoFilterBackend,) if has_filters else (),
         'filterset_class': mapping.filterset_class,
         'filterset_fields': mapping.filterset_fields,
         'pagination_class': None,
-        'permission_classes': (),
         'queryset': mapping.queryset,
         'serializer_class': mapping.serializer,
         '__doc__': f'List all {model._meta.verbose_name_plural}.',
     }
+    attrs.update(auth_attributes or _get_hawk_auth_attributes())
 
     view_set = type(
         f'{mapping.model.__name__}ViewSet',
-        (GenericViewSet, ListModelMixin),
+        view_set_types or (HawkResponseSigningMixin, GenericViewSet, ListModelMixin),
         attrs,
     )
 
@@ -32,10 +38,38 @@ def _create_metadata_view(mapping):
     })
 
 
+def _get_hawk_auth_attributes():
+    return {
+        'authentication_classes': (HawkAuthentication, ),
+        'permission_classes': (HawkScopePermission, ),
+        'required_hawk_scope': HawkScope.metadata,
+    }
+
+
+# TODO: this function needs be removed after a deprecation period
+def _get_public_access_auth_attributes():
+    return {
+        'authentication_classes': (),
+        'permission_classes': (),
+    }
+
+
 urls_args = []
 
 # programmatically generate metadata views
 for name, mapping in registry.mappings.items():
     view = _create_metadata_view(mapping)
+    urls_args.append(((name, view), {'name': name}))
+
+
+# TODO: views below need to be removed after deprecation period is over
+legacy_urls_args = []
+
+for name, mapping in registry.mappings.items():
+    view = _create_metadata_view(
+        mapping,
+        (GenericViewSet, ListModelMixin),
+        _get_public_access_auth_attributes(),
+    )
     path = f'{name}/'
-    urls_args.append(((path, view), {'name': name}))
+    legacy_urls_args.append(((path, view), {'name': name}))


### PR DESCRIPTION
### Description of change

This deprecates existing `/metadata/*` endpoints and replaces them with `/v4/metadata/*` endpoints that use Hawk authorisation.

This updates Hawk authorisation to support multiple scopes for one credential.

Existing metadata tests were moved unchanged (except `test_view_name_generation` to point at legacy urls) to `test_legacy_views.py`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [x] Has the README been updated (if needed)?
