### PR TITLE
Update-from-dnb admin tool

### DIFF
--- a/changelog/company/unhappy-path-admin.feature.md
+++ b/changelog/company/unhappy-path-admin.feature.md
@@ -1,0 +1,3 @@
+A tool was added to django admin to allow administrators to pull fresh data from DNB for a company with a `duns_number`.
+
+This allows administrators to resolve the unhappy-path for the new add-a-company journey by adding a `duns_number` to a company record followed by pulling data from DNB for the given company.

--- a/datahub/company/admin/company.py
+++ b/datahub/company/admin/company.py
@@ -11,6 +11,7 @@ from django.utils.safestring import mark_safe
 from reversion.admin import VersionAdmin
 
 from datahub.company.admin.archiving.unarchive import unarchive_company
+from datahub.company.admin.dnb import update_from_dnb
 from datahub.company.admin.merge.step_1 import merge_select_other_company
 from datahub.company.admin.merge.step_2 import select_primary_company
 from datahub.company.admin.merge.step_3 import confirm_merge
@@ -259,6 +260,12 @@ class CompanyAdmin(BaseModelAdminMixin, VersionAdmin):
                 self.admin_site.admin_view(partial(unarchive_company, self)),
                 name=f'{model_meta.app_label}_'
                      f'{model_meta.model_name}_unarchive-company',
+            ),
+            path(
+                '<path:object_id>/update-from-dnb/',
+                self.admin_site.admin_view(partial(update_from_dnb, self)),
+                name=f'{model_meta.app_label}_'
+                     f'{model_meta.model_name}_update-from-dnb',
             ),
             *super().get_urls(),
         ]

