### PR TITLE
Move create changelog utility functions to script_utils

### DIFF
--- a/scripts/create_changelog.py
+++ b/scripts/create_changelog.py
@@ -26,6 +26,7 @@ from pathlib import Path
 from urllib.parse import quote
 
 from script_utils.current_version import get_current_version
+from script_utils.git import any_uncommitted_changes, local_branch_exists, remote_branch_exists
 from script_utils.version import Version
 
 parser = argparse.ArgumentParser(description='Create and push a changelog for a new version.')
@@ -34,40 +35,6 @@ parser.add_argument('release_type', choices=Version._fields)
 
 class CommandError(Exception):
     """A fatal error when running the script."""
-
-
-def any_uncommitted_changes():
-    """Checks if there are any uncommitted changes."""
-    result = subprocess.run(
-        ['git', 'status', '--porcelain'],
-        check=True,
-        capture_output=True,
-    )
-    return bool(result.stdout)
-
-
-def local_branch_exists(branch):
-    """Checks if a local branch exists."""
-    try:
-        subprocess.run(['git', 'show-ref', '--quiet', '--heads', '--', branch], check=True)
-    except subprocess.CalledProcessError:
-        return False
-
-    return True
-
-
-def remote_branch_exists(branch):
-    """Checks if a remote branch exists."""
-    try:
-        subprocess.run(
-            ['git', 'ls-remote', '--quiet', '--exit-code', 'origin', branch],
-            check=True,
-            stdout=subprocess.DEVNULL,
-        )
-    except subprocess.CalledProcessError:
-        return False
-
-    return True
 
 
 def list_news_fragments():

--- a/scripts/create_changelog.py
+++ b/scripts/create_changelog.py
@@ -20,12 +20,12 @@ The script will abort if:
 
 import argparse
 import glob
-import re
 import subprocess
 import webbrowser
 from pathlib import Path
 from urllib.parse import quote
 
+from script_utils.current_version import get_current_version
 from script_utils.version import Version
 
 parser = argparse.ArgumentParser(description='Create and push a changelog for a new version.')
@@ -77,24 +77,6 @@ def list_news_fragments():
     excluded_files = {'.gitignore', '_template.md.jinja2', 'README.md'}
     changelog_files = glob.iglob(f'{root_path}/changelog/**/*')
     return set(changelog_files) - excluded_files
-
-
-def get_current_version():
-    """
-    Gets the current version number from the changelog.
-
-    Note: In future we may want to write and obtain the version number to and from a more
-    authoritative source e.g. a module in the datahub package.
-    """
-    with open('CHANGELOG.md', 'r') as file:
-        changelog = file.read(10_000)
-
-    match = re.search(r' (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+) ', changelog)
-
-    if match:
-        return Version.from_dict(match.groupdict())
-
-    return None
 
 
 def create_changelog(release_type):

--- a/scripts/script_utils/current_version.py
+++ b/scripts/script_utils/current_version.py
@@ -1,0 +1,25 @@
+import re
+from pathlib import PurePath
+
+from script_utils.version import Version
+
+
+CHANGELOG_PATH = PurePath(__file__).parents[2] / 'CHANGELOG.md'
+
+
+def get_current_version():
+    """
+    Gets the current version number from the changelog.
+
+    Note: In future we may want to write and obtain the version number to and from a more
+    authoritative source e.g. a module in the datahub package.
+    """
+    with open(CHANGELOG_PATH, 'r') as file:
+        changelog = file.read(10_000)
+
+    match = re.search(r' (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+) ', changelog)
+
+    if match:
+        return Version.from_dict(match.groupdict())
+
+    return None

