### PR TITLE
Rename and refactor Elasticsearch pytest fixtures

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -221,8 +221,15 @@ def _es_session(_es_client):
 
 
 @pytest.fixture
-def setup_es(_es_session, synchronous_on_commit):
-    """Sets up ES and deletes all the records after each run."""
+def es_with_signals(_es_session, synchronous_on_commit):
+    """
+    Function-scoped pytest fixture that:
+
+    - ensures Elasticsearch is available for the test
+    - connects search signal receivers so that Elasticsearch documents are automatically
+    created for model instances saved during the test
+    - deletes all documents from Elasticsearch at the end of the test
+    """
     for search_app in get_search_apps():
         search_app.connect_signals()
 

--- a/datahub/cleanup/test/commands/conftest.py
+++ b/datahub/cleanup/test/commands/conftest.py
@@ -5,7 +5,7 @@ from datahub.search.apps import get_search_apps
 
 
 @pytest.fixture
-def disconnect_delete_search_signal_receivers(setup_es):
+def disconnect_delete_search_signal_receivers(es_with_signals):
     """
     Fixture that disables signal receivers that delete documents in Elasticsearch.
 
@@ -27,8 +27,8 @@ def disconnect_delete_search_signal_receivers(setup_es):
 
     yield
 
-    # We reconnect the receivers for completeness, though in theory it's not necessary as setup_es
-    # will disconnect them anyway
+    # We reconnect the receivers for completeness, though in theory it's not necessary as
+    # es_with_signals will disconnect them anyway
 
     for receiver in disconnected_signal_receivers:
         receiver.connect()

--- a/datahub/company/test/test_public_company_view.py
+++ b/datahub/company/test/test_public_company_view.py
@@ -70,7 +70,7 @@ class TestPublicCompanyViewSet:
 
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
-    def test_response_is_signed(self, setup_es, public_company_api_client):
+    def test_response_is_signed(self, es_with_signals, public_company_api_client):
         """Test that responses are signed."""
         company = CompanyFactory()
         url = reverse('api-v4:company:public-item', kwargs={'pk': company.pk})

--- a/datahub/search/apps.py
+++ b/datahub/search/apps.py
@@ -162,7 +162,7 @@ class SearchConfig(AppConfig):
 
         for app in get_search_apps():
             # For tests we disable automatic connection of signal receivers on app ready.
-            # They are instead only enabled for tests that use the setup_es pytest fixture
+            # They are instead only enabled for tests that use the es_with_signals pytest fixture
             if settings.SEARCH_CONNECT_SIGNAL_RECEIVERS_ON_READY:
                 app.connect_signals()
 

--- a/datahub/search/companieshousecompany/test/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/test/test_elasticsearch.py
@@ -12,7 +12,7 @@ from datahub.search.companieshousecompany.models import (
 pytestmark = pytest.mark.django_db
 
 
-def test_mapping(es_with_signals):
+def test_mapping(es):
     """Test the ES mapping for a companies house company."""
     mapping = Mapping.from_es(
         CompaniesHouseCompanySearchApp.es_model.get_target_index_name(),
@@ -127,16 +127,16 @@ def test_mapping(es_with_signals):
     }
 
 
-def test_indexed_doc(es_with_signals):
+def test_indexed_doc(es):
     """Test the ES data of an indexed companies house company."""
     ch_company = CompaniesHouseCompanyFactory()
 
     doc = ESCompaniesHouseCompany.es_document(ch_company)
     elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
-    es_with_signals.indices.refresh()
+    es.indices.refresh()
 
-    indexed_ch_company = es_with_signals.get(
+    indexed_ch_company = es.get(
         index=ESCompaniesHouseCompany.get_write_index(),
         doc_type=CompaniesHouseCompanySearchApp.name,
         id=ch_company.pk,

--- a/datahub/search/companieshousecompany/test/test_elasticsearch.py
+++ b/datahub/search/companieshousecompany/test/test_elasticsearch.py
@@ -12,7 +12,7 @@ from datahub.search.companieshousecompany.models import (
 pytestmark = pytest.mark.django_db
 
 
-def test_mapping(setup_es):
+def test_mapping(es_with_signals):
     """Test the ES mapping for a companies house company."""
     mapping = Mapping.from_es(
         CompaniesHouseCompanySearchApp.es_model.get_target_index_name(),
@@ -127,16 +127,16 @@ def test_mapping(setup_es):
     }
 
 
-def test_indexed_doc(setup_es):
+def test_indexed_doc(es_with_signals):
     """Test the ES data of an indexed companies house company."""
     ch_company = CompaniesHouseCompanyFactory()
 
     doc = ESCompaniesHouseCompany.es_document(ch_company)
     elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    indexed_ch_company = setup_es.get(
+    indexed_ch_company = es_with_signals.get(
         index=ESCompaniesHouseCompany.get_write_index(),
         doc_type=CompaniesHouseCompanySearchApp.name,
         id=ch_company.pk,

--- a/datahub/search/companieshousecompany/test/test_views_v3.py
+++ b/datahub/search/companieshousecompany/test/test_views_v3.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(setup_es):
+def setup_data(es_with_signals):
     """Sets up data for the tests."""
     companies = (
         CompaniesHouseCompanyFactory(
@@ -49,7 +49,7 @@ def setup_data(setup_es):
     for company in companies:
         sync_object(CompaniesHouseCompanySearchApp, company.pk)
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
 
 class TestSearchCompaniesHouseCompany(APITestMixin):
@@ -113,7 +113,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
         assert len(response_data['results']) == len(expected_results)
         assert actual_results == expected_results
 
-    def test_response_body(self, setup_es):
+    def test_response_body(self, es_with_signals):
         """Tests the response body of a search query."""
         company = CompaniesHouseCompanyFactory(
             name='Pallas',
@@ -122,7 +122,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
             company_status='jumping',
         )
         sync_object(CompaniesHouseCompanySearchApp, company.pk)
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:companieshousecompany')
         response = self.api_client.post(url)

--- a/datahub/search/companieshousecompany/test/test_views_v4.py
+++ b/datahub/search/companieshousecompany/test/test_views_v4.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(setup_es):
+def setup_data(es_with_signals):
     """Sets up data for the tests."""
     companies = (
         CompaniesHouseCompanyFactory(
@@ -49,7 +49,7 @@ def setup_data(setup_es):
     for company in companies:
         sync_object(CompaniesHouseCompanySearchApp, company.pk)
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
 
 class TestSearchCompaniesHouseCompany(APITestMixin):
@@ -113,7 +113,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
         assert len(response_data['results']) == len(expected_results)
         assert actual_results == expected_results
 
-    def test_response_body(self, setup_es):
+    def test_response_body(self, es_with_signals):
         """Tests the response body of a search query."""
         company = CompaniesHouseCompanyFactory(
             name='Pallas',
@@ -122,7 +122,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
             company_status='jumping',
         )
         sync_object(CompaniesHouseCompanySearchApp, company.pk)
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v4:search:companieshousecompany')
         response = self.api_client.post(url)

--- a/datahub/search/company/test/test_basic_search_views.py
+++ b/datahub/search/company/test/test_basic_search_views.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(setup_es):
+def setup_data(es_with_signals):
     """Sets up data for the tests."""
     country_uk = constants.Country.united_kingdom.value.id
     country_us = constants.Country.united_states.value.id
@@ -32,7 +32,7 @@ def setup_data(setup_es):
         address_country_id=country_us,
         registered_address_country_id=country_us,
     )
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
 
 class TestBasicSearch(APITestMixin):
@@ -97,7 +97,7 @@ class TestBasicSearch(APITestMixin):
             ('moine', None),
         ),
     )
-    def test_search_in_name(self, setup_es, name_term, matched_company_name):
+    def test_search_in_name(self, es_with_signals, name_term, matched_company_name):
         """Tests basic aggregate companies query."""
         CompanyFactory(
             name='whiskers and tabby',
@@ -107,7 +107,7 @@ class TestBasicSearch(APITestMixin):
             name='1a',
             trading_names=['3a', '4a'],
         )
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         response = self.api_client.get(
@@ -137,7 +137,14 @@ class TestBasicSearch(APITestMixin):
             ('registered_address_postcode', 'SW1A 1AA', 'SW1A 1AB', False),
         ),
     )
-    def test_search_in_field(self, setup_es, model_field, model_value, search_term, match_found):
+    def test_search_in_field(
+        self,
+        es_with_signals,
+        model_field,
+        model_value,
+        search_term,
+        match_found,
+    ):
         """Tests basic aggregate companies query."""
         CompanyFactory()
         CompanyFactory(
@@ -146,7 +153,7 @@ class TestBasicSearch(APITestMixin):
                 model_field: model_value,
             },
         )
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         response = self.api_client.get(

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -12,7 +12,7 @@ from datahub.search.query_builder import (
 )
 
 
-def test_mapping(es_with_signals):
+def test_mapping(es):
     """Test the ES mapping for a company."""
     mapping = Mapping.from_es(
         CompanySearchApp.es_model.get_write_index(),
@@ -492,7 +492,7 @@ def test_limited_get_search_by_entity_query():
 
 
 @pytest.mark.django_db
-def test_indexed_doc(es_with_signals):
+def test_indexed_doc(es):
     """Test the ES data of an indexed company."""
     company = CompanyFactory(
         trading_names=['a', 'b'],
@@ -501,9 +501,9 @@ def test_indexed_doc(es_with_signals):
     doc = ESCompany.es_document(company)
     elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
-    es_with_signals.indices.refresh()
+    es.indices.refresh()
 
-    indexed_company = es_with_signals.get(
+    indexed_company = es.get(
         index=CompanySearchApp.es_model.get_write_index(),
         doc_type=CompanySearchApp.name,
         id=company.pk,

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -12,7 +12,7 @@ from datahub.search.query_builder import (
 )
 
 
-def test_mapping(setup_es):
+def test_mapping(es_with_signals):
     """Test the ES mapping for a company."""
     mapping = Mapping.from_es(
         CompanySearchApp.es_model.get_write_index(),
@@ -492,7 +492,7 @@ def test_limited_get_search_by_entity_query():
 
 
 @pytest.mark.django_db
-def test_indexed_doc(setup_es):
+def test_indexed_doc(es_with_signals):
     """Test the ES data of an indexed company."""
     company = CompanyFactory(
         trading_names=['a', 'b'],
@@ -501,9 +501,9 @@ def test_indexed_doc(setup_es):
     doc = ESCompany.es_document(company)
     elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    indexed_company = setup_es.get(
+    indexed_company = es_with_signals.get(
         index=CompanySearchApp.es_model.get_write_index(),
         doc_type=CompanySearchApp.name,
         id=company.pk,

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.django_db
 class TestCompanyElasticModel:
     """Test for the company elasticsearch model"""
 
-    def test_company_dbmodel_to_dict(self, setup_es):
+    def test_company_dbmodel_to_dict(self, es_with_signals):
         """Tests conversion of db model to dict."""
         company = CompanyFactory()
 
@@ -54,7 +54,7 @@ class TestCompanyElasticModel:
 
         assert set(result.keys()) == keys
 
-    def test_company_dbmodels_to_es_documents(self, setup_es):
+    def test_company_dbmodels_to_es_documents(self, es_with_signals):
         """Tests conversion of db models to Elasticsearch documents."""
         companies = CompanyFactory.create_batch(2)
 

--- a/datahub/search/company/test/test_public_search_view.py
+++ b/datahub/search/company/test/test_public_search_view.py
@@ -14,7 +14,7 @@ from datahub.core.test_utils import HawkAPITestClient
 
 
 @pytest.fixture
-def setup_data(setup_es):
+def setup_data(es_with_signals):
     """Sets up data for the tests."""
     country_uk = constants.Country.united_kingdom.value.id
     country_us = constants.Country.united_states.value.id
@@ -46,7 +46,7 @@ def setup_data(setup_es):
         registered_address_country_id=country_anguilla,
         archived=True,
     )
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
 
 @pytest.fixture
@@ -95,7 +95,7 @@ class TestPublicCompanySearch:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_response_body(self, setup_es, public_company_api_client):
+    def test_response_body(self, es_with_signals, public_company_api_client):
         """Tests the response body of a search query."""
         company = CompanyFactory(
             company_number='123',
@@ -104,7 +104,7 @@ class TestPublicCompanySearch:
             one_list_tier=None,
             one_list_account_owner=None,
         )
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v4:search:public-company')
         response = public_company_api_client.post(url, {})
@@ -191,7 +191,7 @@ class TestPublicCompanySearch:
             ],
         }
 
-    def test_response_is_signed(self, setup_es, public_company_api_client):
+    def test_response_is_signed(self, es_with_signals, public_company_api_client):
         """Test that responses are signed."""
         url = reverse('api-v4:search:public-company')
         response = public_company_api_client.post(url, {})
@@ -266,7 +266,7 @@ class TestPublicCompanySearch:
     def test_composite_name_filter(
         self,
         public_company_api_client,
-        setup_es,
+        es_with_signals,
         name_term,
         matched_company_name,
     ):
@@ -279,7 +279,7 @@ class TestPublicCompanySearch:
             name='1a',
             trading_names=['3a', '4a'],
         )
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v4:search:public-company')
         request_data = {
@@ -297,7 +297,7 @@ class TestPublicCompanySearch:
             assert response.data['count'] == 0
             assert len(response.data['results']) == 0
 
-    def test_pagination(self, public_company_api_client, setup_es):
+    def test_pagination(self, public_company_api_client, es_with_signals):
         """Test result pagination."""
         total_records = 9
         page_size = 2
@@ -311,7 +311,7 @@ class TestPublicCompanySearch:
             trading_names=[],
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v4:search:public-company')
 

--- a/datahub/search/company/test/test_signals.py
+++ b/datahub/search/company/test/test_signals.py
@@ -7,20 +7,20 @@ from datahub.search.query_builder import get_basic_search_query
 pytestmark = pytest.mark.django_db
 
 
-def test_company_auto_sync_to_es(setup_es):
+def test_company_auto_sync_to_es(es_with_signals):
     """Tests if company gets synced to Elasticsearch."""
     test_name = 'very_hard_to_find_company'
     CompanyFactory(
         name=test_name,
     )
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     result = get_basic_search_query(Company, test_name).execute()
 
     assert result.hits.total == 1
 
 
-def test_company_auto_updates_to_es(setup_es):
+def test_company_auto_updates_to_es(es_with_signals):
     """Tests if company gets updated in Elasticsearch."""
     test_name = 'very_hard_to_find_company_international'
     company = CompanyFactory(
@@ -29,7 +29,7 @@ def test_company_auto_updates_to_es(setup_es):
     new_test_name = 'very_hard_to_find_company_local'
     company.name = new_test_name
     company.save()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     result = get_basic_search_query(Company, new_test_name).execute()
 

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -9,7 +9,7 @@ from datahub.search.query_builder import (
 )
 
 
-def test_mapping(setup_es):
+def test_mapping(es_with_signals):
     """Test the ES mapping for a contact."""
     mapping = Mapping.from_es(
         ContactSearchApp.es_model.get_write_index(),

--- a/datahub/search/contact/test/test_elasticsearch.py
+++ b/datahub/search/contact/test/test_elasticsearch.py
@@ -9,7 +9,7 @@ from datahub.search.query_builder import (
 )
 
 
-def test_mapping(es_with_signals):
+def test_mapping(es):
     """Test the ES mapping for a contact."""
     mapping = Mapping.from_es(
         ContactSearchApp.es_model.get_write_index(),

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -7,7 +7,7 @@ from datahub.search.contact.models import Contact as ESContact
 pytestmark = pytest.mark.django_db
 
 
-def test_contact_dbmodel_to_dict(setup_es):
+def test_contact_dbmodel_to_dict(es_with_signals):
     """Tests conversion of db model to dict."""
     contact = ContactFactory()
 
@@ -51,7 +51,7 @@ def test_contact_dbmodel_to_dict(setup_es):
     assert set(result.keys()) == keys
 
 
-def test_contact_dbmodels_to_es_documents(setup_es):
+def test_contact_dbmodels_to_es_documents(es_with_signals):
     """Tests conversion of db models to Elasticsearch documents."""
     contacts = ContactFactory.create_batch(2)
 
@@ -60,7 +60,7 @@ def test_contact_dbmodels_to_es_documents(setup_es):
     assert len(list(result)) == len(contacts)
 
 
-def test_contact_dbmodels_to_es_documents_without_country(setup_es):
+def test_contact_dbmodels_to_es_documents_without_country(es_with_signals):
     """
     Tests conversion of db models to Elasticsearch documents when
     country is None.

