### PR TITLE
Update metadata hawk configuration key name

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -527,7 +527,7 @@ _add_hawk_credentials(
 
 _add_hawk_credentials(
     'DATA_HUB_FRONTEND_ACCESS_KEY_ID',
-    'DATA_HUB_FRONTEND_ACCESS_KEY',
+    'DATA_HUB_FRONTEND_SECRET_ACCESS_KEY',
     (HawkScope.metadata, ),
 )
 


### PR DESCRIPTION
### Description of change

I have made a mistake and added incorrect key label for hawk credentials. This fixes it.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
