### PR TITLE
Add `global_ultimate_duns_number` to company  API

### DIFF
--- a/changelog/company/return_global_ultimate_duns_number.api.md
+++ b/changelog/company/return_global_ultimate_duns_number.api.md
@@ -1,0 +1,6 @@
+The field `global_ultimate_duns_number` was added to the response of the following company API
+ endpoints:
+
+- `GET /v4/company`
+- `GET /v4/company/<pk>`
+- `POST /v4/dnb/company-create`

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -444,6 +444,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'export_potential',
             'great_profile_status',
             'is_global_ultimate',
+            'global_ultimate_duns_number',
         )
         read_only_fields = (
             'archived',
@@ -461,6 +462,7 @@ class CompanySerializer(PermittedFieldsModelSerializer):
             'export_potential',
             'great_profile_status',
             'is_global_ultimate',
+            'global_ultimate_duns_number',
         )
         dnb_read_only_fields = (
             'name',

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -360,6 +360,7 @@ class TestGetCompany(APITestMixin):
             'transfer_reason': '',
             'pending_dnb_investigation': False,
             'is_global_ultimate': company.is_global_ultimate,
+            'global_ultimate_duns_number': company.global_ultimate_duns_number,
         }
 
     def test_get_company_without_country(self):
@@ -431,7 +432,7 @@ class TestGetCompany(APITestMixin):
             False,
         ),
     )
-    def test_get_company_global_ultimate(self, is_global_ultimate):
+    def test_get_company_is_global_ultimate(self, is_global_ultimate):
         """
         Test that `is_global_ultimate` is set for a company API result
         as expected.
@@ -446,6 +447,29 @@ class TestGetCompany(APITestMixin):
 
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['is_global_ultimate'] == is_global_ultimate
+
+    @pytest.mark.parametrize(
+        'global_ultimate_overrides',
+        (
+            {'global_ultimate_duns_number': ''},
+            {'global_ultimate_duns_number': '123456789'},
+            {'global_ultimate_duns_number': '123456789', 'duns_number': '123456789'},
+        ),
+    )
+    def test_get_company_global_ultimate_duns_number(self, global_ultimate_overrides):
+        """
+        Test that `global_ultimate_duns_number` is set for a company API result
+        as expected.
+        """
+        company = CompanyFactory(
+            **global_ultimate_overrides,
+        )
+        url = reverse('api-v4:company:item', kwargs={'pk': company.pk})
+        response = self.api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        global_ultimate_duns_number = global_ultimate_overrides['global_ultimate_duns_number']
+        assert response.json()['global_ultimate_duns_number'] == global_ultimate_duns_number
 
     @pytest.mark.parametrize(
         'build_company',

--- a/datahub/dnb_api/serializers.py
+++ b/datahub/dnb_api/serializers.py
@@ -77,7 +77,6 @@ class DNBCompanySerializer(CompanySerializer):
     class Meta(CompanySerializer.Meta):
         read_only_fields = []
         dnb_read_only_fields = []
-        fields = CompanySerializer.Meta.fields + ('global_ultimate_duns_number', )
         validators = (
             RulesBasedValidator(
                 ValidationRule(


### PR DESCRIPTION
### Description of change



### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
