### PR TITLE
Add monitoring code to dnb_api views.

### DIFF
--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -1,4 +1,5 @@
 import datetime
+from unittest.mock import Mock
 
 import pytest
 from django.utils.timezone import utc
@@ -203,3 +204,16 @@ def investigation_payload():
         'sector': Sector.renewable_energy_wind.value.id,
         'uk_region': UKRegion.east_midlands.value.id,
     }
+
+
+@pytest.fixture
+def statsd_mock(monkeypatch):
+    """
+    Returns a mock statsd client instance.
+    """
+    mock_statsd = Mock()
+    monkeypatch.setattr(
+        'datahub.dnb_api.views.statsd',
+        mock_statsd,
+    )
+    return mock_statsd

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -307,6 +307,40 @@ class TestDNBCompanySearchAPI(APITestMixin):
         assert response.status_code == response_status_code
         assert json.loads(response.content) == response_data
 
+    @pytest.mark.parametrize(
+        'response_status_code',
+        (
+            status.HTTP_200_OK,
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
+    def test_monitoring(
+        self,
+        dnb_company_search_feature_flag,
+        requests_mock,
+        statsd_mock,
+        response_status_code,
+    ):
+        """
+        Test that the right counter is incremented for the given status code
+        returned by the dnb-service.
+        """
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=response_status_code,
+            json={},
+        )
+        self.api_client.post(
+            reverse('api-v4:dnb-api:company-search'),
+            content_type='application/json',
+        )
+        statsd_mock.incr.assert_called_once_with(
+            f'dnb.search.{response_status_code}',
+        )
+
 
 class TestDNBCompanyCreateAPI(APITestMixin):
     """
@@ -681,6 +715,68 @@ class TestDNBCompanyCreateAPI(APITestMixin):
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
+    @pytest.mark.parametrize(
+        'response_status_code',
+        (
+            status.HTTP_200_OK,
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
+    def test_monitoring_search(
+        self,
+        dnb_company_search_feature_flag,
+        requests_mock,
+        statsd_mock,
+        response_status_code,
+    ):
+        """
+        Test that the right counter is incremented for the given status code
+        returned by the dnb-service.
+        """
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=response_status_code,
+            json={},
+        )
+        self.api_client.post(
+            reverse('api-v4:dnb-api:company-create'),
+            data={
+                'duns_number': 123456789,
+            },
+        )
+        statsd_mock.incr.assert_called_once_with(
+            f'dnb.search.{response_status_code}',
+        )
+
+    def test_monitoring_create(
+        self,
+        dnb_company_search_feature_flag,
+        dnb_response_uk,
+        requests_mock,
+        statsd_mock,
+    ):
+        """
+        Test that the right counter is incremented when a company gets
+        created using dnb-service.
+        """
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=status.HTTP_200_OK,
+            json=dnb_response_uk,
+        )
+        self.api_client.post(
+            reverse('api-v4:dnb-api:company-create'),
+            data={
+                'duns_number': 123456789,
+            },
+        )
+        statsd_mock.incr.assert_called_with(
+            f'dnb.create.company',
+        )
+
 
 class TestDNBCompanyCreateInvestigationAPI(APITestMixin):
     """
@@ -822,3 +918,21 @@ class TestDNBCompanyCreateInvestigationAPI(APITestMixin):
         )
 
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_monitoring_create(
+        self,
+        dnb_company_search_feature_flag,
+        investigation_payload,
+        statsd_mock,
+    ):
+        """
+        Test that the right counter is incremented when a stub company
+        gets created for investigation by DNB.
+        """
+        self.api_client.post(
+            reverse('api-v4:dnb-api:company-create-investigation'),
+            data=investigation_payload,
+        )
+        statsd_mock.incr.assert_called_with(
+            f'dnb.create.investigation',
+        )


### PR DESCRIPTION
### Description of change

Adding a bit of monitoring around `dnb` endpoints in preparation for release.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?