### PR TITLE
Speed up search tests

### DIFF
--- a/changelog/speed-up-search-tests.internal.md
+++ b/changelog/speed-up-search-tests.internal.md
@@ -1,0 +1,1 @@
+The speed of search tests was improved by using more efficient test set-up. The reduction in running time of the search tests is approximately 65%.

--- a/datahub/company/test/test_public_company_view.py
+++ b/datahub/company/test/test_public_company_view.py
@@ -70,7 +70,7 @@ class TestPublicCompanyViewSet:
 
         assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
 
-    def test_response_is_signed(self, es_with_signals, public_company_api_client):
+    def test_response_is_signed(self, public_company_api_client):
         """Test that responses are signed."""
         company = CompanyFactory()
         url = reverse('api-v4:company:public-item', kwargs={'pk': company.pk})

--- a/datahub/core/test/test_utils.py
+++ b/datahub/core/test/test_utils.py
@@ -7,12 +7,38 @@ import pytest
 from datahub.core.constants import Constant
 from datahub.core.test.support.models import MetadataModel
 from datahub.core.utils import (
+    force_uuid,
     get_financial_year,
     join_truthy_strings,
     load_constants_to_database,
     reverse_with_query_string,
     slice_iterable_into_chunks,
 )
+
+
+class TestForceUUID:
+    """Tests for force_uuid()."""
+
+    @pytest.mark.parametrize(
+        'value,expected_result',
+        (
+            (None, None),
+            ('b3eb3eb2-9b83-4253-b77c-f3eca5a6a660', UUID('b3eb3eb2-9b83-4253-b77c-f3eca5a6a660')),
+            (
+                UUID('b3eb3eb2-9b83-4253-b77c-f3eca5a6a660'),
+                UUID('b3eb3eb2-9b83-4253-b77c-f3eca5a6a660'),
+            ),
+        ),
+    )
+    def test_converts_values(self, value, expected_result):
+        """Test that values are converted to UUIDs as necessary."""
+        assert force_uuid(value) == expected_result
+
+    @pytest.mark.parametrize('value', (b'', []))
+    def test_raises_error_on_unexpected_type(self, value):
+        """Test that an error is raised on unexpected types."""
+        with pytest.raises(TypeError):
+            force_uuid(value)
 
 
 @pytest.mark.parametrize(

--- a/datahub/core/utils.py
+++ b/datahub/core/utils.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from itertools import islice
 from logging import getLogger
+from uuid import UUID
 
 import requests
 from django.conf import settings
@@ -44,6 +45,25 @@ class EchoUTF8:
         if isinstance(value, str):
             return value.encode('utf-8')
         return value
+
+
+def force_uuid(value):
+    """
+    Convert value to a UUID if it isn't already and isn't None.
+
+    Useful if you have a value that could be a UUID object or a UUID as a string, but
+    want it to be a UUID in all cases.
+    """
+    if value is None:
+        return None
+
+    if isinstance(value, UUID):
+        return value
+
+    if isinstance(value, str):
+        return UUID(value)
+
+    raise TypeError('The value must be None or an instance of str or UUID.')
 
 
 def join_truthy_strings(*args, sep=' '):

--- a/datahub/investment/project/models.py
+++ b/datahub/investment/project/models.py
@@ -20,7 +20,7 @@ from datahub.core.models import (
     BaseModel,
     BaseOrderedConstantModel,
 )
-from datahub.core.utils import get_front_end_url, StrEnum
+from datahub.core.utils import force_uuid, get_front_end_url, StrEnum
 from datahub.investment.project import constants
 
 MAX_LENGTH = settings.CHAR_FIELD_MAX_LENGTH
@@ -252,8 +252,8 @@ class IProjectAbstract(models.Model):
         if self.level_of_involvement_id is None:
             return self.INVOLVEMENT.unspecified
 
-        not_involved = uuid.UUID(constants.Involvement.no_involvement.value.id)
-        if self.level_of_involvement_id == not_involved:
+        not_involved_id = constants.Involvement.no_involvement.value.id
+        if force_uuid(self.level_of_involvement_id) == force_uuid(not_involved_id):
             return self.INVOLVEMENT.not_involved
 
         return self.INVOLVEMENT.involved

--- a/datahub/search/companieshousecompany/test/test_views_v3.py
+++ b/datahub/search/companieshousecompany/test/test_views_v3.py
@@ -13,43 +13,38 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(es_with_signals):
+def setup_data(es_with_collector):
     """Sets up data for the tests."""
-    companies = (
-        CompaniesHouseCompanyFactory(
-            name='Pallas',
-            company_number='111',
-            incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
-            registered_address_postcode='SW1A 1AA',
-            company_status='jumping',
-        ),
-        CompaniesHouseCompanyFactory(
-            name='Jaguarundi',
-            company_number='222',
-            incorporation_date=dateutil_parse('2015-09-12T00:00:00Z'),
-            registered_address_postcode='E1 6JE',
-            company_status='sleeping',
-        ),
-        CompaniesHouseCompanyFactory(
-            name='Cheetah',
-            company_number='333',
-            incorporation_date=dateutil_parse('2016-09-12T00:00:00Z'),
-            registered_address_postcode='SW1A 0PW',
-            company_status='purring',
-        ),
-        CompaniesHouseCompanyFactory(
-            name='Pallas Second',
-            company_number='444',
-            incorporation_date=dateutil_parse('2019-09-12T00:00:00Z'),
-            registered_address_postcode='WC1B 3DG',
-            company_status='crying',
-        ),
+    CompaniesHouseCompanyFactory(
+        name='Pallas',
+        company_number='111',
+        incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
+        registered_address_postcode='SW1A 1AA',
+        company_status='jumping',
+    )
+    CompaniesHouseCompanyFactory(
+        name='Jaguarundi',
+        company_number='222',
+        incorporation_date=dateutil_parse('2015-09-12T00:00:00Z'),
+        registered_address_postcode='E1 6JE',
+        company_status='sleeping',
+    )
+    CompaniesHouseCompanyFactory(
+        name='Cheetah',
+        company_number='333',
+        incorporation_date=dateutil_parse('2016-09-12T00:00:00Z'),
+        registered_address_postcode='SW1A 0PW',
+        company_status='purring',
+    )
+    CompaniesHouseCompanyFactory(
+        name='Pallas Second',
+        company_number='444',
+        incorporation_date=dateutil_parse('2019-09-12T00:00:00Z'),
+        registered_address_postcode='WC1B 3DG',
+        company_status='crying',
     )
 
-    for company in companies:
-        sync_object(CompaniesHouseCompanySearchApp, company.pk)
-
-    es_with_signals.indices.refresh()
+    es_with_collector.flush_and_refresh()
 
 
 class TestSearchCompaniesHouseCompany(APITestMixin):
@@ -113,7 +108,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
         assert len(response_data['results']) == len(expected_results)
         assert actual_results == expected_results
 
-    def test_response_body(self, es_with_signals):
+    def test_response_body(self, es):
         """Tests the response body of a search query."""
         company = CompaniesHouseCompanyFactory(
             name='Pallas',
@@ -122,7 +117,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
             company_status='jumping',
         )
         sync_object(CompaniesHouseCompanySearchApp, company.pk)
-        es_with_signals.indices.refresh()
+        es.indices.refresh()
 
         url = reverse('api-v3:search:companieshousecompany')
         response = self.api_client.post(url)

--- a/datahub/search/companieshousecompany/test/test_views_v4.py
+++ b/datahub/search/companieshousecompany/test/test_views_v4.py
@@ -13,43 +13,38 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(es_with_signals):
+def setup_data(es_with_collector):
     """Sets up data for the tests."""
-    companies = (
-        CompaniesHouseCompanyFactory(
-            name='Pallas',
-            company_number='111',
-            incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
-            registered_address_postcode='SW1A 1AA',
-            company_status='jumping',
-        ),
-        CompaniesHouseCompanyFactory(
-            name='Jaguarundi',
-            company_number='222',
-            incorporation_date=dateutil_parse('2015-09-12T00:00:00Z'),
-            registered_address_postcode='E1 6JE',
-            company_status='sleeping',
-        ),
-        CompaniesHouseCompanyFactory(
-            name='Cheetah',
-            company_number='333',
-            incorporation_date=dateutil_parse('2016-09-12T00:00:00Z'),
-            registered_address_postcode='SW1A 0PW',
-            company_status='purring',
-        ),
-        CompaniesHouseCompanyFactory(
-            name='Pallas Second',
-            company_number='444',
-            incorporation_date=dateutil_parse('2019-09-12T00:00:00Z'),
-            registered_address_postcode='WC1B 3DG',
-            company_status='crying',
-        ),
+    CompaniesHouseCompanyFactory(
+        name='Pallas',
+        company_number='111',
+        incorporation_date=dateutil_parse('2012-09-12T00:00:00Z'),
+        registered_address_postcode='SW1A 1AA',
+        company_status='jumping',
+    )
+    CompaniesHouseCompanyFactory(
+        name='Jaguarundi',
+        company_number='222',
+        incorporation_date=dateutil_parse('2015-09-12T00:00:00Z'),
+        registered_address_postcode='E1 6JE',
+        company_status='sleeping',
+    )
+    CompaniesHouseCompanyFactory(
+        name='Cheetah',
+        company_number='333',
+        incorporation_date=dateutil_parse('2016-09-12T00:00:00Z'),
+        registered_address_postcode='SW1A 0PW',
+        company_status='purring',
+    )
+    CompaniesHouseCompanyFactory(
+        name='Pallas Second',
+        company_number='444',
+        incorporation_date=dateutil_parse('2019-09-12T00:00:00Z'),
+        registered_address_postcode='WC1B 3DG',
+        company_status='crying',
     )
 
-    for company in companies:
-        sync_object(CompaniesHouseCompanySearchApp, company.pk)
-
-    es_with_signals.indices.refresh()
+    es_with_collector.flush_and_refresh()
 
 
 class TestSearchCompaniesHouseCompany(APITestMixin):
@@ -113,7 +108,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
         assert len(response_data['results']) == len(expected_results)
         assert actual_results == expected_results
 
-    def test_response_body(self, es_with_signals):
+    def test_response_body(self, es):
         """Tests the response body of a search query."""
         company = CompaniesHouseCompanyFactory(
             name='Pallas',
@@ -122,7 +117,7 @@ class TestSearchCompaniesHouseCompany(APITestMixin):
             company_status='jumping',
         )
         sync_object(CompaniesHouseCompanySearchApp, company.pk)
-        es_with_signals.indices.refresh()
+        es.indices.refresh()
 
         url = reverse('api-v4:search:companieshousecompany')
         response = self.api_client.post(url)

--- a/datahub/search/company/test/test_basic_search_views.py
+++ b/datahub/search/company/test/test_basic_search_views.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(es_with_signals):
+def setup_data(es_with_collector):
     """Sets up data for the tests."""
     country_uk = constants.Country.united_kingdom.value.id
     country_us = constants.Country.united_states.value.id
@@ -32,7 +32,7 @@ def setup_data(es_with_signals):
         address_country_id=country_us,
         registered_address_country_id=country_us,
     )
-    es_with_signals.indices.refresh()
+    es_with_collector.flush_and_refresh()
 
 
 class TestBasicSearch(APITestMixin):
@@ -97,7 +97,7 @@ class TestBasicSearch(APITestMixin):
             ('moine', None),
         ),
     )
