### PR TITLE
Add `is_global_ultimate` to API endpoints

### DIFF
--- a/changelog/company/add-is-global-ultimate-property.api.md
+++ b/changelog/company/add-is-global-ultimate-property.api.md
@@ -1,0 +1,5 @@
+The property `is_global_ultimate` (a boolean) was added as a field to the following company API views:
+
+- `GET /v4/company`
+- `GET /v4/company/<pk>`
+- `POST /v4/dnb/company-create`

--- a/changelog/company/add-is-global-ultimate-property.api.md
+++ b/changelog/company/add-is-global-ultimate-property.api.md
@@ -1,4 +1,5 @@
-The property `is_global_ultimate` (a boolean) was added as a field to the following company API views:
+The property `is_global_ultimate` (a boolean) was added as a field to the following company API
+endpoints:
 
 - `GET /v4/company`
 - `GET /v4/company/<pk>`

--- a/changelog/company/add-is-global-ultimate-property.api.md
+++ b/changelog/company/add-is-global-ultimate-property.api.md
@@ -1,6 +1,7 @@
 The property `is_global_ultimate` (a boolean) was added as a field to the following company API
-endpoints:
+endpoints as a read-only field:
 
 - `GET /v4/company`
+- `POST /v4/company` - returned in the result
 - `GET /v4/company/<pk>`
 - `POST /v4/dnb/company-create`

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -443,6 +443,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'pending_dnb_investigation',
             'export_potential',
             'great_profile_status',
+            'is_global_ultimate',
         )
         read_only_fields = (
             'archived',
@@ -459,6 +460,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'pending_dnb_investigation',
             'export_potential',
             'great_profile_status',
+            'is_global_ultimate',
         )
         dnb_read_only_fields = (
             'name',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -330,7 +330,7 @@ class TestGetCompany(APITestMixin):
             'transferred_to': None,
             'transfer_reason': '',
             'pending_dnb_investigation': False,
-            'is_global_ultimate': False,
+            'is_global_ultimate': company.is_global_ultimate,
         }
 
     def test_get_company_without_country(self):

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -330,6 +330,7 @@ class TestGetCompany(APITestMixin):
             'transferred_to': None,
             'transfer_reason': '',
             'pending_dnb_investigation': False,
+            'is_global_ultimate': False,
         }
 
     def test_get_company_without_country(self):
@@ -393,6 +394,29 @@ class TestGetCompany(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['pending_dnb_investigation'] == pending_dnb_investigation
+
+    @pytest.mark.parametrize(
+        'is_global_ultimate',
+        (
+            True,
+            False,
+        ),
+    )
+    def test_get_company_global_ultimate(self, is_global_ultimate):
+        """
+        Test that `is_global_ultimate` is set for a company API result
+        as expected.
+        """
+        kwargs = {}
+        if is_global_ultimate:
+            kwargs['duns_number'] = 123456789
+            kwargs['global_ultimate_duns_number'] = 123456789
+        company = CompanyFactory(**kwargs)
+        url = reverse('api-v4:company:item', kwargs={'pk': company.pk})
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['is_global_ultimate'] == is_global_ultimate
 
     @pytest.mark.parametrize(
         'build_company',

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -387,6 +387,9 @@ class TestDNBCompanyCreateAPI(APITestMixin):
             'county': dnb_company.get('registered_address_county') or '',
             'postcode': dnb_company.get('registered_address_postcode') or '',
         } if required_registered_address_fields_present else None
+        is_global_ultimate = True if (
+            dnb_company['global_ultimate_duns_number'] == dnb_company['duns_number']
+        ) else False
 
         assert company == {
             'name': dnb_company['primary_name'],
@@ -440,6 +443,7 @@ class TestDNBCompanyCreateAPI(APITestMixin):
             'contacts': [],
             'pending_dnb_investigation': False,
             'global_ultimate_duns_number': dnb_company['global_ultimate_duns_number'],
+            'is_global_ultimate': is_global_ultimate,
         }
 
     @override_settings(DNB_SERVICE_BASE_URL=None)

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -387,9 +387,6 @@ class TestDNBCompanyCreateAPI(APITestMixin):
             'county': dnb_company.get('registered_address_county') or '',
             'postcode': dnb_company.get('registered_address_postcode') or '',
         } if required_registered_address_fields_present else None
-        is_global_ultimate = True if (
-            dnb_company['global_ultimate_duns_number'] == dnb_company['duns_number']
-        ) else False
 
         assert company == {
             'name': dnb_company['primary_name'],
@@ -443,7 +440,9 @@ class TestDNBCompanyCreateAPI(APITestMixin):
             'contacts': [],
             'pending_dnb_investigation': False,
             'global_ultimate_duns_number': dnb_company['global_ultimate_duns_number'],
-            'is_global_ultimate': is_global_ultimate,
+            'is_global_ultimate': (
+                dnb_company['global_ultimate_duns_number'] == dnb_company['duns_number']
+            ),
         }
 
     @override_settings(DNB_SERVICE_BASE_URL=None)


### PR DESCRIPTION
### Description of change

This PR exposes `is_global_ultimate` on the relevant company API endpoints.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
