### PR TITLE
Optimise use of sub-factories in tests

### DIFF
--- a/datahub/company/test/factories.py
+++ b/datahub/company/test/factories.py
@@ -36,7 +36,7 @@ class CompanyFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
     name = factory.Faker('company')
     trading_names = factory.List([
         factory.Faker('company'),
@@ -155,7 +155,7 @@ class ContactFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
     title_id = constants.Title.wing_commander.value.id
     first_name = factory.Faker('first_name')
     last_name = factory.Faker('last_name')

--- a/datahub/event/test/factories.py
+++ b/datahub/event/test/factories.py
@@ -14,7 +14,7 @@ class EventFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
     name = factory.Faker('text')
     event_type_id = EventType.seminar.value.id
     start_date = factory.Faker('date_object')

--- a/datahub/feature_flag/test/factories.py
+++ b/datahub/feature_flag/test/factories.py
@@ -16,7 +16,7 @@ class FeatureFlagFactory(factory.django.DjangoModelFactory):
 
     created_on = now()
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
 
     class Meta:
         model = 'feature_flag.FeatureFlag'

--- a/datahub/interaction/test/factories.py
+++ b/datahub/interaction/test/factories.py
@@ -55,7 +55,7 @@ class InteractionFactoryBase(factory.django.DjangoModelFactory):
     """Factory for creating an interaction relating to a company."""
 
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
     company = factory.SubFactory(CompanyFactory)
     subject = factory.Faker('sentence', nb_words=8)
     date = factory.Faker('past_datetime', start_date='-5y', tzinfo=utc)

--- a/datahub/investment/project/proposition/test/factories.py
+++ b/datahub/investment/project/proposition/test/factories.py
@@ -24,8 +24,8 @@ class PropositionFactory(factory.django.DjangoModelFactory):
     scope = factory.Faker('text')
 
     created_on = now()
-    created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    created_by = factory.SelfAttribute('adviser')
+    modified_by = factory.SelfAttribute('adviser')
 
     class Meta:
         model = Proposition

--- a/datahub/investment/project/report/test/factories.py
+++ b/datahub/investment/project/report/test/factories.py
@@ -16,7 +16,7 @@ class SPIReportFactory(factory.django.DjangoModelFactory):
 
     created_on = now()
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
 
     class Meta:
         model = SPIReport

--- a/datahub/investment/project/test/factories.py
+++ b/datahub/investment/project/test/factories.py
@@ -36,7 +36,7 @@ class InvestmentProjectFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
     name = factory.Sequence(lambda n: f'name {n}')
     description = factory.Sequence(lambda n: f'desc {n}')
     comments = factory.Faker('text')

--- a/datahub/omis/order/test/factories.py
+++ b/datahub/omis/order/test/factories.py
@@ -22,7 +22,7 @@ class OrderFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
     company = factory.SubFactory(CompanyFactory)
     contact = factory.SubFactory(
         ContactFactory,

--- a/datahub/omis/payment/test/factories.py
+++ b/datahub/omis/payment/test/factories.py
@@ -43,7 +43,7 @@ class RequestedRefundFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
     order = factory.SubFactory(OrderPaidFactory)
     reference = factory.Faker('pystr')
     status = RefundStatus.requested
@@ -64,11 +64,11 @@ class ApprovedRefundFactory(RequestedRefundFactory):
     status = RefundStatus.approved
 
     level1_approved_on = factory.Faker('date_time', tzinfo=utc)
-    level1_approved_by = factory.SubFactory(AdviserFactory)
+    level1_approved_by = factory.SelfAttribute('created_by')
     level1_approval_notes = factory.Faker('text')
 
     level2_approved_on = factory.Faker('date_time', tzinfo=utc)
-    level2_approved_by = factory.SubFactory(AdviserFactory)
+    level2_approved_by = factory.SelfAttribute('created_by')
     level2_approval_notes = factory.Faker('text')
 
     method = constants.PaymentMethod.bacs

--- a/datahub/omis/quote/test/factories.py
+++ b/datahub/omis/quote/test/factories.py
@@ -12,7 +12,7 @@ class QuoteFactory(factory.django.DjangoModelFactory):
 
     id = factory.LazyFunction(uuid.uuid4)
     created_by = factory.SubFactory(AdviserFactory)
-    modified_by = factory.SubFactory(AdviserFactory)
+    modified_by = factory.SelfAttribute('created_by')
     reference = factory.Faker('text', max_nb_chars=10)
     content = factory.Faker('text')
     expires_on = factory.Faker('future_date')
@@ -26,7 +26,7 @@ class CancelledQuoteFactory(QuoteFactory):
     """Cancelled Order factory."""
 
     cancelled_on = now()
-    cancelled_by = factory.SubFactory(AdviserFactory)
+    cancelled_by = factory.SelfAttribute('created_by')
 
 
 class AcceptedQuoteFactory(QuoteFactory):


### PR DESCRIPTION
### Description of change

This reduces the use of adviser sub-factories in tests for certain fields like `modified_by` by making them reuse advisers from other fields.

These uses of sub-factories were generally unnecessary and added a fair bit of overhead. (The values can still be overridden in specific tests if really needed.)

For me, these changes reduces the running time of the tests under `datahub/omis/` by about 10% (46 seconds vs 41 seconds). The whole test suite goes down from about 700 seconds to 635 seconds (-9%) (could be less accurate as this is more difficult to measure).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
