### PR TITLE
Add function to create new StatsClient.

### DIFF
--- a/datahub/core/statsd.py
+++ b/datahub/core/statsd.py
@@ -1,0 +1,37 @@
+from django.conf import settings
+from statsd import defaults
+from statsd.client import StatsClient
+
+HOST = settings.STATSD_HOST
+PORT = settings.STATSD_PORT
+PREFIX = settings.STATSD_PREFIX
+MAXUDPSIZE = defaults.MAXUDPSIZE
+IPV6 = defaults.IPV6
+
+
+def statsd():
+    """
+    Returns a new StatsD client.
+
+    Use this instead of:
+        statsd.defaults.django.statsd
+
+    because statsd.defaults.django.statsd is a singleton
+    initialised at the start of the process and therefore
+    does not deal with chnages to the IP of the statsd instance.
+    """
+    return StatsClient(
+        host=HOST,
+        port=PORT,
+        prefix=PREFIX,
+        maxudpsize=MAXUDPSIZE,
+        ipv6=IPV6,
+    )
+
+
+def incr(*args, **kwargs):
+    """
+    Increments the given stat by `count` after
+    creating a new `StatsClient`.
+    """
+    statsd().incr(*args, **kwargs)

--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -1,5 +1,4 @@
 import datetime
-from unittest.mock import Mock
 
 import pytest
 from django.utils.timezone import utc
@@ -204,16 +203,3 @@ def investigation_payload():
         'sector': Sector.renewable_energy_wind.value.id,
         'uk_region': UKRegion.east_midlands.value.id,
     }
-
-
-@pytest.fixture
-def statsd_mock(monkeypatch):
-    """
-    Returns a mock statsd client instance.
-    """
-    mock_statsd = Mock()
-    monkeypatch.setattr(
-        'datahub.dnb_api.views.statsd',
-        mock_statsd,
-    )
-    return mock_statsd

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import Mock
 from urllib.parse import urljoin
 
 import pytest
@@ -319,15 +320,17 @@ class TestDNBCompanySearchAPI(APITestMixin):
     )
     def test_monitoring(
         self,
+        monkeypatch,
         dnb_company_search_feature_flag,
         requests_mock,
-        statsd_mock,
         response_status_code,
     ):
         """
         Test that the right counter is incremented for the given status code
         returned by the dnb-service.
         """
+        statsd_mock = Mock()
+        monkeypatch.setattr('datahub.dnb_api.utils.statsd', statsd_mock)
         requests_mock.post(
             DNB_SEARCH_URL,
             status_code=response_status_code,
@@ -766,15 +769,17 @@ class TestDNBCompanyCreateAPI(APITestMixin):
     )
     def test_monitoring_search(
         self,
+        monkeypatch,
         dnb_company_search_feature_flag,
         requests_mock,
-        statsd_mock,
         response_status_code,
     ):
         """
         Test that the right counter is incremented for the given status code
         returned by the dnb-service.
         """
