### PR TITLE
Fix issue with pagination cutoff and small refactor of the dataset app

### DIFF
--- a/changelog/disable-pagination-offset-cutoff.bugfix.md
+++ b/changelog/disable-pagination-offset-cutoff.bugfix.md
@@ -1,0 +1,1 @@
+Unset cursor pagination `offset_cutoff` on dataset endpoints to fix issue when duplicate `created_on` dates are encountered.

--- a/datahub/dataset/company/pagination.py
+++ b/datahub/dataset/company/pagination.py
@@ -1,9 +1,0 @@
-from rest_framework.pagination import CursorPagination
-
-
-class CompaniesDatasetViewCursorPagination(CursorPagination):
-    """
-    Cursor Pagination for CompaniesDatasetView
-    """
-
-    ordering = ('created_on', 'pk')

--- a/datahub/dataset/company/views.py
+++ b/datahub/dataset/company/views.py
@@ -1,35 +1,15 @@
-from rest_framework.views import APIView
-
-from config.settings.types import HawkScope
 from datahub.company.models import Company
-from datahub.core.hawk_receiver import (
-    HawkAuthentication,
-    HawkResponseSigningMixin,
-    HawkScopePermission,
-)
-from datahub.dataset.company.pagination import CompaniesDatasetViewCursorPagination
+from datahub.dataset.core.views import BaseDatasetView
 from datahub.metadata.query_utils import get_sector_name_subquery
 
 
-class CompaniesDatasetView(HawkResponseSigningMixin, APIView):
+class CompaniesDatasetView(BaseDatasetView):
     """
     A GET API view to return the data for all companies as required
     for syncing by Data-flow periodically.
     Data-flow uses the resulting response to insert data into Data workspace which can
     then be queried to create custom reports for users.
     """
-
-    authentication_classes = (HawkAuthentication, )
-    permission_classes = (HawkScopePermission, )
-    required_hawk_scope = HawkScope.data_flow_api
-    pagination_class = CompaniesDatasetViewCursorPagination
-
-    def get(self, request):
-        """Endpoint which serves all records for the Companies Dataset"""
-        dataset = self.get_dataset()
-        paginator = self.pagination_class()
-        page = paginator.paginate_queryset(dataset, request, view=self)
-        return paginator.get_paginated_response(page)
 
     def get_dataset(self):
         """Returns list of Company records"""

--- a/datahub/dataset/contact/pagination.py
+++ b/datahub/dataset/contact/pagination.py
@@ -1,9 +1,0 @@
-from rest_framework.pagination import CursorPagination
-
-
-class ContactsDatasetViewCursorPagination(CursorPagination):
-    """
-    Cursor Pagination for ContactsDatasetView
-    """
-
-    ordering = ('created_on', 'pk')

--- a/datahub/dataset/contact/views.py
+++ b/datahub/dataset/contact/views.py
@@ -1,18 +1,10 @@
-from rest_framework.views import APIView
-
-from config.settings.types import HawkScope
 from datahub.company.models.contact import Contact
-from datahub.core.hawk_receiver import (
-    HawkAuthentication,
-    HawkResponseSigningMixin,
-    HawkScopePermission,
-)
 from datahub.core.query_utils import get_full_name_expression
-from datahub.dataset.contact.pagination import ContactsDatasetViewCursorPagination
+from datahub.dataset.core.views import BaseDatasetView
 from datahub.metadata.query_utils import get_sector_name_subquery
 
 
-class ContactsDatasetView(HawkResponseSigningMixin, APIView):
+class ContactsDatasetView(BaseDatasetView):
     """
     An APIView that provides 'get' action which queries and returns desired fields for
     Contacts Dataset to be consumed by Data-flow periodically. Data-flow uses response result
@@ -20,18 +12,6 @@ class ContactsDatasetView(HawkResponseSigningMixin, APIView):
     various reports to the users out of flattened table and let analyst to work on denormalized
     table to get more meaningful insight.
     """
-
-    authentication_classes = (HawkAuthentication, )
-    permission_classes = (HawkScopePermission, )
-    required_hawk_scope = HawkScope.data_flow_api
-    pagination_class = ContactsDatasetViewCursorPagination
-
-    def get(self, request):
-        """Endpoint which serves all records for Contacts Dataset"""
-        dataset = self.get_dataset()
-        paginator = self.pagination_class()
-        page = paginator.paginate_queryset(dataset, request, view=self)
-        return paginator.get_paginated_response(page)
 
     def get_dataset(self):
         """Returns list of Contacts Dataset records"""

--- a/datahub/dataset/core/pagination.py
+++ b/datahub/dataset/core/pagination.py
@@ -1,0 +1,16 @@
+from rest_framework.pagination import CursorPagination
+
+
+class DatasetCursorPagination(CursorPagination):
+    """
+    Cursor Pagination for dataset api endpoints
+    """
+
+    ordering = ('created_on', 'pk')
+
+    # We need to unset the pagination `offset_cutoff` value as we hit an issue
+    # with pagination ordering when the model has many thousands of duplicate
+    # `created_on` dates. Effectively, if the number of duplicate timestamps
+    # is greater than the `offset_cutoff` the `next_page` in the response would
+    # point to the current page creating an infinite loop.
+    offset_cutoff = None