-    def test_search_in_name(self, es_with_signals, name_term, matched_company_name):
+    def test_search_in_name(self, es_with_collector, name_term, matched_company_name):
         """Tests basic aggregate companies query."""
         CompanyFactory(
             name='whiskers and tabby',
@@ -107,7 +107,7 @@ class TestBasicSearch(APITestMixin):
             name='1a',
             trading_names=['3a', '4a'],
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:basic')
         response = self.api_client.get(
@@ -139,7 +139,7 @@ class TestBasicSearch(APITestMixin):
     )
     def test_search_in_field(
         self,
-        es_with_signals,
+        es_with_collector,
         model_field,
         model_value,
         search_term,
@@ -153,7 +153,7 @@ class TestBasicSearch(APITestMixin):
                 model_field: model_value,
             },
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:basic')
         response = self.api_client.get(

--- a/datahub/search/company/test/test_entity_search_views.py
+++ b/datahub/search/company/test/test_entity_search_views.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(es_with_signals):
+def setup_data(es_with_collector):
     """Sets up data for the tests."""
     country_uk = constants.Country.united_kingdom.value.id
     country_us = constants.Country.united_states.value.id
@@ -79,11 +79,11 @@ def setup_data(es_with_signals):
         registered_address_country_id=country_anguilla,
         archived=True,
     )
-    es_with_signals.indices.refresh()
+    es_with_collector.flush_and_refresh()
 
 
 @pytest.fixture
-def setup_headquarters_data(es_with_signals):
+def setup_headquarters_data(es_with_collector):
     """Sets up data for headquarter type tests."""
     CompanyFactory(
         name='ghq',
@@ -101,7 +101,7 @@ def setup_headquarters_data(es_with_signals):
         name='none',
         headquarter_type_id=None,
     )
-    es_with_signals.indices.refresh()
+    es_with_collector.flush_and_refresh()
 
 
 class TestSearch(APITestMixin):
@@ -115,7 +115,7 @@ class TestSearch(APITestMixin):
         response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_response_body(self, es_with_signals):
+    def test_response_body(self, es_with_collector):
         """Tests the response body of a search query."""
         company = CompanyFactory(
             company_number='123',
@@ -124,7 +124,7 @@ class TestSearch(APITestMixin):
             one_list_tier=None,
             one_list_account_owner=None,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:company')
         response = self.api_client.post(url)
@@ -365,7 +365,7 @@ class TestSearch(APITestMixin):
         'sector_level',
         (0, 1, 2),
     )
-    def test_sector_descends_filter(self, hierarchical_sectors, es_with_signals, sector_level):
+    def test_sector_descends_filter(self, hierarchical_sectors, es_with_collector, sector_level):
         """Test the sector_descends filter."""
         num_sectors = len(hierarchical_sectors)
         sectors_ids = [sector.pk for sector in hierarchical_sectors]
@@ -381,7 +381,7 @@ class TestSearch(APITestMixin):
             )),
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:company')
         body = {
@@ -406,13 +406,13 @@ class TestSearch(APITestMixin):
             (constants.Country.anguilla.value.id, False),
         ),
     )