--- a/datahub/search/contact/test/test_signals.py
+++ b/datahub/search/contact/test/test_signals.py
@@ -7,20 +7,20 @@ from datahub.search.query_builder import get_basic_search_query
 pytestmark = pytest.mark.django_db
 
 
-def test_contact_auto_sync_to_es(setup_es):
+def test_contact_auto_sync_to_es(es_with_signals):
     """Tests if contact gets synced to Elasticsearch."""
     test_name = 'very_hard_to_find_contact'
     ContactFactory(
         first_name=test_name,
     )
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     result = get_basic_search_query(Contact, test_name).execute()
 
     assert result.hits.total == 1
 
 
-def test_contact_auto_updates_to_es(setup_es):
+def test_contact_auto_updates_to_es(es_with_signals):
     """Tests if contact gets updated in Elasticsearch."""
     test_name = 'very_hard_to_find_contact_ii'
     contact = ContactFactory(
@@ -31,7 +31,7 @@ def test_contact_auto_updates_to_es(setup_es):
     new_test_name = 'very_hard_to_find_contact_v'
     contact.first_name = new_test_name
     contact.save()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     result = get_basic_search_query(Contact, new_test_name).execute()
 

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -66,9 +66,9 @@ class TestSearch(APITestMixin):
         response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_search_contact(self, setup_es, setup_data):
+    def test_search_contact(self, es_with_signals, setup_data):
         """Tests detailed contact search."""
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'abc defg'
 
@@ -89,7 +89,7 @@ class TestSearch(APITestMixin):
         contact = response.data['results'][0]
         assert contact['address_country']['id'] == united_kingdom_id
 
-    def test_filter_contact(self, setup_es):
+    def test_filter_contact(self, es_with_signals):
         """Tests matching contact using multiple filters."""
         contact = ContactFactory(
             address_same_as_company=True,
@@ -100,7 +100,7 @@ class TestSearch(APITestMixin):
                 sector_id=Sector.renewable_energy_wind.value.id,
             ),
         )
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -122,7 +122,7 @@ class TestSearch(APITestMixin):
         assert result['company_uk_region']['id'] == contact.company.uk_region_id
         assert result['company_sector']['id'] == contact.company.sector_id
 
-    def test_filter_without_uk_region(self, setup_es):
+    def test_filter_without_uk_region(self, es_with_signals):
         """Tests matching contact without uk_region using multiple filters."""
         company = CompanyFactory(
             registered_address_country_id=Country.united_states.value.id,
@@ -135,7 +135,7 @@ class TestSearch(APITestMixin):
             company=company,
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -160,7 +160,12 @@ class TestSearch(APITestMixin):
         'sector_level',
         (0, 1, 2),
     )
