### PR TITLE
Add script to automate the creation of a release branch

### DIFF
--- a/docs/How to prepare a release.md
+++ b/docs/How to prepare a release.md
@@ -40,20 +40,22 @@ When ready, merge `changelog/<version>` into `develop` and delete the merged bra
 
 ## Prepare the release
 
-Create a release branch from develop:
+Create and push a release branch from develop by running:
 
-```
-git checkout develop && git pull
-git checkout -b release/<version>
-```
-
-Push the branch:
-
-```
-git push origin release/<version>
+```shell
+scripts/create_release_pr.py
 ```
 
-In GitHub open a PR to merge `release/<version>` into `master` and assign at least two developers for review.
+The command will:
+
+- run `git fetch`
+- create a branch `release/<version>` based on `origin/develop`
+- push this branch
+- open a web browser window to the create PR page for the pushed branch (with `master` as the base branch)
+
+Once your web browser has opened, double-check that the details are correct and that the base branch is set to `master`.
+
+Add at least two developers as reviewers and click 'Create pull request'.
 
 ## Release to staging
 

--- a/scripts/create_changelog.py
+++ b/scripts/create_changelog.py
@@ -19,14 +19,13 @@ The script will abort if:
 """
 
 import argparse
-import glob
 import subprocess
 import webbrowser
-from pathlib import Path
 from urllib.parse import quote, urlencode
 
 from script_utils.current_version import get_current_version
 from script_utils.git import any_uncommitted_changes, local_branch_exists, remote_branch_exists
+from script_utils.news_fragments import list_news_fragments
 from script_utils.version import Version
 
 BASE_GITHUB_REPO_URL = 'https://github.com/uktrade/data-hub-leeloo'
@@ -37,15 +36,6 @@ parser.add_argument('release_type', choices=Version._fields)
 
 class CommandError(Exception):
     """A fatal error when running the script."""
-
-
-def list_news_fragments():
-    """Return a list of files that are probable news fragments."""
-    path = Path(__file__)
-    root_path = path.resolve().parents[1]
-    excluded_files = {'.gitignore', '_template.md.jinja2', 'README.md'}
-    changelog_files = glob.iglob(f'{root_path}/changelog/**/*')
-    return set(changelog_files) - excluded_files
 
 
 def create_changelog(release_type):

--- a/scripts/create_release_pr.py
+++ b/scripts/create_release_pr.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+
+"""
+This is a script that:
+
+- runs `git fetch`
+- creates a branch release/<version> based on origin/develop
+- pushes this branch
+- opens your web browser to the create PR page for the pushed branch (with master as
+the base branch)
+
+The script will abort if:
+
+- a tag for the current version already exists
+- there are news fragments on origin/develop
+- there are uncommitted changes
+- the release branch for the current version already exists
+"""
+
+import argparse
+import subprocess
+import webbrowser
+from urllib.parse import quote, urlencode
+
+from script_utils.current_version import get_current_version
+from script_utils.git import (
+    any_uncommitted_changes,
+    local_branch_exists,
+    remote_branch_exists,
+    remote_tag_exists,
+)
+from script_utils.news_fragments import list_news_fragments
+
+GITHUB_BASE_REPO_URL = 'https://github.com/uktrade/data-hub-leeloo'
+RELEASE_GUIDE_URL = (
+    'https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/'
+    'How%20to%20prepare%20a%20release.md'
+)
+PR_BODY_TEMPLATE = """This is the release PR for version {version}.
+
+Refer to [How to prepare a release]({release_guide_url}) for further information and the next \
+steps.
+"""
+
+# Currently no real arguments – just used for --help etc.
+parser = argparse.ArgumentParser(
+    description='Create and push a release branch for the current version.',
+)
+
+
+class CommandError(Exception):
+    """A fatal error when running the script."""
+
+
+def create_release_branch():
+    """Create and push a release branch."""
+    remote = 'origin'
+
+    if any_uncommitted_changes():
+        raise CommandError(
+            'There are uncommitted changes. Please commit, stash or delete them and try again.',
+        )
+
+    subprocess.run(['git', 'fetch'], check=True)
+    subprocess.run(['git', 'checkout', f'{remote}/develop'], check=True, capture_output=True)
+
+    version = get_current_version()
+
+    branch = f'release/{version}'
+    tag = f'v{version}'
+
+    if remote_tag_exists(tag):
+        raise CommandError(
+            f'A remote tag {tag} currently exists. It looks like version {version} has '
+            f'already been released.',
+        )
+
+    news_fragment_paths = list_news_fragments()
+    if news_fragment_paths:
+        joined_paths = '\n'.join(news_fragment_paths)
+
+        raise CommandError(
+            'These are news fragments on origin/develop:\n\n'
+            f'{joined_paths}\n\n'
+            'Is the changelog up to date?',
+        )
+
+    if local_branch_exists(branch):
+        raise CommandError(
+            f'Branch {branch} already exists locally. Please delete it and try again.',
+        )
+
+    if remote_branch_exists(branch):
+        raise CommandError(
+            f'Branch {branch} already exists remotely. Please delete it on GitHub and try again.',
+        )
+
+    subprocess.run(['git', 'checkout', '-b', branch, f'{remote}/develop'], check=True)
+    subprocess.run(['git', 'push', '--set-upstream', remote, branch], check=True)
+
+    params = {
+        'expand': '1',
+        'title': f'Release {version}',
+        'body': PR_BODY_TEMPLATE.format(version=version, release_guide_url=RELEASE_GUIDE_URL),
+    }
+    encoded_params = urlencode(params)
+    escaped_branch_name = quote(branch)
+    webbrowser.open(
+        f'{GITHUB_BASE_REPO_URL}/compare/master...{escaped_branch_name}?{encoded_params}',
+    )
+
+    return branch
+
+
+def main():
+    """Run the script from the command line."""
+    parser.parse_args()
+
+    try:
+        branch_name = create_release_branch()
+    except (CommandError, subprocess.CalledProcessError) as exc:
+        print(f'ERROR: {exc}')  # noqa: T001
+        return
+
+    print(  # noqa: T001
+        f'Branch {branch_name} was created, pushed and opened in your web browser.',
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/script_utils/git.py
+++ b/scripts/script_utils/git.py
@@ -1,8 +1,9 @@
 import subprocess
+from enum import Enum
 
 
 def any_uncommitted_changes():
-    """Checks if there are any uncommitted changes."""
+    """Check if there are any uncommitted changes."""
     result = subprocess.run(
         ['git', 'status', '--porcelain'],
         check=True,
@@ -12,7 +13,7 @@ def any_uncommitted_changes():
 
 
 def local_branch_exists(branch):
-    """Checks if a local branch exists."""
+    """Check if a local branch exists."""
     try:
         subprocess.run(['git', 'show-ref', '--quiet', '--heads', '--', branch], check=True)
     except subprocess.CalledProcessError:
@@ -22,10 +23,25 @@ def local_branch_exists(branch):
 
 
 def remote_branch_exists(branch):
-    """Checks if a remote branch exists."""
+    """Check if a remote branch exists."""
+    return _remote_ref_exists(branch, _RefTypeArg.head)
+
+
+def remote_tag_exists(tag):
+    """Check if a remote tag exists."""
+    return _remote_ref_exists(tag, _RefTypeArg.tag)
+
+
+class _RefTypeArg(Enum):
+    head = '--heads'
+    tag = '--tags'
+
+
+def _remote_ref_exists(ref, ref_type_arg):
+    """Checks if a remote reference exists."""
     try:
         subprocess.run(
-            ['git', 'ls-remote', '--quiet', '--exit-code', 'origin', branch],
+            ['git', 'ls-remote', '--quiet', '--exit-code', ref_type_arg.value, 'origin', ref],
             check=True,
             stdout=subprocess.DEVNULL,
         )

--- a/scripts/script_utils/news_fragments.py
+++ b/scripts/script_utils/news_fragments.py
@@ -1,0 +1,12 @@
+import glob
+from pathlib import PurePath
+
+
+IGNORED_FILES = {'.gitignore', '_template.md.jinja2', 'README.md'}
+ROOT_PATH = PurePath(__file__).parents[2]
+
+
+def list_news_fragments():
+    """Return a list of files that are probable news fragments."""
+    changelog_files = glob.iglob(f'{ROOT_PATH}/changelog/**/*')
+    return set(changelog_files) - IGNORED_FILES

--- a/scripts/script_utils/test/test_git.py
+++ b/scripts/script_utils/test/test_git.py
@@ -3,7 +3,12 @@ from unittest.mock import Mock
 
 import pytest
 
-from script_utils.git import any_uncommitted_changes, local_branch_exists, remote_branch_exists
+from script_utils.git import (
+    any_uncommitted_changes,
+    local_branch_exists,
+    remote_branch_exists,
+    remote_tag_exists,
+)
 
 
 @pytest.fixture
@@ -54,3 +59,17 @@ def test_remote_branch_exists(side_effect, expected_result, mock_subprocess_run)
     mock_subprocess_run.side_effect = side_effect
 
     assert remote_branch_exists('test-branch') == expected_result
+
+
+@pytest.mark.parametrize(
+    'side_effect,expected_result',
+    [
+        (None, True),
+        (subprocess.CalledProcessError(2, ''), False),
+    ],
+)
+def test_remote_tag_exists(side_effect, expected_result, mock_subprocess_run):
+    """Test that remote_tag_exists() returns the expected value in various scenarios."""
+    mock_subprocess_run.side_effect = side_effect
+
+    assert remote_tag_exists('test-tag') == expected_result


### PR DESCRIPTION
### Description of change

This adds a script that automates the creation of a release branch (in a similar way to the create changelog script).

Running `scripts/create_release_pr.py` will:

- run `git fetch`
- create a branch `release/<version>` based on `origin/develop`
- push this branch
- open a web browser window to the create PR page for the pushed branch (with master as the base branch)

The script will abort if:

- a tag for the current version already exists
- there are uncommitted changes
- the release branch for the current version already exists

The release instructions have been updated to reflect these changes.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