-    def test_composite_country_filter(self, es_with_signals, country, match):
+    def test_composite_country_filter(self, es_with_collector, country, match):
         """Tests composite country filter."""
         company = CompanyFactory(
             address_country_id=constants.Country.cayman_islands.value.id,
             registered_address_country_id=constants.Country.montserrat.value.id,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:company')
 
@@ -459,7 +459,7 @@ class TestSearch(APITestMixin):
             ('moine', None),
         ),
     )
-    def test_composite_name_filter(self, es_with_signals, name_term, matched_company_name):
+    def test_composite_name_filter(self, es_with_collector, name_term, matched_company_name):
         """Tests composite name filter."""
         CompanyFactory(
             name='whiskers and tabby',
@@ -469,7 +469,7 @@ class TestSearch(APITestMixin):
             name='1a',
             trading_names=['3a', '4a'],
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:company')
 
@@ -491,7 +491,7 @@ class TestSearch(APITestMixin):
             assert response.data['count'] == 0
             assert len(response.data['results']) == 0
 
-    def test_company_search_paging(self, es_with_signals):
+    def test_company_search_paging(self, es_with_collector):
         """
         Tests the pagination.
 
@@ -511,7 +511,7 @@ class TestSearch(APITestMixin):
             trading_names=[],
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:company')
         for page in range((len(ids) + page_size - 1) // page_size):
@@ -544,7 +544,7 @@ class TestCompanyExportView(APITestMixin):
             (CompanyPermission.export_company,),
         ),
     )
-    def test_user_without_permission_cannot_export(self, es_with_signals, permissions):
+    def test_user_without_permission_cannot_export(self, es, permissions):
         """Test that a user without the correct permissions cannot export data."""
         user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -563,7 +563,7 @@ class TestCompanyExportView(APITestMixin):
     )
     def test_export(
         self,
-        es_with_signals,
+        es_with_collector,
         request_sortby,
         orm_ordering,
     ):
@@ -586,7 +586,7 @@ class TestCompanyExportView(APITestMixin):
             export_to_countries=Country.objects.order_by('?')[:2],
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         data = {}
         if request_sortby:
@@ -732,7 +732,7 @@ class TestAutocompleteSearch(APITestMixin):
     )
     def test_response_body(
         self,
-        es_with_signals,
+        es_with_collector,
         monkeypatch,
         search,
         use_context_serializer,
@@ -761,7 +761,7 @@ class TestAutocompleteSearch(APITestMixin):
             registered_address_country_id=constants.Country.united_kingdom.value.id,
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:company-autocomplete')
         response = self.api_client.get(
@@ -853,7 +853,7 @@ class TestAutocompleteSearch(APITestMixin):
             ('help qrs', []),
         ),
     )
-    def test_searching_with_a_query(self, es_with_signals, query, expected_companies):
+    def test_searching_with_a_query(self, es_with_collector, query, expected_companies):
         """Tests case where search queries are provided."""
         url = reverse('api-v4:search:company-autocomplete')
 
@@ -872,7 +872,7 @@ class TestAutocompleteSearch(APITestMixin):
             registered_address_country_id=country_us,
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         response = self.api_client.get(url, data={'term': query})
 
@@ -892,7 +892,7 @@ class TestAutocompleteSearch(APITestMixin):
             (1, ['abc defg ltd']),
         ),
     )
-    def test_searching_with_limit(self, es_with_signals, limit, expected_companies):
+    def test_searching_with_limit(self, es_with_collector, limit, expected_companies):
         """Tests case where search limit is provided."""
         url = reverse('api-v4:search:company-autocomplete')
 
@@ -911,7 +911,7 @@ class TestAutocompleteSearch(APITestMixin):
             registered_address_country_id=country_us,
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         response = self.api_client.get(
             url,

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -12,7 +12,7 @@ pytestmark = pytest.mark.django_db
 class TestCompanyElasticModel:
     """Test for the company elasticsearch model"""
 
-    def test_company_dbmodel_to_dict(self, es_with_signals):
+    def test_company_dbmodel_to_dict(self, es):
         """Tests conversion of db model to dict."""
         company = CompanyFactory()
 
@@ -54,7 +54,7 @@ class TestCompanyElasticModel:
 
         assert set(result.keys()) == keys
 
-    def test_company_dbmodels_to_es_documents(self, es_with_signals):
+    def test_company_dbmodels_to_es_documents(self, es):
         """Tests conversion of db models to Elasticsearch documents."""
         companies = CompanyFactory.create_batch(2)
 

--- a/datahub/search/company/test/test_public_search_view.py
+++ b/datahub/search/company/test/test_public_search_view.py
@@ -14,7 +14,7 @@ from datahub.core.test_utils import HawkAPITestClient
 
 
 @pytest.fixture
-def setup_data(es_with_signals):
+def setup_data(es_with_collector):
     """Sets up data for the tests."""
     country_uk = constants.Country.united_kingdom.value.id
     country_us = constants.Country.united_states.value.id
@@ -46,7 +46,7 @@ def setup_data(es_with_signals):
         registered_address_country_id=country_anguilla,
         archived=True,
     )
-    es_with_signals.indices.refresh()
+    es_with_collector.flush_and_refresh()
 
 
 @pytest.fixture
@@ -95,7 +95,7 @@ class TestPublicCompanySearch:
 
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
-    def test_response_body(self, es_with_signals, public_company_api_client):
+    def test_response_body(self, es_with_collector, public_company_api_client):
         """Tests the response body of a search query."""
         company = CompanyFactory(
             company_number='123',
@@ -104,7 +104,7 @@ class TestPublicCompanySearch:
             one_list_tier=None,
             one_list_account_owner=None,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:public-company')
         response = public_company_api_client.post(url, {})
@@ -191,7 +191,7 @@ class TestPublicCompanySearch:
             ],
         }
 
-    def test_response_is_signed(self, es_with_signals, public_company_api_client):
+    def test_response_is_signed(self, es, public_company_api_client):
         """Test that responses are signed."""
         url = reverse('api-v4:search:public-company')
         response = public_company_api_client.post(url, {})
@@ -266,7 +266,7 @@ class TestPublicCompanySearch:
     def test_composite_name_filter(
         self,
         public_company_api_client,
-        es_with_signals,
+        es_with_collector,
         name_term,
         matched_company_name,
     ):
@@ -279,7 +279,7 @@ class TestPublicCompanySearch:
             name='1a',
             trading_names=['3a', '4a'],
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:public-company')
         request_data = {
@@ -297,7 +297,7 @@ class TestPublicCompanySearch:
             assert response.data['count'] == 0
             assert len(response.data['results']) == 0
 
-    def test_pagination(self, public_company_api_client, es_with_signals):
+    def test_pagination(self, public_company_api_client, es_with_collector):
         """Test result pagination."""
         total_records = 9
         page_size = 2
@@ -311,7 +311,7 @@ class TestPublicCompanySearch:
             trading_names=[],
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v4:search:public-company')
 

--- a/datahub/search/contact/test/test_models.py
+++ b/datahub/search/contact/test/test_models.py
@@ -7,7 +7,7 @@ from datahub.search.contact.models import Contact as ESContact
 pytestmark = pytest.mark.django_db
 
 
-def test_contact_dbmodel_to_dict(es_with_signals):
+def test_contact_dbmodel_to_dict(es):
     """Tests conversion of db model to dict."""
     contact = ContactFactory()
 
@@ -51,7 +51,7 @@ def test_contact_dbmodel_to_dict(es_with_signals):
     assert set(result.keys()) == keys
 
 
-def test_contact_dbmodels_to_es_documents(es_with_signals):
+def test_contact_dbmodels_to_es_documents(es):
     """Tests conversion of db models to Elasticsearch documents."""
     contacts = ContactFactory.create_batch(2)
 
@@ -60,7 +60,7 @@ def test_contact_dbmodels_to_es_documents(es_with_signals):
     assert len(list(result)) == len(contacts)
 
 
-def test_contact_dbmodels_to_es_documents_without_country(es_with_signals):
+def test_contact_dbmodels_to_es_documents_without_country(es):
     """
     Tests conversion of db models to Elasticsearch documents when
     country is None.

--- a/datahub/search/contact/test/test_views.py
+++ b/datahub/search/contact/test/test_views.py
@@ -66,9 +66,9 @@ class TestSearch(APITestMixin):
         response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_search_contact(self, es_with_signals, setup_data):
+    def test_search_contact(self, es_with_collector, setup_data):
         """Tests detailed contact search."""
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         term = 'abc defg'
 
@@ -89,7 +89,7 @@ class TestSearch(APITestMixin):
         contact = response.data['results'][0]
         assert contact['address_country']['id'] == united_kingdom_id
 
-    def test_filter_contact(self, es_with_signals):
+    def test_filter_contact(self, es_with_collector):
         """Tests matching contact using multiple filters."""
         contact = ContactFactory(
             address_same_as_company=True,
@@ -100,7 +100,7 @@ class TestSearch(APITestMixin):
                 sector_id=Sector.renewable_energy_wind.value.id,
             ),
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -122,7 +122,7 @@ class TestSearch(APITestMixin):
         assert result['company_uk_region']['id'] == contact.company.uk_region_id
         assert result['company_sector']['id'] == contact.company.sector_id
 
-    def test_filter_without_uk_region(self, es_with_signals):
+    def test_filter_without_uk_region(self, es_with_collector):
         """Tests matching contact without uk_region using multiple filters."""
         company = CompanyFactory(
             registered_address_country_id=Country.united_states.value.id,
@@ -135,7 +135,7 @@ class TestSearch(APITestMixin):
             company=company,
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -163,7 +163,7 @@ class TestSearch(APITestMixin):
     def test_company_sector_descends_filter(
         self,
         hierarchical_sectors,
-        es_with_signals,
+        es_with_collector,
         sector_level,
     ):
         """Test the company_sector_descends filter."""
@@ -190,7 +190,7 @@ class TestSearch(APITestMixin):
             company=factory.Iterator(other_companies),
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
         body = {
@@ -233,7 +233,7 @@ class TestSearch(APITestMixin):
             ('moine', None),
         ),
     )
-    def test_filter_by_company_name(self, es_with_signals, name_term, matched_company_name):
+    def test_filter_by_company_name(self, es_with_collector, name_term, matched_company_name):
         """Tests filtering contact by company name."""
         matching_company1 = CompanyFactory(
             name='whiskers and tabby',
@@ -251,7 +251,7 @@ class TestSearch(APITestMixin):
         ContactFactory(company=matching_company2)
         ContactFactory(company=non_matching_company)
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -272,11 +272,11 @@ class TestSearch(APITestMixin):
             assert response.data['count'] == 0
             assert len(response.data['results']) == 0
 
-    def test_search_contact_by_partial_name(self, es_with_signals, setup_data):
+    def test_search_contact_by_partial_name(self, es_with_collector, setup_data):
         """Tests filtering by partially matching name."""
         contact = ContactFactory(first_name='xyzxyz')
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -298,11 +298,11 @@ class TestSearch(APITestMixin):
             False,
         ),
     )
