### PR TITLE
Add remove company account manager endpoint

### DIFF
--- a/changelog/company/remove-account-manager.api.md
+++ b/changelog/company/remove-account-manager.api.md
@@ -1,0 +1,7 @@
+A new endpoint, `POST /v4/company/<ID>/remove-account-manager`, was added. 
+
+The endpoint removes the assigned tier and account manager for a One List company on tier 'Tier D - Interaction Trade Adviser Accounts'.
+
+If the company is on a One List tier other than 'Tier D - Interaction Trade Adviser Accounts', the operation is not allowed.
+
+The `company.change_company` and `company.change_regional_account_manager` permissions are required to use this endpoint.

--- a/datahub/company/models/company.py
+++ b/datahub/company/models/company.py
@@ -410,6 +410,16 @@ class Company(ArchivableModel, BaseModel):
         self.one_list_tier_id = one_list_tier_id
         self.save()
 
+    def remove_from_one_list(self):
+        """
+        Remove the company from the One List.
+
+        This is done by unsetting the company's One List account manager and tier.
+        """
+        self.one_list_account_owner = None
+        self.one_list_tier = None
+        self.save()
+
 
 class OneListCoreTeamMember(models.Model):
     """

--- a/datahub/company/serializers.py
+++ b/datahub/company/serializers.py
@@ -570,6 +570,36 @@ class SelfAssignAccountManagerSerializer(serializers.Serializer):
         return self.instance
 
 
+class RemoveAccountManagerSerializer(serializers.Serializer):
+    """
+    Serialiser for removing an interaction trade adviser as the account manager of a
+    company.
+    """
+
+    allowed_one_list_tier_id = OneListTierID.tier_d_international_trade_advisers.value
+    default_error_messages = {
+        'cannot_change_account_manager_for_other_one_list_tiers':
+            gettext_lazy("A lead adviser can't be removed from companies on this One List tier."),
+    }
+
+    def validate(self, attrs):
+        """Validate that the change of One List account manager and tier is allowed."""
+        attrs = super().validate(attrs)
+
+        if self.instance.one_list_tier_id not in (None, self.allowed_one_list_tier_id):
+            raise serializers.ValidationError(
+                self.error_messages['cannot_change_account_manager_for_other_one_list_tiers'],
+                code='cannot_change_account_manager_for_other_one_list_tiers',
+            )
+
+        return attrs
+
+    def save(self, adviser):
+        """Unset the company's One List account manager and tier."""
+        self.instance.remove_from_one_list()
+        return self.instance
+
+
 class PublicCompanySerializer(CompanySerializer):
     """
     Read-only serialiser for the Hawk-authenticated company view.

--- a/datahub/company/test/test_company_views_account_manager.py
+++ b/datahub/company/test/test_company_views_account_manager.py
@@ -32,10 +32,6 @@ def _random_non_ita_one_list_tier():
     return random_obj_for_queryset(queryset)
 
 
-def _get_url(company):
-    return reverse('api-v4:company:self-assign-account-manager', kwargs={'pk': company.pk})
-
-
 class TestSelfAssignCompanyAccountManagerView(APITestMixin):
     """
     Tests for the self-assign company account manager view.
@@ -43,10 +39,14 @@ class TestSelfAssignCompanyAccountManagerView(APITestMixin):
     (Implemented in CompanyViewSet.self_assign_account_manager().)
     """
 
+    @staticmethod
+    def _get_url(company):
+        return reverse('api-v4:company:self-assign-account-manager', kwargs={'pk': company.pk})
+
     def test_returns_401_if_unauthenticated(self, api_client):
         """Test that a 401 is returned if no credentials are provided."""
         company = CompanyFactory()
-        url = _get_url(company)
+        url = self._get_url(company)
         response = api_client.post(url)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -66,7 +66,7 @@ class TestSelfAssignCompanyAccountManagerView(APITestMixin):
         company = CompanyFactory()
         user = create_test_user(permission_codenames=permission_codenames, dit_team=None)
         api_client = self.create_api_client(user=user)
-        url = _get_url(company)
+        url = self._get_url(company)
 
         response = api_client.post(url)
         assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -97,7 +97,7 @@ class TestSelfAssignCompanyAccountManagerView(APITestMixin):
         """
         company = company_factory()
         api_client = self.create_api_client(user=international_trade_adviser)
-        url = _get_url(company)
+        url = self._get_url(company)
 
         response = api_client.post(url)
         assert response.status_code == status.HTTP_204_NO_CONTENT
@@ -145,7 +145,7 @@ class TestSelfAssignCompanyAccountManagerView(APITestMixin):
         """
         company = company_factory()
         api_client = self.create_api_client(user=international_trade_adviser)
-        url = _get_url(company)
+        url = self._get_url(company)
 
         response = api_client.post(url)
         assert response.status_code == status.HTTP_400_BAD_REQUEST

--- a/datahub/company/urls/company.py
+++ b/datahub/company/urls/company.py
@@ -30,6 +30,10 @@ company_self_assign_account_manager = CompanyViewSet.as_action_view(
     'self_assign_account_manager',
 )
 
+company_remove_account_manager = CompanyViewSet.as_action_view(
+    'remove_account_manager',
+)
+
 one_list_group_core_team = OneListGroupCoreTeamViewSet.as_view({
     'get': 'list',
 })
@@ -48,6 +52,11 @@ urls = [
         'company/<uuid:pk>/self-assign-account-manager',
         company_self_assign_account_manager,
         name='self-assign-account-manager',
+    ),
+    path(
+        'company/<uuid:pk>/remove-account-manager',
+        company_remove_account_manager,
+        name='remove-account-manager',
     ),
     path(
         'company/<uuid:pk>/one-list-group-core-team',


### PR DESCRIPTION
### Description of change

This adds a new endpoint, `POST /v4/company/<ID>/remove-account-manager`, that removes the assigned One List tier and account manager for a company on One List tier 'Tier D - Interaction Trade Adviser Accounts'.

If the company is on a One List tier other than 'Tier D - Interaction Trade Adviser Accounts', the operation is not allowed.

The `company.change_company` and `company.change_regional_account_manager` permissions are required to use this endpoint.

A similar pattern to the self-assign account manager view and other action views in the code base was followed.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [x] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