-    def test_company_sector_descends_filter(self, hierarchical_sectors, setup_es, sector_level):
+    def test_company_sector_descends_filter(
+        self,
+        hierarchical_sectors,
+        es_with_signals,
+        sector_level,
+    ):
         """Test the company_sector_descends filter."""
         num_sectors = len(hierarchical_sectors)
         sectors_ids = [sector.pk for sector in hierarchical_sectors]
@@ -185,7 +190,7 @@ class TestSearch(APITestMixin):
             company=factory.Iterator(other_companies),
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
         body = {
@@ -228,7 +233,7 @@ class TestSearch(APITestMixin):
             ('moine', None),
         ),
     )
-    def test_filter_by_company_name(self, setup_es, name_term, matched_company_name):
+    def test_filter_by_company_name(self, es_with_signals, name_term, matched_company_name):
         """Tests filtering contact by company name."""
         matching_company1 = CompanyFactory(
             name='whiskers and tabby',
@@ -246,7 +251,7 @@ class TestSearch(APITestMixin):
         ContactFactory(company=matching_company2)
         ContactFactory(company=non_matching_company)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -267,11 +272,11 @@ class TestSearch(APITestMixin):
             assert response.data['count'] == 0
             assert len(response.data['results']) == 0
 
-    def test_search_contact_by_partial_name(self, setup_es, setup_data):
+    def test_search_contact_by_partial_name(self, es_with_signals, setup_data):
         """Tests filtering by partially matching name."""
         contact = ContactFactory(first_name='xyzxyz')
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -293,11 +298,11 @@ class TestSearch(APITestMixin):
             False,
         ),
     )
-    def test_search_contact_by_archived(self, setup_es, setup_data, archived):
+    def test_search_contact_by_archived(self, es_with_signals, setup_data, archived):
         """Tests filtering by archived."""
         ContactFactory.create_batch(5, archived=True)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -316,7 +321,7 @@ class TestSearch(APITestMixin):
         'created_on_exists',
         (True, False),
     )
-    def test_filter_by_created_on_exists(self, setup_es, created_on_exists):
+    def test_filter_by_created_on_exists(self, es_with_signals, created_on_exists):
         """Tests filtering contact by created_on exists."""
         ContactFactory.create_batch(3)
         no_created_on = ContactFactory.create_batch(3)
@@ -324,7 +329,7 @@ class TestSearch(APITestMixin):
             contact.created_on = None
             contact.save()
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
         request_data = {
@@ -342,12 +347,12 @@ class TestSearch(APITestMixin):
             for result in results
         )
 
-    def test_search_contact_by_company_id(self, setup_es, setup_data):
+    def test_search_contact_by_company_id(self, es_with_signals, setup_data):
         """Tests filtering by company id."""
         company = CompanyFactory()
         ContactFactory(company=company)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -363,12 +368,12 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['company']['id'] == str(company.id)
 
-    def test_search_contact_by_created_by(self, setup_es, setup_data):
+    def test_search_contact_by_created_by(self, es_with_signals, setup_data):
         """Tests filtering by created_by."""
         adviser = AdviserFactory()
         ContactFactory(created_by=adviser)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -384,12 +389,12 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['created_by']['id'] == str(adviser.id)
 
-    def test_company_name_trigram_filter(self, setup_es):
+    def test_company_name_trigram_filter(self, es_with_signals):
         """Tests edge case of partially matching company name."""
         ContactFactory(
             company=CompanyFactory(name='United States'),
         )
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -404,9 +409,9 @@ class TestSearch(APITestMixin):
         assert response.data['count'] == 0
         assert len(response.data['results']) == 0
 
-    def test_search_contact_no_filters(self, setup_es, setup_data):
+    def test_search_contact_no_filters(self, es_with_signals, setup_data):
         """Tests case where there is no filters provided."""
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
         response = self.api_client.post(url, {})
@@ -414,14 +419,14 @@ class TestSearch(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data['results']) > 0
 
-    def test_search_contact_sort_by_last_name_desc(self, setup_es):
+    def test_search_contact_sort_by_last_name_desc(self, es_with_signals):
         """Tests sorting in descending order."""
         ContactFactory(first_name='test_name', last_name='abcdef')
         ContactFactory(first_name='test_name', last_name='bcdefg')
         ContactFactory(first_name='test_name', last_name='cdefgh')
         ContactFactory(first_name='test_name', last_name='defghi')
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'test_name'
 
@@ -455,7 +460,7 @@ class TestContactExportView(APITestMixin):
             (ContactPermission.export_contact,),
         ),
     )
-    def test_user_without_permission_cannot_export(self, setup_es, permissions):
+    def test_user_without_permission_cannot_export(self, es_with_signals, permissions):
         """Test that a user without the correct permissions cannot export data."""
         user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -478,7 +483,7 @@ class TestContactExportView(APITestMixin):
     )
     def test_export(
         self,
-        setup_es,
+        es_with_signals,
         request_sortby,
         orm_ordering,
     ):
@@ -498,7 +503,7 @@ class TestContactExportView(APITestMixin):
             interaction=interaction_with_multiple_teams,
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         data = {}
         if request_sortby:
@@ -583,9 +588,9 @@ def _format_interaction_team_names(interaction):
 class TestBasicSearch(APITestMixin):
     """Tests basic search view."""
 
-    def test_basic_search_contacts(self, setup_es, setup_data):
+    def test_basic_search_contacts(self, es_with_signals, setup_data):
         """Tests basic aggregate contacts query."""
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'abc defg'
 
@@ -604,11 +609,11 @@ class TestBasicSearch(APITestMixin):
         assert response.data['results'][0]['last_name'] in term
         assert [{'count': 1, 'entity': 'contact'}] == response.data['aggregations']
 
-    def test_search_contact_has_sector(self, setup_es, setup_data):
+    def test_search_contact_has_sector(self, es_with_signals, setup_data):
         """Tests if contact has a sector."""
         ContactFactory(first_name='sector_testing')
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'sector_testing'
 
@@ -626,7 +631,7 @@ class TestBasicSearch(APITestMixin):
         sector_name = Sector.aerospace_assembly_aircraft.value.name
         assert sector_name == response.data['results'][0]['company_sector']['name']
 
-    def test_search_contact_has_sector_updated(self, setup_es):
+    def test_search_contact_has_sector_updated(self, es_with_signals):
         """Tests if contact has a correct sector after company update."""
         contact = ContactFactory(first_name='sector_update')
 
@@ -635,7 +640,7 @@ class TestBasicSearch(APITestMixin):
         company.sector_id = Sector.renewable_energy_wind.value.id
         company.save()
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'sector_update'
 
@@ -653,7 +658,7 @@ class TestBasicSearch(APITestMixin):
         sector_name = Sector.renewable_energy_wind.value.name
         assert sector_name == response.data['results'][0]['company_sector']['name']
 