-    def test_search_contact_by_archived(self, es_with_signals, setup_data, archived):
+    def test_search_contact_by_archived(self, es_with_collector, setup_data, archived):
         """Tests filtering by archived."""
         ContactFactory.create_batch(5, archived=True)
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -321,7 +321,7 @@ class TestSearch(APITestMixin):
         'created_on_exists',
         (True, False),
     )
-    def test_filter_by_created_on_exists(self, es_with_signals, created_on_exists):
+    def test_filter_by_created_on_exists(self, es_with_collector, created_on_exists):
         """Tests filtering contact by created_on exists."""
         ContactFactory.create_batch(3)
         no_created_on = ContactFactory.create_batch(3)
@@ -329,7 +329,7 @@ class TestSearch(APITestMixin):
             contact.created_on = None
             contact.save()
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
         request_data = {
@@ -347,12 +347,12 @@ class TestSearch(APITestMixin):
             for result in results
         )
 
-    def test_search_contact_by_company_id(self, es_with_signals, setup_data):
+    def test_search_contact_by_company_id(self, es_with_collector, setup_data):
         """Tests filtering by company id."""
         company = CompanyFactory()
         ContactFactory(company=company)
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -368,12 +368,12 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['company']['id'] == str(company.id)
 
-    def test_search_contact_by_created_by(self, es_with_signals, setup_data):
+    def test_search_contact_by_created_by(self, es_with_collector, setup_data):
         """Tests filtering by created_by."""
         adviser = AdviserFactory()
         ContactFactory(created_by=adviser)
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -389,12 +389,12 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['created_by']['id'] == str(adviser.id)
 
