### PR TITLE
Add `global_ultimate_duns_number`.

### DIFF
--- a/changelog/company/add_global_ultimate_duns_number.api.md
+++ b/changelog/company/add_global_ultimate_duns_number.api.md
@@ -1,0 +1,4 @@
+The field `global_ultimate_duns_number` was added to the `DNBCompanySerializer`.
+
+This means that the `global_ultimate_duns_number` returned in the D&B responses will now be saved
+to the `global_ultimate_duns_number` field on the `Company` model.

--- a/datahub/company/test/admin/test_update_from_dnb.py
+++ b/datahub/company/test/admin/test_update_from_dnb.py
@@ -46,6 +46,7 @@ def dnb_response():
                         'registration_type': 'uk_companies_house_number',
                     },
                 ],
+                'global_ultimate_duns_number': '987654321',
             },
         ],
     }

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -67,9 +67,17 @@ class DNBCompanySerializer(CompanySerializer):
         validators=(integer_validator,),
     )
 
+    global_ultimate_duns_number = serializers.CharField(
+        allow_blank=True,
+        max_length=9,
+        min_length=9,
+        validators=(integer_validator, ),
+    )
+
     class Meta(CompanySerializer.Meta):
         read_only_fields = []
         dnb_read_only_fields = []
+        fields = CompanySerializer.Meta.fields + ('global_ultimate_duns_number', )
         validators = (
             RulesBasedValidator(
                 ValidationRule(

--- a/datahub/dnb_api/test/test_utils.py
+++ b/datahub/dnb_api/test/test_utils.py
@@ -143,4 +143,5 @@ def test_get_company_valid(
         'is_turnover_estimated': None,
         'uk_based': True,
         'website': 'http://foo.com',
+        'global_ultimate_duns_number': '291332174',
     }

--- a/datahub/dnb_api/test/test_views.py
+++ b/datahub/dnb_api/test/test_views.py
@@ -439,6 +439,7 @@ class TestDNBCompanyCreateAPI(APITestMixin):
             'transferred_on': None,
             'contacts': [],
             'pending_dnb_investigation': False,
+            'global_ultimate_duns_number': dnb_company['global_ultimate_duns_number'],
         }
 
     @override_settings(DNB_SERVICE_BASE_URL=None)
@@ -650,6 +651,7 @@ class TestDNBCompanyCreateAPI(APITestMixin):
             {'address_line_2': ''},
             {'address_county': ''},
             {'address_postcode': ''},
+            {'global_ultimate_duns_number': None},
         ),
     )
     def test_post_missing_optional_fields(
@@ -724,6 +726,40 @@ class TestDNBCompanyCreateAPI(APITestMixin):
         that does not exist in DataHub.
         """
         dnb_response_uk['results'][0]['address_country'] = 'FOO'
+        requests_mock.post(
+            DNB_SEARCH_URL,
+            json=dnb_response_uk,
+        )
+
+        response = self.api_client.post(
+            reverse('api-v4:dnb-api:company-create'),
+            data={
+                'duns_number': 123456789,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.parametrize(
+        'global_ultimate_override',
+        (
+            {'global_ultimate_duns_number': 'foobarbaz'},
+            {'global_ultimate_duns_number': '12345678'},
+            {'global_ultimate_duns_number': '1234567890'},
+        ),
+    )
+    def test_post_invalid_global_ultimate(
+        self,
+        requests_mock,
+        dnb_company_search_feature_flag,
+        dnb_response_uk,
+        global_ultimate_override,
+    ):
+        """
+        Test if create-company endpoint returns 400 if the global_ultimate_duns_number
+        returned from D&B is invalid.
+        """
+        dnb_response_uk['results'][0]['global_ultimate_duns_number'] = global_ultimate_override
         requests_mock.post(
             DNB_SEARCH_URL,
             json=dnb_response_uk,

--- a/datahub/dnb_api/utils.py
+++ b/datahub/dnb_api/utils.py
@@ -157,14 +157,15 @@ def format_dnb_company(dnb_company):
         'turnover': dnb_company.get('annual_sales'),
         'is_turnover_estimated': dnb_company.get('is_annual_sales_estimated'),
         'website': company_website,
+        # `Company.global_ultimate_duns_number` is not nullable but allows blank values. Sample
+        # response from the D&B search API suggests that this field can be set to null.
+        'global_ultimate_duns_number': dnb_company.get('global_ultimate_duns_number') or '',
         # TODO: Extract sensible values for the following fields form the data:
         # 'business_type': None,
         # 'description': None,
         # 'uk_region': None,
         # 'sector': None,
         # 'vat_number': None,
-        # 'global_headquarters': None,
-        # 'headquarter_type': None,
     }
 
 


### PR DESCRIPTION
### Description of change

Adds the `global_ultimate_duns_number` field to the `DNBCompanySerializer`.

This means that we will now save this field from D&B responses to the Company model.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
