### PR TITLE
import data science export potential data into company model

### DIFF
--- a/changelog/company/import-csv-export-potential-score.feature.md
+++ b/changelog/company/import-csv-export-potential-score.feature.md
@@ -1,0 +1,1 @@
+A new dbmaintenance Django command was added to import data from csv format, with two fields `datahub_company_id` and `export_propensity` provided by Data Science platform, into Data Hub comapany model.

--- a/datahub/dbmaintenance/management/commands/update_company_export_potential.py
+++ b/datahub/dbmaintenance/management/commands/update_company_export_potential.py
@@ -1,0 +1,35 @@
+from logging import getLogger
+
+import reversion
+
+from datahub.company.models import Company
+from datahub.dbmaintenance.management.base import CSVBaseCommand
+from datahub.dbmaintenance.utils import parse_limited_string, parse_uuid
+
+
+logger = getLogger(__name__)
+
+
+class Command(CSVBaseCommand):
+    """Command to update Company.export_potential."""
+
+    def _process_row(self, row, simulate=False, **options):
+        """Process one single row."""
+        score_dict = {value.lower(): key for key, value in Company.EXPORT_POTENTIAL_SCORES}
+
+        pk = parse_uuid(row['datahub_company_id'])
+        company = Company.objects.get(pk=pk)
+        raw_potential = parse_limited_string(row['export_propensity'])
+        export_potential = score_dict[raw_potential.lower()]
+
+        if company.export_potential == export_potential:
+            return
+
+        company.export_potential = export_potential
+
+        if simulate:
+            return
+
+        with reversion.create_revision():
+            company.save(update_fields=('export_potential',))
+            reversion.set_comment('Export potential updated.')

--- a/datahub/dbmaintenance/test/commands/test_update_company_export_potential.py
+++ b/datahub/dbmaintenance/test/commands/test_update_company_export_potential.py
@@ -1,0 +1,164 @@
+from datetime import datetime, timezone
+from io import BytesIO
+
+import factory
+import pytest
+from django.core.management import call_command
+from freezegun import freeze_time
+from reversion.models import Version
+
+from datahub.company.models import Company
+from datahub.company.test.factories import CompanyFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def test_run(s3_stubber, caplog):
+    """Test that the command updates the specified records (ignoring ones with errors)."""
+    caplog.set_level('ERROR')
+
+    original_datetime = datetime(2017, 1, 1, tzinfo=timezone.utc)
+
+    with freeze_time(original_datetime):
+        export_potential_scores = [
+            Company.EXPORT_POTENTIAL_SCORES.very_high,
+            Company.EXPORT_POTENTIAL_SCORES.medium,
+            Company.EXPORT_POTENTIAL_SCORES.low,
+            Company.EXPORT_POTENTIAL_SCORES.very_high,
+            Company.EXPORT_POTENTIAL_SCORES.high,
+        ]
+        companies = CompanyFactory.create_batch(
+            5,
+            export_potential=factory.Iterator(export_potential_scores),
+        )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""datahub_company_id,export_propensity
+00000000-0000-0000-0000-000000000000,Low
+{companies[0].pk},High
+{companies[1].pk},Very high
+{companies[2].pk},dummy
+{companies[3].pk},High
+{companies[4].pk},Very high
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    with freeze_time('2018-11-11 00:00:00'):
+        call_command('update_company_export_potential', bucket, object_key)
+
+    for company in companies:
+        company.refresh_from_db()
+
+    assert 'Company matching query does not exist' in caplog.text
+    assert "KeyError: \'dummy\'" in caplog.text
+    assert len(caplog.records) == 2
+
+    assert [company.export_potential for company in companies] == [
+        Company.EXPORT_POTENTIAL_SCORES.high,
+        Company.EXPORT_POTENTIAL_SCORES.very_high,
+        Company.EXPORT_POTENTIAL_SCORES.low,
+        Company.EXPORT_POTENTIAL_SCORES.high,
+        Company.EXPORT_POTENTIAL_SCORES.very_high,
+    ]
+    assert all(company.modified_on == original_datetime for company in companies)
+
+
+def test_simulate(s3_stubber, caplog):
+    """Test that the command simulates updates if --simulate is passed in."""
+    caplog.set_level('ERROR')
+
+    export_potential_scores = [
+        Company.EXPORT_POTENTIAL_SCORES.very_high,
+        Company.EXPORT_POTENTIAL_SCORES.medium,
+        Company.EXPORT_POTENTIAL_SCORES.low,
+        Company.EXPORT_POTENTIAL_SCORES.very_high,
+        Company.EXPORT_POTENTIAL_SCORES.high,
+    ]
+    companies = CompanyFactory.create_batch(
+        5,
+        export_potential=factory.Iterator(export_potential_scores),
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""datahub_company_id,export_propensity
+00000000-0000-0000-0000-000000000000,Low
+{companies[0].pk},High
+{companies[1].pk},Very high
+{companies[2].pk},Low
+{companies[3].pk},High
+{companies[4].pk},Very high
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_company_export_potential', bucket, object_key, simulate=True)
+
+    for company in companies:
+        company.refresh_from_db()
+
+    assert 'Company matching query does not exist' in caplog.text
+    assert len(caplog.records) == 1
+
+    assert [company.export_potential for company in companies] == export_potential_scores
+
+
+def test_audit_log(s3_stubber):
+    """Test that reversion revisions are created."""
+    company_without_change = CompanyFactory(
+        export_potential=Company.EXPORT_POTENTIAL_SCORES.high,
+    )
+    company_with_change = CompanyFactory(
+        export_potential=Company.EXPORT_POTENTIAL_SCORES.medium,
+    )
+
+    bucket = 'test_bucket'
+    object_key = 'test_key'
+    csv_content = f"""datahub_company_id,export_propensity
+{company_without_change.pk},High
+{company_with_change.pk},Very high
+"""
+
+    s3_stubber.add_response(
+        'get_object',
+        {
+            'Body': BytesIO(csv_content.encode(encoding='utf-8')),
+        },
+        expected_params={
+            'Bucket': bucket,
+            'Key': object_key,
+        },
+    )
+
+    call_command('update_company_export_potential', bucket, object_key)
+
+    company_without_change.refresh_from_db()
+    assert company_without_change.export_potential == Company.EXPORT_POTENTIAL_SCORES.high
+    versions = Version.objects.get_for_object(company_without_change)
+    assert versions.count() == 0
+
+    company_with_change.refresh_from_db()
+    assert company_with_change.export_potential == Company.EXPORT_POTENTIAL_SCORES.very_high
+    versions = Version.objects.get_for_object(company_with_change)
+    assert versions.count() == 1
+    assert versions[0].revision.get_comment() == 'Export potential updated.'


### PR DESCRIPTION
### Description of change
Adding a django management command to import export propensity data in csv format into Data Hub's company model.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
