### PR TITLE
Improve create changelog script

### DIFF
--- a/scripts/create_changelog.py
+++ b/scripts/create_changelog.py
@@ -23,11 +23,13 @@ import glob
 import subprocess
 import webbrowser
 from pathlib import Path
-from urllib.parse import quote
+from urllib.parse import quote, urlencode
 
 from script_utils.current_version import get_current_version
 from script_utils.git import any_uncommitted_changes, local_branch_exists, remote_branch_exists
 from script_utils.version import Version
+
+BASE_GITHUB_REPO_URL = 'https://github.com/uktrade/data-hub-leeloo'
 
 parser = argparse.ArgumentParser(description='Create and push a changelog for a new version.')
 parser.add_argument('release_type', choices=Version._fields)
@@ -58,6 +60,8 @@ def create_changelog(release_type):
     remote = 'origin'
     branch = f'changelog/{new_version}'
     commit_message = f'Add changelog for version {new_version}'
+    pr_title = f'Add changelog for version {new_version}'
+    pr_body = f'This adds the changelog for version {new_version}.'
 
     if any_uncommitted_changes():
         raise CommandError(
@@ -97,7 +101,12 @@ def create_changelog(release_type):
     subprocess.run(['git', 'push', '--set-upstream', remote, branch], check=True)
 
     escaped_branch_name = quote(branch)
-    webbrowser.open(f'https://github.com/uktrade/data-hub-leeloo/pull/new/{escaped_branch_name}')
+    params = {
+        'expand': '1',
+        'title': pr_title,
+        'body': pr_body,
+    }
+    webbrowser.open(f'{BASE_GITHUB_REPO_URL}/compare/{escaped_branch_name}?{urlencode(params)}')
 
     return branch
 


### PR DESCRIPTION
### Description of change

This improves the create changelog script by:

- making it get the current version number after checking out `origin/develop` (to make sure it is the latest version number)
- setting the PR title and message when opening a web browser window

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