--- a/datahub/company/admin/dnb.py
+++ b/datahub/company/admin/dnb.py
@@ -1,0 +1,233 @@
+import functools
+import logging
+
+import reversion
+from django.contrib import messages
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.core.exceptions import PermissionDenied, SuspiciousOperation
+from django.http import HttpResponseRedirect
+from django.template.response import TemplateResponse
+from django.urls import reverse
+from django.utils.decorators import method_decorator
+from django.utils.translation import gettext_lazy
+from django.views.decorators.csrf import csrf_protect
+from django.views.decorators.http import require_http_methods
+from rest_framework import serializers
+
+from datahub.dnb_api.serializers import DNBCompanySerializer
+from datahub.dnb_api.utils import (
+    DNBServiceError,
+    DNBServiceInvalidRequest,
+    DNBServiceInvalidResponse,
+    get_company,
+)
+from datahub.metadata.models import Country
+
+
+logger = logging.getLogger(__name__)
+
+
+def _format_company_diff(dh_company, dnb_company):
+    """
+    Format the Datahub and D&B companies for templates.
+    """
+    def get_field(name):
+        return dh_company._meta.get_field(name)
+
+    return {
+        get_field('name'): (
+            dh_company.name,
+            dnb_company['name'],
+        ),
+        get_field('address_1'): (
+            dh_company.address_1,
+            dnb_company['address']['line_1'],
+        ),
+        get_field('address_2'): (
+            dh_company.address_2,
+            dnb_company['address']['line_2'],
+        ),
+        get_field('address_town'): (
+            dh_company.address_town,
+            dnb_company['address']['town'],
+        ),
+        get_field('address_county'): (
+            dh_company.address_county,
+            dnb_company['address']['county'],
+        ),
+        get_field('address_postcode'): (
+            dh_company.address_postcode,
+            dnb_company['address']['postcode'],
+        ),
+        get_field('address_country'): (
+            dh_company.address_country,
+            Country.objects.get(id=dnb_company['address']['country']),
+        ),
+        get_field('registered_address_1'): (
+            dh_company.registered_address_1,
+            dnb_company['registered_address']['line_1'],
+        ),
+        get_field('registered_address_2'): (
+            dh_company.registered_address_2,
+            dnb_company['registered_address']['line_2'],
+        ),
+        get_field('registered_address_town'): (
+            dh_company.registered_address_town,
+            dnb_company['registered_address']['town'],
+        ),
+        get_field('registered_address_county'): (
+            dh_company.registered_address_county,
+            dnb_company['registered_address']['county'],
+        ),
+        get_field('registered_address_postcode'): (
+            dh_company.registered_address_postcode,
+            dnb_company['registered_address']['postcode'],
+        ),
+        get_field('registered_address_country'): (
+            dh_company.registered_address_country,
+            Country.objects.get(id=dnb_company['registered_address']['country']),
+        ),
+        get_field('company_number'): (
+            dh_company.company_number,
+            dnb_company['company_number'],
+        ),
+        get_field('trading_names'): (
+            ', '.join(dh_company.trading_names),
+            ', '.join(dnb_company['trading_names']),
+        ),
+        get_field('website'): (
+            dh_company.website,
+            dnb_company['website'],
+        ),
+        get_field('number_of_employees'): (
+            dh_company.number_of_employees,
+            dnb_company['number_of_employees'],
+        ),
+        get_field('is_number_of_employees_estimated'): (
+            dh_company.is_number_of_employees_estimated,
+            dnb_company['is_number_of_employees_estimated'],
+        ),
+        get_field('turnover'): (
+            dh_company.turnover,
+            dnb_company['turnover'],
+        ),
+        get_field('is_turnover_estimated'): (
+            dh_company.is_turnover_estimated,
+            dnb_company['is_turnover_estimated'],
+        ),
+    }
+
+
+def redirect_with_message(func):
+    """
+    Decorator that redirects to a given URL with a given
+    message for the user in case of an error.
+    """
+    @functools.wraps(func)
+    def wrapper(model_admin, request, *args, **kwargs):
+        try:
+            return func(model_admin, request, *args, **kwargs)
+        except AdminException as exc:
+            message, redirect_url = exc.args
+            messages.add_message(request, messages.ERROR, message)
+            return HttpResponseRedirect(redirect_url)
+    return wrapper
+
+
+class AdminException(Exception):
+    """
+    Exception in an admin view. Contains the message
+    to be displayed to the usr and the redirect_url.
+    """
+
+
+def _update_from_dnb(dh_company, dnb_company, user):
+    """
+    Updates `dh_company` with `dnb_company` while setting
+    `modified_by` to the given user and creating a revision.
+
+    Raises serializers.ValidationError if data is invalid.
+    """
+    company_serializer = DNBCompanySerializer(
+        dh_company,
+        data=dnb_company,
+        partial=True,
+    )
+
+    try:
+        company_serializer.is_valid(raise_exception=True)
+
+    except serializers.ValidationError:
+        logger.error(
+            'Data from D&B did not pass the Data Hub validation checks.',
+            extra={'dnb_company': dnb_company, 'errors': company_serializer.errors},
+        )
+        raise
+
+    with reversion.create_revision():
+        company_serializer.save(
+            modified_by=user,
+            pending_dnb_investigation=False,
+        )
+        reversion.set_user(user)
+        reversion.set_comment('Updated from D&B')
+
+
+@redirect_with_message
+@method_decorator(require_http_methods(['GET', 'POST']))
+@method_decorator(csrf_protect)
+def update_from_dnb(model_admin, request, object_id):
+    """
+    Tool to let admin users update company with a valid `duns_number`
+    by pulling fresh data from D&B.
+
+    The company record will be versioned after the update from
+    D&B is applied.
+
+    The `pending_dnb_investigation` field will
+    be set to False.
+    """
+    if not model_admin.has_change_permission(request):
+        raise PermissionDenied()
+
+    dh_company = model_admin.get_object(request, object_id)
+
+    company_change_page = reverse(
+        admin_urlname(model_admin.model._meta, 'change'),
+        kwargs={'object_id': dh_company.pk},
+    )
+
+    if dh_company is None or dh_company.duns_number is None:
+        raise SuspiciousOperation()
+
+    try:
+        dnb_company = get_company(dh_company.duns_number)
+
+    except (DNBServiceError, DNBServiceInvalidResponse):
+        message = 'Something went wrong in an upstream service.'
+        raise AdminException(message, company_change_page)
+
+    except DNBServiceInvalidRequest:
+        message = 'No matching company found in D&B database.'
+        raise AdminException(message, company_change_page)
+
+    if request.method == 'GET':
+        return TemplateResponse(
+            request,
+            'admin/company/company/update-from-dnb.html',
+            {
+                **model_admin.admin_site.each_context(request),
+                'media': model_admin.media,
+                'opts': model_admin.model._meta,
+                'object': dh_company,
+                'title': gettext_lazy('Confirm update from D&B'),
+                'diff': _format_company_diff(dh_company, dnb_company),
+            },
+        )
+
+    try:
+        _update_from_dnb(dh_company, dnb_company, request.user)
+        return HttpResponseRedirect(company_change_page)
+    except serializers.ValidationError:
+        message = 'Data from D&B did not pass the Data Hub validation checks.'
+        raise AdminException(message, company_change_page)

