### PR TITLE
Replace [] with get() to get around missing fields

### DIFF
--- a/datahub/company/admin/dnb.py
+++ b/datahub/company/admin/dnb.py
@@ -34,86 +34,93 @@ def _format_company_diff(dh_company, dnb_company):
     def get_field(name):
         return dh_company._meta.get_field(name)
 
+    def get_country(address):
+        country = address.get('country')
+        return None if country is None else Country.objects.get(id=country)
+
+    address = dnb_company.get('address') or {}
+    registered_address = dnb_company.get('registered_address') or {}
+
     return {
         get_field('name'): (
             dh_company.name,
-            dnb_company['name'],
+            dnb_company.get('name'),
         ),
         get_field('address_1'): (
             dh_company.address_1,
-            dnb_company['address']['line_1'],
+            address.get('line_1'),
         ),
         get_field('address_2'): (
             dh_company.address_2,
-            dnb_company['address']['line_2'],
+            address.get('line_2'),
         ),
         get_field('address_town'): (
             dh_company.address_town,
-            dnb_company['address']['town'],
+            address.get('town'),
         ),
         get_field('address_county'): (
             dh_company.address_county,
-            dnb_company['address']['county'],
+            address.get('county'),
         ),
         get_field('address_postcode'): (
             dh_company.address_postcode,
-            dnb_company['address']['postcode'],
+            address.get('postcode'),
         ),
         get_field('address_country'): (
             dh_company.address_country,
-            Country.objects.get(id=dnb_company['address']['country']),
+            get_country(address),
         ),
         get_field('registered_address_1'): (
             dh_company.registered_address_1,
-            dnb_company['registered_address']['line_1'],
+            registered_address.get('line_1'),
         ),
         get_field('registered_address_2'): (
             dh_company.registered_address_2,
-            dnb_company['registered_address']['line_2'],
+            registered_address.get('line_2'),
         ),
         get_field('registered_address_town'): (
             dh_company.registered_address_town,
-            dnb_company['registered_address']['town'],
+            registered_address.get('town'),
         ),
         get_field('registered_address_county'): (
             dh_company.registered_address_county,
-            dnb_company['registered_address']['county'],
+            registered_address.get('county'),
         ),
         get_field('registered_address_postcode'): (
             dh_company.registered_address_postcode,
-            dnb_company['registered_address']['postcode'],
+            registered_address.get('postcode'),
         ),
         get_field('registered_address_country'): (
             dh_company.registered_address_country,
-            Country.objects.get(id=dnb_company['registered_address']['country']),
+            get_country(registered_address),
         ),
         get_field('company_number'): (
             dh_company.company_number,
-            dnb_company['company_number'],
+            dnb_company.get('company_number'),
         ),
         get_field('trading_names'): (
             ', '.join(dh_company.trading_names),
-            ', '.join(dnb_company['trading_names']),
+            ', '.join(dnb_company.get('trading_names', [])),
         ),
         get_field('website'): (
             dh_company.website,
-            dnb_company['website'],
+            dnb_company.get('website'),
         ),
         get_field('number_of_employees'): (
             dh_company.number_of_employees,
-            dnb_company['number_of_employees'],
+            dnb_company.get('number_of_employees'),
         ),
         get_field('is_number_of_employees_estimated'): (
             dh_company.is_number_of_employees_estimated,
-            dnb_company['is_number_of_employees_estimated'],
+            dnb_company.get('is_number_of_employees_estimated'),
         ),
         get_field('turnover'): (
             dh_company.turnover,
-            dnb_company['turnover'],
+            dnb_company.get('turnover'),
         ),
         get_field('is_turnover_estimated'): (
             dh_company.is_turnover_estimated,
-            dnb_company['is_turnover_estimated'],
+            dnb_company.get('is_turnover_estimated'),
         ),
     }
 

--- a/datahub/company/templates/admin/company/company/update-from-dnb.html
+++ b/datahub/company/templates/admin/company/company/update-from-dnb.html
@@ -30,10 +30,7 @@
       </thead>
       {% for field, value in diff.items %}
       <tr>
-        <td>{{field.verbose_name|capfirst}}</td>
-        {% comment %}
         <td>{{field.verbose_name | capfirst}}</td>
-        {% endcomment %}
         <td>{{value.0}}</td>
         <td>{{value.1}}</td>
       </tr>


### PR DESCRIPTION
### Description of change

I found in dev that some companies from D&B did not have `registered_address` fields set. 

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?