--- a/datahub/dataset/core/views.py
+++ b/datahub/dataset/core/views.py
@@ -1,0 +1,33 @@
+from rest_framework.views import APIView
+
+from config.settings.types import HawkScope
+from datahub.core.auth import PaaSIPAuthentication
+from datahub.core.hawk_receiver import (
+    HawkAuthentication,
+    HawkResponseSigningMixin,
+    HawkScopePermission,
+)
+from datahub.dataset.core.pagination import DatasetCursorPagination
+
+
+class BaseDatasetView(HawkResponseSigningMixin, APIView):
+    """
+    Base API view to be used for creating endpoints for consumption
+    by Data Flow and insertion into Data Workspace.
+    """
+
+    authentication_classes = (PaaSIPAuthentication, HawkAuthentication)
+    permission_classes = (HawkScopePermission, )
+    required_hawk_scope = HawkScope.data_flow_api
+    pagination_class = DatasetCursorPagination
+
+    def get(self, request):
+        """Endpoint which serves all records for a specific Dataset"""
+        dataset = self.get_dataset()
+        paginator = self.pagination_class()
+        page = paginator.paginate_queryset(dataset, request, view=self)
+        return paginator.get_paginated_response(page)
+
+    def get_dataset(self):
+        """Return a list of records"""
+        raise NotImplementedError

--- a/datahub/dataset/interaction/pagination.py
+++ b/datahub/dataset/interaction/pagination.py
@@ -1,7 +1,0 @@
-from rest_framework.pagination import CursorPagination
-
-
-class InteractionsDatasetViewCursorPagination(CursorPagination):
-    """Cursor Pagination for InteractionsDatasetView"""
-
-    ordering = ('created_on', 'pk')

--- a/datahub/dataset/interaction/views.py
+++ b/datahub/dataset/interaction/views.py
@@ -1,39 +1,20 @@
 from django.contrib.postgres.aggregates import ArrayAgg
-from rest_framework.views import APIView
 
-from config.settings.types import HawkScope
-from datahub.core.auth import PaaSIPAuthentication
-from datahub.core.hawk_receiver import (
-    HawkAuthentication,
-    HawkResponseSigningMixin,
-    HawkScopePermission,
-)
 from datahub.core.query_utils import (
     get_aggregate_subquery,
     get_front_end_url_expression,
 )
-from datahub.dataset.interaction.pagination import InteractionsDatasetViewCursorPagination
+from datahub.dataset.core.views import BaseDatasetView
 from datahub.interaction.models import Interaction
 from datahub.interaction.queryset import get_base_interaction_queryset
 from datahub.metadata.query_utils import get_sector_name_subquery, get_service_name_subquery
 
 
-class InteractionsDatasetView(HawkResponseSigningMixin, APIView):
+class InteractionsDatasetView(BaseDatasetView):
     """
     A GET API view to return all interaction data as required for syncing by
     Data-flow periodically.
     """
-
-    authentication_classes = (PaaSIPAuthentication, HawkAuthentication)
-    permission_classes = (HawkScopePermission, )
-    required_hawk_scope = HawkScope.data_flow_api
-    pagination_class = InteractionsDatasetViewCursorPagination
-
-    def get(self, request):
-        """Endpoint which serves all interaction records"""
-        paginator = self.pagination_class()
-        page = paginator.paginate_queryset(self.get_dataset(), request, view=self)
-        return paginator.get_paginated_response(page)
 
     def get_dataset(self):
         """Returns a list of all interaction records"""

--- a/datahub/dataset/order/pagination.py
+++ b/datahub/dataset/order/pagination.py
@@ -1,9 +1,0 @@
-from rest_framework.pagination import CursorPagination
-
-
-class OMISDatasetViewCursorPagination(CursorPagination):
-    """
-    Cursor Pagination for OMISDatasetView
-    """
-
-    ordering = ('created_on', 'pk')

--- a/datahub/dataset/order/views.py
+++ b/datahub/dataset/order/views.py
@@ -1,19 +1,10 @@
-from rest_framework.views import APIView
-
-from config.settings.types import HawkScope
-from datahub.core.auth import PaaSIPAuthentication
-from datahub.core.hawk_receiver import (
-    HawkAuthentication,
-    HawkResponseSigningMixin,
-    HawkScopePermission,
-)
 from datahub.core.query_utils import get_string_agg_subquery
-from datahub.dataset.order.pagination import OMISDatasetViewCursorPagination
+from datahub.dataset.core.views import BaseDatasetView
 from datahub.metadata.query_utils import get_sector_name_subquery
 from datahub.omis.order.models import Order
 
 
-class OMISDatasetView(HawkResponseSigningMixin, APIView):
+class OMISDatasetView(BaseDatasetView):
     """
     An APIView that provides 'get' action which queries and returns desired fields for OMIS Dataset
     to be consumed by Data-flow periodically. Data-flow uses response result to insert data into
@@ -21,18 +12,6 @@ class OMISDatasetView(HawkResponseSigningMixin, APIView):
     users out of flattened table and let analyst to work on denormalized table to get
     more meaningful insight.
     """
-
-    authentication_classes = (PaaSIPAuthentication, HawkAuthentication)
-    permission_classes = (HawkScopePermission,)
-    required_hawk_scope = HawkScope.data_flow_api
-    pagination_class = OMISDatasetViewCursorPagination
-
-    def get(self, request):
-        """Endpoint which serves all records for OMIS Dataset"""
-        dataset = self.get_dataset()
-        paginator = self.pagination_class()
-        page = paginator.paginate_queryset(dataset, request, view=self)
-        return paginator.get_paginated_response(page)
 
     def get_dataset(self):
         """Returns list of OMIS Dataset records"""


### PR DESCRIPTION
### Description of change

Fix issue where models with a lot of duplicate `created_on` dates were causing infinite loops in dataset pagination.

Also includes a small refactor of the datasets app to remove duplicate view/pagination code.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