--- a/datahub/company/templates/admin/company/company/change_form_object_tools.html
+++ b/datahub/company/templates/admin/company/company/change_form_object_tools.html
@@ -16,5 +16,12 @@
     </li>
     {% endif %}
   {% endif %}
+  {% if has_change_permission and original.duns_number %}
+  <li>
+    <a href="{% url opts|admin_urlname:'update-from-dnb' original.pk %}">
+      Update from D&B
+    </a>
+  </li>
+  {% endif %}
 {{block.super}}
 {% endblock %}

--- a/datahub/company/templates/admin/company/company/update-from-dnb.html
+++ b/datahub/company/templates/admin/company/company/update-from-dnb.html
@@ -1,0 +1,52 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_urls static %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media }}
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+<a href="{% url 'admin:index' %}">{% trans 'Home' %}</a>
+&rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+&rsaquo; <a href="{% url opts|admin_urlname:'change' object.pk|admin_urlquote %}">{{ object|truncatewords:"18" }}</a>
+&rsaquo; {% trans 'Update from D&B' %}
+</div>
+{% endblock %}
+
+{% block content %}
+  {% if diff %}
+  <p>{% blocktrans %}Please review the changes and confirm if you are happy to proceed:{% endblocktrans %}</p>
+  <br>
+  <table>
+      <thead>
+        <th>Field</th>
+        <th>Current Values</th>
+        <th>New Values</th>
+      </thead>
+      {% for field, value in diff.items %}
+      <tr>
+        <td>{{field.verbose_name|capfirst}}</td>
+        {% comment %}
+        <td>{{field.verbose_name | capfirst}}</td>
+        {% endcomment %}
+        <td>{{value.0}}</td>
+        <td>{{value.1}}</td>
+      </tr>
+      {% endfor %}
+  </table>
+  <br>
+  <form action="" method="post">
+    {% csrf_token %}
+    <div>
+      <input type="submit" value="{% trans 'Confirm' %}">
+    </div>
+  </form>
+  {% else %}
+  <p>Something went wrong. The engineers have been notified. Please contact support if this does not get resolved.</p>
+  {% endif %}
+{% endblock %}

