### PR TITLE
Add a metadata endpoint for one list tiers

### DIFF
--- a/changelog/company/one-list-tier-metadata.api.rst
+++ b/changelog/company/one-list-tier-metadata.api.rst
@@ -1,0 +1,12 @@
+A metadata API endpoint was added for One List Tiers.
+``GET /metadata/one-list-tier`` lists all One List Tier models in the following
+format::
+
+    [
+        {
+            "id": "b91bf800-8d53-e311-aef3-441ea13961e2",
+            "name": "Tier A - Strategic Account",
+            "disabled_on": null
+        },
+        ...,
+    ]

--- a/changelog/company/one-list-tier-metadata.api.rst
+++ b/changelog/company/one-list-tier-metadata.api.rst
@@ -1,6 +1,6 @@
-A metadata API endpoint was added for One List Tiers.
-``GET /metadata/one-list-tier`` lists all One List Tier models in the following
-format::
+Two metdata API endpoints were added for One List Tiers.
+``GET /metadata/one-list-tier/`` and ``GET /v4/metadata/one-list-tier`` list 
+all One List Tier models in the following format::
 
     [
         {

--- a/datahub/company/metadata.py
+++ b/datahub/company/metadata.py
@@ -19,5 +19,5 @@ registry.register(
 registry.register(
     metadata_id='one-list-tier',
     model=OneListTier,
-    queryset=OneListTier.objects.filter(disabled_on__isnull=True),
+    queryset=OneListTier.objects.all(),
 )

--- a/datahub/company/metadata.py
+++ b/datahub/company/metadata.py
@@ -19,5 +19,4 @@ registry.register(
 registry.register(
     metadata_id='one-list-tier',
     model=OneListTier,
-    queryset=OneListTier.objects.all(),
 )

--- a/datahub/company/metadata.py
+++ b/datahub/company/metadata.py
@@ -1,4 +1,4 @@
-from datahub.company.models import ExportExperienceCategory
+from datahub.company.models import ExportExperienceCategory, OneListTier
 from datahub.metadata.fixtures import Fixture
 from datahub.metadata.registry import registry
 
@@ -14,4 +14,10 @@ class InteractionFixtures(Fixture):
 registry.register(
     metadata_id='export-experience-category',
     model=ExportExperienceCategory,
+)
+
+registry.register(
+    metadata_id='one-list-tier',
+    model=OneListTier,
+    queryset=OneListTier.objects.filter(disabled_on__isnull=True),
 )


### PR DESCRIPTION
### Description of change

As part of work to allow users to filter Interaction searches by a company's one list group tier, we need to expose one list tiers to the frontend as a consumable metadata endpoint.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
