### PR TITLE
Fixed DNB company create endpoint when domain is null

### DIFF
--- a/changelog/dnb-api-save-company-website.bugfix.rst
+++ b/changelog/dnb-api-save-company-website.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed a bug in the DNB company save API endpoint which prevented DNB companies
+with no value for `domain` being saved as Data Hub companies.

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -613,8 +613,9 @@ class TestDNBCompanyCreateAPI(APITestMixin):
         field_overrides,
     ):
         """
-        Test if dnb-service returns a company with missing required fields,
-        the create-company endpoint returns 400.
+        Test if dnb-service returns a company with missing optional fields,
+        the create-company endpoint still returns 200 and the company is saved
+        successfully.
         """
         dnb_response_uk['results'][0].update(field_overrides)
         requests_mock.post(

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -595,6 +595,44 @@ class TestDNBCompanyCreateAPI(APITestMixin):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json() == expected_error
 
+    @pytest.mark.parametrize(
+        'field_overrides',
+        (
+            {'domain': None},
+            {'trading_names': []},
+            {'annual_sales': None},
+            {'employee_number': None},
+            {'is_employee_number_estimated': None},
+        ),
+    )
+    def test_post_missing_optional_fields(
+        self,
+        requests_mock,
+        dnb_company_search_feature_flag,
+        dnb_response_uk,
+        field_overrides,
+    ):
+        """
+        Test if dnb-service returns a company with missing required fields,
+        the create-company endpoint returns 400.
+        """
+        dnb_response_uk['results'][0].update(field_overrides)
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response_uk,
+        )
+
+        response = self.api_client.post(
+            reverse('api-v4:dnb-api:company-create'),
+            data={
+                'duns_number': 123456789,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        created_company = Company.objects.first()
+        assert created_company.name == dnb_response_uk['results'][0]['primary_name']
+
     def test_post_existing(
         self,
         dnb_company_search_feature_flag,

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -45,6 +45,9 @@ def format_dnb_company(dnb_company):
         for reg in dnb_company['registration_numbers']
     }
 
+    domain = dnb_company.get('domain')
+    company_website = f'http://{domain}' if domain else None
+
     return {
         'name': dnb_company.get('primary_name'),
         'trading_names': dnb_company.get('trading_names'),
@@ -66,7 +69,7 @@ def format_dnb_company(dnb_company):
         'is_number_of_employees_estimated': dnb_company.get('is_employees_number_estimated'),
         'turnover': dnb_company.get('annual_sales'),
         'is_turnover_estimated': dnb_company.get('is_annual_sales_estimated'),
-        'website': f'http://{dnb_company.get("domain")}',
+        'website': company_website,
         # TODO: Extract sensible values for the following fields form the data:
         # 'business_type': None,
         # 'description': None,

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -46,7 +46,7 @@ def format_dnb_company(dnb_company):
     }
 
     domain = dnb_company.get('domain')
-    company_website = f'http://{domain}' if domain else None
+    company_website = f'http://{domain}' if domain else ''
 
     return {
         'name': dnb_company.get('primary_name'),


### PR DESCRIPTION
### Description of change

This fixes a bug where the DNB company create endpoint was giving a 400 when DNB responded with a company response which had `"domain": null`.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