+        statsd_mock = Mock()
+        monkeypatch.setattr('datahub.dnb_api.utils.statsd', statsd_mock)
         requests_mock.post(
             DNB_SEARCH_URL,
             status_code=response_status_code,
@@ -792,15 +797,17 @@ class TestDNBCompanyCreateAPI(APITestMixin):
 
     def test_monitoring_create(
         self,
+        monkeypatch,
         dnb_company_search_feature_flag,
         dnb_response_uk,
         requests_mock,
-        statsd_mock,
     ):
         """
         Test that the right counter is incremented when a company gets
         created using dnb-service.
         """
+        statsd_mock = Mock()
+        monkeypatch.setattr('datahub.dnb_api.views.statsd', statsd_mock)
         requests_mock.post(
             DNB_SEARCH_URL,
             status_code=status.HTTP_200_OK,
@@ -960,14 +967,16 @@ class TestDNBCompanyCreateInvestigationAPI(APITestMixin):
 
     def test_monitoring_create(
         self,
+        monkeypatch,
         dnb_company_search_feature_flag,
         investigation_payload,
-        statsd_mock,
     ):
         """
         Test that the right counter is incremented when a stub company
         gets created for investigation by DNB.
         """
+        statsd_mock = Mock()
+        monkeypatch.setattr('datahub.dnb_api.views.statsd', statsd_mock)
         self.api_client.post(
             reverse('api-v4:dnb-api:company-create-investigation'),
             data=investigation_payload,

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
+from datahub.core import statsd
 from datahub.core.api_client import APIClient, TokenAuth
 from datahub.metadata.models import Country
 
@@ -22,11 +23,13 @@ def search_dnb(query_params):
     """
     if not settings.DNB_SERVICE_BASE_URL:
         raise ImproperlyConfigured('The setting DNB_SERVICE_BASE_URL has not been set')
-    return api_client.request(
+    response = api_client.request(
         'POST',
         'companies/search/',
         json=query_params,
     )
+    statsd.incr(f'dnb.search.{response.status_code}')
+    return response
 
 
 def format_dnb_company(dnb_company):

--- a/datahub/dnb_api/views.py
+++ b/datahub/dnb_api/views.py
@@ -7,9 +7,9 @@ from rest_framework import serializers
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from statsd.defaults.django import statsd
 
 from datahub.company.models import CompanyPermission
+from datahub.core import statsd
 from datahub.core.exceptions import APIBadRequestException, APIUpstreamException
 from datahub.core.permissions import HasPermissions
 from datahub.core.view_utils import enforce_request_content_type
@@ -51,7 +51,6 @@ class DNBCompanySearchView(APIView):
         on Data Hub.
         """
         upstream_response = search_dnb(request.data)
-        statsd.incr(f'dnb.search.{upstream_response.status_code}')
 
         if upstream_response.status_code == status.HTTP_200_OK:
             response_body = upstream_response.json()
@@ -162,7 +161,6 @@ class DNBCompanyCreateView(APIView):
         duns_number = duns_serializer.validated_data['duns_number']
 
         dnb_response = search_dnb({'duns_number': duns_number})
-        statsd.incr(f'dnb.search.{dnb_response.status_code}')
 
         if dnb_response.status_code != status.HTTP_200_OK:
             error_message = f'DNB service returned: {dnb_response.status_code}'

--- a/datahub/interaction/email_processors/notify.py
+++ b/datahub/interaction/email_processors/notify.py
@@ -2,8 +2,8 @@ from enum import Enum
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
-from statsd.defaults.django import statsd
 
+from datahub.core import statsd
 from datahub.feature_flag.utils import is_feature_flag_active
 from datahub.interaction import INTERACTION_EMAIL_NOTIFICATION_FEATURE_FLAG_NAME
 from datahub.notification.notify import notify_adviser_by_email


### PR DESCRIPTION
### Description of change

From discussion with PaaS devs the other day:

> One thing that we haven’t communicated very well to tenants is that internal networking is meshed, and load balancing is done client side.
When you make a request to x.cloudapps.digital it goes through our routers, which are fronted by ELBs (who’s IPs do not change often), or by Cloudfront (if you are using a custom domain)
When you make a request to x.apps.internal it goes directly between apps, with no routing component other than a sidecar proxy. This means that applications which do any sort of DNS caching without retries run into networking issues when applications are redeployed, or cells are rolled. Ideally applications would not cache DNS at all for internal apps.

[Python StatsD module](https://github.com/jsocol/pystatsd) creates a `StatsClient` singleton at the [start of the process](https://github.com/jsocol/pystatsd/blob/master/statsd/defaults/django.py). 

This combined with UDP means that e.g. if the IP of `StatsD` changes, the packets will not make their way to StatsD and there is no error and therefore no way to create a new `StatsClient` instance.

This PR has the simplest solution to this which is to create a new `StatsClient` for every metric update. In future, we might want to cache the `StatsClient` with a suitable TTL.

If you want to see this working end-to-end:

```
$ docker run -d -p 9102:9102 -p 9125:9125/udp prom/statsd-exporter
$ pytest datahub/dnb_api/test/test_views.py
$ curl localhost:9102 | grep dnb
```

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?