### PR TITLE
POC for a way to speed up search tests.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -161,6 +161,19 @@ def synchronous_on_commit_for_class(monkeyclass):
     monkeyclass.setattr('django.db.transaction.on_commit', _synchronous_on_commit)
 
 
+@pytest.fixture(scope='class')
+def django_db_for_class(request, django_db_setup, django_db_blocker):
+    """
+    Make the db available for use in a class-scoped fixture.
+    """
+    django_db_blocker.unblock()
+    request.addfinalizer(django_db_blocker.restore)
+    from django.test import TestCase
+    test_case = TestCase(methodName='__init__')
+    test_case._pre_setup()
+    request.addfinalizer(test_case._post_teardown)
+
+
 def _synchronous_submit_to_thread_pool(fn, *args, **kwargs):
     fn(*args, **kwargs)
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import factory
 import pytest
@@ -6,6 +6,7 @@ from botocore.stub import Stubber
 from django.conf import settings
 from django.core.cache import CacheHandler
 from django.core.management import call_command
+from django.db import transaction
 from elasticsearch.helpers.test import get_test_client
 from pytest_django.lazy_django import skip_if_no_django
 
@@ -147,18 +148,10 @@ def synchronous_on_commit(monkeypatch):
 
 
 @pytest.fixture(scope='class')
-def monkeyclass():
-    """Monkeypatch fixture which works in the class scope"""
-    from _pytest.monkeypatch import MonkeyPatch
-    mpatch = MonkeyPatch()
-    yield mpatch
-    mpatch.undo()
-
-
-@pytest.fixture(scope='class')
-def synchronous_on_commit_for_class(monkeyclass):
+def synchronous_on_commit_for_class():
     """synchronous_on_commit fixture which works in the class scope"""
-    monkeyclass.setattr('django.db.transaction.on_commit', _synchronous_on_commit)
+    with patch.object(transaction, 'on_commit', side_effect=_synchronous_on_commit):
+        yield
 
 
 @pytest.fixture(scope='class')

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -541,17 +541,11 @@ class TestOrderExportView(APITestMixin):
     @classmethod
     @pytest.fixture(scope='class', autouse=True)
     def one_time_setup(
-        self, request, setup_es_for_class, django_db_setup, django_db_blocker,  # noqa: N804
+        cls, request, setup_es_for_class, django_db_for_class,
     ):
         """
-        One time data setup for the class. No tests will modify data so can be re-used.
+        One time data setup for the class. No tests will modify data so can be class-scoped.
         """
-        django_db_blocker.unblock()
-        request.addfinalizer(django_db_blocker.restore)
-        from django.test import TestCase
-        test_case = TestCase(methodName='__init__')
-        test_case._pre_setup()
-        request.addfinalizer(test_case._post_teardown)
         factories = (
             OrderCancelledFactory,
             OrderCompleteFactory,


### PR DESCRIPTION
There are a good number of tests that have expensive setup which is not
mutated, and which can be re-used across a number of tests.

This PR shows how this might be done with one particularly slow set of tests. Setup time on my machine for each of the 6 tests in TestOrderExportView was 21.5 seconds. Therefore by reusing the setup we can potentially save around 105 seconds. However, as noted below, this gain is reduced by parallelism.

Some things that need more consideration:
1. ~How can we reuse the boiler plate at the beginning of the one_time_setup function?~
*I have now put this boilerplate in a django_db_for_class fixture in conftest.*
2. The gains are reduced by parallelism as the expensive setup needs to be performed by each worker. If there were some way of making a whole class of tests remain together in a single worker that would be ideal. *Suggestion: Mark these tests as "non-parallelized". Run the non-parallelised tests as a separate step in the build pipeline.*
3.~It would be ideal if we didn't need separate fixtures for the class scope for each of monkeypatch, setup_es_class, and synchronous_on_commmit, but I'm not sure if there is any way of avoiding that.~ *I am no longer concerned with this*
4. ~The test_user_without_permission_cannot_export test in particular only uses the setup_es fixture and its setup time is 9 seconds. If there are many other tests like this then we could potentially have a session-scoped setup_es fixture for massive savings.~ Turns out this 9 seconds is not primarily a result of the setup_es fixture

### Description of change



### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
