### PR TITLE
Factor out `get_company`

### DIFF
--- a/datahub/dnb_api/test/conftest.py
+++ b/datahub/dnb_api/test/conftest.py
@@ -28,7 +28,7 @@ def dnb_response_non_uk():
     return {
         'results': [
             {
-                'duns_number': '157270606',
+                'duns_number': '123456789',
                 'primary_name': 'Acme Corporation',
                 'trading_names': [
                     'Acme',
@@ -102,7 +102,7 @@ def dnb_response_uk():
                 'annual_sales': 50651895.0,
                 'annual_sales_currency': 'USD',
                 'domain': 'foo.com',
-                'duns_number': '291332174',
+                'duns_number': '123456789',
                 'employee_number': 260,
                 'global_ultimate_duns_number': '291332174',
                 'global_ultimate_primary_name': 'FOO BICYCLE LIMITED',

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -1,0 +1,140 @@
+from urllib.parse import urljoin
+from uuid import UUID
+
+import pytest
+from django.conf import settings
+from rest_framework import status
+
+from datahub.dnb_api.utils import (
+    DNBServiceError,
+    DNBServiceInvalidRequest,
+    DNBServiceInvalidResponse,
+    get_company,
+)
+
+
+DNB_SEARCH_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/search/')
+
+
+@pytest.mark.parametrize(
+    'dnb_response_status',
+    (
+        status.HTTP_400_BAD_REQUEST,
+        status.HTTP_401_UNAUTHORIZED,
+        status.HTTP_403_FORBIDDEN,
+        status.HTTP_404_NOT_FOUND,
+        status.HTTP_405_METHOD_NOT_ALLOWED,
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+    ),
+)
+def test_get_company_dnb_service_error(
+    caplog,
+    requests_mock,
+    dnb_company_search_feature_flag,
+    dnb_response_status,
+):
+    """
+    Test if the dnb-service returns a status code that is not
+    200, we log it and raise the exception with an appropriate
+    message.
+    """
+    requests_mock.post(
+        DNB_SEARCH_URL,
+        status_code=dnb_response_status,
+    )
+
+    with pytest.raises(DNBServiceError) as e:
+        get_company('123456789')
+
+    expected_message = f'DNB service returned: {dnb_response_status}'
+
+    assert e.value.args[0] == expected_message
+    assert len(caplog.records) == 1
+    assert caplog.records[0].getMessage() == expected_message
+
+
+@pytest.mark.parametrize(
+    'search_results, expected_exception, expected_message',
+    (
+        (
+            [],
+            DNBServiceInvalidRequest,
+            'Cannot find a company with duns_number: 123456789',
+        ),
+        (
+            ['foo', 'bar'],
+            DNBServiceInvalidResponse,
+            'Multiple companies found with duns_number: 123456789',
+        ),
+        (
+            [{'duns_number': '012345678'}],
+            DNBServiceInvalidResponse,
+            'DUNS number of the company: 012345678 '
+            'did not match searched DUNS number: 123456789',
+        ),
+    ),
+)
+def test_get_company_invalid_request_response(
+    caplog,
+    requests_mock,
+    dnb_company_search_feature_flag,
+    search_results,
+    expected_exception,
+    expected_message,
+):
+    """
+    Test if a given `duns_number` gets anything other than a single company
+    from dnb-service, the get_company function raises an exception.
+    """
+    requests_mock.post(
+        DNB_SEARCH_URL,
+        json={'results': search_results},
+    )
+
+    with pytest.raises(expected_exception) as e:
+        get_company('123456789')
+
+    assert e.value.args[0] == expected_message
+    assert len(caplog.records) == 1
+    assert caplog.records[0].getMessage() == expected_message
+
+
+def test_get_company_valid(
+    caplog,
+    requests_mock,
+    dnb_company_search_feature_flag,
+    dnb_response_uk,
+):
+    """
+    Test if dnb-service returns a valid response, get_company
+    returns a formatted dict.
+    """
+    requests_mock.post(
+        DNB_SEARCH_URL,
+        json=dnb_response_uk,
+    )
+
+    dnb_company = get_company('123456789')
+
+    assert dnb_company == {
+        'company_number': '01261539',
+        'name': 'FOO BICYCLE LIMITED',
+        'duns_number': '123456789',
+        'trading_names': [],
+        'address': {
+            'country': {
+                'id': UUID('80756b9a-5d95-e211-a939-e4115bead28a'),
+            },
+            'county': '',
+            'line_1': 'Unit 10, Ockham Drive',
+            'line_2': '',
+            'postcode': 'UB6 0F2',
+            'town': 'GREENFORD',
+        },
+        'number_of_employees': 260,
+        'is_number_of_employees_estimated': True,
+        'turnover': 50651895.0,
+        'is_turnover_estimated': None,
+        'uk_based': True,
+        'website': 'http://foo.com',
+    }

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -524,8 +524,22 @@ class TestDNBCompanyCreateAPI(APITestMixin):
     @pytest.mark.parametrize(
         'results, expected_status_code, expected_message',
         (
-            ([], 400, 'Cannot find a company with duns_number: 123456789'),
-            (['foo', 'bar'], 502, 'Multiple companies found with duns_number: 123456789'),
+            (
+                [],
+                400,
+                'Cannot find a company with duns_number: 123456789',
+            ),
+            (
+                ['foo', 'bar'],
+                502,
+                'Multiple companies found with duns_number: 123456789',
+            ),
+            (
+                [{'duns_number': '012345678'}],
+                502,
+                'DUNS number of the company: 012345678 '
+                'did not match searched DUNS number: 123456789',
+            ),
         ),
     )
     def test_post_none_or_multiple_companies_found(
@@ -561,7 +575,6 @@ class TestDNBCompanyCreateAPI(APITestMixin):
         (
             ('primary_name', {'name': ['This field may not be null.']}),
             ('trading_names', {'trading_names': ['This field may not be null.']}),
-            ('duns_number', {'duns_number': ['This field may not be null.']}),
             ('address_line_1', {'address': {'line_1': ['This field may not be null.']}}),
             ('address_line_2', {'address': {'line_2': ['This field may not be null.']}}),
             ('address_town', {'address': {'town': ['This field may not be null.']}}),


### PR DESCRIPTION
### Description of change
This factors out code that searches the company with the given `duns_number` and handles exceptions into a utility function. 

I will be reusing this new function in the upcoming unhappy-path-admin PR.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