--- a/datahub/company/test/admin/test_update_from_dnb.py
+++ b/datahub/company/test/admin/test_update_from_dnb.py
@@ -1,0 +1,237 @@
+from urllib.parse import urljoin
+
+import pytest
+from django.conf import settings
+from django.contrib.admin.templatetags.admin_urls import admin_urlname
+from django.contrib.messages import get_messages
+from django.urls import reverse
+from rest_framework import status
+from reversion.models import Version
+
+from datahub.company.models import Company, CompanyPermission
+from datahub.company.test.factories import CompanyFactory
+from datahub.core.test_utils import AdminTestMixin, create_test_user
+
+
+DNB_SEARCH_URL = urljoin(f'{settings.DNB_SERVICE_BASE_URL}/', 'companies/search/')
+
+
+@pytest.fixture
+def dnb_response():
+    """
+    Minimal valid DNB response
+    """
+    return {
+        'results': [
+            {
+                'address_line_1': '10 Fake Drive',
+                'address_line_2': '',
+                'address_postcode': 'AB0 1CD',
+                'address_town': 'London',
+                'address_county': '',
+                'address_country': 'GB',
+                'registered_address_line_1': '11 Fake Drive',
+                'registered_address_line_2': '',
+                'registered_address_postcode': 'AB0 2CD',
+                'registered_address_town': 'London',
+                'registered_address_county': '',
+                'registered_address_country': 'GB',
+                'domain': 'foo.com',
+                'duns_number': '123456789',
+                'primary_name': 'FOO BICYCLES LIMITED',
+                'trading_names': [],
+                'registration_numbers': [
+                    {
+                        'registration_number': '012345',
+                        'registration_type': 'uk_companies_house_number',
+                    },
+                ],
+            },
+        ],
+    }
+
+
+class TestUpdateFromDNB(AdminTestMixin):
+    """
+    Tests GET requests to 'Update from DNB'.
+    """
+
+    def _create_company(self, **kwargs):
+        self.company = CompanyFactory(**kwargs)
+        change_url = reverse(
+            admin_urlname(Company._meta, 'change'),
+            args=(self.company.pk, ),
+        )
+        update_url = reverse(
+            admin_urlname(Company._meta, 'update-from-dnb'),
+            args=(self.company.pk, ),
+        )
+        return (change_url, update_url)
+
+    def test_get(self, requests_mock, dnb_response):
+        """
+        Test that the link exists for a company with duns_number
+        and a user with the change company permission.
+        """
+        change_url, update_url = self._create_company(duns_number='123456789')
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response,
+        )
+        response = self.client.get(change_url)
+        assert update_url in response.rendered_content
+        response = self.client.get(update_url)
+        response.status_code == status.HTTP_200_OK
+
+    def test_get_view_permission_only(self):
+        """
+        Test that the link does not exist for a company with duns_number
+        but a user with only the view company permission.
+        """
+        change_url, update_url = self._create_company(duns_number='123456789')
+        user = create_test_user(
+            permission_codenames=(CompanyPermission.view_company,),
+            is_staff=True,
+            password=self.PASSWORD,
+        )
+        client = self.create_client(user=user)
+        response = client.get(change_url)
+        assert update_url not in response.rendered_content
+        response = client.get(update_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_get_no_duns_number(self):
+        """
+        Test that the link does not exist when the company does not
+        have a duns_number.
+        """
+        change_url, update_url = self._create_company()
+        response = self.client.get(change_url)
+        assert update_url not in response.rendered_content
+        response = self.client.get(update_url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_post(self, requests_mock, dnb_response):
+        """
+        Test that a post request to 'upddate-from-dnb' updates
+        the company.
+        """
+        _, update_url = self._create_company(
+            duns_number='123456789',
+            pending_dnb_investigation=True,
+        )
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response,
+        )
+        response = self.client.post(update_url)
+        assert response.status_code == status.HTTP_302_FOUND
+
+        self.company.refresh_from_db()
+        dnb_company = dnb_response['results'][0]
+
+        assert self.company.name == dnb_company['primary_name']
+        assert self.company.address_1 == dnb_company['address_line_1']
+        assert self.company.address_2 == dnb_company['address_line_2']
+        assert self.company.address_town == dnb_company['address_town']
+        assert self.company.address_county == dnb_company['address_county']
+        assert self.company.address_country.iso_alpha2_code == dnb_company['address_country']
+        assert self.company.registered_address_1 == dnb_company['registered_address_line_1']
+        assert self.company.registered_address_2 == dnb_company['registered_address_line_2']
+        assert self.company.registered_address_town == dnb_company['registered_address_town']
+        assert self.company.registered_address_county == dnb_company['registered_address_county']
+        assert self.company.registered_address_country.iso_alpha2_code == dnb_company['registered_address_country']  # noqa
+        assert not self.company.pending_dnb_investigation
+
+        versions = list(Version.objects.get_for_object(self.company))
+        assert len(versions) == 1
+        assert versions[0].revision.comment == 'Updated from D&B'
+
+    @pytest.mark.parametrize(
+        'dnb_response_code',
+        (
+            status.HTTP_400_BAD_REQUEST,
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+            status.HTTP_404_NOT_FOUND,
+            status.HTTP_500_INTERNAL_SERVER_ERROR,
+        ),
+    )
+    def test_post_dnb_error(self, requests_mock, dnb_response_code):
+        """
+        Tests that the users get an error message if the dnb-service
+        doesn't return with a 200 status code.
+        """
+        _, update_url = self._create_company(duns_number='123456789')
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            status_code=dnb_response_code,
+        )
+        response = self.client.post(update_url)
+        assert response.status_code == status.HTTP_302_FOUND
+
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 1
+        assert str(messages[0]) == 'Something went wrong in an upstream service.'
+
+    @pytest.mark.parametrize(
+        'search_results, expected_message',
+        (
+            (
+                [],
+                'No matching company found in D&B database.',
+            ),
+            (
+                ['foo', 'bar'],
+                'Something went wrong in an upstream service.',
+            ),
+            (
+                [{'duns_number': '012345678'}],
+                'Something went wrong in an upstream service.',
+            ),
+        ),
+    )
+    def test_post_dnb_response_invalid(
+        self,
+        requests_mock,
+        search_results,
+        expected_message,
+    ):
+        """
+        Test if we gets anything other than a single company from dnb-service,
+        we return an error message to the user.
+        """
+        _, update_url = self._create_company(duns_number='123456789')
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json={'results': search_results},
+        )
+        response = self.client.post(update_url)
+        assert response.status_code == status.HTTP_302_FOUND
+
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 1
+        assert str(messages[0]) == expected_message
+
+    def test_post_dnb_data_invalid(
+        self,
+        requests_mock,
+        dnb_response,
+    ):
+        """
+        Tests that if the data returned from DNB does not
+        clear DataHub validation, we show an appropriate
+        message to our users.
+        """
+        _, update_url = self._create_company(duns_number='123456789')
+        dnb_response['results'][0]['primary_name'] = None
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response,
+        )
+        response = self.client.post(update_url)
+        assert response.status_code == status.HTTP_302_FOUND
+
+        messages = list(get_messages(response.wsgi_request))
+        assert len(messages) == 1
+        assert str(messages[0]) == 'Data from D&B did not pass the Data Hub validation checks.'


