### PR TITLE
Add API endpoint for fetching all interactions and service deliveries

### DIFF
--- a/changelog/interaction/interactions-dataset-api-endpoint.api.rst
+++ b/changelog/interaction/interactions-dataset-api-endpoint.api.rst
@@ -1,0 +1,3 @@
+Added service deliveries and interactions endpoint:
+
+- ``GET /v4/dataset/service-deliveries-and-interactions-dataset``: Returns all interactions to be consumed by data-flow and used in data-workspace for reporting and analyst access.

--- a/changelog/interaction/interactions-dataset-api-endpoint.api.rst
+++ b/changelog/interaction/interactions-dataset-api-endpoint.api.rst
@@ -1,3 +1,3 @@
 Added service deliveries and interactions endpoint:
 
-- ``GET /v4/dataset/service-deliveries-and-interactions-dataset``: Returns all interactions to be consumed by data-flow and used in data-workspace for reporting and analyst access.
+- ``GET /v4/dataset/interactions-dataset``: Returns all interactions to be consumed by data-flow and used in data-workspace for reporting and analyst access.

--- a/datahub/dataset/pagination.py
+++ b/datahub/dataset/pagination.py
@@ -15,3 +15,11 @@ class ContactsDatasetViewCursorPagination(CursorPagination):
     """
 
     ordering = ('created_on', 'pk')
+
+
+class InteractionsDatasetViewCursorPagination(CursorPagination):
+    """
+    Cursor Pagination for InteractionsDatasetView
+    """
+
+    ordering = ('created_on', 'pk')

--- a/datahub/dataset/urls.py
+++ b/datahub/dataset/urls.py
@@ -6,9 +6,5 @@ from datahub.dataset.views import ContactsDatasetView, InteractionsDatasetView, 
 urlpatterns = [
     path('omis-dataset', OMISDatasetView.as_view(), name='omis-dataset'),
     path('contacts-dataset', ContactsDatasetView.as_view(), name='contacts-dataset'),
-    path(
-        'service-deliveries-and-interactions-dataset',
-        InteractionsDatasetView.as_view(),
-        name='interactions-dataset',
-    ),
+    path('interactions-dataset', InteractionsDatasetView.as_view(), name='interactions-dataset'),
 ]

--- a/datahub/dataset/urls.py
+++ b/datahub/dataset/urls.py
@@ -1,9 +1,14 @@
 from django.urls import path
 
-from datahub.dataset.views import ContactsDatasetView, OMISDatasetView
+from datahub.dataset.views import ContactsDatasetView, InteractionsDatasetView, OMISDatasetView
 
 
 urlpatterns = [
     path('omis-dataset', OMISDatasetView.as_view(), name='omis-dataset'),
     path('contacts-dataset', ContactsDatasetView.as_view(), name='contacts-dataset'),
+    path(
+        'service-deliveries-and-interactions-dataset',
+        InteractionsDatasetView.as_view(),
+        name='interactions-dataset',
+    ),
 ]

--- a/datahub/dataset/views.py
+++ b/datahub/dataset/views.py
@@ -1,3 +1,5 @@
+from django.db.models import OuterRef, Subquery, Value
+from django.db.models.functions import Concat
 from rest_framework.views import APIView
 
 from config.settings.types import HawkScope
@@ -7,15 +9,21 @@ from datahub.core.hawk_receiver import (
     HawkResponseSigningMixin,
     HawkScopePermission,
 )
+from datahub.core.model_helpers import get_m2m_model
 from datahub.core.query_utils import (
+    get_front_end_url_expression,
     get_full_name_expression,
     get_string_agg_subquery,
+    get_top_related_expression_subquery,
 )
 from datahub.dataset.pagination import (
     ContactsDatasetViewCursorPagination,
+    InteractionsDatasetViewCursorPagination,
     OMISDatasetViewCursorPagination,
 )
-from datahub.metadata.query_utils import get_sector_name_subquery
+from datahub.interaction.models import Interaction, InteractionDITParticipant
+from datahub.interaction.queryset import get_base_interaction_queryset
+from datahub.metadata.query_utils import get_sector_name_subquery, get_service_name_subquery
 from datahub.omis.order.models import Order
 
 
@@ -122,4 +130,122 @@ class ContactsDatasetView(HawkResponseSigningMixin, APIView):
             'notes',
             'telephone_alternative',
             'telephone_number',
+        )
+
+
+class InteractionsDatasetView(HawkResponseSigningMixin, APIView):
+    """
+    A GET API view to return all interaction and service delivery data as required
+    for syncing by Data-flow periodically.
+
+    Data-flow uses the resulting response to insert data into Dataworkspace which can
+    then be queried to create custom reports for users.
+    """
+
+    authentication_classes = (HawkAuthentication, )
+    permission_classes = (HawkScopePermission, )
+    required_hawk_scope = HawkScope.data_flow_api
+    pagination_class = InteractionsDatasetViewCursorPagination
+
+    def get(self, request):
+        """Endpoint which serves all records for service deliveries and interactions dataset"""
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(self.get_dataset(), request, view=self)
+        return paginator.get_paginated_response(page)
+
+    def get_dataset(self):
+        """Returns a list of all interaction and service delivery records"""
+        contacts_m2m_model = get_m2m_model(Interaction, 'contacts')
+        first_contact_queryset = contacts_m2m_model.objects.filter(
+            interaction_id=OuterRef('pk'),
+        ).order_by(
+            'pk',
+        )[:1]
+        return get_base_interaction_queryset().annotate(
+            sector=get_sector_name_subquery('company__sector'),
+            contacts_name=get_full_name_expression(person_field_name='contacts'),
+            interaction_link=get_front_end_url_expression('interaction', 'pk'),
+            adviser_name=get_top_related_expression_subquery(
+                InteractionDITParticipant.interaction.field,
+                get_full_name_expression('adviser'),
+                ('-id',),
+            ),
+            adviser_phone=get_top_related_expression_subquery(
+                InteractionDITParticipant.interaction.field,
+                'adviser__telephone_number',
+                ('-id',),
+            ),
+            adviser_email=get_top_related_expression_subquery(
+                InteractionDITParticipant.interaction.field,
+                'adviser__email',
+                ('-id',),
+            ),
+            adviser_team=get_top_related_expression_subquery(
+                InteractionDITParticipant.interaction.field,
+                'adviser__dit_team__name',
+                ('-id',),
+            ),
+            service_delivery=get_service_name_subquery('service'),
+            event_service=get_service_name_subquery('event__service'),
+            contact_first_name=Subquery(first_contact_queryset.values('contact__first_name')),
+            contact_last_name=Subquery(first_contact_queryset.values('contact__last_name')),
+            contact_name=Concat('contact_first_name', Value(' '), 'contact_last_name'),
+            contact_telephone_number=Subquery(
+                first_contact_queryset.values('contact__telephone_number'),
+            ),
+            contact_email=Subquery(first_contact_queryset.values('contact__email')),
+            contact_address_postcode=Subquery(
+                first_contact_queryset.values('contact__address_postcode'),
+            ),
+            contact_address_1=Subquery(first_contact_queryset.values('contact__address_1')),
+            contact_address_2=Subquery(first_contact_queryset.values('contact__address_2')),
+            contact_address_town=Subquery(first_contact_queryset.values('contact__address_town')),
+            contact_address_country=Subquery(
+                first_contact_queryset.values('contact__address_country__name'),
+            ),
+        ).values(
+            'date',
+            'kind',
+            'company__name',
+            'company__company_number',
+            'company__id',
+            'investment_project__cdms_project_code',
+            'company__address_postcode',
+            'company__address_1',
+            'company__address_2',
+            'company__address_town',
+            'company__address_country__name',
+            'company__website',
+            'company__employee_range__name',
+            'company__turnover_range__name',
+            'sector',
+            'contact_name',
+            'contact_telephone_number',
+            'contact_email',
+            'contact_address_postcode',
+            'contact_address_1',
+            'contact_address_2',
+            'contact_address_town',
+            'contact_address_country',
+            'adviser_name',
+            'adviser_phone',
+            'adviser_email',
+            'adviser_team',
+            'company__uk_region__name',
+            'service_delivery',
+            'subject',
+            'notes',
+            'net_company_receipt',
+            'grant_amount_offered',
+            'service_delivery_status__name',
+            'event__name',
+            'event__event_type__name',
+            'event__start_date',
+            'event__address_town',
+            'event__address_country__name',
+            'event__uk_region__name',
+            'event_service',
+            'created_on',
+            'communication_channel__name',
+            'interaction_link',
         )


### PR DESCRIPTION
### Description of change

Adds a new API endpoint (`/v4/dataset/service-deliveries-and-interactions-dataset`) under the datasets app and associated tests.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
