### PR TITLE
Use quicker password hasher in tests

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -42,6 +42,12 @@ GOVUK_PAY_URL = 'https://payments.example.com/'
 
 INTERACTION_ADMIN_CSV_IMPORT_MAX_SIZE = 5 * 1024
 
+# The default password hasher is intentionally slow and slows downs tests
+# See https://docs.djangoproject.com/en/2.2/topics/testing/overview/#password-hashing
+PASSWORD_HASHERS = [
+    'django.contrib.auth.hashers.MD5PasswordHasher',
+]
+
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.dummy.DummyCache'


### PR DESCRIPTION
### Description of change

The default password hasher is intentionally slow and was slowing down tests. The Django docs suggest using the MD5 password hasher in tests, so this switches to that.

See https://docs.djangoproject.com/en/2.2/topics/testing/overview/#password-hashing

The impact of this will vary by test (depending on whether they set passwords for users – e.g. the admin site tests do this).

For the tests under `datahub/company/`, I saw a 15% reduction in running time (104 seconds vs 125 seconds).

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
