### PR TITLE
Add self-assign company account manager endpoint

### DIFF
--- a/changelog/company/assign-ita-as-account-manager.api.md
+++ b/changelog/company/assign-ita-as-account-manager.api.md
@@ -1,0 +1,11 @@
+A new endpoint, `POST /v4/company/<ID>/self-assign-account-manager`, was added. It:
+
+- sets the authenticated user as the One List account manager
+- sets the One List tier of the company to 'Tier D - Interaction Trade Adviser Accounts'
+
+The operation is not allowed if:
+
+- the company is a subsidiary of a One List company (on any tier)
+- the company is already a One List company on a different tier (i.e. not 'Tier D - Interaction Trade Adviser Accounts')
+
+The `company.change_company` and `company.change_regional_account_manager` permissions are required to use this endpoint.

--- a/datahub/company/constants.py
+++ b/datahub/company/constants.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from uuid import UUID
 
 from datahub.core.constants import Constant
 
@@ -47,3 +48,9 @@ class BusinessTypeConstant(Enum):
     community_interest_company = Constant(
         'Community interest company', '34e4cb83-e5e1-421e-ac90-8a52edcc209c',
     )
+
+
+class OneListTierID(Enum):
+    """One List tier IDs."""
+
+    tier_d_international_trade_advisers = UUID('1929c808-99b4-4abf-a891-45f2e187b410')

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -38,6 +38,8 @@ class CompanyPermission(StrEnum):
     view_company_timeline = 'view_company_timeline'
     export_company = 'export_company'
     add_company = 'add_company'
+    change_company = 'change_company'
+    # Indicates that the user can assign regional One List account managers to companies
     change_regional_account_manager = 'change_regional_account_manager'
 
 
@@ -401,6 +403,12 @@ class Company(ArchivableModel, BaseModel):
         """
         group_global_headquarters = self.get_group_global_headquarters()
         return group_global_headquarters.one_list_account_owner
+
+    def assign_one_list_account_manager_and_tier(self, adviser, one_list_tier_id):
+        """Update the company's One List account manager and tier."""
+        self.one_list_account_owner = adviser
+        self.one_list_tier_id = one_list_tier_id
+        self.save()
 
 
 class OneListCoreTeamMember(models.Model):

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -7,7 +7,7 @@ from django.db import models
 from django.utils.translation import gettext_lazy
 from rest_framework import serializers
 
