### PR TITLE
Add `global_ultimate_duns_number` filter to Company collection API

### DIFF
--- a/changelog/company/global-ultimate-duns-number-filter.api.md
+++ b/changelog/company/global-ultimate-duns-number-filter.api.md
@@ -1,0 +1,2 @@
+Added a filter to the company collection API to allow callers to filter by
+`global_ultimate_duns_number` - e.g. `GET /v4/company?global_ultimate_duns_number=123456789`.

--- a/changelog/company/global-ultimate-duns-number-filter.api.md
+++ b/changelog/company/global-ultimate-duns-number-filter.api.md
@@ -1,2 +1,2 @@
-Added a filter to the company collection API to allow callers to filter by
+A filter was added to the company collection API to allow callers to filter by
 `global_ultimate_duns_number` - e.g. `GET /v4/company?global_ultimate_duns_number=123456789`.

--- a/datahub/company/test/test_company_views.py
+++ b/datahub/company/test/test_company_views.py
@@ -63,6 +63,27 @@ class TestListCompanies(APITestMixin):
         actual_ids = {result['id'] for result in response_data['results']}
         assert expected_ids == actual_ids
 
+    def test_filter_by_global_ultimate_duns_number(self):
+        """Test filtering by global_ultimat_duns_number."""
+        ultimate_duns = '123456789'
+        subsidiaries = CompanyFactory.create_batch(2, global_ultimate_duns_number=ultimate_duns)
+        CompanyFactory.create_batch(2)
+
+        url = reverse('api-v4:company:collection')
+        response = self.api_client.get(
+            url,
+            data={
+                'global_ultimate_duns_number': ultimate_duns,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['count'] == len(subsidiaries)
+        expected_ids = {str(subsidiary.pk) for subsidiary in subsidiaries}
+        actual_ids = {result['id'] for result in response_data['results']}
+        assert expected_ids == actual_ids
+
     def test_sort_by_name(self):
         """Test sorting by name."""
         companies = CompanyFactory.create_batch(

--- a/datahub/company/views.py
+++ b/datahub/company/views.py
@@ -49,7 +49,7 @@ class CompanyViewSet(ArchivableViewSetMixin, CoreViewSet):
     required_scopes = (Scope.internal_front_end,)
     unarchive_validators = (NotATransferredCompanyValidator(),)
     filter_backends = (DjangoFilterBackend, OrderingFilter)
-    filterset_fields = ('global_headquarters_id',)
+    filterset_fields = ('global_headquarters_id', 'global_ultimate_duns_number')
     ordering_fields = ('name', 'created_on')
     queryset = Company.objects.select_related(
         'address_country',


### PR DESCRIPTION
### Description of change

Added a filter to the company collection API to allow callers to filter by `global_ultimate_duns_number` - e.g. `GET /v4/company?global_ultimate_duns_number=123456789`.

### Checklist

* [X] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
