### PR TITLE
Fix intermittently failing company autocomplete tests

### DIFF
--- a/changelog/company/flakey-autocomplete-tests.internal.md
+++ b/changelog/company/flakey-autocomplete-tests.internal.md
@@ -1,0 +1,1 @@
+Some intermittently failing company autocomplete tests were corrected so that they now consistently pass.

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -829,16 +829,16 @@ class TestAutocompleteSearch(APITestMixin):
     @pytest.mark.parametrize(
         'query,expected_companies',
         (
-            ('abc', ['abc abc defg ltd', 'abc defg us ltd']),
+            ('abc', ['abc defg ltd', 'abc defg us ltd']),
             ('abv', []),
-            ('ABC', ['abc abc defg ltd', 'abc defg us ltd']),
+            ('ABC', ['abc defg ltd', 'abc defg us ltd']),
             ('hello', []),
             ('', []),
             (1, []),
-            ('abc abc defg ltd', ['abc abc defg ltd']),
-            ('defg', ['abc abc defg ltd', 'abc defg us ltd']),
+            ('abc defg ltd', ['abc defg ltd']),
+            ('defg', ['abc defg ltd', 'abc defg us ltd']),
             ('us', ['abc defg us ltd']),
-            ('hel', ['abc abc defg ltd', 'abc defg us ltd']),
+            ('hel', ['abc defg ltd', 'abc defg us ltd']),
             ('qrs', ['abc defg us ltd']),
             ('help qrs', []),
         ),
@@ -850,8 +850,8 @@ class TestAutocompleteSearch(APITestMixin):
         country_uk = constants.Country.united_kingdom.value.id
         country_us = constants.Country.united_states.value.id
         CompanyFactory(
-            name='abc abc defg ltd',
-            trading_names=['helm', 'nop'],
+            name='abc defg ltd',
+            trading_names=['abc', 'helm', 'nop'],
             address_country_id=country_uk,
             registered_address_country_id=country_uk,
         )
@@ -876,9 +876,9 @@ class TestAutocompleteSearch(APITestMixin):
     @pytest.mark.parametrize(
         'limit,expected_companies',
         (
-            (10, ['abc abc defg ltd', 'abc defg us ltd']),  # only 2 found
-            (2, ['abc abc defg ltd', 'abc defg us ltd']),
-            (1, ['abc abc defg ltd']),
+            (10, ['abc defg ltd', 'abc defg us ltd']),  # only 2 found
+            (2, ['abc defg ltd', 'abc defg us ltd']),
+            (1, ['abc defg ltd']),
         ),
     )
     def test_searching_with_limit(self, setup_es, limit, expected_companies):
@@ -888,8 +888,8 @@ class TestAutocompleteSearch(APITestMixin):
         country_uk = constants.Country.united_kingdom.value.id
         country_us = constants.Country.united_states.value.id
         CompanyFactory(
-            name='abc abc defg ltd',
-            trading_names=['helm', 'nop'],
+            name='abc defg ltd',
+            trading_names=['abc', 'helm', 'nop'],
             address_country_id=country_uk,
             registered_address_country_id=country_uk,
         )


### PR DESCRIPTION
### Description of change

This fixes two intermittently failing company autocomplete search tests.

The tests assumed that the two companies would be returned in a particular order, but this was not guaranteed because the two documents had the same term frequency for the search term (our code does some deduplication when building the suggestion terms during indexing).

This adds the search term to another company field for one of the objects used in the test, in order to increase the term frequency for that object to make sure it is returned first.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
