### PR TITLE
Fixing import export_potential_score command.

### DIFF
--- a/changelog/company/import-command-export-potential.bugfix.md
+++ b/changelog/company/import-command-export-potential.bugfix.md
@@ -1,0 +1,1 @@
+The dbmaintenance command `update_company_export_potential` is fixed to disable search signal receivers for company, to avoid queuing huge number of Celery tasks for syncing companies to Elasticsearch.

--- a/datahub/dbmaintenance/management/commands/update_company_export_potential.py
+++ b/datahub/dbmaintenance/management/commands/update_company_export_potential.py
@@ -5,6 +5,7 @@ import reversion
 from datahub.company.models import Company
 from datahub.dbmaintenance.management.base import CSVBaseCommand
 from datahub.dbmaintenance.utils import parse_limited_string, parse_uuid
+from datahub.search.signals import disable_search_signal_receivers
 
 
 logger = getLogger(__name__)
@@ -12,6 +13,15 @@ logger = getLogger(__name__)
 
 class Command(CSVBaseCommand):
     """Command to update Company.export_potential."""
+
+    @disable_search_signal_receivers(Company)
+    def _handle(self, *args, **options):
+        """
+        Disables search signal receivers for companies.
+        Avoid queuing huge number of Celery tasks for syncing companies to Elasticsearch.
+        (Syncing can be manually performed afterwards using sync_es if required.)
+        """
+        return super()._handle(*args, **options)
 
     def _process_row(self, row, simulate=False, **options):
         """Process one single row."""


### PR DESCRIPTION
To disable search signal receivers for companies
This is to avoid queuing large number of Celery tasks for syncing companies to Elasticsearch.
Syncing will have to run manually once import is finished.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
