### PR TITLE
Add company search filters for future_interest_countries and export_to_countries fields

### DIFF
--- a/changelog/company/export-to-countries-filter.api.md
+++ b/changelog/company/export-to-countries-filter.api.md
@@ -1,0 +1,1 @@
+`POST /v4/search/company`: A filter was added for the `export_to_countries` field. This accepts a list of country IDs. A company will only be returned if it contains one of the specified countries in this field.

--- a/changelog/company/future-interest-countries-filter.api.md
+++ b/changelog/company/future-interest-countries-filter.api.md
@@ -1,0 +1,1 @@
+`POST /v4/search/company`: A filter was added for the `future_interest_countries` field. This accepts a list of country IDs. A company will only be returned if it contains one of the specified countries in this field.

--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -8,6 +8,7 @@ from datahub.company.ch_constants import COMPANY_CATEGORY_TO_BUSINESS_TYPE_MAPPI
 from datahub.company.constants import BusinessTypeConstant
 from datahub.company.models import Advisor, Company, ExportExperienceCategory
 from datahub.core import constants
+from datahub.core.test.factories import to_many_field
 from datahub.core.test_utils import random_obj_for_model
 from datahub.metadata.models import EmployeeRange, HeadquarterType, TurnoverRange
 from datahub.metadata.test.factories import TeamFactory
@@ -67,6 +68,20 @@ class CompanyFactory(factory.django.DjangoModelFactory):
     is_number_of_employees_estimated = True
     archived_documents_url_path = factory.Faker('uri_path')
     created_on = now()
+
+    @to_many_field
+    def export_to_countries(self):  # noqa: D102
+        """
+        Add support for setting `export_to_countries`.
+        """
+        return []
+
+    @to_many_field
+    def future_interest_countries(self):  # noqa: D102
+        """
+        Add support for setting `future_interest_countries`.
+        """
+        return []
 
     class Params:
         hq = factory.Trait(

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -21,6 +21,8 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
     country = SingleOrListField(child=StringUUIDField(), required=False)
     uk_based = serializers.BooleanField(required=False)
     uk_region = SingleOrListField(child=StringUUIDField(), required=False)
+    export_to_countries = SingleOrListField(child=StringUUIDField(), required=False)
+    future_interest_countries = SingleOrListField(child=StringUUIDField(), required=False)
 
     SORT_BY_FIELDS = (
         'modified_on',

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -46,6 +46,13 @@ def setup_data(setup_es):
         address_country_id=country_uk,
         registered_address_country_id=country_uk,
         uk_region_id=uk_region,
+        export_to_countries=[
+            constants.Country.france.value.id,
+        ],
+        future_interest_countries=[
+            constants.Country.japan.value.id,
+            constants.Country.united_states.value.id,
+        ],
     )
     CompanyFactory(
         name='abc defg us ltd',
@@ -54,6 +61,13 @@ def setup_data(setup_es):
         address_town='Downtown',
         address_country_id=country_us,
         registered_address_country_id=country_us,
+        export_to_countries=[
+            constants.Country.canada.value.id,
+            constants.Country.france.value.id,
+        ],
+        future_interest_countries=[
+            constants.Country.japan.value.id,
+        ],
     )
     CompanyFactory(
         name='archived',
@@ -235,6 +249,38 @@ class TestSearch(APITestMixin):
             (
                 {
                     'uk_based': True,
+                },
+                ['abc defg ltd'],
+            ),
+
+            # export_to_countries
+            (
+                {
+                    'export_to_countries': constants.Country.france.value.id,
+                },
+                ['abc defg ltd', 'abc defg us ltd'],
+            ),
+
+            # export_to_countries
+            (
+                {
+                    'export_to_countries': constants.Country.canada.value.id,
+                },
+                ['abc defg us ltd'],
+            ),
+
+            # future_interest_countries
+            (
+                {
+                    'future_interest_countries': constants.Country.japan.value.id,
+                },
+                ['abc defg ltd', 'abc defg us ltd'],
+            ),
+
+            # future_interest_countries
+            (
+                {
+                    'future_interest_countries': constants.Country.united_states.value.id,
                 },
                 ['abc defg ltd'],
             ),

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -859,14 +859,31 @@ class TestAutocompleteSearch(APITestMixin):
     @pytest.mark.parametrize(
         'limit,expected_companies',
         (
-            (10, ['abc defg ltd', 'abc defg us ltd']),  # only 2 found
-            (2, ['abc defg ltd', 'abc defg us ltd']),
-            (1, ['abc defg ltd']),
+            (10, ['abc abc defg ltd', 'abc defg us ltd']),  # only 2 found
+            (2, ['abc abc defg ltd', 'abc defg us ltd']),
+            (1, ['abc abc defg ltd']),
         ),
     )
-    def test_searching_with_limit(self, setup_data, limit, expected_companies):
+    def test_searching_with_limit(self, setup_es, limit, expected_companies):
         """Tests case where search limit is provided."""
         url = reverse('api-v4:search:company-autocomplete')
+
+        country_uk = constants.Country.united_kingdom.value.id
+        country_us = constants.Country.united_states.value.id
+        CompanyFactory(
+            name='abc abc defg ltd',
+            trading_names=['helm', 'nop'],
+            address_country_id=country_uk,
+            registered_address_country_id=country_uk,
+        )
+        CompanyFactory(
+            name='abc defg us ltd',
+            trading_names=['helm', 'nop', 'qrs'],
+            address_country_id=country_us,
+            registered_address_country_id=country_us,
+        )
+
+        setup_es.indices.refresh()
 
         response = self.api_client.get(
             url,

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -46,11 +46,15 @@ class SearchCompanyAPIViewMixin:
         'country',
         'uk_based',
         'uk_region',
+        'export_to_countries',
+        'future_interest_countries',
     )
 
     REMAP_FIELDS = {
         'headquarter_type': 'headquarter_type.id',
         'uk_region': 'uk_region.id',
+        'export_to_countries': 'export_to_countries.id',
+        'future_interest_countries': 'future_interest_countries.id',
     }
 
     COMPOSITE_FILTERS = {


### PR DESCRIPTION
### Description of change
Add new filters to search companies based on: 
* export_to_countries and 
* future_interest_countries.
as part of Jira ticket, FEX-177

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.rst](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.rst) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
