### PR TITLE
Replace duplicate dataset tests with a base test class

### DIFF
--- a/datahub/dataset/adviser/test/test_views.py
+++ b/datahub/dataset/adviser/test/test_views.py
@@ -1,28 +1,13 @@
 from datetime import datetime
 
 import pytest
-from django.conf import settings
+from django.utils.timezone import utc
 from rest_framework import status
 from rest_framework.reverse import reverse
 
 from datahub.company.test.factories import AdviserFactory
-from datahub.core.test_utils import format_date_or_datetime, HawkAPITestClient
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
-
-
-@pytest.fixture
-def data_flow_api_client(hawk_api_client):
-    """Hawk API client fixture configured to use credentials with the data_flow_api scope."""
-    hawk_api_client.set_credentials(
-        'data-flow-api-id',
-        'data-flow-api-key',
-    )
-    yield hawk_api_client
+from datahub.core.test_utils import format_date_or_datetime
+from datahub.dataset.core.test import BaseDatasetViewTest
 
 
 def get_expected_data_from_adviser(adviser):
@@ -40,43 +25,13 @@ def get_expected_data_from_adviser(adviser):
 
 
 @pytest.mark.django_db
-class TestAdviserDatasetViewSet:
+class TestAdviserDatasetViewSet(BaseDatasetViewTest):
     """
     Tests for the advisers data-flow export endpoint
     """
 
     view_url = reverse('api-v4:dataset:advisers-dataset')
-
-    @pytest.mark.parametrize('method', ('delete', 'patch', 'post', 'put'))
-    def test_other_methods_not_allowed(
-        self,
-        data_flow_api_client,
-        method,
-    ):
-        """Test that various HTTP methods are not allowed."""
-        response = data_flow_api_client.request(method, self.view_url)
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-
-    def test_without_scope(self, hawk_api_client):
-        """Test that making a request without the correct Hawk scope returns an error."""
-        hawk_api_client.set_credentials(
-            'test-id-without-scope',
-            'test-key-without-scope',
-        )
-        response = hawk_api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_without_credentials(self, api_client):
-        """Test that making a request without credentials returns an error."""
-        response = api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_without_whitelisted_ip(self, data_flow_api_client):
-        """Test that making a request without the whitelisted IP returns an error."""
-        data_flow_api_client.set_http_x_forwarded_for('1.1.1.1')
-        response = data_flow_api_client.get(self.view_url)
-
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    factory = AdviserFactory
 
     def test_success(self, data_flow_api_client):
         """Test that endpoint returns with expected data for a single company"""
@@ -89,10 +44,10 @@ class TestAdviserDatasetViewSet:
 
     def test_with_multiple_advisers(self, data_flow_api_client):
         """Test that endpoint returns correct order of records"""
-        adviser_1 = AdviserFactory(date_joined=datetime(2019, 1, 2))
-        adviser_2 = AdviserFactory(date_joined=datetime(2019, 1, 3))
-        adviser_3 = AdviserFactory(date_joined=datetime(2019, 1, 1))
-        adviser_4 = AdviserFactory(date_joined=datetime(2019, 1, 1))
+        adviser_1 = AdviserFactory(date_joined=datetime(2019, 1, 2, tzinfo=utc))
+        adviser_2 = AdviserFactory(date_joined=datetime(2019, 1, 3, tzinfo=utc))
+        adviser_3 = AdviserFactory(date_joined=datetime(2019, 1, 1, tzinfo=utc))
+        adviser_4 = AdviserFactory(date_joined=datetime(2019, 1, 1, tzinfo=utc))
 
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
@@ -101,15 +56,3 @@ class TestAdviserDatasetViewSet:
             str(a.id)
             for a in sorted([adviser_3, adviser_4], key=lambda x: x.id) + [adviser_1, adviser_2]
         ]
-
-    def test_pagination(self, data_flow_api_client):
-        """Test that when page size higher than threshold response returns with next page url"""
-        AdviserFactory.create_batch(settings.REST_FRAMEWORK['PAGE_SIZE'] + 1)
-        response = data_flow_api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json()['next'] is not None
-
-    def test_no_data(self, data_flow_api_client):
-        """Test that without any data available, endpoint completes the request successfully"""
-        response = data_flow_api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_200_OK

--- a/datahub/dataset/conftest.py
+++ b/datahub/dataset/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+from datahub.core.test_utils import HawkAPITestClient
+
+
+@pytest.fixture
+def hawk_api_client():
+    """Hawk API client fixture."""
+    yield HawkAPITestClient()
+
+
+@pytest.fixture
+def data_flow_api_client(hawk_api_client):
+    """Hawk API client fixture configured to use credentials with the data_flow_api scope."""
+    hawk_api_client.set_credentials(
+        'data-flow-api-id',
+        'data-flow-api-key',
+    )
+    yield hawk_api_client

--- a/datahub/dataset/core/test.py
+++ b/datahub/dataset/core/test.py
@@ -1,5 +1,6 @@
+from unittest import mock
+
 import pytest
-from django.conf import settings
 from rest_framework import status
 
 
@@ -50,9 +51,10 @@ class BaseDatasetViewTest:
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
 
+    @mock.patch('datahub.dataset.core.pagination.DatasetCursorPagination.page_size', 2)
     def test_pagination(self, data_flow_api_client):
         """Test that when page size higher than threshold response returns with next page url"""
-        self.factory.create_batch(settings.REST_FRAMEWORK['PAGE_SIZE'] + 1)
+        self.factory.create_batch(2 + 1)
         response = data_flow_api_client.get(self.view_url)
         assert response.status_code == status.HTTP_200_OK
         assert response.json()['next'] is not None

