### PR TITLE
Disable Elasticsearch automatic refresh in tests

### DIFF
--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -29,6 +29,16 @@ ES_INDEX_SETTINGS = {
     **ES_INDEX_SETTINGS,
     'number_of_shards': 1,
     'number_of_replicas': 0,
+    # Refresh is the process in Elasticsearch that makes newly-indexed documents available for
+    # querying (see
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html
+    # for more details).
+    #
+    # Relying on automatic refreshing in tests leads to flakiness, and so all tests that use
+    # Elasticsearch explicitly refresh indices after documents have been added to Elasticsearch.
+    #
+    # This disables automatic refresh in tests to avoid inadvertently relying on it.
+    'refresh_interval': -1,
 }
 DOCUMENT_BUCKET = 'test-bucket'
 AV_V2_SERVICE_URL = 'http://av-service/'


### PR DESCRIPTION
### Description of change

Refresh is the process in Elasticsearch that makes newly-indexed documents available for querying (see https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-refresh.html for more details).

Relying on automatic refreshing in tests leads to flakiness, and so all tests that use Elasticsearch explicitly refresh indices after documents have been added to Elasticsearch.

This disables automatic refresh in tests to avoid inadvertently relying on it.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
