### PR TITLE
Make search deleted object collector safe to use in web processes

### DIFF
--- a/changelog/search-deletion-collector.internal.md
+++ b/changelog/search-deletion-collector.internal.md
@@ -1,0 +1,1 @@
+A correction was made to the deleted object collector (used to delete objects from Elasticsearch in bulk) to make it safe to use in web processes. This change has no current effect as the collector has only been used in management commands to date. 

--- a/datahub/search/deletion.py
+++ b/datahub/search/deletion.py
@@ -100,7 +100,7 @@ class Collector:
             receiver.connect()
 
         for receiver in self.signal_receivers_to_disable:
-            receiver.disconnect()
+            receiver.disable()
 
     def disconnect(self):
         """Starts listening to post_delete signals on all search models."""
@@ -108,7 +108,7 @@ class Collector:
             receiver.disconnect()
 
         for receiver in self.signal_receivers_to_disable:
-            receiver.connect()
+            receiver.enable()
 
     def _collect(self, instance):
         """Logic that gets run on post_delete."""

--- a/datahub/search/test/test_deletion.py
+++ b/datahub/search/test/test_deletion.py
@@ -101,23 +101,23 @@ def test_collector(monkeypatch, es_with_signals):
 
     # mock the receiver methods so that we can check they are called
     for receiver in collector.signal_receivers_to_disable:
-        monkeypatch.setattr(receiver, 'connect', mock.Mock())
-        monkeypatch.setattr(receiver, 'disconnect', mock.Mock())
+        monkeypatch.setattr(receiver, 'enable', mock.Mock())
+        monkeypatch.setattr(receiver, 'disable', mock.Mock())
 
     collector.connect()
 
-    # check that the existing signal receivers are disconnected
+    # check that the existing signal receivers are disabled
     for receiver in collector.signal_receivers_to_disable:
-        assert receiver.disconnect.called
-        assert not receiver.connect.called
+        assert receiver.disable.called
+        assert not receiver.enable.called
 
     obj.delete()
 
     collector.disconnect()
 
-    # check that the existing signal receivers are connected back
+    # check that the existing signal receivers are re-enabled
     for receiver in collector.signal_receivers_to_disable:
-        assert receiver.connect.called
+        assert receiver.enable.called
 
     assert collector.deletions == {
         SimpleModel: [es_doc],


### PR DESCRIPTION
### Description of change

While working on #2208, I spotted that `datahub.search.deletion.Collector` wasn't using the most appropriate methods to temporarily disable search signal receivers.

This updates it to use `SignalReceiver.disable()` and `SignalReceiver.enable()` which makes the class safe to use in web processes (where gevent is usually active).

The class had only been used in management commands (via the `update_es_after_deletions()` context manager), so this wasn't causing any problems currently, but it could've caused a problem if someone used the class or context manager in a web process in future.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