--- a/datahub/dataset/core/test.py
+++ b/datahub/dataset/core/test.py
@@ -1,0 +1,58 @@
+import pytest
+from django.conf import settings
+from rest_framework import status
+
+
+class BaseDatasetViewTest:
+    """Base test class for dataset view tests.
+
+    When subclassed by a view test class adds authentication and authorization
+    tests common for all views.
+
+    """
+
+    view_url = None
+    factory = None
+
+    @pytest.mark.parametrize('method', ('delete', 'patch', 'post', 'put'))
+    def test_other_methods_not_allowed(
+        self,
+        data_flow_api_client,
+        method,
+    ):
+        """Test that various HTTP methods are not allowed."""
+        response = data_flow_api_client.request(method, self.view_url)
+        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
+
+    def test_without_scope(self, hawk_api_client):
+        """Test that making a request without the correct Hawk scope returns an error."""
+        hawk_api_client.set_credentials(
+            'test-id-without-scope',
+            'test-key-without-scope',
+        )
+        response = hawk_api_client.get(self.view_url)
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_without_credentials(self, api_client):
+        """Test that making a request without credentials returns an error."""
+        response = api_client.get(self.view_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_without_whitelisted_ip(self, data_flow_api_client):
+        """Test that making a request without the whitelisted IP returns an error."""
+        data_flow_api_client.set_http_x_forwarded_for('1.1.1.1')
+        response = data_flow_api_client.get(self.view_url)
+
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_no_data(self, data_flow_api_client):
+        """Test that without any data available, endpoint completes the request successfully"""
+        response = data_flow_api_client.get(self.view_url)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_pagination(self, data_flow_api_client):
+        """Test that when page size higher than threshold response returns with next page url"""
+        self.factory.create_batch(settings.REST_FRAMEWORK['PAGE_SIZE'] + 1)
+        response = data_flow_api_client.get(self.view_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()['next'] is not None

--- a/datahub/dataset/team/test/test_views.py
+++ b/datahub/dataset/team/test/test_views.py
@@ -1,27 +1,10 @@
 import pytest
-from django.conf import settings
 from rest_framework import status
 from rest_framework.reverse import reverse
 
-from datahub.core.test_utils import HawkAPITestClient
+from datahub.dataset.core.test import BaseDatasetViewTest
 from datahub.metadata.models import Team
 from datahub.metadata.test.factories import TeamFactory
-
-
-@pytest.fixture
-def hawk_api_client():
-    """Hawk API client fixture."""
-    yield HawkAPITestClient()
-
-
-@pytest.fixture
-def data_flow_api_client(hawk_api_client):
-    """Hawk API client fixture configured to use credentials with the data_flow_api scope."""
-    hawk_api_client.set_credentials(
-        'data-flow-api-id',
-        'data-flow-api-key',
-    )
-    yield hawk_api_client
 
 
 def get_expected_data_from_team(team):
@@ -36,43 +19,13 @@ def get_expected_data_from_team(team):
 
 
 @pytest.mark.django_db
-class TestTeamDatasetViewSet:
+class TestTeamDatasetViewSet(BaseDatasetViewTest):
     """
     Tests for the teams data-flow export endpoint
     """
 
     view_url = reverse('api-v4:dataset:teams-dataset')
-
-    @pytest.mark.parametrize('method', ('delete', 'patch', 'post', 'put'))
-    def test_other_methods_not_allowed(
-        self,
-        data_flow_api_client,
-        method,
-    ):
-        """Test that various HTTP methods are not allowed."""
-        response = data_flow_api_client.request(method, self.view_url)
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-
-    def test_without_scope(self, hawk_api_client):
-        """Test that making a request without the correct Hawk scope returns an error."""
-        hawk_api_client.set_credentials(
-            'test-id-without-scope',
-            'test-key-without-scope',
-        )
-        response = hawk_api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_403_FORBIDDEN
-
-    def test_without_credentials(self, api_client):
-        """Test that making a request without credentials returns an error."""
-        response = api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-    def test_without_whitelisted_ip(self, data_flow_api_client):
-        """Test that making a request without the whitelisted IP returns an error."""
-        data_flow_api_client.set_http_x_forwarded_for('1.1.1.1')
-        response = data_flow_api_client.get(self.view_url)
-
-        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+    factory = TeamFactory
 
     def test_success(self, data_flow_api_client):
         """Test that endpoint returns with expected data for a single company"""
@@ -93,15 +46,3 @@ class TestTeamDatasetViewSet:
         results = response.json()['results']
 
         assert results == sorted(results, key=lambda t: t['id'])
-
-    def test_pagination(self, data_flow_api_client):
-        """Test that when page size higher than threshold response returns with next page url"""
-        TeamFactory.create_batch(settings.REST_FRAMEWORK['PAGE_SIZE'] + 1)
-        response = data_flow_api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_200_OK
-        assert response.json()['next'] is not None
-
-    def test_no_data(self, data_flow_api_client):
-        """Test that without any data available, endpoint completes the request successfully"""
-        response = data_flow_api_client.get(self.view_url)
-        assert response.status_code == status.HTTP_200_OK


### PR DESCRIPTION
### Description of change

### Add a dataset base view test class and shared fixtures

We have some largely identical tests that are repeated for each view. They tests authentication and basic responses and the only differences are the view url and the object factory used to set them up, which can be easily configured with class attributes.

This moves common tests to a base class in dataset.core.test. Since the tests depend on pytest fixtures we need to move them to a shared conftest to avoid unused imports in other test modules.

The base class could be in the conftest as well, but I think it makes more sense alongside the base view itself.

### Replace duplicate dataset tests with a base test class

This removes repeated tests and fixtures and replaces them with the conftest fixtures and test methods on the BaseDatasetViewTest class.


### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