-    def test_search_contact_has_company_address_updated(self, setup_es):
+    def test_search_contact_has_company_address_updated(self, es_with_signals):
         """Tests if contact has a correct address after company address update."""
         contact = ContactFactory(
             address_same_as_company=True,
@@ -673,7 +678,7 @@ class TestBasicSearch(APITestMixin):
         company.address_country.id = Country.united_kingdom.value.id
         company.save()
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
         response = self.api_client.post(
@@ -694,7 +699,7 @@ class TestBasicSearch(APITestMixin):
         country = contact.company.address_country.name
         assert country == result['address_country']['name']
 
-    def test_search_contact_has_own_address(self, setup_es):
+    def test_search_contact_has_own_address(self, es_with_signals):
         """Tests if contact can have its own address."""
         address = {
             'address_same_as_company': False,
@@ -708,7 +713,7 @@ class TestBasicSearch(APITestMixin):
             **address,
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:contact')
         response = self.api_client.post(

--- a/datahub/search/dashboard/test/test_views.py
+++ b/datahub/search/dashboard/test/test_views.py
@@ -16,7 +16,7 @@ from datahub.interaction.test.factories import (
 class TestDashboard(APITestMixin):
     """Dashboard test case."""
 
-    def test_intelligent_homepage(self, setup_es):
+    def test_intelligent_homepage(self, es_with_signals):
         """Intelligent homepage."""
         datetimes = [datetime(year, 1, 1) for year in range(2015, 2030)]
         interactions = []
@@ -30,7 +30,7 @@ class TestDashboard(APITestMixin):
                 interactions.append(interaction)
                 contacts.append(ContactFactory(created_by=self.user))
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('dashboard:intelligent-homepage')
         response = self.api_client.get(url)
@@ -58,12 +58,12 @@ class TestDashboard(APITestMixin):
         assert isinstance(actual_first_interaction['company'], dict)
         assert actual_first_interaction['company']['name'] == interactions[-1].company.name
 
-    def test_intelligent_homepage_limit(self, setup_es):
+    def test_intelligent_homepage_limit(self, es_with_signals):
         """Test the limit param."""
         CompanyInteractionFactory.create_batch(15, dit_participants__adviser=self.user)
         ContactFactory.create_batch(15, created_by=self.user)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('dashboard:intelligent-homepage')
         response = self.api_client.get(
@@ -78,7 +78,7 @@ class TestDashboard(APITestMixin):
         assert len(response_data['contacts']) == 10
         assert len(response_data['interactions']) == 10
 
-    def test_contact_permission(self, setup_es):
+    def test_contact_permission(self, es_with_signals):
         """Test that the contact view permission is enforced."""
         requester = create_test_user(
             permission_codenames=(InteractionPermission.view_all,),
@@ -86,7 +86,7 @@ class TestDashboard(APITestMixin):
         CompanyInteractionFactory.create_batch(5, dit_participants__adviser=requester)
         ContactFactory.create_batch(5, created_by=requester)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         api_client = self.create_api_client(user=requester)
 
@@ -103,7 +103,7 @@ class TestDashboard(APITestMixin):
         assert response_data['contacts'] == []
         assert len(response_data['interactions']) == 5
 
-    def test_interaction_permission(self, setup_es):
+    def test_interaction_permission(self, es_with_signals):
         """Test that the interaction view permission is enforced."""
         requester = create_test_user(
             permission_codenames=('view_contact',),
@@ -111,7 +111,7 @@ class TestDashboard(APITestMixin):
         InteractionDITParticipantFactory.create_batch(5, adviser=requester)
         ContactFactory.create_batch(5, created_by=requester)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         api_client = self.create_api_client(user=requester)
 

--- a/datahub/search/event/test/test_elasticsearch.py
+++ b/datahub/search/event/test/test_elasticsearch.py
@@ -3,7 +3,7 @@ from elasticsearch_dsl import Mapping
 from datahub.search.event import EventSearchApp
 
 
-def test_mapping(setup_es):
+def test_mapping(es_with_signals):
     """Test the ES mapping for an event."""
     mapping = Mapping.from_es(
         EventSearchApp.es_model.get_write_index(),

--- a/datahub/search/event/test/test_elasticsearch.py
+++ b/datahub/search/event/test/test_elasticsearch.py
@@ -3,7 +3,7 @@ from elasticsearch_dsl import Mapping
 from datahub.search.event import EventSearchApp
 
 
-def test_mapping(es_with_signals):
+def test_mapping(es):
     """Test the ES mapping for an event."""
     mapping = Mapping.from_es(
         EventSearchApp.es_model.get_write_index(),

--- a/datahub/search/event/test/test_models.py
+++ b/datahub/search/event/test/test_models.py
@@ -6,7 +6,7 @@ from datahub.search.event.models import Event as ESEvent
 pytestmark = pytest.mark.django_db
 
 
-def test_event_dbmodel_to_dict(setup_es):
+def test_event_dbmodel_to_dict(es_with_signals):
     """Tests conversion of db model to dict."""
     event = EventFactory()
 
@@ -40,7 +40,7 @@ def test_event_dbmodel_to_dict(setup_es):
     assert result.keys() == keys
 
 
-def test_event_dbmodels_to_es_documents(setup_es):
+def test_event_dbmodels_to_es_documents(es_with_signals):
     """Tests conversion of db models to Elasticsearch documents."""
     events = EventFactory.create_batch(2)
 

--- a/datahub/search/event/test/test_signals.py
+++ b/datahub/search/event/test/test_signals.py
@@ -6,27 +6,27 @@ from datahub.search.event.apps import EventSearchApp
 pytestmark = pytest.mark.django_db
 
 
-def test_new_event_synced(setup_es):
+def test_new_event_synced(es_with_signals):
     """Test that new events are synced to ES."""
     event = EventFactory()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    assert setup_es.get(
+    assert es_with_signals.get(
         index=EventSearchApp.es_model.get_write_index(),
         doc_type=EventSearchApp.name,
         id=event.pk,
     )
 
 
-def test_updated_event_synced(setup_es):
+def test_updated_event_synced(es_with_signals):
     """Test that when an event is updated it is synced to ES."""
     event = EventFactory()
     new_name = 'cat'
     event.name = new_name
     event.save()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=EventSearchApp.es_model.get_write_index(),
         doc_type=EventSearchApp.name,
         id=event.pk,

--- a/datahub/search/interaction/test/test_models.py
+++ b/datahub/search/interaction/test/test_models.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.django_db
         CompanyInteractionFactoryWithPolicyFeedback,
     ),
 )
-def test_interaction_to_dict(setup_es, factory_cls):
+def test_interaction_to_dict(es_with_signals, factory_cls):
     """Test converting an interaction to a dict."""
     interaction = factory_cls()
 
@@ -119,7 +119,7 @@ def test_interaction_to_dict(setup_es, factory_cls):
     }
 
 
-def test_service_delivery_to_dict(setup_es):
+def test_service_delivery_to_dict(es_with_signals):
     """Test converting an interaction to a dict."""
     interaction = ServiceDeliveryFactory()
 
@@ -196,7 +196,7 @@ def test_service_delivery_to_dict(setup_es):
     }
 
 
-def test_interactions_to_es_documents(setup_es):
+def test_interactions_to_es_documents(es_with_signals):
     """Test converting 2 orders to Elasticsearch documents."""
     interactions = CompanyInteractionFactory.create_batch(2)
 

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -8,7 +8,7 @@ from datahub.search.query_builder import (
 )
 
 
-def test_mapping(es_with_signals):
+def test_mapping(es):
     """Test the ES mapping for an investment project."""
     mapping = Mapping.from_es(
         ESInvestmentProject.get_write_index(),

--- a/datahub/search/investment/test/test_elasticsearch.py
+++ b/datahub/search/investment/test/test_elasticsearch.py
@@ -8,7 +8,7 @@ from datahub.search.query_builder import (
 )
 
 
-def test_mapping(setup_es):
+def test_mapping(es_with_signals):
     """Test the ES mapping for an investment project."""
     mapping = Mapping.from_es(
         ESInvestmentProject.get_write_index(),

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -52,7 +52,7 @@ def project_with_max_gross_value_added():
         )
 
 
-def test_investment_project_to_dict(setup_es):
+def test_investment_project_to_dict(es_with_signals):
     """Tests conversion of db model to dict."""
     project = InvestmentProjectFactory()
     result = ESInvestmentProject.db_object_to_dict(project)
@@ -149,7 +149,7 @@ def test_investment_project_to_dict(setup_es):
     assert set(result.keys()) == keys
 
 
-def test_investment_project_dbmodels_to_es_documents(setup_es):
+def test_investment_project_dbmodels_to_es_documents(es_with_signals):
     """Tests conversion of db models to Elasticsearch documents."""
     projects = InvestmentProjectFactory.create_batch(2)
 
@@ -159,7 +159,7 @@ def test_investment_project_dbmodels_to_es_documents(setup_es):
 
 
 def test_max_values_of_doubles_gross_value_added_and_foreign_equity_investment(
-    setup_es,
+    es_with_signals,
     project_with_max_gross_value_added,
 ):
     """

--- a/datahub/search/investment/test/test_views.py
+++ b/datahub/search/investment/test/test_views.py
@@ -79,7 +79,7 @@ def project_with_max_gross_value_added():
 
 
 @pytest.fixture
-def setup_data(setup_es, project_with_max_gross_value_added):
+def setup_data(es_with_signals, project_with_max_gross_value_added):
     """Sets up data for the tests."""
     investment_projects = [
         InvestmentProjectFactory(
@@ -130,13 +130,13 @@ def setup_data(setup_es, project_with_max_gross_value_added):
             likelihood_to_land_id=LikelihoodToLand.low.value.id,
         ),
     ]
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     yield investment_projects
 
 
 @pytest.fixture
-def created_on_data(setup_es):
+def created_on_data(es_with_signals):
     """Setup data for created_on date filter test."""
     investment_projects = []
     dates = (
@@ -149,7 +149,7 @@ def created_on_data(setup_es):
                 InvestmentProjectFactory(),
             )
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     yield investment_projects
 
@@ -233,7 +233,7 @@ class TestSearch(APITestMixin):
             == Counter(expected_project_name)
         ), expected_project_name
 
-    def test_search_adviser_filter(self, setup_es):
+    def test_search_adviser_filter(self, es_with_signals):
         """Tests the adviser filter."""
         adviser = AdviserFactory()
 
@@ -261,7 +261,7 @@ class TestSearch(APITestMixin):
         )
         InvestmentProjectTeamMemberFactory(adviser=adviser, investment_project=project_6)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:investment_project')
 
@@ -726,7 +726,7 @@ class TestSearch(APITestMixin):
         'sector_level',
         (0, 1, 2),
     )
-    def test_sector_descends_filter(self, hierarchical_sectors, setup_es, sector_level):
+    def test_sector_descends_filter(self, hierarchical_sectors, es_with_signals, sector_level):
         """Test the sector_descends filter."""
         num_sectors = len(hierarchical_sectors)
         sectors_ids = [sector.pk for sector in hierarchical_sectors]
@@ -742,7 +742,7 @@ class TestSearch(APITestMixin):
             )),
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:investment_project')
         body = {
@@ -766,7 +766,7 @@ class TestSearch(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data['results']) > 0
 
-    def test_search_investment_project_multiple_filters(self, setup_es):
+    def test_search_investment_project_multiple_filters(self, es_with_signals):
         """Tests multiple filters in investment project search.
         We make sure that out of provided investment projects, we will
         receive only those that match our filter.
@@ -795,7 +795,7 @@ class TestSearch(APITestMixin):
             stage_id=constants.InvestmentProjectStage.prospect.value.id,
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         response = self.api_client.post(
             url,
@@ -842,7 +842,7 @@ class TestSearch(APITestMixin):
             for investment_project in response.data['results']
         }
 
-    def test_search_sort_nested_desc(self, setup_es, setup_data):
+    def test_search_sort_nested_desc(self, es_with_signals, setup_data):
         """Tests sorting by nested field."""
         InvestmentProjectFactory(
             name='Potato 1',
@@ -861,7 +861,7 @@ class TestSearch(APITestMixin):
             stage_id=constants.InvestmentProjectStage.won.value.id,
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'Potato'
 
@@ -904,7 +904,7 @@ class TestSearchPermissions(APITestMixin):
             (InvestmentProjectPermission.view_associated, InvestmentProjectPermission.view_all),
         ),
     )
-    def test_non_restricted_user_can_see_all_projects(self, setup_es, permissions):
+    def test_non_restricted_user_can_see_all_projects(self, es_with_signals, permissions):
         """Test that normal users can see all projects."""
         team = TeamFactory()
         team_others = TeamFactory()
@@ -923,7 +923,7 @@ class TestSearchPermissions(APITestMixin):
         InvestmentProjectTeamMemberFactory(adviser=adviser_1, investment_project=iproject_1)
         InvestmentProjectTeamMemberFactory(adviser=adviser_2, investment_project=iproject_2)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:investment_project')
         response = api_client.post(url, {})
@@ -935,7 +935,7 @@ class TestSearchPermissions(APITestMixin):
             result['id'] for result in response_data['results']
         }
 
-    def test_restricted_user_with_no_team_cannot_see_projects(self, setup_es):
+    def test_restricted_user_with_no_team_cannot_see_projects(self, es_with_signals):
         """
         Checks that a restricted user that doesn't have a team cannot view any projects (in
         particular projects associated with other advisers that don't have teams).
@@ -951,7 +951,7 @@ class TestSearchPermissions(APITestMixin):
         InvestmentProjectFactory()
         InvestmentProjectFactory(created_by=adviser_other)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         response = api_client.post(url, {})
 
@@ -959,7 +959,7 @@ class TestSearchPermissions(APITestMixin):
         response_data = response.json()
         assert response_data['count'] == 0
 
-    def test_restricted_users_cannot_see_other_teams_projects(self, setup_es):
+    def test_restricted_users_cannot_see_other_teams_projects(self, es_with_signals):
         """Test that restricted users cannot see other teams' projects."""
         url = reverse('api-v3:search:investment_project')
 
@@ -983,7 +983,7 @@ class TestSearchPermissions(APITestMixin):
         InvestmentProjectTeamMemberFactory(adviser=adviser_other, investment_project=project_other)
         InvestmentProjectTeamMemberFactory(adviser=adviser_same_team, investment_project=project_1)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         response = api_client.post(url, {})
 
@@ -1011,7 +1011,7 @@ class TestInvestmentProjectExportView(APITestMixin):
             (InvestmentProjectPermission.export,),
         ),
     )
-    def test_user_without_permission_cannot_export(self, setup_es, permissions):
+    def test_user_without_permission_cannot_export(self, es_with_signals, permissions):
         """Test that a user without the correct permissions cannot export data."""
         user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -1020,7 +1020,7 @@ class TestInvestmentProjectExportView(APITestMixin):
         response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_restricted_users_cannot_see_other_teams_projects(self, setup_es):
+    def test_restricted_users_cannot_see_other_teams_projects(self, es_with_signals):
         """Test that restricted users cannot see other teams' projects in the export."""
         team = TeamFactory()
         team_other = TeamFactory()
@@ -1050,7 +1050,7 @@ class TestInvestmentProjectExportView(APITestMixin):
             investment_project=team_projects[0],
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:investment_project-export')
         response = api_client.post(url, {})
@@ -1078,7 +1078,7 @@ class TestInvestmentProjectExportView(APITestMixin):
             ('stage.name', 'stage__name'),
         ),
     )
-    def test_export(self, setup_es, request_sortby, orm_ordering):
+    def test_export(self, es_with_signals, request_sortby, orm_ordering):
         """Test export of investment project search results."""
         url = reverse('api-v3:search:investment_project-export')
 
@@ -1098,7 +1098,7 @@ class TestInvestmentProjectExportView(APITestMixin):
             ),
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         data = {}
         if request_sortby:
@@ -1243,7 +1243,7 @@ class TestBasicSearchPermissions(APITestMixin):
             (InvestmentProjectPermission.view_associated, InvestmentProjectPermission.view_all),
         ),
     )
