### PR TITLE
POC for keeping the audit history working

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -604,3 +604,7 @@ DATAHUB_SUPPORT_EMAIL_ADDRESS = env('DATAHUB_SUPPORT_EMAIL_ADDRESS', default=Non
 STATSD_HOST = env('STATSD_HOST', default='localhost')
 STATSD_PORT = env('STATSD_PORT', default='9125')
 STATSD_PREFIX = env('STATSD_PREFIX', default='datahub-api')
+
+SERIALIZATION_MODULES = {
+    'company': 'datahub.company.django_serializers.company',
+}

--- a/datahub/company/django_serializers/company.py
+++ b/datahub/company/django_serializers/company.py
@@ -6,7 +6,6 @@ from django.core.serializers.json import (
 
 class Serializer(JSONSerializer):
     def handle_m2m_field(self, obj, field):
-
         if field.name == 'future_interest_countries':
             self._current[field.name] = [
                 self._value_from_field(value, value._meta.pk)

--- a/datahub/company/django_serializers/company.py
+++ b/datahub/company/django_serializers/company.py
@@ -1,0 +1,20 @@
+from django.core.serializers.json import (
+    Serializer as JSONSerializer,
+    Deserializer as JSONDeserializer,
+)
+
+
+class Serializer(JSONSerializer):
+    def handle_m2m_field(self, obj, field):
+
+        if field.name == 'future_interest_countries':
+            self._current[field.name] = [
+                self._value_from_field(value, value._meta.pk)
+                for value in obj.get_active_future_export_countries()
+            ]
+        else:
+            super().handle_m2m_field(obj, field)
+
+
+class Deserializer(JSONSerializer):
+    pass

--- a/datahub/company/django_serializers/company.py
+++ b/datahub/company/django_serializers/company.py
@@ -1,11 +1,26 @@
 from django.core.serializers.json import (
-    Serializer as JSONSerializer,
     Deserializer as JSONDeserializer,
+    Serializer as JSONSerializer,
 )
 
 
 class Serializer(JSONSerializer):
+    """
+    Serializer to customise the way we store companies in reversion Versions.
+    1. Change future_interest_countries field in the serialised format to a list
+        of IDs of countries returned by the get_active_future_export_countries method on the
+        company.
+    """
+
     def handle_m2m_field(self, obj, field):
+        """
+        Custom handling of m2m fields. For most fields,
+        return the default rendering from the super class.
+        However:
+        1. If the field name is 'future_interest_countries',
+            instead call the get_active_future_export_countries method on the object,
+            and return a list of ids of the countries thereby returned.
+        """
         if field.name == 'future_interest_countries':
             self._current[field.name] = [
                 self._value_from_field(value, value._meta.pk)
@@ -15,5 +30,8 @@ class Serializer(JSONSerializer):
             super().handle_m2m_field(obj, field)
 
 
-class Deserializer(JSONSerializer):
-    pass
+def Deserializer(stream_or_string, **options):  # noqa: N802
+    """
+    TODO: Do we need this to work?
+    """
+    return JSONDeserializer(stream_or_string, **options)

--- a/datahub/company/django_serializers/company.py
+++ b/datahub/company/django_serializers/company.py
@@ -12,22 +12,16 @@ class Serializer(JSONSerializer):
         company.
     """
 
-    def handle_m2m_field(self, obj, field):
+    def end_object(self, obj):
         """
-        Custom handling of m2m fields. For most fields,
-        return the default rendering from the super class.
-        However:
-        1. If the field name is 'future_interest_countries',
-            instead call the get_active_future_export_countries method on the object,
-            and return a list of ids of the countries thereby returned.
+        Change the serialized data for the future_interest_countries field,
+        and then call end_object on the super class.
         """
-        if field.name == 'future_interest_countries':
-            self._current[field.name] = [
-                self._value_from_field(value, value._meta.pk)
-                for value in obj.get_active_future_export_countries()
-            ]
-        else:
-            super().handle_m2m_field(obj, field)
+        self._current['future_interest_countries'] = [
+            self._value_from_field(value, value._meta.pk)
+            for value in obj.get_active_future_export_countries()
+        ]
+        return super().end_object(obj)
 
 
 def Deserializer(stream_or_string, **options):  # noqa: N802

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -51,7 +51,8 @@ class OneListTier(BaseOrderedConstantModel):
     """One List tier."""
 
 
-@reversion.register_base_model(follow=['unfiltered_export_countries'])
+import datahub.company.django_serializers.company
+@reversion.register_base_model(follow=['unfiltered_export_countries'], format="company")
 class Company(ArchivableModel, BaseModel):
     """Representation of the company."""
 
@@ -510,7 +511,7 @@ class CompaniesHouseCompany(models.Model):
         verbose_name_plural = 'Companies House companies'
 
 
-@reversion.register_base_model()
+@reversion.register_base_model(follow=('company',))
 class CompanyExportCountry(models.Model):
     """
     Record that a Company is interested in exporting to a Country.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -51,7 +51,7 @@ class OneListTier(BaseOrderedConstantModel):
     """One List tier."""
 
 
-@reversion.register_base_model(format="company")
+@reversion.register_base_model(format='company')
 class Company(ArchivableModel, BaseModel):
     """Representation of the company."""
 

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -51,8 +51,7 @@ class OneListTier(BaseOrderedConstantModel):
     """One List tier."""
 
 
-import datahub.company.django_serializers.company
-@reversion.register_base_model(follow=['unfiltered_export_countries'], format="company")
+@reversion.register_base_model(format="company")
 class Company(ArchivableModel, BaseModel):
     """Representation of the company."""
 

--- a/datahub/company/signals.py
+++ b/datahub/company/signals.py
@@ -49,3 +49,17 @@ def notify_dnb_investigation_post_save(sender, instance, created, raw, **kwargs)
 def _notify_dnb_investigation_post_save(instance):
     logger.info(f'Company with ID {instance.id} is pending DNB investigation.')
     notify_new_dnb_investigation(instance)
+
+
+import reversion
+def _re_add_company_to_revision(sender, revision, versions, **kwargs):
+    found_companies = []
+    import ipdb
+    ipdb.set_trace()
+    for version in versions:
+        if isinstance(version.object, Company):
+            found_companies.append(version.object)
+    for company in found_companies:
+        reversion.add_to_revision(company)
+
+reversion.signals.pre_revision_commit.connect(_re_add_company_to_revision)

--- a/datahub/company/signals.py
+++ b/datahub/company/signals.py
@@ -51,10 +51,11 @@ def _notify_dnb_investigation_post_save(instance):
     logger.info(f'Company with ID {instance.id} is pending DNB investigation.')
     notify_new_dnb_investigation(instance)
 
+
 @receiver(
     post_save,
     sender=CompanyExportCountry,
-    dispatch_uid='add_company_to_revision_after_post_export_country_save'
+    dispatch_uid='add_company_to_revision_after_post_export_country_save',
 )
 def _add_company_to_revision_post_save(sender, instance, created, raw, **kwargs):
     """
@@ -76,7 +77,7 @@ def _add_company_to_revision_post_save(sender, instance, created, raw, **kwargs)
 @receiver(
     post_delete,
     sender=CompanyExportCountry,
-    dispatch_uid='add_company_to_revision_after_post_export_country_delete'
+    dispatch_uid='add_company_to_revision_after_post_export_country_delete',
 )
 def _add_company_to_revision_post_delete(sender, instance, using, **kwargs):
     """


### PR DESCRIPTION
This is a POC only to show a solution that actually does everything we need it to, but might be slightly hacky.

The problem is that the feature under development in feature/country-of-interest-model will break audit history for future_interest_countries. This branch creates a custom django serializer which fills that old field name using the new get_active_future_export_countries method.