-    def test_company_name_trigram_filter(self, es_with_signals):
+    def test_company_name_trigram_filter(self, es_with_collector):
         """Tests edge case of partially matching company name."""
         ContactFactory(
             company=CompanyFactory(name='United States'),
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
 
@@ -409,9 +409,9 @@ class TestSearch(APITestMixin):
         assert response.data['count'] == 0
         assert len(response.data['results']) == 0
 
-    def test_search_contact_no_filters(self, es_with_signals, setup_data):
+    def test_search_contact_no_filters(self, es_with_collector, setup_data):
         """Tests case where there is no filters provided."""
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
         response = self.api_client.post(url, {})
@@ -419,14 +419,14 @@ class TestSearch(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data['results']) > 0
 
-    def test_search_contact_sort_by_last_name_desc(self, es_with_signals):
+    def test_search_contact_sort_by_last_name_desc(self, es_with_collector):
         """Tests sorting in descending order."""
         ContactFactory(first_name='test_name', last_name='abcdef')
         ContactFactory(first_name='test_name', last_name='bcdefg')
         ContactFactory(first_name='test_name', last_name='cdefgh')
         ContactFactory(first_name='test_name', last_name='defghi')
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         term = 'test_name'
 
@@ -460,7 +460,7 @@ class TestContactExportView(APITestMixin):
             (ContactPermission.export_contact,),
         ),
     )
-    def test_user_without_permission_cannot_export(self, es_with_signals, permissions):
+    def test_user_without_permission_cannot_export(self, es_with_collector, permissions):
         """Test that a user without the correct permissions cannot export data."""
         user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
         api_client = self.create_api_client(user=user)
@@ -483,7 +483,7 @@ class TestContactExportView(APITestMixin):
     )
     def test_export(
         self,
-        es_with_signals,
+        es_with_collector,
         request_sortby,
         orm_ordering,
     ):
@@ -503,7 +503,7 @@ class TestContactExportView(APITestMixin):
             interaction=interaction_with_multiple_teams,
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         data = {}
         if request_sortby:
@@ -588,9 +588,9 @@ def _format_interaction_team_names(interaction):
 class TestBasicSearch(APITestMixin):
     """Tests basic search view."""
 
-    def test_basic_search_contacts(self, es_with_signals, setup_data):
+    def test_basic_search_contacts(self, es_with_collector, setup_data):
         """Tests basic aggregate contacts query."""
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         term = 'abc defg'
 
@@ -609,11 +609,11 @@ class TestBasicSearch(APITestMixin):
         assert response.data['results'][0]['last_name'] in term
         assert [{'count': 1, 'entity': 'contact'}] == response.data['aggregations']
 
-    def test_search_contact_has_sector(self, es_with_signals, setup_data):
+    def test_search_contact_has_sector(self, es_with_collector, setup_data):
         """Tests if contact has a sector."""
         ContactFactory(first_name='sector_testing')
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         term = 'sector_testing'
 
@@ -631,7 +631,7 @@ class TestBasicSearch(APITestMixin):
         sector_name = Sector.aerospace_assembly_aircraft.value.name
         assert sector_name == response.data['results'][0]['company_sector']['name']
 
-    def test_search_contact_has_sector_updated(self, es_with_signals):
+    def test_search_contact_has_sector_updated(self, es_with_collector):
         """Tests if contact has a correct sector after company update."""
         contact = ContactFactory(first_name='sector_update')
 
@@ -640,7 +640,7 @@ class TestBasicSearch(APITestMixin):
         company.sector_id = Sector.renewable_energy_wind.value.id
         company.save()
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         term = 'sector_update'
 
@@ -658,7 +658,7 @@ class TestBasicSearch(APITestMixin):
         sector_name = Sector.renewable_energy_wind.value.name
         assert sector_name == response.data['results'][0]['company_sector']['name']
 
