### PR TITLE
Add is_global_ultimate property to Company

### DIFF
--- a/changelog/company/add-is-global-ultimate-property.internal.md
+++ b/changelog/company/add-is-global-ultimate-property.internal.md
@@ -1,0 +1,2 @@
+A property `is_global_ultimate` was added to the `Company` model - this exposes
+whether or not a company is the global ultimate.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -308,6 +308,15 @@ class Company(ArchivableModel, BaseModel):
             except CompaniesHouseCompany.DoesNotExist:
                 return None
 
+    @property
+    def is_global_ultimate(self):
+        """
+        Whether this company is the global ultimate or not.
+        """
+        if not self.duns_number:
+            return False
+        return self.duns_number == self.global_ultimate_duns_number
+
     def mark_as_transferred(self, to, reason, user):
         """
         Marks a company record as having been transferred to another company record.

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -122,6 +122,7 @@ class TestDNBInvestigationData:
     'duns_number,global_ultimate_duns_number,expected_is_global_ultimate',
     (
         ('', '', False),
+        (None, '', False),
         ('123456789', '123456789', True),
         ('999999999', '123456789', False),
     ),

--- a/datahub/company/test/models/test_company.py
+++ b/datahub/company/test/models/test_company.py
@@ -14,7 +14,9 @@ from datahub.core.constants import (
 from datahub.core.test_utils import APITestMixin
 
 
-@pytest.mark.django_db
+pytestmark = pytest.mark.django_db
+
+
 class TestPendingDNBInvestigation(APITestMixin):
     """
     Test if the `pending_dnb_investigation` field is set to False
@@ -80,7 +82,6 @@ class TestPendingDNBInvestigation(APITestMixin):
         assert not company.pending_dnb_investigation
 
 
-@pytest.mark.django_db
 class TestDNBInvestigationData:
     """
     Test `dnb_investigation_data`.
@@ -115,3 +116,23 @@ class TestDNBInvestigationData:
         company = CompanyFactory(dnb_investigation_data=investigation_data)
         db_company = Company.objects.get(id=company.id)
         assert db_company.dnb_investigation_data == investigation_data
+
+
+@pytest.mark.parametrize(
+    'duns_number,global_ultimate_duns_number,expected_is_global_ultimate',
+    (
+        ('', '', False),
+        ('123456789', '123456789', True),
+        ('999999999', '123456789', False),
+    ),
+)
+def test_is_global_ultimate(duns_number, global_ultimate_duns_number, expected_is_global_ultimate):
+    """
+    Test that the `Company.is_global_ultimate` property returns the correct response
+    for a variety of scenarios.
+    """
+    company = CompanyFactory(
+        duns_number=duns_number,
+        global_ultimate_duns_number=global_ultimate_duns_number,
+    )
+    assert company.is_global_ultimate == expected_is_global_ultimate


### PR DESCRIPTION
### Description of change

Add `is_global_ultimate` property to Company model.  This will later be exposed on the CompanySerializer class for company related API endpoints.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
