### PR TITLE
Remove changelog conversion instruction from 'How to prepare a release'

### DIFF
--- a/docs/How to prepare a release.md
+++ b/docs/How to prepare a release.md
@@ -81,7 +81,7 @@ In GitHub, [create a release](https://github.com/uktrade/data-hub-leeloo/release
 * **Tag version**: `v<version>` e.g. `v6.3.0`
 * **Target**: `master`
 * **Release title**: `v<version>` e.g. `v6.3.0`
-* **Describe this release**: copy/paste the notes from the compiled changelog after converting the rst text into md using something like [pandoc](http://pandoc.org/try/).
+* **Describe this release**: copy/paste the notes from the compiled changelog.
 
 And click on _Publish release_.
 


### PR DESCRIPTION
### Description of change

As the changelog is now in Markdown, there is no longer a need to convert it when publishing the release on GitHub.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
