### PR TITLE
Add `pending_dnb_investigation` to company serializer and API endpoints

### DIFF
--- a/changelog/company/company-pending-dnb-investigation.api.rst
+++ b/changelog/company/company-pending-dnb-investigation.api.rst
@@ -1,0 +1,7 @@
+The ``GET /v4/company`` and ``GET /v4/company/<uuid:pk>`` endpoints were 
+modified to return the boolean ``pending_dnb_investigation`` in responses.  
+The format of the responses are as follows::
+
+  ...
+  "pending_dnb_investigation": true,
+  ...

--- a/changelog/dnb-create-company-pending-investigation.api.rst
+++ b/changelog/dnb-create-company-pending-investigation.api.rst
@@ -1,0 +1,10 @@
+The ``POST /v4/dnb/company-create`` endpoint was modified to return the boolean
+``pending_dnb_investigation`` in responses representing created Data Hub 
+companies.  
+
+The format of the response is as follows::
+
+  ...
+  "pending_dnb_investigation": true,
+  ...
+

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -439,6 +439,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'export_experience_category',
             'address',
             'registered_address',
+            'pending_dnb_investigation',
         )
         read_only_fields = (
             'archived',
@@ -452,6 +453,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'is_turnover_estimated',
             'number_of_employees',
             'is_number_of_employees_estimated',
+            'pending_dnb_investigation',
         )
         dnb_read_only_fields = (
             'name',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -326,6 +326,7 @@ class TestGetCompany(APITestMixin):
             'transferred_on': None,
             'transferred_to': None,
             'transfer_reason': '',
+            'pending_dnb_investigation': False,
         }
 
     def test_get_company_without_country(self):
@@ -368,6 +369,27 @@ class TestGetCompany(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['website'] == expected_website
+
+    @pytest.mark.parametrize(
+        'pending_dnb_investigation',
+        (
+            True,
+            False,
+        ),
+    )
+    def test_get_company_pending_dnb_investigation(self, pending_dnb_investigation):
+        """
+        Test that `pending_dnb_investigation` is set for a company API result
+        as expected.
+        """
+        company = CompanyFactory(
+            pending_dnb_investigation=pending_dnb_investigation,
+        )
+        url = reverse('api-v4:company:item', kwargs={'pk': company.pk})
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['pending_dnb_investigation'] == pending_dnb_investigation
 
     @pytest.mark.parametrize(
         'build_company',
@@ -664,6 +686,7 @@ class TestUpdateCompany(APITestMixin):
             is_turnover_estimated=False,
             number_of_employees=95,
             is_number_of_employees_estimated=False,
+            pending_dnb_investigation=True,
         )
 
         url = reverse('api-v4:company:item', kwargs={'pk': company.pk})
@@ -679,6 +702,7 @@ class TestUpdateCompany(APITestMixin):
                 'is_turnover_estimated': True,
                 'number_of_employees': 96,
                 'is_number_of_employees_estimated': True,
+                'pending_dnb_investigation': False,
             },
         )
 
@@ -696,6 +720,7 @@ class TestUpdateCompany(APITestMixin):
         assert not response_data['is_turnover_estimated']
         assert response_data['number_of_employees'] == 95
         assert not response_data['is_number_of_employees_estimated']
+        assert response_data['pending_dnb_investigation']
 
     def test_cannot_update_dnb_readonly_fields_if_duns_number_is_set(self):
         """

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -375,6 +375,7 @@ class TestDNBCompanyCreateAPI(APITestMixin):
             'transferred_to': None,
             'transferred_on': None,
             'contacts': [],
+            'pending_dnb_investigation': False,
         }
 
     def test_post_non_uk(


### PR DESCRIPTION
### Description of change

The ``GET /v4/company`` and ``GET /v4/company/<uuid:pk>`` endpoints were modified to return the boolean ``pending_dnb_investigation`` in responses.

This will allow the frontend to display a banner expressing that the company is under investigation on the company detail page.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