-    def test_search_contact_has_company_address_updated(self, es_with_signals):
+    def test_search_contact_has_company_address_updated(self, es_with_collector):
         """Tests if contact has a correct address after company address update."""
         contact = ContactFactory(
             address_same_as_company=True,
@@ -678,7 +678,7 @@ class TestBasicSearch(APITestMixin):
         company.address_country.id = Country.united_kingdom.value.id
         company.save()
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
         response = self.api_client.post(
@@ -699,7 +699,7 @@ class TestBasicSearch(APITestMixin):
         country = contact.company.address_country.name
         assert country == result['address_country']['name']
 
-    def test_search_contact_has_own_address(self, es_with_signals):
+    def test_search_contact_has_own_address(self, es_with_collector):
         """Tests if contact can have its own address."""
         address = {
             'address_same_as_company': False,
@@ -713,7 +713,7 @@ class TestBasicSearch(APITestMixin):
             **address,
         )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:contact')
         response = self.api_client.post(

--- a/datahub/search/event/test/test_models.py
+++ b/datahub/search/event/test/test_models.py
@@ -6,7 +6,7 @@ from datahub.search.event.models import Event as ESEvent
 pytestmark = pytest.mark.django_db
 
 
-def test_event_dbmodel_to_dict(es_with_signals):
+def test_event_dbmodel_to_dict(es):
     """Tests conversion of db model to dict."""
     event = EventFactory()
 
@@ -40,7 +40,7 @@ def test_event_dbmodel_to_dict(es_with_signals):
     assert result.keys() == keys
 
 
-def test_event_dbmodels_to_es_documents(es_with_signals):
+def test_event_dbmodels_to_es_documents(es):
     """Tests conversion of db models to Elasticsearch documents."""
     events = EventFactory.create_batch(2)
 

--- a/datahub/search/event/test/test_views.py
+++ b/datahub/search/event/test/test_views.py
@@ -32,13 +32,13 @@ class TestSearch(APITestMixin):
         response = api_client.get(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
-    def test_search_event(self, es_with_signals, setup_data):
+    def test_search_event(self, es_with_collector, setup_data):
         """Tests detailed event search."""
         event_name = '012345catsinspace'
         EventFactory(
             name=event_name,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -54,9 +54,9 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['name'] == event_name
 
-    def test_event_search_paging(self, es_with_signals, setup_data):
+    def test_event_search_paging(self, es_with_collector, setup_data):
         """Tests pagination of results."""
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
         response = self.api_client.post(
@@ -71,9 +71,9 @@ class TestSearch(APITestMixin):
         assert response.data['count'] > 1
         assert len(response.data['results']) == 1
 
-    def test_search_event_no_filters(self, es_with_signals, setup_data):
+    def test_search_event_no_filters(self, es_with_collector, setup_data):
         """Tests case where there is no filters provided."""
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
         response = self.api_client.post(url, {})
@@ -81,13 +81,13 @@ class TestSearch(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data['results']) > 0
 
-    def test_search_event_name(self, es_with_signals, setup_data):
+    def test_search_event_name(self, es_with_collector, setup_data):
         """Tests event_name filter."""
         event_name = '0000000000'
         EventFactory(
             name=event_name,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -103,13 +103,13 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['name'] == event_name
 
-    def test_search_event_organiser(self, es_with_signals, setup_data):
+    def test_search_event_organiser(self, es_with_collector, setup_data):
         """Tests organiser filter."""
         organiser = AdviserFactory()
         EventFactory(
             organiser=organiser,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -125,7 +125,7 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['organiser']['id'] == str(organiser.id)
 
-    def test_search_event_organiser_name(self, es_with_signals, setup_data):
+    def test_search_event_organiser_name(self, es_with_collector, setup_data):
         """Tests organiser_name filter."""
         organiser_name = '00000000 000000000'
         EventFactory(
@@ -134,7 +134,7 @@ class TestSearch(APITestMixin):
                 last_name=organiser_name.split(' ', maxsplit=1)[1],
             ),
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -150,13 +150,13 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['organiser']['name'] == organiser_name
 
-    def test_search_event_address_country(self, es_with_signals, setup_data):
+    def test_search_event_address_country(self, es_with_collector, setup_data):
         """Tests address_country filter."""
         country_id = constants.Country.united_states.value.id
         EventFactory(
             address_country_id=country_id,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -172,14 +172,14 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['address_country']['id'] == country_id
 
-    def test_search_event_lead_team(self, es_with_signals):
+    def test_search_event_lead_team(self, es_with_collector):
         """Tests lead_team filter."""
         url = reverse('api-v3:search:event')
 
         team = TeamFactory()
         EventFactory.create_batch(5)
         EventFactory.create_batch(5, lead_team_id=team.id)
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         response = self.api_client.post(
             url,
@@ -196,7 +196,7 @@ class TestSearch(APITestMixin):
 
         assert all(team_id == str(team.id) for team_id in team_ids)
 
-    def test_search_event_teams(self, es_with_signals):
+    def test_search_event_teams(self, es_with_collector):
         """Tests teams filter."""
         url = reverse('api-v3:search:event')
 
@@ -207,7 +207,7 @@ class TestSearch(APITestMixin):
         EventFactory.create_batch(5, teams=(team_a, team_b))
         EventFactory.create_batch(5, teams=(team_b,))
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         response = self.api_client.post(
             url,
@@ -225,7 +225,7 @@ class TestSearch(APITestMixin):
             team_ids = {team['id'] for team in teams}
             assert len(team_ids.intersection({str(team_a.id), str(team_c.id)})) > 0
 
-    def test_search_event_nested_disabled_on_after_or_none(self, es_with_signals):
+    def test_search_event_nested_disabled_on_after_or_none(self, es_with_collector):
         """Tests nested disabled_on filter."""
         url = reverse('api-v3:search:event')
 
@@ -235,7 +235,7 @@ class TestSearch(APITestMixin):
         EventFactory.create_batch(3, disabled_on=old_datetime)
         EventFactory.create_batch(5, disabled_on=current_datetime)
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         response = self.api_client.post(
             url,
@@ -257,7 +257,7 @@ class TestSearch(APITestMixin):
             for disabled_on in disabled_ons
         )
 
-    def test_search_event_disabled_on_doesnt_exist(self, es_with_signals):
+    def test_search_event_disabled_on_doesnt_exist(self, es_with_collector):
         """Tests disabled_on is null filter."""
         url = reverse('api-v3:search:event')
 
@@ -265,7 +265,7 @@ class TestSearch(APITestMixin):
         EventFactory.create_batch(5)
         EventFactory.create_batch(5, disabled_on=current_datetime)
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         response = self.api_client.post(
             url,
@@ -281,7 +281,7 @@ class TestSearch(APITestMixin):
         disabled_ons = (result['disabled_on'] for result in response.data['results'])
         assert all(disabled_on is None for disabled_on in disabled_ons)
 
-    def test_search_event_disabled_on_exists(self, es_with_signals):
+    def test_search_event_disabled_on_exists(self, es_with_collector):
         """Tests disabled_on is null filter."""
         url = reverse('api-v3:search:event')
 
@@ -289,7 +289,7 @@ class TestSearch(APITestMixin):
         EventFactory.create_batch(5)
         EventFactory.create_batch(5, disabled_on=current_datetime)
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         response = self.api_client.post(
             url,
@@ -306,7 +306,7 @@ class TestSearch(APITestMixin):
         disabled_ons = (result['disabled_on'] for result in response.data['results'])
         assert all(disabled_on is not None for disabled_on in disabled_ons)
 
-    def test_search_event_uk_region(self, es_with_signals):
+    def test_search_event_uk_region(self, es_with_collector):
         """Tests uk_region filter."""
         country_id = constants.Country.united_kingdom.value.id
         uk_region_id = constants.UKRegion.jersey.value.id
@@ -314,7 +314,7 @@ class TestSearch(APITestMixin):
             address_country_id=country_id,
             uk_region_id=uk_region_id,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -331,13 +331,13 @@ class TestSearch(APITestMixin):
         assert response.data['results'][0]['address_country']['id'] == country_id
         assert response.data['results'][0]['uk_region']['id'] == uk_region_id
 
-    def test_search_event_date(self, es_with_signals, setup_data):
+    def test_search_event_date(self, es_with_collector, setup_data):
         """Tests start_date filter."""
         start_date = datetime.date(2017, 7, 2)
         event = EventFactory(
             start_date=start_date,
         )
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -355,13 +355,13 @@ class TestSearch(APITestMixin):
         assert len(response.data['results']) == 1
         assert response.data['results'][0]['id'] == str(event.id)
 
-    def test_search_event_sortby_start_date(self, es_with_signals, setup_data):
+    def test_search_event_sortby_start_date(self, es_with_collector, setup_data):
         """Tests sort by start_date desc."""
         start_date_a = datetime.date(2011, 9, 29)
         start_date_b = datetime.date(2011, 9, 30)
         EventFactory(start_date=start_date_a)
         EventFactory(start_date=start_date_b)
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -380,14 +380,14 @@ class TestSearch(APITestMixin):
         assert response.data['results'][0]['start_date'] == start_date_b.isoformat()
         assert response.data['results'][1]['start_date'] == start_date_a.isoformat()
 
-    def test_search_event_sortby_end_date(self, es_with_signals, setup_data):
+    def test_search_event_sortby_end_date(self, es_with_collector, setup_data):
         """Tests sort by end_date desc."""
         start_date = datetime.date(2000, 9, 29)
         end_date_a = datetime.date(2014, 9, 29)
         end_date_b = datetime.date(2015, 9, 29)
         EventFactory(start_date=start_date, end_date=end_date_a)
         EventFactory(start_date=start_date, end_date=end_date_b)
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -407,14 +407,14 @@ class TestSearch(APITestMixin):
         assert response.data['results'][0]['end_date'] == end_date_b.isoformat()
         assert response.data['results'][1]['end_date'] == end_date_a.isoformat()
 
-    def test_search_event_sortby_modified_on(self, es_with_signals, setup_data):
+    def test_search_event_sortby_modified_on(self, es_with_collector, setup_data):
         """Tests sort by modified_on desc."""
         start_date = datetime.date(2001, 9, 29)
         event_a = EventFactory(start_date=start_date)
         event_b = EventFactory(start_date=start_date)
         event_a.name = 'testing'
         event_a.save()
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')
 
@@ -437,9 +437,9 @@ class TestSearch(APITestMixin):
 class TestBasicSearch(APITestMixin):
     """Tests basic search view."""
 
-    def test_all_events(self, es_with_signals, setup_data):
+    def test_all_events(self, es_with_collector, setup_data):
         """Tests basic aggregate all events query."""
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         term = ''
 
@@ -455,11 +455,11 @@ class TestBasicSearch(APITestMixin):
         assert response.status_code == status.HTTP_200_OK
         assert response.data['count'] > 0
 
-    def test_aggregations(self, es_with_signals, setup_data):
+    def test_aggregations(self, es_with_collector, setup_data):
         """Tests basic aggregate events query."""
         EventFactory(name='abcdefghijkl')
         EventFactory(name='abcdefghijkm')
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:basic')
         response = self.api_client.get(
@@ -475,9 +475,9 @@ class TestBasicSearch(APITestMixin):
         assert response.data['results'][0]['name'].startswith('abcdefg')
         assert [{'count': 2, 'entity': 'event'}] == response.data['aggregations']
 
-    def test_no_results(self, es_with_signals, setup_data):
+    def test_no_results(self, es_with_collector, setup_data):
         """Tests case where there should be no results."""
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         term = 'there-should-be-no-match'
 

--- a/datahub/search/interaction/test/test_models.py
+++ b/datahub/search/interaction/test/test_models.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.django_db
         CompanyInteractionFactoryWithPolicyFeedback,
     ),
 )
-def test_interaction_to_dict(es_with_signals, factory_cls):
+def test_interaction_to_dict(es, factory_cls):
     """Test converting an interaction to a dict."""
     interaction = factory_cls()
 
@@ -119,7 +119,7 @@ def test_interaction_to_dict(es_with_signals, factory_cls):
     }
 
 
-def test_service_delivery_to_dict(es_with_signals):
+def test_service_delivery_to_dict(es):
     """Test converting an interaction to a dict."""
     interaction = ServiceDeliveryFactory()
 
@@ -196,7 +196,7 @@ def test_service_delivery_to_dict(es_with_signals):
     }
 
 
-def test_interactions_to_es_documents(es_with_signals):
+def test_interactions_to_es_documents(es):
     """Test converting 2 orders to Elasticsearch documents."""
     interactions = CompanyInteractionFactory.create_batch(2)
 

--- a/datahub/search/investment/test/test_models.py
+++ b/datahub/search/investment/test/test_models.py
@@ -52,7 +52,7 @@ def project_with_max_gross_value_added():
         )
 
 
-def test_investment_project_to_dict(es_with_signals):
+def test_investment_project_to_dict(es):
     """Tests conversion of db model to dict."""
     project = InvestmentProjectFactory()
     result = ESInvestmentProject.db_object_to_dict(project)
@@ -149,7 +149,7 @@ def test_investment_project_to_dict(es_with_signals):
     assert set(result.keys()) == keys
 
 
-def test_investment_project_dbmodels_to_es_documents(es_with_signals):
+def test_investment_project_dbmodels_to_es_documents(es):
     """Tests conversion of db models to Elasticsearch documents."""
     projects = InvestmentProjectFactory.create_batch(2)
 

--- a/datahub/search/large_investor_profile/test/test_models.py
+++ b/datahub/search/large_investor_profile/test/test_models.py
@@ -11,7 +11,7 @@ pytestmark = pytest.mark.django_db
 class TestLargeInvestorProfileElasticModel:
     """Test for the large investor profile elasticsearch model"""
 
-    def test_large_investor_profile_dbmodel_to_dict(self, es_with_signals):
+    def test_large_investor_profile_dbmodel_to_dict(self, es):
         """Tests conversion of db model to dict."""
         large_investor_profile = LargeCapitalInvestorProfileFactory()
 
@@ -43,7 +43,7 @@ class TestLargeInvestorProfileElasticModel:
         }
         assert set(result.keys()) == keys
 
-    def test_investment_project_dbmodels_to_es_documents(self, es_with_signals):
+    def test_investment_project_dbmodels_to_es_documents(self, es):
         """Tests conversion of db models to Elasticsearch documents."""
         large_profiles = LargeCapitalInvestorProfileFactory.create_batch(2)
 

--- a/datahub/search/large_investor_profile/test/test_views.py
+++ b/datahub/search/large_investor_profile/test/test_views.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.django_db
 
 
 @pytest.fixture
-def setup_data(es_with_signals):
+def setup_data(es_with_collector):
     """Sets up data for the tests."""
     investor_company = CompanyFactory(name='large abcdef')
     argentina_investor_company = CompanyFactory(
@@ -175,7 +175,7 @@ def setup_data(es_with_signals):
             north_project,
             south_project,
         ]
-    es_with_signals.indices.refresh()
+    es_with_collector.flush_and_refresh()
 
     yield investor_profiles
 
@@ -609,7 +609,7 @@ class TestLargeInvestorProfileExportView(APITestMixin):
         ),
     )
     def test_user_needs_correct_permissions_to_export_data(
-        self, es_with_signals, permissions, expected_status_code,
+        self, es, permissions, expected_status_code,
     ):
         """Test that a user without the correct permissions cannot export data."""
         user = create_test_user(dit_team=TeamFactory(), permission_codenames=permissions)
@@ -629,7 +629,7 @@ class TestLargeInvestorProfileExportView(APITestMixin):
             ('investor_company.name', 'investor_company__name'),
         ),
     )
-    def test_export(self, es_with_signals, request_sortby, orm_ordering):
+    def test_export(self, es_with_collector, request_sortby, orm_ordering):
         """Test export large capital investor profile search results."""
         url = reverse('api-v4:search:large-investor-profile-export')
 
@@ -643,7 +643,7 @@ class TestLargeInvestorProfileExportView(APITestMixin):
                 global_assets_under_management=200,
             )
 
-        es_with_signals.indices.refresh()
+        es_with_collector.flush_and_refresh()
 
         data = {}
         if request_sortby:

--- a/datahub/search/test/test_bulk_sync.py
+++ b/datahub/search/test/test_bulk_sync.py
@@ -66,7 +66,7 @@ def test_sync_app_logic(monkeypatch):
 
 @pytest.mark.django_db
 @disable_search_signal_receivers(Company)
-def test_sync_app_uses_latest_data(monkeypatch, es_with_signals):
+def test_sync_app_uses_latest_data(monkeypatch, es):
     """Test that sync_app() picks up updates made to records between batches."""
     CompanyFactory.create_batch(2, name='old name')
 
@@ -84,10 +84,10 @@ def test_sync_app_uses_latest_data(monkeypatch, es_with_signals):
     monkeypatch.setattr('datahub.search.bulk_sync.sync_objects', mock_sync_objects)
     sync_app(CompanySearchApp, batch_size=1)
 
-    es_with_signals.indices.refresh()
+    es.indices.refresh()
 
     company = mock_sync_objects.call_args_list[1][0][1][0]
-    fetched_company = es_with_signals.get(
+    fetched_company = es.get(
         index=CompanySearchApp.es_model.get_read_alias(),
         doc_type=CompanySearchApp.name,
         id=company.pk,

--- a/datahub/search/test/test_fields.py
+++ b/datahub/search/test/test_fields.py
@@ -13,7 +13,7 @@ from datahub.search.test.search_support.simplemodel import SimpleModelSearchApp
 class TestNormalizedField(APITestMixin):
     """Tests the behaviour of NormalizedKeyword."""
 
-    def test_sorting(self, es_with_signals):
+    def test_sorting(self, es):
         """Test to demonstrate how NormalizedKeyword sorts."""
         names = [
             'Alice',
@@ -29,7 +29,7 @@ class TestNormalizedField(APITestMixin):
             obj.save()
             sync_object(SimpleModelSearchApp, obj.pk)
 
-        es_with_signals.indices.refresh()
+        es.indices.refresh()
 
         user = create_test_user(permission_codenames=['view_simplemodel'])
         api_client = self.create_api_client(user=user)

--- a/datahub/search/test/test_sync_object.py
+++ b/datahub/search/test/test_sync_object.py
@@ -8,17 +8,17 @@ from datahub.search.test.utils import doc_exists
 
 
 @pytest.mark.django_db
-def test_sync_object_task_syncs_using_celery(es_with_signals):
+def test_sync_object_task_syncs_using_celery(es):
     """Test that an object can be synced to Elasticsearch using Celery."""
     obj = SimpleModel.objects.create()
     sync_object_async(SimpleModelSearchApp, obj.pk)
-    es_with_signals.indices.refresh()
+    es.indices.refresh()
 
-    assert doc_exists(es_with_signals, SimpleModelSearchApp, obj.pk)
+    assert doc_exists(es, SimpleModelSearchApp, obj.pk)
 
 
 @pytest.mark.django_db
-def test_sync_related_objects_syncs_using_celery(es_with_signals):
+def test_sync_related_objects_syncs_using_celery(es):
     """Test that related objects can be synced to Elasticsearch using Celery."""
     simpleton = SimpleModel.objects.create()
     relation_1 = RelatedModel.objects.create(simpleton=simpleton)
@@ -26,8 +26,8 @@ def test_sync_related_objects_syncs_using_celery(es_with_signals):
     unrelated_obj = RelatedModel.objects.create()
 
     sync_related_objects_async(simpleton, 'relatedmodel_set')
-    es_with_signals.indices.refresh()
+    es.indices.refresh()
 
-    assert doc_exists(es_with_signals, RelatedModelSearchApp, relation_1.pk)
-    assert doc_exists(es_with_signals, RelatedModelSearchApp, relation_2.pk)
-    assert not doc_exists(es_with_signals, RelatedModelSearchApp, unrelated_obj.pk)
+    assert doc_exists(es, RelatedModelSearchApp, relation_1.pk)
+    assert doc_exists(es, RelatedModelSearchApp, relation_2.pk)
+    assert not doc_exists(es, RelatedModelSearchApp, unrelated_obj.pk)

--- a/datahub/search/test/test_tasks.py
+++ b/datahub/search/test/test_tasks.py
@@ -43,16 +43,16 @@ def test_sync_all_models(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_sync_object_task_syncs(es_with_signals):
+def test_sync_object_task_syncs(es):
     """Test that the object task syncs an object to Elasticsearch."""
     obj = SimpleModel.objects.create()
     sync_object_task.apply(args=(SimpleModelSearchApp.name, str(obj.pk)))
-    es_with_signals.indices.refresh()
+    es.indices.refresh()
 
-    assert doc_exists(es_with_signals, SimpleModelSearchApp, obj.pk)
+    assert doc_exists(es, SimpleModelSearchApp, obj.pk)
 
 
-def test_sync_object_task_retries_on_error(monkeypatch, es_with_signals):
+def test_sync_object_task_retries_on_error(monkeypatch, es):
     """Test that the object task retries on error."""
     sync_object_mock = Mock(side_effect=[Exception, None])
     monkeypatch.setattr('datahub.search.sync_object.sync_object', sync_object_mock)


### PR DESCRIPTION
### Description of change

This adds a new pytest fixture, `es_with_collector`, that collects saved objects and syncs them to Elasticsearch in bulk.

Tests that do not specifically test the search signal receivers have been updated to use this fixture. (Tests that do specifically test the signal receivers are still using `es_with_signals`.)

Locally, the running time of `pytest -n2 --reuse-db datahub/search/` is reduced from about 6.2 to 2.2 minutes. (Running _all_ tests locally now takes 7 minutes.)

There are two reasons that the new fixture helps:

- the standard signal-based syncing path re-fetches objects from the database individually (as it goes via a Celery task)
- the standard signal-based syncing path indexes objects individually

The new fixture re-fetches and indexes objects in bulk (resulting in the speed-up).

Another bit of slowness on CircleCI seems to be the database migrations (it spends about two minutes applying them) – we should be able to speed that up by squashing and optimising the migrations.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