### PR DESCRIPTION
### Description of change
This PR adds a tool to Django admin to allow administrators to pull fresh data from DNB for a company with a `duns_number`.

This allows administrators to resolve the unhappy-path for the new add-a-company journey by adding a `duns_number` to a company record followed by pulling data from DNB for the given company.

In order to test this locally:

1. Paste the following code at the end of `datahub/dnb_api/utils.py`:

```
from unittest.mock import Mock
dnb_response = Mock()
dnb_response.status_code = 200
dnb_response.json = lambda: {
    'results': [
        {
            'address_country': '',
            'address_county': '',
            'address_line_1': 'Unit 10, Ockham Drive',
            'address_line_2': '',
            'address_postcode': 'UB6 0F2',
            'address_town': 'GREENFORD',
            'annual_sales': 50651895.0,
            'annual_sales_currency': 'USD',
            'domain': 'foo.com',
            'duns_number': '291332174',
            'primary_name': 'FOO BICYCLE LIMITED',
            'registration_numbers': [
                {
                    'registration_number': '01261539',
                    'registration_type': 'uk_companies_house_number',
                },
            ],
            'trading_names': [],
        },
    ],
}
search_dnb = lambda _: dnb_response
```

2. Run the local server
3. Navigate to the change view for a company, paste `291332174 ` as the `duns_number` and hit save.
4. Hit "Update from DNB" button.

P.S. The tests are specifically testing the admin functionality added as part of the PR. The underlying functions etc. have good test coverage and so I chose to not add more test for these.

Here is a screenshot of how it looks like:

<img width="1438" alt="Screenshot 2019-10-10 at 11 33 48" src="https://user-images.githubusercontent.com/3349430/66561773-04b00180-eb52-11e9-9707-6a65bd4df50d.png">

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