--- a/scripts/script_utils/git.py
+++ b/scripts/script_utils/git.py
@@ -1,0 +1,35 @@
+import subprocess
+
+
+def any_uncommitted_changes():
+    """Checks if there are any uncommitted changes."""
+    result = subprocess.run(
+        ['git', 'status', '--porcelain'],
+        check=True,
+        capture_output=True,
+    )
+    return bool(result.stdout)
+
+
+def local_branch_exists(branch):
+    """Checks if a local branch exists."""
+    try:
+        subprocess.run(['git', 'show-ref', '--quiet', '--heads', '--', branch], check=True)
+    except subprocess.CalledProcessError:
+        return False
+
+    return True
+
+
+def remote_branch_exists(branch):
+    """Checks if a remote branch exists."""
+    try:
+        subprocess.run(
+            ['git', 'ls-remote', '--quiet', '--exit-code', 'origin', branch],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError:
+        return False
+
+    return True

--- a/scripts/script_utils/test/test_current_version.py
+++ b/scripts/script_utils/test/test_current_version.py
@@ -1,0 +1,32 @@
+import builtins
+import io
+from unittest.mock import Mock
+
+import pytest
+
+from script_utils.current_version import get_current_version
+from script_utils.version import Version
+
+
+FAKE_CHANGELOG_CONTENT = """# Data Hub API 15.2.0 (2019-09-26)
+
+## Removals
+"""
+
+
+@pytest.mark.parametrize(
+    'changelog_content,expected_version',
+    [
+        (FAKE_CHANGELOG_CONTENT, Version(15, 2, 0)),
+        ('', None),
+    ],
+)
+def test_get_current_version(changelog_content, expected_version, monkeypatch):
+    """Test that get_current_version() parses and returns the latest version number."""
+    # As we're patching open(), keep the patch active for as short as possible to avoid
+    # unintended side effects
+    with monkeypatch.context() as patch_context:
+        patch_context.setattr(builtins, 'open', Mock(return_value=io.StringIO(changelog_content)))
+        actual_version = get_current_version()
+
+    assert actual_version == expected_version

--- a/scripts/script_utils/test/test_git.py
+++ b/scripts/script_utils/test/test_git.py
@@ -1,0 +1,56 @@
+import subprocess
+from unittest.mock import Mock
+
+import pytest
+
+from script_utils.git import any_uncommitted_changes, local_branch_exists, remote_branch_exists
+
+
+@pytest.fixture
+def mock_subprocess_run(monkeypatch):
+    """Patch subprocess.run()."""
+    run_mock = Mock()
+    monkeypatch.setattr(subprocess, 'run', run_mock)
+    yield run_mock
+
+
+@pytest.mark.parametrize(
+    'stdout,expected_result',
+    [
+        (' M scripts/create_changelog.py\n', True),
+        ('', False),
+    ],
+)
+def test_any_uncommitted_changes(stdout, expected_result, mock_subprocess_run):
+    """Test that any_uncommitted_changes() returns the expected value in various scenarios."""
+    mock_subprocess_run.return_value = subprocess.CompletedProcess((), 0, stdout=stdout)
+
+    assert any_uncommitted_changes() == expected_result
+
+
+@pytest.mark.parametrize(
+    'side_effect,expected_result',
+    [
+        (None, True),
+        (subprocess.CalledProcessError(1, ''), False),
+    ],
+)
+def test_local_branch_exists(side_effect, expected_result, mock_subprocess_run):
+    """Test that local_branch_exists() returns the expected value in various scenarios."""
+    mock_subprocess_run.side_effect = side_effect
+
+    assert local_branch_exists('test-branch') == expected_result
+
+
+@pytest.mark.parametrize(
+    'side_effect,expected_result',
+    [
+        (None, True),
+        (subprocess.CalledProcessError(2, ''), False),
+    ],
+)
+def test_remote_branch_exists(side_effect, expected_result, mock_subprocess_run):
+    """Test that remote_branch_exists() returns the expected value in various scenarios."""
+    mock_subprocess_run.side_effect = side_effect
+
+    assert remote_branch_exists('test-branch') == expected_result


### PR DESCRIPTION
### Description of change

This moves some of the utility functions that were in the `create_changelog.py` script to the `script_utils` package.

This is so that they can be used by the upcoming script for creating a release branch.

Some tests for these functions were also added.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
