### PR TITLE
Add `global_ultimate_duns_number` to `update-from-dnb` admin tool

### DIFF
--- a/changelog/company/add-global-ultimate-to-update-from-dnb-tool.feature.md
+++ b/changelog/company/add-global-ultimate-to-update-from-dnb-tool.feature.md
@@ -1,0 +1,1 @@
+The `update-from-dnb` admin tool now shows changes to `global_ultimate_duns_number` field in the "review changes" table.

--- a/datahub/company/admin/dnb.py
+++ b/datahub/company/admin/dnb.py
@@ -122,6 +122,10 @@ def _format_company_diff(dh_company, dnb_company):
             dh_company.is_turnover_estimated,
             dnb_company.get('is_turnover_estimated'),
         ),
+        get_field('global_ultimate_duns_number'): (
+            dh_company.global_ultimate_duns_number,
+            dnb_company.get('global_ultimate_duns_number'),
+        ),
     }
 
 

--- a/datahub/company/test/admin/test_update_from_dnb.py
+++ b/datahub/company/test/admin/test_update_from_dnb.py
@@ -141,8 +141,15 @@ class TestUpdateFromDNB(AdminTestMixin):
         assert self.company.registered_address_2 == dnb_company['registered_address_line_2']
         assert self.company.registered_address_town == dnb_company['registered_address_town']
         assert self.company.registered_address_county == dnb_company['registered_address_county']
-        assert self.company.registered_address_country.iso_alpha2_code == dnb_company['registered_address_country']  # noqa
+        assert (
+            self.company.registered_address_country.iso_alpha2_code
+            == dnb_company['registered_address_country']
+        )
         assert not self.company.pending_dnb_investigation
+        assert (
+            self.company.global_ultimate_duns_number
+            == dnb_company['global_ultimate_duns_number']
+        )
 
         versions = list(Version.objects.get_for_object(self.company))
         assert len(versions) == 1


### PR DESCRIPTION
### Description of change

The `update-from-dnb` admin too now includes the `global_ultimate_duns_number` field in preview.

In doing this, I thought long and hard about refactoring the `dnb_api` module to have a single function that knows about the fields we are ingesting but it seems this will be much simpler once we remove the old `add-a-company` journey from the codebase.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
