### PR TITLE
Add API (V4) endpoint for fetching Contacts Dataset

### DIFF
--- a/changelog/contact/contacts-dataset-api-endpoint.api.rst
+++ b/changelog/contact/contacts-dataset-api-endpoint.api.rst
@@ -1,0 +1,3 @@
+The following endpoint was added:
+
+- ``GET /v4/dataset/contacts-dataset``: Present required fields data of all contacts to be consumed by data-flow and used in data-workspace for reporting and analyst access.

--- a/datahub/dataset/pagination.py
+++ b/datahub/dataset/pagination.py
@@ -7,3 +7,11 @@ class OMISDatasetViewCursorPagination(CursorPagination):
     """
 
     ordering = ('created_on', 'pk')
+
+
+class ContactsDatasetViewCursorPagination(CursorPagination):
+    """
+    Cursor Pagination for ContactsDatasetView
+    """
+
+    ordering = ('created_on', 'pk')

--- a/datahub/dataset/test/test_views.py
+++ b/datahub/dataset/test/test_views.py
@@ -4,6 +4,11 @@ from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
+from datahub.company.test.factories import (
+    ArchivedContactFactory,
+    ContactFactory,
+    ContactWithOwnAddressFactory,
+)
 from datahub.core.test_utils import (
     format_date_or_datetime,
     get_attr_or_none,
@@ -43,6 +48,12 @@ def data_flow_api_client(hawk_api_client):
 def omis_dataset_view_url():
     """Returns OMISDatasetView url"""
     yield reverse('api-v4:dataset:omis-dataset')
+
+
+@pytest.fixture
+def contacts_dataset_view_url():
+    """Returns ContactsDatasetView url"""
+    yield reverse('api-v4:dataset:contacts-dataset')
 
 
 def get_expected_data_from_order(order):
@@ -165,4 +176,105 @@ class TestOMISDatasetViewSet:
     def test_no_data(self, data_flow_api_client, omis_dataset_view_url):
         """Test that without any data available, endpoint completes the request successfully"""
         response = data_flow_api_client.get(omis_dataset_view_url)
+        assert response.status_code == status.HTTP_200_OK
+
+
+def get_expected_data_from_contact(contact):
+    """Returns expected dictionary based on given contact"""
+    return {
+        'accepts_dit_email_marketing': contact.accepts_dit_email_marketing,
+        'address_country__name': get_attr_or_none(contact, 'address_country.name'),
+        'address_postcode': contact.address_postcode,
+        'company__company_number': get_attr_or_none(contact, 'company.company_number'),
+        'company__name': get_attr_or_none(contact, 'company.name'),
+        'company__uk_region__name': get_attr_or_none(contact, 'company.uk_region.name'),
+        'company_sector': get_attr_or_none(contact, 'company.sector.name'),
+        'created_on': format_date_or_datetime(contact.created_on),
+        'email': contact.email,
+        'email_alternative': contact.email_alternative,
+        'job_title': contact.job_title,
+        'name': contact.name,
+        'notes': contact.notes,
+        'telephone_alternative': contact.telephone_alternative,
+        'telephone_number': contact.telephone_number,
+    }
+
+
+@pytest.mark.django_db
+class TestContactsDatasetViewSet:
+    """
+    Tests for ContactsDatasetView
+    """
+
+    @pytest.mark.parametrize('method', ('delete', 'patch', 'post', 'put'))
+    def test_other_methods_not_allowed(
+        self,
+        data_flow_api_client,
+        method,
+        contacts_dataset_view_url,
+    ):
+        """Test that various HTTP methods are not allowed."""
+        response = data_flow_api_client.request(method, contacts_dataset_view_url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_without_scope(self, hawk_api_client, contacts_dataset_view_url):
+        """Test that making a request without the correct Hawk scope returns an error."""
+        hawk_api_client.set_credentials(
+            'test-id-without-scope',
+            'test-key-without-scope',
+        )
+        response = hawk_api_client.get(contacts_dataset_view_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_without_credentials(self, api_client, contacts_dataset_view_url):
+        """Test that making a request without credentials returns an error."""
+        response = api_client.get(contacts_dataset_view_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'contact_factory', (
+            ArchivedContactFactory,
+            ContactFactory,
+            ContactWithOwnAddressFactory,
+        ))
+    def test_success(self, data_flow_api_client, contacts_dataset_view_url, contact_factory):
+        """Test that endpoint returns with expected data for a single order"""
+        contact = contact_factory()
+        response = data_flow_api_client.get(contacts_dataset_view_url)
+        assert response.status_code == status.HTTP_200_OK
+        response_results = response.json()['results']
+        assert len(response_results) == 1
+        result = response_results[0]
+        expected_result = get_expected_data_from_contact(contact)
+        assert result == expected_result
+
+    def test_with_multiple_contacts(self, data_flow_api_client, contacts_dataset_view_url):
+        """Test that endpoint returns correct number of record in expected contact"""
+        with freeze_time('2019-01-01 12:30:00'):
+            contact_1 = ContactFactory()
+        with freeze_time('2019-01-03 12:00:00'):
+            contact_2 = ContactFactory()
+        with freeze_time('2019-01-01 12:00:00'):
+            contact_3 = ContactFactory()
+            contact_4 = ContactFactory()
+
+        response = data_flow_api_client.get(contacts_dataset_view_url)
+        assert response.status_code == status.HTTP_200_OK
+        response_results = response.json()['results']
+        assert len(response_results) == 4
+        expected_contact_list = sorted([contact_3, contact_4],
+                                       key=lambda item: item.pk) + [contact_1, contact_2]
+        for index, contact in enumerate(expected_contact_list):
+            assert contact.email == response_results[index]['email']
+
+    def test_pagination(self, data_flow_api_client, contacts_dataset_view_url):
+        """Test that when page size higher than threshold response returns with next page url"""
+        OrderFactory.create_batch(settings.REST_FRAMEWORK['PAGE_SIZE'] + 1)
+        response = data_flow_api_client.get(contacts_dataset_view_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['next'] is not None
+
+    def test_no_data(self, data_flow_api_client, contacts_dataset_view_url):
+        """Test that without any data available, endpoint completes the request successfully"""
+        response = data_flow_api_client.get(contacts_dataset_view_url)
         assert response.status_code == status.HTTP_200_OK

--- a/datahub/dataset/urls.py
+++ b/datahub/dataset/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from datahub.dataset.views import OMISDatasetView
+from datahub.dataset.views import ContactsDatasetView, OMISDatasetView
 
 
 urlpatterns = [
     path('omis-dataset', OMISDatasetView.as_view(), name='omis-dataset'),
+    path('contacts-dataset', ContactsDatasetView.as_view(), name='contacts-dataset'),
 ]

--- a/datahub/dataset/views.py
+++ b/datahub/dataset/views.py
@@ -1,13 +1,21 @@
 from rest_framework.views import APIView
 
 from config.settings.types import HawkScope
+from datahub.company.models.contact import Contact
 from datahub.core.hawk_receiver import (
     HawkAuthentication,
     HawkResponseSigningMixin,
     HawkScopePermission,
 )
-from datahub.core.query_utils import get_string_agg_subquery
-from datahub.dataset.pagination import OMISDatasetViewCursorPagination
+from datahub.core.query_utils import (
+    get_full_name_expression,
+    get_string_agg_subquery,
+)
+from datahub.dataset.pagination import (
+    ContactsDatasetViewCursorPagination,
+    OMISDatasetViewCursorPagination,
+)
+from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.omis.order.models import Order
 
 
@@ -69,4 +77,49 @@ class OMISDatasetView(HawkResponseSigningMixin, APIView):
             'status',
             'subtotal_cost',
             'uk_region__name',
+        )
+
+
+class ContactsDatasetView(HawkResponseSigningMixin, APIView):
+    """
+    An APIView that provides 'get' action which queries and returns desired fields for
+    Contacts Dataset to be consumed by Data-flow periodically. Data-flow uses response result
+    to insert data into Dataworkspace through its defined API endpoints. The goal is presenting
+    various reports to the users out of flattened table and let analyst to work on denormalized
+    table to get more meaningful insight.
+    """
+
+    authentication_classes = (HawkAuthentication, )
+    permission_classes = (HawkScopePermission, )
+    required_hawk_scope = HawkScope.data_flow_api
+    pagination_class = ContactsDatasetViewCursorPagination
+
+    def get(self, request):
+        """Endpoint which serves all records for Contacts Dataset"""
+        dataset = self.get_dataset()
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(dataset, request, view=self)
+        return paginator.get_paginated_response(page)
+
+    def get_dataset(self):
+        """Returns list of Contacts Dataset records"""
+        return Contact.objects.annotate(
+            name=get_full_name_expression(),
+            company_sector=get_sector_name_subquery('company__sector'),
+        ).values(
+            'accepts_dit_email_marketing',
+            'address_country__name',
+            'address_postcode',
+            'company__company_number',
+            'company__name',
+            'company__uk_region__name',
+            'company_sector',
+            'created_on',
+            'email',
+            'email_alternative',
+            'job_title',
+            'name',
+            'notes',
+            'telephone_alternative',
+            'telephone_number',
         )


### PR DESCRIPTION
### Description of change
Adds an api endpoint for Contacts dataset under datasets app (/v4/datasets/contacts-dataset)
Adds test for ContactsDatasetView

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [X] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
