### PR TITLE
Log serializer errors when saving DNB companies

### DIFF
--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -137,12 +137,6 @@ class DNBCompanySearchView(APIView):
         return hydrated_results
 
 
-class DNBDataFailedSaveValidation(Exception):
-    """
-    Exception for when DNB company data could not be saved as a Data Hub Company model.
-    """
-
-
 class DNBCompanyCreateView(APIView):
     """
     View for creating datahub company from DNB data.

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -3,6 +3,7 @@ import logging
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
+from rest_framework import serializers
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -136,6 +137,12 @@ class DNBCompanySearchView(APIView):
         return hydrated_results
 
 
+class DNBDataFailedSaveValidation(Exception):
+    """
+    Exception for when DNB company data could not be saved as a Data Hub Company model.
+    """
+
+
 class DNBCompanyCreateView(APIView):
     """
     View for creating datahub company from DNB data.
@@ -180,13 +187,24 @@ class DNBCompanyCreateView(APIView):
             logger.error(error_message)
             raise APIUpstreamException(error_message)
 
+        formatted_company_data = format_dnb_company(
+            dnb_companies[0],
+        )
         company_serializer = DNBCompanySerializer(
-            data=format_dnb_company(
-                dnb_companies[0],
-            ),
+            data=formatted_company_data,
         )
 
-        company_serializer.is_valid(raise_exception=True)
+        try:
+            company_serializer.is_valid(raise_exception=True)
+        except serializers.ValidationError:
+            logger.error(
+                'Company data sourced from DNB:\n'
+                f'{formatted_company_data}\n'
+                'Failed serializer validation with errors:\n'
+                f'{company_serializer.errors}',
+            )
+            raise
+
         datahub_company = company_serializer.save(
             created_by=request.user,
             modified_by=request.user,


### PR DESCRIPTION
### Description of change

This change ensures that any validation errors encountered when serializing DNB company data in to the Data Hub company serializer will be logged to sentry.  This change will allow us to react to problems with the new "add a company" journey much more quickly and will allow cross-team visibility for problems that would not otherwise be exposed.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
