### PR TITLE
Add contact email to endpoints with one list account manager.

### DIFF
--- a/changelog/company/company-one-list-account-manager-email.api.md
+++ b/changelog/company/company-one-list-account-manager-email.api.md
@@ -1,0 +1,1 @@
+The `GET /company/<uuid:pk>` endpoint's read-only field `one_list_group_global_account_manager` now includes the account manager's contact email address under the `contact_email` field.

--- a/changelog/company/one-list-group-core-team-email.api.md
+++ b/changelog/company/one-list-group-core-team-email.api.md
@@ -1,0 +1,1 @@
+Each adviser object returned by `/v4/company/<uuid:pk>/one-list-group-core-team` endpoint now includes a contact email address under the `contact_email` field.

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -72,13 +72,14 @@ NestedAdviserWithTeamField = partial(
 )
 
 # like NestedAdviserField but includes dit_team with uk_region and country
-NestedAdviserWithTeamGeographyField = partial(
+NestedAdviserWithEmailAndTeamGeographyField = partial(
     NestedRelatedField,
     'company.Advisor',
     extra_fields=(
         'name',
         'first_name',
         'last_name',
+        'contact_email',
         ('dit_team', TeamWithGeographyField()),
     ),
 )
@@ -393,7 +394,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         """
         global_account_manager = obj.get_one_list_group_global_account_manager()
 
-        field = NestedAdviserWithTeamGeographyField()
+        field = NestedAdviserWithEmailAndTeamGeographyField()
         return field.to_representation(global_account_manager)
 
     class Meta:
@@ -574,5 +575,5 @@ class PublicCompanySerializer(CompanySerializer):
 class OneListCoreTeamMemberSerializer(serializers.Serializer):
     """One List Core Team Member Serializer."""
 
-    adviser = NestedAdviserWithTeamGeographyField()
+    adviser = NestedAdviserWithEmailAndTeamGeographyField()
     is_global_account_manager = serializers.BooleanField()

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -305,6 +305,7 @@ class TestGetCompany(APITestMixin):
                 'name': ghq.one_list_account_owner.name,
                 'first_name': ghq.one_list_account_owner.first_name,
                 'last_name': ghq.one_list_account_owner.last_name,
+                'contact_email': ghq.one_list_account_owner.contact_email,
                 'dit_team': {
                     'id': str(ghq.one_list_account_owner.dit_team.id),
                     'name': ghq.one_list_account_owner.dit_team.name,
@@ -511,6 +512,7 @@ class TestGetCompany(APITestMixin):
                 'name': global_account_manager.name,
                 'first_name': global_account_manager.first_name,
                 'last_name': global_account_manager.last_name,
+                'contact_email': global_account_manager.contact_email,
                 'dit_team': {
                     'id': str(global_account_manager.dit_team.id),
                     'name': global_account_manager.dit_team.name,

--- a/datahub/company/test/test_company_views_core_team.py
+++ b/datahub/company/test/test_company_views_core_team.py
@@ -84,6 +84,7 @@ class TestOneListGroupCoreTeam(APITestMixin):
                     'name': global_account_manager.name,
                     'first_name': global_account_manager.first_name,
                     'last_name': global_account_manager.last_name,
+                    'contact_email': global_account_manager.contact_email,
                     'dit_team': {
                         'id': str(global_account_manager.dit_team.pk),
                         'name': global_account_manager.dit_team.name,
@@ -156,6 +157,7 @@ class TestOneListGroupCoreTeam(APITestMixin):
                     'name': adviser.name,
                     'first_name': adviser.first_name,
                     'last_name': adviser.last_name,
+                    'contact_email': adviser.contact_email,
                     'dit_team': {
                         'id': str(adviser.dit_team.pk),
                         'name': adviser.dit_team.name,


### PR DESCRIPTION
### Description of change

This adds `contact_email` to endpoints with `one_list_group_global_account_manager`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
