### PR TITLE
Ensure email ingestion auth failures are logged to sentry

### DIFF
--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -1,6 +1,5 @@
 import logging
 
-import sentry_sdk
 from django.http import HttpResponse, JsonResponse
 from django.utils.decorators import method_decorator
 from oauth2_provider.contrib.rest_framework.permissions import IsAuthenticatedOrTokenHasScope
@@ -192,10 +191,12 @@ class DNBCompanyCreateView(APIView):
         try:
             company_serializer.is_valid(raise_exception=True)
         except serializers.ValidationError:
-            with sentry_sdk.push_scope() as scope:
-                scope.set_extra('formatted_dnb_company_data', formatted_company_data)
-                scope.set_extra('dh_company_serializer_errors', company_serializer.errors)
-                sentry_sdk.capture_message('Company data from DNB failed DH serializer validation')
+            message = 'Company data from DNB failed DH serializer validation'
+            extra_data = {
+                'formatted_dnb_company_data': formatted_company_data,
+                'dh_company_serializer_errors': company_serializer.errors,
+            }
+            logger.error(message, extra=extra_data)
             raise
 
         datahub_company = company_serializer.save(
@@ -240,12 +241,12 @@ class DNBCompanyCreateInvestigationView(APIView):
         try:
             company_serializer.is_valid(raise_exception=True)
         except serializers.ValidationError:
-            with sentry_sdk.push_scope() as scope:
-                scope.set_extra('formatted_dnb_company_data', formatted_company_data)
-                scope.set_extra('dh_company_serializer_errors', company_serializer.errors)
-                sentry_sdk.capture_message(
-                    'Company investigation payload failed serializer validation',
-                )
+            message = 'Company investigation payload failed serializer validation'
+            extra_data = {
+                'formatted_dnb_company_data': formatted_company_data,
+                'dh_company_serializer_errors': company_serializer.errors,
+            }
+            logger.error(message, extra=extra_data)
             raise
 
         datahub_company = company_serializer.save(

--- a/datahub/email_ingestion/test/test_validation.py
+++ b/datahub/email_ingestion/test/test_validation.py
@@ -127,9 +127,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
             ]),
             False,
             (
-                'Domain "other.trade.gov.uk" not present in DIT_EMAIL_DOMAINS setting. '
-                'This email had the following authentication results: compauth=pass dkim=pass '
-                'dmarc=pass spf=pass'
+                'Domain "other.trade.gov.uk" not present in DIT_EMAIL_DOMAINS setting.'
             ),
         ),
         # Domain which is not on DIT_EMAIL_DOMAINS setting, fails validation
@@ -145,9 +143,7 @@ from datahub.email_ingestion.validation import was_email_sent_by_dit
             ]),
             False,
             (
-                'Domain "gmail.com" not present in DIT_EMAIL_DOMAINS setting. '
-                'This email had the following authentication results: dkim=pass '
-                'dmarc=pass spf=pass'
+                'Domain "gmail.com" not present in DIT_EMAIL_DOMAINS setting.'
             ),
         ),
         # Blacklisted email
@@ -169,7 +165,7 @@ def test_email_sent_by_dit(
     """
     Tests for was_email_sent_by_dit validator.
     """
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.ERROR)
     message = mock.Mock()
     message.from_ = [['Bill Adama', email]]
     message.authentication_results = authentication_results
@@ -178,7 +174,7 @@ def test_email_sent_by_dit(
     if expected_warning:
         expected_log = (
             'datahub.email_ingestion.validation',
-            30,
+            40,
             expected_warning,
         )
         assert expected_log in caplog.record_tuples

--- a/datahub/email_ingestion/validation.py
+++ b/datahub/email_ingestion/validation.py
@@ -48,11 +48,9 @@ def _log_unknown_domain(from_domain, message):
         auth_header_contents,
         flags=re.IGNORECASE,
     )
-    authentication_results.sort()
-    authentication_results_str = ' '.join(authentication_results)
-    logger.warning(
-        f'Domain "{from_domain}" not present in DIT_EMAIL_DOMAINS setting. '
-        f'This email had the following authentication results: {authentication_results_str}',
+    logger.error(
+        f'Domain "{from_domain}" not present in DIT_EMAIL_DOMAINS setting.',
+        extra={'authentication_results': authentication_results},
     )
 
 


### PR DESCRIPTION
### Description of change

This PR makes certain that we know about email ingestion auth errors when they happen.  Previously we were going to log these at `warning` level and interrogate the logs later - but this seems flaky at the moment.  This approach switches these logs to `error` level so that we can see them in sentry.

@alixedi pointed out a new usage pattern for using python logging in a way that can log extra data structures to sentry - so I've also swapped out the direct calls to `sentry_sdk` for this more preferable approach. https://docs.sentry.io/platforms/python/logging/#usage

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
