### PR TITLE
Properly fix non-deterministic company autocomplete tests

### DIFF
--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -667,17 +667,17 @@ class TestAutocompleteSearch(APITestMixin):
             (
                 {'term': 'abc', 'country': ''},
                 True,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'abc', 'country': constants.Country.united_kingdom.value.id},
                 True,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'abc'},
                 True,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'one', 'country': constants.Country.canada.value.id},
@@ -687,32 +687,32 @@ class TestAutocompleteSearch(APITestMixin):
             (
                 {'term': 'abc', 'country': constants.UKRegion.north_east.value.id},
                 False,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'abc', 'country': constants.Country.canada.value.id},
                 False,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'abc', 'country': constants.Country.ireland.value.id},
                 False,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'abc', 'country': ''},
                 False,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'abc', 'country': constants.Country.united_kingdom.value.id},
                 False,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'abc'},
                 False,
-                ['abc', 'abc 2'],
+                ['abc', 'abc2'],
             ),
             (
                 {'term': 'one', 'country': constants.Country.canada.value.id},
@@ -747,8 +747,8 @@ class TestAutocompleteSearch(APITestMixin):
         )
 
         CompanyFactory(
-            name='abc 2',
-            trading_names=['Xyz trading 2', 'Abc trading 2'],
+            name='abc2',
+            trading_names=['Xyz trading 2', 'Abc2 trading'],
             registered_address_country_id=constants.Country.united_kingdom.value.id,
         )
 
@@ -762,6 +762,7 @@ class TestAutocompleteSearch(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
 
+        # Note: Results are ordered by the term they matched on
         results = [
             self._get_company_search_result(Company.objects.get(name=company_name))
             for company_name in expected_companies
@@ -829,17 +830,17 @@ class TestAutocompleteSearch(APITestMixin):
     @pytest.mark.parametrize(
         'query,expected_companies',
         (
-            ('abc', ['abc defg ltd', 'abc defg us ltd']),
+            ('abc', ['abc defg ltd', 'abc2 defg2 us ltd']),
             ('abv', []),
-            ('ABC', ['abc defg ltd', 'abc defg us ltd']),
+            ('ABC', ['abc defg ltd', 'abc2 defg2 us ltd']),
             ('hello', []),
             ('', []),
             (1, []),
             ('abc defg ltd', ['abc defg ltd']),
-            ('defg', ['abc defg ltd', 'abc defg us ltd']),
-            ('us', ['abc defg us ltd']),
-            ('hel', ['abc defg ltd', 'abc defg us ltd']),
-            ('qrs', ['abc defg us ltd']),
+            ('defg', ['abc defg ltd', 'abc2 defg2 us ltd']),
+            ('us', ['abc2 defg2 us ltd']),
+            ('hel', ['abc defg ltd', 'abc2 defg2 us ltd']),
+            ('qrs', ['abc2 defg2 us ltd']),
             ('help qrs', []),
         ),
     )
@@ -851,13 +852,13 @@ class TestAutocompleteSearch(APITestMixin):
         country_us = constants.Country.united_states.value.id
         CompanyFactory(
             name='abc defg ltd',
-            trading_names=['abc', 'helm', 'nop'],
+            trading_names=['helm', 'nop'],
             address_country_id=country_uk,
             registered_address_country_id=country_uk,
         )
         CompanyFactory(
-            name='abc defg us ltd',
-            trading_names=['helm', 'nop', 'qrs'],
+            name='abc2 defg2 us ltd',
+            trading_names=['helm2', 'nop', 'qrs'],
             address_country_id=country_us,
             registered_address_country_id=country_us,
         )
@@ -870,14 +871,15 @@ class TestAutocompleteSearch(APITestMixin):
         assert response.data['count'] == len(expected_companies)
 
         if expected_companies:
+            # Note: Results are ordered by the term they matched on
             companies = [result['name'] for result in response.data['results']]
             assert companies == expected_companies
 
     @pytest.mark.parametrize(
         'limit,expected_companies',
         (
-            (10, ['abc defg ltd', 'abc defg us ltd']),  # only 2 found
-            (2, ['abc defg ltd', 'abc defg us ltd']),
+            (10, ['abc defg ltd', 'abc2 defg2 us ltd']),  # only 2 found
+            (2, ['abc defg ltd', 'abc2 defg2 us ltd']),
             (1, ['abc defg ltd']),
         ),
     )
@@ -889,12 +891,12 @@ class TestAutocompleteSearch(APITestMixin):
         country_us = constants.Country.united_states.value.id
         CompanyFactory(
             name='abc defg ltd',
-            trading_names=['abc', 'helm', 'nop'],
+            trading_names=['helm', 'nop'],
             address_country_id=country_uk,
             registered_address_country_id=country_uk,
         )
         CompanyFactory(
-            name='abc defg us ltd',
+            name='abc2 defg2 us ltd',
             trading_names=['helm', 'nop', 'qrs'],
             address_country_id=country_us,
             registered_address_country_id=country_us,
@@ -914,6 +916,7 @@ class TestAutocompleteSearch(APITestMixin):
         assert response.data['count'] == len(expected_companies)
 
         if expected_companies:
+            # Note: Results are ordered by the term they matched on
             companies = [result['name'] for result in response.data['results']]
             assert companies == expected_companies
 


### PR DESCRIPTION

### Description of change

The previous fix in #2123 was non-effective, because what was happening was that:

- [we are indexing individual words in company names](https://github.com/uktrade/data-hub-leeloo/blob/260d1e2daa7a375d50a1149ecd2953c9fee7f68c/datahub/search/company/models.py#L48-L53)
- results are ordered by the term they matched on
- two results in the tests were matching on 'abc' and hence came back in an inconsistent order

This changes the test companies used in these tests so that e.g. one matches on 'abc' and the other on 'abc2'. This removes the indeterminism.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