-    def test_global_non_restricted_user_can_see_all_projects(self, setup_es, permissions):
+    def test_global_non_restricted_user_can_see_all_projects(self, es_with_signals, permissions):
         """Test that normal users can see all projects."""
         team = TeamFactory()
         team_others = TeamFactory()
@@ -1262,7 +1262,7 @@ class TestBasicSearchPermissions(APITestMixin):
         InvestmentProjectTeamMemberFactory(adviser=adviser_1, investment_project=iproject_1)
         InvestmentProjectTeamMemberFactory(adviser=adviser_2, investment_project=iproject_2)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         response = api_client.get(
@@ -1280,7 +1280,7 @@ class TestBasicSearchPermissions(APITestMixin):
             result['id'] for result in response_data['results']
         }
 
-    def test_global_restricted_users_cannot_see_other_teams_projects(self, setup_es):
+    def test_global_restricted_users_cannot_see_other_teams_projects(self, es_with_signals):
         """
         Automatic filter to see only associated IP for a specific (leps) user
         """
@@ -1304,7 +1304,7 @@ class TestBasicSearchPermissions(APITestMixin):
         InvestmentProjectTeamMemberFactory(adviser=adviser_other, investment_project=project_other)
         InvestmentProjectTeamMemberFactory(adviser=adviser_same_team, investment_project=project_1)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         response = api_client.get(
@@ -1327,7 +1327,7 @@ class TestBasicSearchPermissions(APITestMixin):
 
         assert {result['id'] for result in results} == expected_ids
 
-    def test_global_restricted_user_with_no_team_cannot_see_projects(self, setup_es):
+    def test_global_restricted_user_with_no_team_cannot_see_projects(self, es_with_signals):
         """
         Checks that a restricted user that doesn't have a team cannot view projects associated
         with other advisers that don't have teams.
@@ -1341,7 +1341,7 @@ class TestBasicSearchPermissions(APITestMixin):
         InvestmentProjectFactory()
         InvestmentProjectFactory(created_by=adviser_other)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         response = api_client.get(

--- a/datahub/search/large_investor_profile/test/test_elasticsearch.py
+++ b/datahub/search/large_investor_profile/test/test_elasticsearch.py
@@ -14,7 +14,7 @@ from datahub.search.large_investor_profile.models import (
 pytestmark = pytest.mark.django_db
 
 
-def test_mapping(es_with_signals):
+def test_mapping(es):
     """Test the ES mapping for a large capital investor profile."""
     mapping = Mapping.from_es(
         LargeInvestorProfileSearchApp.es_model.get_write_index(),
@@ -302,7 +302,7 @@ def test_mapping(es_with_signals):
 
 
 @freezegun.freeze_time('2019-01-01')
-def test_indexed_doc(es_with_signals):
+def test_indexed_doc(es):
     """Test the ES data of an Large investor profile."""
     investor_company = CompanyFactory()
 
@@ -313,9 +313,9 @@ def test_indexed_doc(es_with_signals):
     doc = ESLargeInvestorProfile.es_document(large_investor_profile)
     elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
-    es_with_signals.indices.refresh()
+    es.indices.refresh()
 
-    indexed_large_investor_profile = es_with_signals.get(
+    indexed_large_investor_profile = es.get(
         index=ESLargeInvestorProfile.get_write_index(),
         doc_type=LargeInvestorProfileSearchApp.name,
         id=large_investor_profile.pk,

--- a/datahub/search/large_investor_profile/test/test_elasticsearch.py
+++ b/datahub/search/large_investor_profile/test/test_elasticsearch.py
@@ -14,7 +14,7 @@ from datahub.search.large_investor_profile.models import (
 pytestmark = pytest.mark.django_db
 
 
-def test_mapping(setup_es):
+def test_mapping(es_with_signals):
     """Test the ES mapping for a large capital investor profile."""
     mapping = Mapping.from_es(
         LargeInvestorProfileSearchApp.es_model.get_write_index(),
@@ -302,7 +302,7 @@ def test_mapping(setup_es):
 
 
 @freezegun.freeze_time('2019-01-01')
-def test_indexed_doc(setup_es):
+def test_indexed_doc(es_with_signals):
     """Test the ES data of an Large investor profile."""
     investor_company = CompanyFactory()
 
@@ -313,9 +313,9 @@ def test_indexed_doc(setup_es):
     doc = ESLargeInvestorProfile.es_document(large_investor_profile)
     elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    indexed_large_investor_profile = setup_es.get(
+    indexed_large_investor_profile = es_with_signals.get(
         index=ESLargeInvestorProfile.get_write_index(),
         doc_type=LargeInvestorProfileSearchApp.name,
         id=large_investor_profile.pk,

--- a/datahub/search/large_investor_profile/test/test_models.py
+++ b/datahub/search/large_investor_profile/test/test_models.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.django_db
 class TestLargeInvestorProfileElasticModel:
     """Test for the large investor profile elasticsearch model"""
 
-    def test_large_investor_profile_dbmodel_to_dict(self, setup_es):
+    def test_large_investor_profile_dbmodel_to_dict(self, es_with_signals):
         """Tests conversion of db model to dict."""
         large_investor_profile = LargeCapitalInvestorProfileFactory()
 
@@ -43,7 +43,7 @@ class TestLargeInvestorProfileElasticModel:
         }
         assert set(result.keys()) == keys
 
-    def test_investment_project_dbmodels_to_es_documents(self, setup_es):
+    def test_investment_project_dbmodels_to_es_documents(self, es_with_signals):
         """Tests conversion of db models to Elasticsearch documents."""
         large_profiles = LargeCapitalInvestorProfileFactory.create_batch(2)
 

--- a/datahub/search/large_investor_profile/test/test_signals.py
+++ b/datahub/search/large_investor_profile/test/test_signals.py
@@ -18,19 +18,19 @@ def _get_es_document(setup_es, pk):
     )
 
 
-def test_new_large_investor_profile_synced(setup_es):
+def test_new_large_investor_profile_synced(es_with_signals):
     """Test that new large capital profiles are synced to ES."""
     investor_profile = LargeCapitalInvestorProfileFactory()
-    setup_es.indices.refresh()
-    assert _get_es_document(setup_es, investor_profile.pk)
+    es_with_signals.indices.refresh()
+    assert _get_es_document(es_with_signals, investor_profile.pk)
 
 
-def test_updated_large_investor_profile_synced(setup_es):
+def test_updated_large_investor_profile_synced(es_with_signals):
     """Test that when an large investor profile is updated it is synced to ES."""
     large_investor_profile = LargeCapitalInvestorProfileFactory()
     large_investor_profile.investable_capital = 12345
     large_investor_profile.save()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
 
 @pytest.mark.parametrize(
@@ -40,37 +40,37 @@ def test_updated_large_investor_profile_synced(setup_es):
     ),
 )
 def test_delete_from_es(
-    investor_profile_factory, expected_in_index, expected_to_call_delete, setup_es,
+    investor_profile_factory, expected_in_index, expected_to_call_delete, es_with_signals,
 ):
     """
     Test that when an large investor profile is deleted from db it is also
     calls delete document to delete from ES.
     """
     investor_profile = investor_profile_factory()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     if expected_in_index:
-        assert _get_es_document(setup_es, investor_profile.pk)
+        assert _get_es_document(es_with_signals, investor_profile.pk)
     else:
         with pytest.raises(NotFoundError):
-            assert _get_es_document(setup_es, investor_profile.pk) is None
+            assert _get_es_document(es_with_signals, investor_profile.pk) is None
 
     with mock.patch(
         'datahub.search.large_investor_profile.signals.delete_document',
     ) as mock_delete_document:
         investor_profile.delete()
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
         assert mock_delete_document.called == expected_in_index
 
 
-def test_edit_company_syncs_large_investor_profile_in_es(setup_es):
+def test_edit_company_syncs_large_investor_profile_in_es(es_with_signals):
     """Tests that updating company details also updated the relevant investor profiles."""
     new_company_name = 'SYNC TEST'
     investor_company = CompanyFactory()
     investor_profile = LargeCapitalInvestorProfileFactory(investor_company=investor_company)
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
     investor_company.name = new_company_name
     investor_company.save()
 
-    result = _get_es_document(setup_es, investor_profile.pk)
+    result = _get_es_document(es_with_signals, investor_profile.pk)
     assert result['_source']['investor_company']['name'] == new_company_name

--- a/datahub/search/large_investor_profile/test/test_views.py
+++ b/datahub/search/large_investor_profile/test/test_views.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(setup_es):
+def setup_data(es_with_signals):
     """Sets up data for the tests."""
     investor_company = CompanyFactory(name='large abcdef')
     argentina_investor_company = CompanyFactory(
@@ -175,7 +175,7 @@ def setup_data(setup_es):
             north_project,
             south_project,
         ]
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     yield investor_profiles
 
@@ -609,7 +609,7 @@ class TestLargeInvestorProfileExportView(APITestMixin):
         ),
     )
     def test_user_needs_correct_permissions_to_export_data(
-        self, setup_es, permissions, expected_status_code,
+        self, es_with_signals, permissions, expected_status_code,
     ):
         """Test that a user without the correct permissions cannot export data."""
         user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
@@ -629,7 +629,7 @@ class TestLargeInvestorProfileExportView(APITestMixin):
             ('investor_company.name', 'investor_company__name'),
         ),
     )
-    def test_export(self, setup_es, request_sortby, orm_ordering):
+    def test_export(self, es_with_signals, request_sortby, orm_ordering):
         """Test export large capital investor profile search results."""
         url = reverse('api-v4:search:large-investor-profile-export')
 
@@ -643,7 +643,7 @@ class TestLargeInvestorProfileExportView(APITestMixin):
                 global_assets_under_management=200,
             )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         data = {}
         if request_sortby:

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -15,7 +15,7 @@ from datahub.search.omis.models import Order as ESOrder
 pytestmark = pytest.mark.django_db
 
 
-def test_mapping(es_with_signals):
+def test_mapping(es):
     """Test the ES mapping for an order."""
     mapping = Mapping.from_es(OrderSearchApp.es_model.get_write_index(), OrderSearchApp.name)
 
@@ -492,7 +492,7 @@ def test_mapping(es_with_signals):
         OrderPaidFactory,
     ),
 )
-def test_indexed_doc(order_factory, es_with_signals):
+def test_indexed_doc(order_factory, es):
     """Test the ES data of an indexed order."""
     order = order_factory()
     invoice = order.invoice
@@ -500,9 +500,9 @@ def test_indexed_doc(order_factory, es_with_signals):
     doc = ESOrder.es_document(order)
     elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
-    es_with_signals.indices.refresh()
+    es.indices.refresh()
 
-    indexed_order = es_with_signals.get(
+    indexed_order = es.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,

--- a/datahub/search/omis/test/test_elasticsearch.py
+++ b/datahub/search/omis/test/test_elasticsearch.py
@@ -15,7 +15,7 @@ from datahub.search.omis.models import Order as ESOrder
 pytestmark = pytest.mark.django_db
 
 
-def test_mapping(setup_es):
+def test_mapping(es_with_signals):
     """Test the ES mapping for an order."""
     mapping = Mapping.from_es(OrderSearchApp.es_model.get_write_index(), OrderSearchApp.name)
 
@@ -492,7 +492,7 @@ def test_mapping(setup_es):
         OrderPaidFactory,
     ),
 )
-def test_indexed_doc(order_factory, setup_es):
+def test_indexed_doc(order_factory, es_with_signals):
     """Test the ES data of an indexed order."""
     order = order_factory()
     invoice = order.invoice
@@ -500,9 +500,9 @@ def test_indexed_doc(order_factory, setup_es):
     doc = ESOrder.es_document(order)
     elasticsearch.bulk(actions=(doc, ), chunk_size=1)
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    indexed_order = setup_es.get(
+    indexed_order = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,

--- a/datahub/search/omis/test/test_signals.py
+++ b/datahub/search/omis/test/test_signals.py
@@ -11,27 +11,27 @@ from datahub.search.omis import OrderSearchApp
 pytestmark = pytest.mark.django_db
 
 
-def test_creating_order_syncs_to_es(setup_es):
+def test_creating_order_syncs_to_es(es_with_signals):
     """Test that when I create an order, it gets synced to ES."""
     order = OrderFactory()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    assert setup_es.get(
+    assert es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
     )
 
 
-def test_updating_order_updates_es(setup_es):
+def test_updating_order_updates_es(es_with_signals):
     """Test that when I update an order, the updated version gets synced to ES."""
     order = OrderFactory()
     new_description = 'lorem'
     order.description = new_description
     order.save()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
@@ -39,15 +39,15 @@ def test_updating_order_updates_es(setup_es):
     assert result['_source']['description'] == new_description
 
 
-def test_accepting_quote_updates_es(setup_es):
+def test_accepting_quote_updates_es(es_with_signals):
     """
     Test that when a quote is accepted and the invoice created, the payment_due_date field
     in ES gets updated.
     """
     order = OrderWithOpenQuoteFactory()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
@@ -55,9 +55,9 @@ def test_accepting_quote_updates_es(setup_es):
     assert not result['_source']['payment_due_date']
 
     order.accept_quote(by=None)
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
@@ -65,16 +65,16 @@ def test_accepting_quote_updates_es(setup_es):
     assert result['_source']['payment_due_date'] == order.invoice.payment_due_date.isoformat()
 
 
-def test_adding_subscribers_syncs_order_to_es(setup_es):
+def test_adding_subscribers_syncs_order_to_es(es_with_signals):
     """
     Test that when a subscriber is added to an order,
     the linked order gets synced to ES.
     """
     order = OrderFactory()
     subscribers = OrderSubscriberFactory.create_batch(2, order=order)
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
@@ -86,7 +86,7 @@ def test_adding_subscribers_syncs_order_to_es(setup_es):
     assert len(indexed) == 2
 
 
-def test_removing_subscribers_syncs_order_to_es(setup_es):
+def test_removing_subscribers_syncs_order_to_es(es_with_signals):
     """
     Test that when a subscriber is removed from an order,
     the linked order gets synced to ES.
@@ -94,9 +94,9 @@ def test_removing_subscribers_syncs_order_to_es(setup_es):
     order = OrderFactory()
     subscribers = OrderSubscriberFactory.create_batch(2, order=order)
     subscribers.pop().delete()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
@@ -108,16 +108,16 @@ def test_removing_subscribers_syncs_order_to_es(setup_es):
     assert len(indexed) == 1
 
 
-def test_adding_assignees_syncs_order_to_es(setup_es):
+def test_adding_assignees_syncs_order_to_es(es_with_signals):
     """
     Test that when an assignee is added to an order,
     the linked order gets synced to ES.
     """
     order = OrderFactory(assignees=[])
     assignees = OrderAssigneeFactory.create_batch(2, order=order)
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
@@ -129,7 +129,7 @@ def test_adding_assignees_syncs_order_to_es(setup_es):
     assert len(indexed) == 2
 
 
-def test_removing_assignees_syncs_order_to_es(setup_es):
+def test_removing_assignees_syncs_order_to_es(es_with_signals):
     """
     Test that when an assignee is removed from an order,
     the linked order gets synced to ES.
@@ -137,9 +137,9 @@ def test_removing_assignees_syncs_order_to_es(setup_es):
     order = OrderFactory(assignees=[])
     assignees = OrderAssigneeFactory.create_batch(2, order=order)
     assignees.pop().delete()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
@@ -151,15 +151,15 @@ def test_removing_assignees_syncs_order_to_es(setup_es):
     assert len(indexed) == 1
 
 
-def test_updating_company_name_updates_orders(setup_es):
+def test_updating_company_name_updates_orders(es_with_signals):
     """Test that when a company name is updated, the company's orders are synced to ES."""
     order = OrderFactory()
     new_company_name = 'exogenous'
     order.company.name = new_company_name
     order.company.save()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,
@@ -167,7 +167,7 @@ def test_updating_company_name_updates_orders(setup_es):
     assert result['_source']['company']['name'] == new_company_name
 
 
-def test_updating_contact_name_updates_orders(setup_es):
+def test_updating_contact_name_updates_orders(es_with_signals):
     """Test that when a contact's name is updated, the contacts's orders are synced to ES."""
     order = OrderFactory()
     new_first_name = 'Jamie'
@@ -177,9 +177,9 @@ def test_updating_contact_name_updates_orders(setup_es):
     contact.first_name = new_first_name
     contact.last_name = new_last_name
     contact.save()
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    result = setup_es.get(
+    result = es_with_signals.get(
         index=OrderSearchApp.es_model.get_write_index(),
         doc_type=OrderSearchApp.name,
         id=order.pk,

--- a/datahub/search/omis/test/test_views.py
+++ b/datahub/search/omis/test/test_views.py
@@ -50,7 +50,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(setup_es):
+def setup_data(es_with_signals):
     """Sets up data for the tests."""
     with freeze_time('2017-01-01 13:00:00'):
         company = CompanyFactory(
@@ -110,11 +110,11 @@ def setup_data(setup_es):
             estimated_time=120,
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
 
 @pytest.fixture
-def setup_subtotal_cost_data(setup_es):
+def setup_subtotal_cost_data(es_with_signals):
     """
     Setup Order data for total subtotal cost test.
 
@@ -136,7 +136,7 @@ def setup_subtotal_cost_data(setup_es):
             estimated_time=subtotal_cost * 60 // order.hourly_rate.rate_value,
         )
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
 
 class TestSearchOrder(APITestMixin):
@@ -448,7 +448,7 @@ class TestSearchOrder(APITestMixin):
         'sector_level',
         (0, 1, 2),
     )
-    def test_sector_descends_filter(self, hierarchical_sectors, setup_es, sector_level):
+    def test_sector_descends_filter(self, hierarchical_sectors, es_with_signals, sector_level):
         """Test the sector_descends filter."""
         num_sectors = len(hierarchical_sectors)
         sectors_ids = [sector.pk for sector in hierarchical_sectors]
@@ -464,7 +464,7 @@ class TestSearchOrder(APITestMixin):
             )),
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:order')
         body = {
@@ -525,7 +525,7 @@ class TestOrderExportView(APITestMixin):
             (f'order.{OrderPermission.export}',),
         ),
     )
-    def test_user_without_permission_cannot_export(self, setup_es, permissions):
+    def test_user_without_permission_cannot_export(self, es_with_signals, permissions):
         """Test that a user without the correct permissions cannot export data."""
         user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -547,7 +547,7 @@ class TestOrderExportView(APITestMixin):
     )
     def test_export(
         self,
-        setup_es,
+        es_with_signals,
         request_sortby,
         orm_ordering,
     ):
@@ -585,7 +585,7 @@ class TestOrderExportView(APITestMixin):
         for factory_ in factories:
             factory_.create_batch(2)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         data = {}
         if request_sortby:

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -66,7 +66,7 @@ def test_sync_app_logic(monkeypatch):
 
 @pytest.mark.django_db
 @disable_search_signal_receivers(Company)
-def test_sync_app_uses_latest_data(monkeypatch, setup_es):
+def test_sync_app_uses_latest_data(monkeypatch, es_with_signals):
     """Test that sync_app() picks up updates made to records between batches."""
     CompanyFactory.create_batch(2, name='old name')
 
@@ -84,10 +84,10 @@ def test_sync_app_uses_latest_data(monkeypatch, setup_es):
     monkeypatch.setattr('datahub.search.bulk_sync.sync_objects', mock_sync_objects)
     sync_app(CompanySearchApp, batch_size=1)
 
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
     company = mock_sync_objects.call_args_list[1][0][1][0]
-    fetched_company = setup_es.get(
+    fetched_company = es_with_signals.get(
         index=CompanySearchApp.es_model.get_read_alias(),
         doc_type=CompanySearchApp.name,
         id=company.pk,

--- a/datahub/search/test/test_fields.py
+++ b/datahub/search/test/test_fields.py
@@ -13,7 +13,7 @@ from datahub.search.test.search_support.simplemodel import SimpleModelSearchApp
 class TestNormalizedField(APITestMixin):
     """Tests the behaviour of NormalizedKeyword."""
 
-    def test_sorting(self, setup_es):
+    def test_sorting(self, es_with_signals):
         """Test to demonstrate how NormalizedKeyword sorts."""
         names = [
             'Alice',
@@ -29,7 +29,7 @@ class TestNormalizedField(APITestMixin):
             obj.save()
             sync_object(SimpleModelSearchApp, obj.pk)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         user = create_test_user(permission_codenames=['view_simplemodel'])
         api_client = self.create_api_client(user=user)

--- a/datahub/search/test/test_signals.py
+++ b/datahub/search/test/test_signals.py
@@ -13,7 +13,7 @@ from datahub.search.test.search_support.models import RelatedModel, SimpleModel
 class TestDisableSignalsForModel:
     """Tests for disable_search_signal_receivers()."""
 
-    def test_signal_receivers_are_not_disabled(self, setup_es, monkeypatch):
+    def test_signal_receivers_are_not_disabled(self, es_with_signals, monkeypatch):
         """
         Test that signal receivers are active without the context manager being active.
         """
@@ -27,7 +27,7 @@ class TestDisableSignalsForModel:
 
         callback_mock.assert_called_once()
 
-    def test_signal_receivers_disabled_for_model(self, setup_es, monkeypatch):
+    def test_signal_receivers_disabled_for_model(self, es_with_signals, monkeypatch):
         """
         Test that signal receivers are disabled for the specified model.
 
@@ -46,7 +46,7 @@ class TestDisableSignalsForModel:
 
         callback_mock.assert_not_called()
 
-    def test_does_not_affect_other_models(self, setup_es, monkeypatch):
+    def test_does_not_affect_other_models(self, es_with_signals, monkeypatch):
         """Test that signal receivers are not disabled for other models."""
         callback_mock = Mock()
         monkeypatch.setattr(
@@ -59,7 +59,7 @@ class TestDisableSignalsForModel:
 
         callback_mock.assert_called_once()
 
-    def test_does_not_affect_other_threads(self, setup_es, monkeypatch):
+    def test_does_not_affect_other_threads(self, es_with_signals, monkeypatch):
         """
         Test that signal receivers are not disabled for other threads.
 
@@ -93,7 +93,7 @@ class TestDisableSignalsForModel:
 
         callback_mock.assert_called_once()
 
-    def test_reconnects_if_was_connected(self, setup_es):
+    def test_reconnects_if_was_connected(self, es_with_signals):
         """Test that signal receivers are reconnected on context manager exit."""
         with disable_search_signal_receivers(SimpleModel):
             pass
@@ -105,7 +105,7 @@ class TestDisableSignalsForModel:
             if receiver.sender is SimpleModel
         )
 
-    def test_reconnects_if_exception_raised(self, setup_es):
+    def test_reconnects_if_exception_raised(self, es_with_signals):
         """
         Test that signal receivers are reconnected if an exception is raised while the
         context manager is active.
@@ -127,7 +127,7 @@ class TestDisableSignalsForModel:
         """
         Test that signal receivers are not reconnected when not originally connected.
 
-        Note: Signal receivers are not connected as the setup_es fixture is not used.
+        Note: Signal receivers are not connected as the es_with_signals fixture is not used.
         """
         with disable_search_signal_receivers(SimpleModel):
             pass

--- a/datahub/search/test/test_sync_object.py
+++ b/datahub/search/test/test_sync_object.py
@@ -8,17 +8,17 @@ from datahub.search.test.utils import doc_exists
 
 
 @pytest.mark.django_db
-def test_sync_object_task_syncs_using_celery(setup_es):
+def test_sync_object_task_syncs_using_celery(es_with_signals):
     """Test that an object can be synced to Elasticsearch using Celery."""
     obj = SimpleModel.objects.create()
     sync_object_async(SimpleModelSearchApp, obj.pk)
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    assert doc_exists(setup_es, SimpleModelSearchApp, obj.pk)
+    assert doc_exists(es_with_signals, SimpleModelSearchApp, obj.pk)
 
 
 @pytest.mark.django_db
-def test_sync_related_objects_syncs_using_celery(setup_es):
+def test_sync_related_objects_syncs_using_celery(es_with_signals):
     """Test that related objects can be synced to Elasticsearch using Celery."""
     simpleton = SimpleModel.objects.create()
     relation_1 = RelatedModel.objects.create(simpleton=simpleton)
@@ -26,8 +26,8 @@ def test_sync_related_objects_syncs_using_celery(setup_es):
     unrelated_obj = RelatedModel.objects.create()
 
     sync_related_objects_async(simpleton, 'relatedmodel_set')
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    assert doc_exists(setup_es, RelatedModelSearchApp, relation_1.pk)
-    assert doc_exists(setup_es, RelatedModelSearchApp, relation_2.pk)
-    assert not doc_exists(setup_es, RelatedModelSearchApp, unrelated_obj.pk)
+    assert doc_exists(es_with_signals, RelatedModelSearchApp, relation_1.pk)
+    assert doc_exists(es_with_signals, RelatedModelSearchApp, relation_2.pk)
+    assert not doc_exists(es_with_signals, RelatedModelSearchApp, unrelated_obj.pk)

--- a/datahub/search/test/test_tasks.py
+++ b/datahub/search/test/test_tasks.py
@@ -43,16 +43,16 @@ def test_sync_all_models(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_sync_object_task_syncs(setup_es):
+def test_sync_object_task_syncs(es_with_signals):
     """Test that the object task syncs an object to Elasticsearch."""
     obj = SimpleModel.objects.create()
     sync_object_task.apply(args=(SimpleModelSearchApp.name, str(obj.pk)))
-    setup_es.indices.refresh()
+    es_with_signals.indices.refresh()
 
-    assert doc_exists(setup_es, SimpleModelSearchApp, obj.pk)
+    assert doc_exists(es_with_signals, SimpleModelSearchApp, obj.pk)
 
 
-def test_sync_object_task_retries_on_error(monkeypatch, setup_es):
+def test_sync_object_task_retries_on_error(monkeypatch, es_with_signals):
     """Test that the object task retries on error."""
     sync_object_mock = Mock(side_effect=[Exception, None])
     monkeypatch.setattr('datahub.search.sync_object.sync_object', sync_object_mock)

--- a/datahub/search/test/test_views.py
+++ b/datahub/search/test/test_views.py
@@ -184,7 +184,7 @@ class TestBasicSearch(APITestMixin):
     search apps.
     """
 
-    def test_pagination(self, setup_es):
+    def test_pagination(self, es_with_signals):
         """Tests the pagination."""
         total_records = 9
         page_size = 2
@@ -200,7 +200,7 @@ class TestBasicSearch(APITestMixin):
             trading_names=[],
         )
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         for page in range((len(ids) + page_size - 1) // page_size):
@@ -221,7 +221,7 @@ class TestBasicSearch(APITestMixin):
             assert ids[start:end] == [UUID(company['id']) for company in response.data['results']]
 
     @pytest.mark.parametrize('entity', ('sloth', 'companieshousecompany'))
-    def test_400_with_invalid_entity(self, setup_es, entity):
+    def test_400_with_invalid_entity(self, es_with_signals, entity):
         """Tests case where provided entity is invalid."""
         url = reverse('api-v3:search:basic')
         response = self.api_client.get(
@@ -237,14 +237,14 @@ class TestBasicSearch(APITestMixin):
             'entity': [f'"{entity}" is not a valid choice.'],
         }
 
-    def test_quality(self, setup_es, setup_data):
+    def test_quality(self, es_with_signals, setup_data):
         """Tests quality of results."""
         CompanyFactory(name='The Risk Advisory Group', trading_names=[])
         CompanyFactory(name='The Advisory Group', trading_names=[])
         CompanyFactory(name='The Advisory', trading_names=[])
         CompanyFactory(name='The Advisories', trading_names=[])
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'The Advisory'
 
@@ -267,14 +267,14 @@ class TestBasicSearch(APITestMixin):
             'The Risk Advisory Group',
         ] == [company['name'] for company in response.data['results']]
 
-    def test_partial_match(self, setup_es, setup_data):
+    def test_partial_match(self, es_with_signals, setup_data):
         """Tests partial matching."""
         CompanyFactory(name='Veryuniquename1', trading_names=[])
         CompanyFactory(name='Veryuniquename2', trading_names=[])
         CompanyFactory(name='Veryuniquename3', trading_names=[])
         CompanyFactory(name='Veryuniquename4', trading_names=[])
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'Veryuniquenam'
 
@@ -298,14 +298,14 @@ class TestBasicSearch(APITestMixin):
             'Veryuniquename4',
         } == {company['name'] for company in response.data['results']}
 
-    def test_hyphen_match(self, setup_es, setup_data):
+    def test_hyphen_match(self, es_with_signals, setup_data):
         """Tests hyphen query."""
         CompanyFactory(name='t-shirt', trading_names=[])
         CompanyFactory(name='tshirt', trading_names=[])
         CompanyFactory(name='electronic shirt', trading_names=[])
         CompanyFactory(name='t and e and a', trading_names=[])
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 't-shirt'
 
@@ -327,14 +327,14 @@ class TestBasicSearch(APITestMixin):
             'tshirt',
         ] == [company['name'] for company in response.data['results']]
 
-    def test_search_by_id(self, setup_es, setup_data):
+    def test_search_by_id(self, es_with_signals, setup_data):
         """Tests exact id matching."""
         CompanyFactory(id='0fb3379c-341c-4dc4-b125-bf8d47b26baa')
         CompanyFactory(id='0fb2379c-341c-4dc4-b225-bf8d47b26baa')
         CompanyFactory(id='0fb4379c-341c-4dc4-b325-bf8d47b26baa')
         CompanyFactory(id='0fb5379c-341c-4dc4-b425-bf8d47b26baa')
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = '0fb4379c-341c-4dc4-b325-bf8d47b26baa'
 
@@ -351,7 +351,7 @@ class TestBasicSearch(APITestMixin):
         assert response.data['count'] == 1
         assert '0fb4379c-341c-4dc4-b325-bf8d47b26baa' == response.data['results'][0]['id']
 
-    def test_400_with_invalid_sortby(self, setup_es, setup_data):
+    def test_400_with_invalid_sortby(self, es_with_signals, setup_data):
         """Tests attempt to sort by non existent field."""
         url = reverse('api-v3:search:basic')
         response = self.api_client.get(
@@ -365,13 +365,13 @@ class TestBasicSearch(APITestMixin):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-    def test_aggregations(self, setup_es, setup_data):
+    def test_aggregations(self, es_with_signals, setup_data):
         """Tests basic aggregate query."""
         company = CompanyFactory(name='very_unique_company')
         ContactFactory(company=company)
         InvestmentProjectFactory(investor_company=company)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'very_unique_company'
 
@@ -395,12 +395,12 @@ class TestBasicSearch(APITestMixin):
         ]
         assert all(aggregation in response.data['aggregations'] for aggregation in aggregations)
 
-    def test_ignored_models_excluded_from_aggregations(self, setup_es):
+    def test_ignored_models_excluded_from_aggregations(self, es_with_signals):
         """That that companieshousecompany is not included in aggregations."""
         ch_company = CompaniesHouseCompanyFactory()
         sync_object(CompaniesHouseCompanySearchApp, ch_company.pk)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         response = self.api_client.get(
@@ -438,7 +438,7 @@ class TestBasicSearch(APITestMixin):
             'order',
         ),
     )
-    def test_permissions(self, setup_es, permission, permission_entity, entity):
+    def test_permissions(self, es_with_signals, permission, permission_entity, entity):
         """Tests model permissions enforcement in basic search."""
         user = create_test_user(permission_codenames=[permission], dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
@@ -450,7 +450,7 @@ class TestBasicSearch(APITestMixin):
         CompanyInteractionFactory()
         OrderFactory()
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         response = api_client.get(
@@ -468,7 +468,7 @@ class TestBasicSearch(APITestMixin):
         assert len(response_data['aggregations']) == 1
         assert response_data['aggregations'][0]['entity'] == permission_entity
 
-    def test_basic_search_no_permissions(self, setup_es):
+    def test_basic_search_no_permissions(self, es_with_signals):
         """Tests model permissions enforcement in basic search for a user with no permissions."""
         user = create_test_user(permission_codenames=[], dit_team=TeamFactory())
         api_client = self.create_api_client(user=user)
@@ -480,7 +480,7 @@ class TestBasicSearch(APITestMixin):
         CompanyInteractionFactory()
         OrderFactory()
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         url = reverse('api-v3:search:basic')
         response = api_client.get(
@@ -506,12 +506,12 @@ class TestFilteredSearch(APITestMixin):
     search apps.
     """
 
-    def test_search_sort_asc_with_null_values(self, setup_es, setup_data):
+    def test_search_sort_asc_with_null_values(self, es_with_signals, setup_data):
         """Tests placement of null values in sorted results when order is ascending."""
         InvestmentProjectFactory(name='Earth 1', estimated_land_date=datetime.date(2010, 1, 1))
         InvestmentProjectFactory(name='Earth 2', estimated_land_date=None)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'Earth'
 
@@ -534,12 +534,12 @@ class TestFilteredSearch(APITestMixin):
             for investment in response.data['results']
         ]
 
-    def test_search_sort_desc_with_null_values(self, setup_es, setup_data):
+    def test_search_sort_desc_with_null_values(self, es_with_signals, setup_data):
         """Tests placement of null values in sorted results when order is descending."""
         InvestmentProjectFactory(name='Ether 1', estimated_land_date=datetime.date(2010, 1, 1))
         InvestmentProjectFactory(name='Ether 2', estimated_land_date=None)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         term = 'Ether'
 
@@ -566,7 +566,7 @@ class TestFilteredSearch(APITestMixin):
 class TestSearchExportAPIView(APITestMixin):
     """Tests for SearchExportAPIView."""
 
-    def test_creates_user_event_log_entries(self, setup_es):
+    def test_creates_user_event_log_entries(self, es_with_signals):
         """Tests that when an export is performed, a user event is recorded."""
         user = create_test_user(permission_codenames=['view_simplemodel'])
         api_client = self.create_api_client(user=user)
@@ -577,7 +577,7 @@ class TestSearchExportAPIView(APITestMixin):
         simple_obj.save()
         sync_object(SimpleModelSearchApp, simple_obj.pk)
 
-        setup_es.indices.refresh()
+        es_with_signals.indices.refresh()
 
         frozen_time = datetime.datetime(2018, 1, 2, 12, 30, 50, tzinfo=utc)
         with freeze_time(frozen_time):


### PR DESCRIPTION
### Description of change

This:

- renames the `_es_client` pytest fixture to `_es_session`
- splits the `setup_es` pytest fixture into `es` and `es_with_signals`

I'd recommend reviewing the three commits individually. (Most of the changes are just changing references to `setup_es` to `es_with_signals`.)

### Context

It was observed that a fair bit of time is wasted in some search tests indexing search documents individually rather than in bulk.

We're also currently implicitly testing search app signal receivers in every search test, which is not really necessary (they have their own dedicated tests).

This refactor is a precursor to adding a new fixture that can be used to index documents in bulk (rather than relying on the signal receivers), and hence reduce the running time of search tests that create a lot of model objects.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