-from datahub.company.constants import BusinessTypeConstant
+from datahub.company.constants import BusinessTypeConstant, OneListTierID
 from datahub.company.models import (
     Advisor,
     CompaniesHouseCompany,
@@ -522,6 +522,48 @@ class CompanySerializer(PermittedFieldsModelSerializer):
         permissions = {
             f'company.{CompanyPermission.view_company_document}': 'archived_documents_url_path',
         }
+
+
+class SelfAssignAccountManagerSerializer(serializers.Serializer):
+    """
+    Serialiser for assigning an interaction trade adviser as the account manager of a
+    company.
+    """
+
+    target_one_list_tier_id = OneListTierID.tier_d_international_trade_advisers.value
+    default_error_messages = {
+        'cannot_change_account_manager_of_one_list_subsidiary':
+            gettext_lazy("A lead adviser can't be set on a subsidiary of a One List company."),
+        'cannot_change_account_manager_for_other_one_list_tiers':
+            gettext_lazy("A lead adviser can't be set for companies on this One List tier."),
+    }
+
+    def validate(self, attrs):
+        """Validate that the change of One List account manager and tier is allowed."""
+        attrs = super().validate(attrs)
+        global_headquarters = self.instance.global_headquarters
+
+        if global_headquarters and global_headquarters.one_list_tier_id:
+            raise serializers.ValidationError(
+                self.error_messages['cannot_change_account_manager_of_one_list_subsidiary'],
+                code='cannot_change_account_manager_of_one_list_subsidiary',
+            )
+
+        if self.instance.one_list_tier_id not in (None, self.target_one_list_tier_id):
+            raise serializers.ValidationError(
+                self.error_messages['cannot_change_account_manager_for_other_one_list_tiers'],
+                code='cannot_change_account_manager_for_other_one_list_tiers',
+            )
+
+        return attrs
+
+    def save(self, adviser):
+        """Update the company's One List account manager and tier."""
+        self.instance.assign_one_list_account_manager_and_tier(
+            adviser,
+            self.target_one_list_tier_id,
+        )
+        return self.instance
 
 
 class PublicCompanySerializer(CompanySerializer):

--- a/datahub/company/test/test_company_views_account_manager.py
+++ b/datahub/company/test/test_company_views_account_manager.py
@@ -1,0 +1,152 @@
+import pytest
+from rest_framework import status
+from rest_framework.reverse import reverse
+from rest_framework.settings import api_settings
+
+from datahub.company.constants import OneListTierID
+from datahub.company.models import CompanyPermission, OneListTier
+from datahub.company.test.factories import AdviserFactory, CompanyFactory, SubsidiaryFactory
+from datahub.core.test_utils import (
+    APITestMixin,
+    create_test_user,
+    random_obj_for_model,
+    random_obj_for_queryset,
+)
+
+
+@pytest.fixture
+def international_trade_adviser():
+    """An adviser with permission to change regional account managers."""
+    permission_codenames = [
+        CompanyPermission.change_company,
+        CompanyPermission.change_regional_account_manager,
+    ]
+
+    return create_test_user(permission_codenames=permission_codenames, dit_team=None)
+
+
+def _random_non_ita_one_list_tier():
+    queryset = OneListTier.objects.exclude(
+        pk=OneListTierID.tier_d_international_trade_advisers.value,
+    )
+    return random_obj_for_queryset(queryset)
+
+
+def _get_url(company):
+    return reverse('api-v4:company:self-assign-account-manager', kwargs={'pk': company.pk})
+
+
+class TestSelfAssignCompanyAccountManagerView(APITestMixin):
+    """
+    Tests for the self-assign company account manager view.
+
+    (Implemented in CompanyViewSet.self_assign_account_manager().)
+    """
+
+    def test_returns_401_if_unauthenticated(self, api_client):
+        """Test that a 401 is returned if no credentials are provided."""
+        company = CompanyFactory()
+        url = _get_url(company)
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    @pytest.mark.parametrize(
+        'permission_codenames',
+        (
+            (),
+            (CompanyPermission.change_company,),
+            (CompanyPermission.change_regional_account_manager,),
+        ),
+    )
+    def test_returns_403_if_without_permission(self, permission_codenames):
+        """
+        Test that a 403 is returned if the user does not have all of the required
+        permissions.
+        """
+        company = CompanyFactory()
+        user = create_test_user(permission_codenames=permission_codenames, dit_team=None)
+        api_client = self.create_api_client(user=user)
+        url = _get_url(company)
+
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @pytest.mark.parametrize(
+        'company_factory',
+        (
+            pytest.param(
+                lambda: CompanyFactory(one_list_account_owner=None, one_list_tier=None),
+                id='no-existing-account-manager',
+            ),
+            pytest.param(
+                lambda: CompanyFactory(
+                    one_list_account_owner=AdviserFactory(),
+                    one_list_tier_id=OneListTierID.tier_d_international_trade_advisers.value,
+                ),
+                id='existing-international-trade-adviser-account-manager',
+            ),
+        ),
+    )
+    @pytest.mark.django_db
+    def test_assigns_account_manager(self, company_factory, international_trade_adviser):
+        """
+        Test that an account manager can be assigned to:
+
+        - a company not on the One List
+        - a company on the One List tier 'Tier D - International Trade Adviser Accounts'
+        """
+        company = company_factory()
+        api_client = self.create_api_client(user=international_trade_adviser)
+        url = _get_url(company)
+
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        company.refresh_from_db()
+        assert company.one_list_account_owner == international_trade_adviser
+        assert company.one_list_tier_id == OneListTierID.tier_d_international_trade_advisers.value
+
+    @pytest.mark.parametrize(
+        'company_factory,expected_errors',
+        (
+            pytest.param(
+                lambda: SubsidiaryFactory(
+                    global_headquarters__one_list_tier=random_obj_for_model(OneListTier),
+                    global_headquarters__one_list_account_owner=AdviserFactory(),
+                ),
+                {
+                    api_settings.NON_FIELD_ERRORS_KEY: [
+                        "A lead adviser can't be set on a subsidiary of a One List company.",
+                    ],
+                },
+                id='subsidiary-of-one-list-company',
+            ),
+            pytest.param(
+                lambda: CompanyFactory(
+                    one_list_tier=_random_non_ita_one_list_tier(),
+                    one_list_account_owner=AdviserFactory(),
+                ),
+                {
+                    api_settings.NON_FIELD_ERRORS_KEY: [
+                        "A lead adviser can't be set for companies on this One List tier.",
+                    ],
+                },
+                id='already-on-another-one-list-tier',
+            ),
+        ),
+    )
+    @pytest.mark.django_db
+    def test_validation(self, company_factory, expected_errors, international_trade_adviser):
+        """
+        Test that an account manager can't be assigned to:
+
+        - a company on a One List tier other than 'Tier D - International Trade Adviser Accounts'
+        - a company on that is a subsidiary of any One List company
+        """
+        company = company_factory()
+        api_client = self.create_api_client(user=international_trade_adviser)
+        url = _get_url(company)
+
+        response = api_client.post(url)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == expected_errors

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -26,6 +26,10 @@ company_archive = CompanyViewSet.as_action_view('archive')
 
 company_unarchive = CompanyViewSet.as_action_view('unarchive')
 
+company_self_assign_account_manager = CompanyViewSet.as_action_view(
+    'self_assign_account_manager',
+)
+
 one_list_group_core_team = OneListGroupCoreTeamViewSet.as_view({
     'get': 'list',
 })
@@ -40,6 +44,11 @@ urls = [
     path('company/<uuid:pk>/archive', company_archive, name='archive'),
     path('company/<uuid:pk>/unarchive', company_unarchive, name='unarchive'),
     path('company/<uuid:pk>/audit', company_audit, name='audit-item'),
+    path(
+        'company/<uuid:pk>/self-assign-account-manager',
+        company_self_assign_account_manager,
+        name='self-assign-account-manager',
+    ),
     path(
         'company/<uuid:pk>/one-list-group-core-team',
         one_list_group_core_team,


### PR DESCRIPTION
### Description of change

This adds a new endpoint `POST /v4/company/<ID>/self-assign-account-manager` that:

- sets the authenticated user as the One List account manager
- sets the One List tier of the company to 'Tier D - Interaction Trade Adviser Accounts'

The operation is not allowed if:

- the company is a subsidiary of a One List company (on any tier)
- the company is already a One List company on a different tier (i.e. not 'Tier D - Interaction Trade Adviser Accounts')

The `company.change_company` and `company.change_regional_account_manager` permissions are required to use the endpoint.

I followed a similar pattern to the  OMIS action views (e.g. cancel order) as those have worked well.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
