### PR TITLE
Squash interaction migrations up to 0068

### DIFF
--- a/changelog/interaction/squash-migrations.internal.md
+++ b/changelog/interaction/squash-migrations.internal.md
@@ -1,0 +1,1 @@
+Database migrations up to 0068 were squashed in order to reduce build times. The old migrations will be removed once the squashed migration has been applied to all environments.

--- a/datahub/interaction/migrations/0001_initial_communication_channels.yaml
+++ b/datahub/interaction/migrations/0001_initial_communication_channels.yaml
@@ -1,0 +1,34 @@
+# Interaction communication channel
+- model: interaction.communicationchannel
+  pk: 70c226d7-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: null, name: Email/Website}
+- model: interaction.communicationchannel
+  pk: 72c226d7-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: null, name: Telephone}
+- model: interaction.communicationchannel
+  pk: 74c226d7-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: null, name: Letter/Fax}
+- model: interaction.communicationchannel
+  pk: a5d71fdd-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: null, name: Face to Face}
+- model: interaction.communicationchannel
+  pk: a7d71fdd-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: null, name: Video/Teleconf.}
+- model: interaction.communicationchannel
+  pk: a8d71fdd-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: null, name: Social Media}
+- model: interaction.communicationchannel
+  pk: 71c226d7-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: '2013-03-25T14:08:00Z', name: Fax}
+- model: interaction.communicationchannel
+  pk: 73c226d7-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: '2013-03-25T14:08:00Z', name: Telex}
+- model: interaction.communicationchannel
+  pk: 75c226d7-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: '2013-03-25T14:08:00Z', name: UKTI Website}
+- model: interaction.communicationchannel
+  pk: a4d71fdd-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: '2013-03-25T14:08:00Z', name: SMS}
+- model: interaction.communicationchannel
+  pk: a6d71fdd-5d95-e211-a939-e4115bead28a
+  fields: {disabled_on: '2013-03-25T14:08:00Z', name: Business Card}

--- a/datahub/interaction/migrations/0001_initial_issue_types.yaml
+++ b/datahub/interaction/migrations/0001_initial_issue_types.yaml
@@ -1,0 +1,15 @@
+- model: interaction.policyissuetype
+  pk: 688ac22e-89d4-4d1f-bf0b-013588bf63a7
+  fields: {disabled_on: null, name: Domestic, order: 100.0}
+- model: interaction.policyissuetype
+  pk: a4d65900-3c83-4d2f-884b-be8977a554c4
+  fields: {disabled_on: null, name: Non-EU trade priority, order: 300.0}
+- model: interaction.policyissuetype
+  pk: c1543164-7612-42df-b556-f59ae5173042
+  fields: {disabled_on: null, name: Economic risk, order: 500.0}
+- model: interaction.policyissuetype
+  pk: c1f1e29b-17ba-402f-ac98-aa23f9dc9bcb
+  fields: {disabled_on: null, name: EU exit, order: 200.0}
+- model: interaction.policyissuetype
+  pk: fa35595d-780d-4faa-b575-35f1c319bfee
+  fields: {disabled_on: null, name: Economic opportunity, order: 400.0}

--- a/datahub/interaction/migrations/0001_initial_policy_areas.yaml
+++ b/datahub/interaction/migrations/0001_initial_policy_areas.yaml
@@ -1,0 +1,153 @@
+- model: interaction.policyarea
+  pk: 01861666-4150-4aaf-b659-31f84e459612
+  fields: {disabled_on: null, name: Local Growth, order: 3200.0}
+- model: interaction.policyarea
+  pk: 0da4abf1-6344-48bc-85cf-1834b5fb26e1
+  fields: {disabled_on: null, name: Imports, order: 2700.0}
+- model: interaction.policyarea
+  pk: 121b75fa-02a1-481e-8bb6-968d81f104b9
+  fields: {disabled_on: null, name: Northern Powerhouse, order: 3900.0}
+- model: interaction.policyarea
+  pk: 1428a832-b726-4008-a1d3-f48ea2a7b580
+  fields: {disabled_on: null, name: European Lobbying Feedback, order: 2100.0}
+- model: interaction.policyarea
+  pk: 1f1c9c0e-f93c-46b1-94f8-28dc48bd6d61
+  fields: {disabled_on: null, name: Gender Pay, order: 2400.0}
+- model: interaction.policyarea
+  pk: 2242e7bd-e54e-4195-a639-3a9e52992c2f
+  fields: {disabled_on: null, name: Company Law and Company Reporting, order: 800.0}
+- model: interaction.policyarea
+  pk: 273bc920-9961-459a-9eb0-b9686d37421d
+  fields: {disabled_on: null, name: Industrial Strategy, order: 2900.0}
+- model: interaction.policyarea
+  pk: 276b98bc-d12e-42e2-b506-27c3f36083a4
+  fields: {disabled_on: null, name: Returnships, order: 4300.0}
+- model: interaction.policyarea
+  pk: 2ca6322b-27e4-4ed9-95d4-342989d98022
+  fields: {disabled_on: null, name: Movement of Services, order: 3600.0}
+- model: interaction.policyarea
+  pk: 3f995c74-f601-4281-9ee4-4b3a73a33dfe
+  fields: {disabled_on: null, name: Education and Skills (including students), order: 1600.0}
+- model: interaction.policyarea
+  pk: 42e8b64d-304e-4de3-9928-b3d278db5a68
+  fields: {disabled_on: null, name: Announcement Feedback, order: 400.0}
+- model: interaction.policyarea
+  pk: 46468f7a-575d-4e95-8350-0879cab5993a
+  fields: {disabled_on: null, name: Regional Devolution, order: 4100.0}
+- model: interaction.policyarea
+  pk: 4b9142df-0520-46bd-9da9-94147cdbae13
+  fields: {disabled_on: null, name: Access to Finance, order: 100.0}
+- model: interaction.policyarea
+  pk: 4e6d6400-61f1-4c9e-ab97-4215e4d7fd49
+  fields: {disabled_on: null, name: Devolved Administration - Scotland, order: 1400.0}
+- model: interaction.policyarea
+  pk: 4fb8c6c6-d3aa-4b36-a954-7578e0337f4d
+  fields: {disabled_on: null, name: Government Communications, order: 2500.0}
+- model: interaction.policyarea
+  pk: 53ca7c82-5851-4bed-908e-92016f77c5b9
+  fields: {disabled_on: null, name: Business Regulation, order: 700.0}
+- model: interaction.policyarea
+  pk: 583c0bb6-d3c5-4e4b-8f25-e861c1e8d9c9
+  fields: {disabled_on: null, name: State Aid, order: 4600.0}
+- model: interaction.policyarea
+  pk: 5bb2abdd-b56f-4d64-8f11-f31c217932fb
+  fields: {disabled_on: null, name: National Security, order: 3700.0}
+- model: interaction.policyarea
+  pk: 6596d1bd-7e23-4f4c-9821-e19cc72aa44d
+  fields: {disabled_on: null, name: Other, order: 4000.0}
+- model: interaction.policyarea
+  pk: 67649465-c70a-443b-af49-00560d8ab6b5
+  fields: {disabled_on: null, name: Employment Law and Labour Market Policy, order: 1700.0}
+- model: interaction.policyarea
+  pk: 6c0b0d7f-1007-437d-bc0b-6f7b8c148bc5
+  fields: {disabled_on: null, name: Energy Market Regulation, order: 1900.0}
+- model: interaction.policyarea
+  pk: 6e414839-8427-402b-a904-2fb95b37f005
+  fields: {disabled_on: null, name: Exporting and Export Support, order: 2200.0}
+- model: interaction.policyarea
+  pk: 6f5db2e8-a128-4d66-ae0a-5e314758933b
+  fields: {disabled_on: null, name: Tariffs and Trade Policy, order: 4800.0}
+- model: interaction.policyarea
+  pk: 6fa2ec0e-073b-4b0d-8e74-3eb9aef34dca
+  fields: {disabled_on: null, name: 'Energy (exploration, production, distribution
+      and use)', order: 1800.0}
+- model: interaction.policyarea
+  pk: 708a84d8-d25f-4b1e-ab56-15105f7537b6
+  fields: {disabled_on: null, name: Inclusive Economy, order: 2800.0}
+- model: interaction.policyarea
+  pk: 75834c92-573f-4cae-b670-3f61dd2448d3
+  fields: {disabled_on: null, name: Transportation (Freight and People), order: 5000.0}
+- model: interaction.policyarea
+  pk: 77e60c71-944b-48e9-b998-c4a21d0f0045
+  fields: {disabled_on: null, name: Law and Justice, order: 3000.0}
+- model: interaction.policyarea
+  pk: 7a1d48ed-84a6-4d17-b065-df6cfb81eb4e
+  fields: {disabled_on: null, name: Health and Social Care (NHS), order: 2600.0}
+- model: interaction.policyarea
+  pk: 7a8ce103-a08f-4068-a236-749f1f0d9e7c
+  fields: {disabled_on: null, name: New Investment/Jobs, order: 3800.0}
+- model: interaction.policyarea
+  pk: 7d5aecf6-d747-4cdc-b06a-5c51c8a0b21c
+  fields: {disabled_on: null, name: Competition Law and Policy, order: 900.0}
+- model: interaction.policyarea
+  pk: 7e22430d-1a6e-42ca-8f4e-60238dc26129
+  fields: {disabled_on: null, name: Devolved Administration - Northern Ireland, order: 1300.0}
+- model: interaction.policyarea
+  pk: 808e2fbb-dd23-4d87-82a3-6eacbf95cfeb
+  fields: {disabled_on: null, name: Facility Locations (Legal HQ/Factory/etc), order: 2300.0}
+- model: interaction.policyarea
+  pk: 8b31e513-c5c8-4c93-a494-9273381b6d14
+  fields: {disabled_on: null, name: Supply Chains and Raw Materials, order: 4700.0}
+- model: interaction.policyarea
+  pk: 8feee1c8-97d5-4169-acb4-e10d2926c856
+  fields: {disabled_on: null, name: Standards, order: 4500.0}
+- model: interaction.policyarea
+  pk: 96b0e3b3-686e-4e5f-bfa5-061b3df6223d
+  fields: {disabled_on: null, name: Market Access, order: 3400.0}
+- model: interaction.policyarea
+  pk: 9a9ae32a-0a12-4e0f-82f9-17050dd95449
+  fields: {disabled_on: null, name: Environmental Law and Policy, order: 2000.0}
+- model: interaction.policyarea
+  pk: 9c5c4f45-09de-4383-83b5-7190c3f58b7b
+  fields: {disabled_on: null, name: 'Science, R&D and Innovation', order: 4400.0}
+- model: interaction.policyarea
+  pk: 9feefd50-7f4c-4b73-a33e-779121d40419
+  fields: {disabled_on: null, name: Access to Public Funding (inc. EU funding), order: 200.0}
+- model: interaction.policyarea
+  pk: a5441150-ce05-4bd9-a49d-5ce6504f9625
+  fields: {disabled_on: null, name: Devolved Administration - Wales, order: 1500.0}
+- model: interaction.policyarea
+  pk: a87aa322-0153-4b1e-a2fd-23a03060204e
+  fields: {disabled_on: null, name: 'Borders, Migration, Immigration and Foreign Travel',
+    order: 600.0}
+- model: interaction.policyarea
+  pk: a89151e6-2bf9-43ec-8ac3-c5cbc3e3554f
+  fields: {disabled_on: null, name: Movement of Goods, order: 3500.0}
+- model: interaction.policyarea
+  pk: c5916321-1c8e-452a-bd5d-05569afd7a5f
+  fields: {disabled_on: null, name: Data Policy, order: 1200.0}
+- model: interaction.policyarea
+  pk: d1614021-6728-4194-84b7-15186295bf45
+  fields: {disabled_on: null, name: Customs Union, order: 1100.0}
+- model: interaction.policyarea
+  pk: d4e57549-1eae-43f0-b7cb-04fc57b9a276
+  fields: {disabled_on: null, name: 'Consumer Rights, Trading Standards, Product Regulation',
+    order: 1000.0}
+- model: interaction.policyarea
+  pk: d54d96c4-20f8-4acd-9d70-fb27f3596d54
+  fields: {disabled_on: null, name: Local Government, order: 3100.0}
+- model: interaction.policyarea
+  pk: d6ef8497-a12c-41a8-a6fe-3652028e7fad
+  fields: {disabled_on: null, name: 'Art, Culture, Sport and Leisure', order: 500.0}
+- model: interaction.policyarea
+  pk: e23a60ba-aaa5-42da-866a-7f1a563dbc3e
+  fields: {disabled_on: null, name: Loss of Investment/Jobs, order: 3300.0}
+- model: interaction.policyarea
+  pk: e28d0a0a-287c-40f4-a7d6-fd03c70ec641
+  fields: {disabled_on: null, name: Agriculture (Regulation/Support), order: 300.0}
+- model: interaction.policyarea
+  pk: ef9ec638-eddf-4936-b039-77a37e45cfb5
+  fields: {disabled_on: null, name: Tax and Revenue, order: 4900.0}
+- model: interaction.policyarea
+  pk: fb4b00c8-93fb-46f5-bd3d-bf1bd7466a86
+  fields: {disabled_on: null, name: Repeal Bill, order: 4200.0}

--- a/datahub/interaction/migrations/0001_initial_statuses.yaml
+++ b/datahub/interaction/migrations/0001_initial_statuses.yaml
@@ -1,0 +1,30 @@
+- model: interaction.servicedeliverystatus
+  pk: 45329c18-6095-e211-a939-e4115bead28a
+  fields:
+    name: Offered
+    disabled_on:
+    order: 100.0
+- model: interaction.servicedeliverystatus
+  pk: 46329c18-6095-e211-a939-e4115bead28a
+  fields:
+    name: Current
+    disabled_on:
+    order: 200.0
+- model: interaction.servicedeliverystatus
+  pk: 47329c18-6095-e211-a939-e4115bead28a
+  fields:
+    name: Completed
+    disabled_on:
+    order: 300.0
+- model: interaction.servicedeliverystatus
+  pk: 48329c18-6095-e211-a939-e4115bead28a
+  fields:
+    name: Withdrawn
+    disabled_on:
+    order: 400.0
+- model: interaction.servicedeliverystatus
+  pk: 49329c18-6095-e211-a939-e4115bead28a
+  fields:
+    name: On hold
+    disabled_on:
+    order: 500.0

--- a/datahub/interaction/migrations/0001_service_questions_and_answers.yaml
+++ b/datahub/interaction/migrations/0001_service_questions_and_answers.yaml
@@ -1,0 +1,332 @@
+# Providing Export Advice & Information
+- model: interaction.servicequestion
+  pk: a5e1124e-e303-4774-bac5-5a3a519273e4
+  fields:
+    disabled_on:
+    name: What did you give advice about?
+    service_id: 76d912d6-e9da-4963-80ae-d07f8f6feed7
+    order: 100.0
+
+- model: interaction.serviceansweroption
+  pk: eee5607c-db40-41f4-ba30-454302907f20
+  fields:
+    disabled_on:
+    name: Banking & Funding
+    question_id: a5e1124e-e303-4774-bac5-5a3a519273e4
+    order: 100.0
+- model: interaction.serviceansweroption
+  pk: 4cff9ba9-ca8c-4777-89db-396066ec9d78
+  fields:
+    disabled_on:
+    name: DIT or Government Services
+    question_id: a5e1124e-e303-4774-bac5-5a3a519273e4
+    order: 200.0
+- model: interaction.serviceansweroption
+  pk: cf30f38c-5689-4b48-8851-8582df326c29
+  fields:
+    disabled_on:
+    name: Documents & Regulations
+    question_id: a5e1124e-e303-4774-bac5-5a3a519273e4
+    order: 300.0
+- model: interaction.serviceansweroption
+  pk: 5b76db2c-8e41-45bc-811b-4e510bacce56
+  fields:
+    disabled_on:
+    name: Markets & Sectors
+    question_id: a5e1124e-e303-4774-bac5-5a3a519273e4
+    order: 400.0
+- model: interaction.serviceansweroption
+  pk: 9535dc21-f390-49af-93d9-afda956c7234
+  fields:
+    disabled_on:
+    name: Marketing & Communication
+    question_id: a5e1124e-e303-4774-bac5-5a3a519273e4
+    order: 500.0
+- model: interaction.serviceansweroption
+  pk: 01ed3464-3fcb-433a-b1e4-5da6ad656c3f
+  fields:
+    disabled_on:
+    name: Skills & Recruitment
+    question_id: a5e1124e-e303-4774-bac5-5a3a519273e4
+    order: 600.0
+- model: interaction.serviceansweroption
+  pk: 1547a6d1-3415-442e-a293-2964d305a1e5
+  fields:
+    disabled_on:
+    name: General
+    question_id: a5e1124e-e303-4774-bac5-5a3a519273e4
+    order: 700.0
+
+# Providing Investment Advice & Information
+- model: interaction.servicequestion
+  pk: 3c69f671-0888-475c-97e5-bc55461db35e
+  fields:
+    disabled_on:
+    name: What did you give advice about?
+    service_id: ef3218c1-bed6-4ad8-b8d5-8af2430d32ff
+    order: 100.0
+
+- model: interaction.serviceansweroption
+  pk: d7293a68-05a6-461b-911c-2f07b4306c1e
+  fields:
+    disabled_on:
+    name: Banking & Funding
+    question_id: 3c69f671-0888-475c-97e5-bc55461db35e
+    order: 100.0
+- model: interaction.serviceansweroption
+  pk: e5f83d7f-f696-4069-b649-a3e295b41046
+  fields:
+    disabled_on:
+    name: DIT or Government Services
+    question_id: 3c69f671-0888-475c-97e5-bc55461db35e
+    order: 200.0
+- model: interaction.serviceansweroption
+  pk: 626890c4-214e-44fd-afc7-117abced123e
+  fields:
+    disabled_on:
+    name: Markets & Sectors
+    question_id: 3c69f671-0888-475c-97e5-bc55461db35e
+    order: 300.0
+- model: interaction.serviceansweroption
+  pk: 58917fa8-2823-417a-907b-a6f0e340e53a
+  fields:
+    disabled_on:
+    name: Marketing & Communication
+    question_id: 3c69f671-0888-475c-97e5-bc55461db35e
+    order: 400.0
+- model: interaction.serviceansweroption
+  pk: 9f4d5ffb-40be-40b7-bb02-df06727110f5
+  fields:
+    disabled_on:
+    name: Rules & Regulations
+    question_id: 3c69f671-0888-475c-97e5-bc55461db35e
+    order: 500.0
+- model: interaction.serviceansweroption
+  pk: a1870be2-0905-46ad-ba75-ed103cbec7cc
+  fields:
+    disabled_on:
+    name: Skills & Recruitment
+    question_id: 3c69f671-0888-475c-97e5-bc55461db35e
+    order: 600.0
+- model: interaction.serviceansweroption
+  pk: cb45d107-5abd-4aad-a601-4264fe362497
+  fields:
+    disabled_on:
+    name: UK Locations
+    question_id: 3c69f671-0888-475c-97e5-bc55461db35e
+    order: 700.0
+- model: interaction.serviceansweroption
+  pk: 6b115592-94b4-496c-9c52-37072c194dc7
+  fields:
+    disabled_on:
+    name: General
+    question_id: 3c69f671-0888-475c-97e5-bc55461db35e
+    order: 800.0
+
+# Providing Other Advice & Information
+- model: interaction.servicequestion
+  pk: afe62f58-8886-4cdb-a3de-be6f849d1cb4
+  fields:
+    disabled_on:
+    name: What did you give advice about?
+    service_id: 90f5533d-6acf-4aff-9528-75da9af9b851
+    order: 100.0
+
+- model: interaction.serviceansweroption
+  pk: cec53078-ee99-4081-8c1c-c859e2d7fcfc
+  fields:
+    disabled_on:
+    name: Banking & Funding
+    question_id: afe62f58-8886-4cdb-a3de-be6f849d1cb4
+    order: 100.0
+- model: interaction.serviceansweroption
+  pk: fe449302-03b0-42b4-a882-1768a7d7c499
+  fields:
+    disabled_on:
+    name: DIT or Government Services
+    question_id: afe62f58-8886-4cdb-a3de-be6f849d1cb4
+    order: 200.0
+- model: interaction.serviceansweroption
+  pk: 5c617b8d-e1cc-4725-b0c3-2867cc51b6f7
+  fields:
+    disabled_on:
+    name: Documents & Regulations
+    question_id: afe62f58-8886-4cdb-a3de-be6f849d1cb4
+    order: 300.0
+- model: interaction.serviceansweroption
+  pk: 447d2a9f-ba21-4bc3-8eee-37f38531d2b5
+  fields:
+    disabled_on:
+    name: Markets & Sectors
+    question_id: afe62f58-8886-4cdb-a3de-be6f849d1cb4
+    order: 400.0
+- model: interaction.serviceansweroption
+  pk: 4aa74c2f-de52-472d-9d99-70493ecf7194
+  fields:
+    disabled_on:
+    name: Marketing & Communication
+    question_id: afe62f58-8886-4cdb-a3de-be6f849d1cb4
+    order: 500.0
+- model: interaction.serviceansweroption
+  pk: 88c82233-046f-4d35-ac09-d92e8ab41425
+  fields:
+    disabled_on:
+    name: Skills & Recruitment
+    question_id: afe62f58-8886-4cdb-a3de-be6f849d1cb4
+    order: 600.0
+- model: interaction.serviceansweroption
+  pk: 42a4ff38-bace-4c23-b409-28b6428f9e62
+  fields:
+    disabled_on:
+    name: General
+    question_id: afe62f58-8886-4cdb-a3de-be6f849d1cb4
+    order: 700.0
+
+# Making Export Introductions
+- model: interaction.servicequestion
+  pk: 054b29fe-c14b-463d-8177-c378d3a819aa
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Who was the company introduced to?
+    service_id: 1477622e-9adb-4017-8d8d-fe3221f1d2fc
+    order: 100.0
+
+- model: interaction.serviceansweroption
+  pk: a0fabd27-587b-49d1-9e56-eb789b66b7cd
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Customers
+    question_id: 054b29fe-c14b-463d-8177-c378d3a819aa
+    order: 100.0
+- model: interaction.serviceansweroption
+  pk: 2ecdad3d-642a-454c-9bd9-8089b448c319
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Business Partners (e.g. distributors or manufacturers)
+    question_id: 054b29fe-c14b-463d-8177-c378d3a819aa
+    order: 200.0
+- model: interaction.serviceansweroption
+  pk: 2a8db035-f8fe-4700-9769-d980754b90af
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Financial and Professional Service Providers
+    question_id: 054b29fe-c14b-463d-8177-c378d3a819aa
+    order: 300.0
+- model: interaction.serviceansweroption
+  pk: c1a1ab4a-a248-4104-b5a1-caab763ebd8b
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Someone else in DIT
+    question_id: 054b29fe-c14b-463d-8177-c378d3a819aa
+    order: 400.0
+- model: interaction.serviceansweroption
+  pk: 91d496af-0185-449c-a19c-4016c8e78cb0
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Another Government Department
+    question_id: 054b29fe-c14b-463d-8177-c378d3a819aa
+    order: 500.0
+- model: interaction.serviceansweroption
+  pk: a7c74e31-f54e-4fc6-9ecd-84a68b0a81e6
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: UK Export Finance (UKEF)
+    question_id: 054b29fe-c14b-463d-8177-c378d3a819aa
+    order: 600.0
+
+# Making Investment Introductions
+- model: interaction.servicequestion
+  pk: 26c08878-8dd1-4abf-bc59-84918086bf29
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Who was the company introduced to?
+    service_id: 7aa9b539-84e9-4ba8-8d93-2e1fdbfd066c
+    order: 100.0
+
+- model: interaction.serviceansweroption
+  pk: 0529377a-57f1-4b27-baa0-4b9d9bbba8cd
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Customers
+    question_id: 26c08878-8dd1-4abf-bc59-84918086bf29
+    order: 100.0
+- model: interaction.serviceansweroption
+  pk: faa5a5c7-5703-46d8-a35c-c92a87850655
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Business Partners (e.g. distributors or manufacturers)
+    question_id: 26c08878-8dd1-4abf-bc59-84918086bf29
+    order: 200.0
+- model: interaction.serviceansweroption
+  pk: 158d945b-7220-47ae-9d80-ce77ef7ef397
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Financial and Professional Service Providers
+    question_id: 26c08878-8dd1-4abf-bc59-84918086bf29
+    order: 300.0
+- model: interaction.serviceansweroption
+  pk: 71c0bb6a-845d-48a1-9764-5f6aa1e80674
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Investment Opportunities
+    question_id: 26c08878-8dd1-4abf-bc59-84918086bf29
+    order: 400.0
+- model: interaction.serviceansweroption
+  pk: 693ef762-dd6b-4f85-8d64-1449ec555003
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Someone else in DIT
+    question_id: 26c08878-8dd1-4abf-bc59-84918086bf29
+    order: 500.0
+- model: interaction.serviceansweroption
+  pk: 3bb0827b-1b62-498b-b940-401e81f27328
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Another Government Department
+    question_id: 26c08878-8dd1-4abf-bc59-84918086bf29
+    order: 600.0
+
+# Making Other Introductions
+- model: interaction.servicequestion
+  pk: 30690502-9fb9-443b-9ddb-897f66f62b7b
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Who was the company introduced to?
+    service_id: 3f5a2216-8cb1-4fb7-9c6b-06ba77d7405b
+    order: 100.0
+
+- model: interaction.serviceansweroption
+  pk: d5312876-921e-4ed0-837b-42115d3d2ad5
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Customers
+    question_id: 30690502-9fb9-443b-9ddb-897f66f62b7b
+    order: 100.0
+- model: interaction.serviceansweroption
+  pk: b2387184-7721-40fe-b2f0-cbb5c3cb0dce
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Business Partners (e.g. distributors or manufacturers)
+    question_id: 30690502-9fb9-443b-9ddb-897f66f62b7b
+    order: 200.0
+- model: interaction.serviceansweroption
+  pk: 7735ef59-6eb9-4044-80ad-30cb5731e6dd
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Financial and Professional Service Providers
+    question_id: 30690502-9fb9-443b-9ddb-897f66f62b7b
+    order: 300.0
+- model: interaction.serviceansweroption
+  pk: 99142407-2c92-4924-9d80-6f27259aeb54
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Someone else in DIT
+    question_id: 30690502-9fb9-443b-9ddb-897f66f62b7b
+    order: 400.0
+- model: interaction.serviceansweroption
+  pk: 04d35056-180c-493b-bfc6-1240a41b2c89
+  fields:
+    disabled_on: '2019-07-04T00:00:00.000Z'
+    name: Another Government Department
+    question_id: 30690502-9fb9-443b-9ddb-897f66f62b7b
+    order: 500.0

--- a/datahub/interaction/migrations/0001_squashed_0068_remove_interaction_location_from_database.py
+++ b/datahub/interaction/migrations/0001_squashed_0068_remove_interaction_location_from_database.py
@@ -1,0 +1,247 @@
+from pathlib import PurePath
+
+from django.conf import settings
+import django.contrib.postgres.fields.jsonb
+import django.contrib.postgres.indexes
+import django.core.serializers.json
+from django.db import migrations, models
+import django.db.models.deletion
+import mptt.fields
+import uuid
+
+from datahub.core.migration_utils import load_yaml_data_in_migration
+
+
+def load_initial_statuses(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0001_initial_statuses.yaml'
+    )
+
+
+def load_initial_policy_area(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0001_initial_policy_areas.yaml'
+    )
+
+
+def load_initial_policy_issue_type(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0001_initial_issue_types.yaml'
+    )
+
+
+def load_initial_communication_channels(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0001_initial_communication_channels.yaml'
+    )
+
+
+def load_service_questions_and_answers(apps, schema_editor):
+    load_yaml_data_in_migration(
+        apps,
+        PurePath(__file__).parent / '0001_service_questions_and_answers.yaml',
+    )
+
+
+class Migration(migrations.Migration):
+
+    replaces = [('interaction', '0001_squashed_0019_rename_default_permissions'), ('interaction', '0020_add_status_model'), ('interaction', '0021_add_status_field'), ('interaction', '0022_grant_amount_offered'), ('interaction', '0023_add_net_company_receipt'), ('interaction', '0024_add_policy_area_and_type_20180321_1201'), ('interaction', '0025_initial_communication_channels'), ('interaction', '0026_add_policy_feedback_permissions'), ('interaction', '0027_add_policy_areas'), ('interaction', '0028_remove_policy_area_from_state'), ('interaction', '0029_remove_policy_area_from_db'), ('interaction', '0030_add_export_permission'), ('interaction', '0031_update_permissions_django_21'), ('interaction', '0032_increase_notes_max_length'), ('interaction', '0033_add_new_policy_feedback_fields'), ('interaction', '0034_add_new_policy_feedback_field_defaults'), ('interaction', '0035_remove_policy_fedback_kind'), ('interaction', '0036_remove_policy_fedback_permissions'), ('interaction', '0037_remove_policy_issue_type_from_state'), ('interaction', '0038_remove_policy_issue_type_from_db'), ('interaction', '0039_make_policy_provided_and_notes_non_nullable'), ('interaction', '0040_make_policy_provided_non_nullable'), ('interaction', '0041_add_contacts_field'), ('interaction', '0042_copy_contact_to_contacts'), ('interaction', '0043_stricter_dit_adviser_and_dit_team'), ('interaction', '0044_add_dit_participants'), ('interaction', '0045_update_dit_participants_unique_constaint'), ('interaction', '0046_populate_dit_participants'), ('interaction', '0047_add_status_location'), ('interaction', '0048_add_archive_fields'), ('interaction', '0049_interaction_source'), ('interaction', '0050_remove_contact_from_model_state'), ('interaction', '0051_remove_contact_from_db'), ('interaction', '0052_add_theme'), ('interaction', '0053_status_not_null'), ('interaction', '0054_location_not_null'), ('interaction', '0055_archived_not_null'), ('interaction', '0056_add_serviceadditionalquestion_serviceansweroption_servicequestion'), ('interaction', '0057_add_modified_on_id_index'), ('interaction', '0058_add_source_gin_index'), ('interaction', '0059_add_service_questions_and_answers'), ('interaction', '0060_interaction_service_answers'), ('interaction', '0061_update_service_questions_and_answers'), ('interaction', '0062_disable_making_introductions_serviceansweroptions'), ('interaction', '0063_add_index_for_company_list'), ('interaction', '0064_update_service_foreign_key'), ('interaction', '0065_remove_dit_adviser_and_team_from_state'), ('interaction', '0066_remove_dit_adviser_and_team_from_db'), ('interaction', '0067_remove_interaction_location_from_django'), ('interaction', '0068_remove_interaction_location_from_database')]
+
+    initial = True
+
+    dependencies = [
+        ('metadata', '0031_update_services'),
+        ('metadata', '0030_add_additional_services'),
+        ('investment', '0001_squashed_0025_remove_non_fdi_type'),
+        ('company', '0001_squashed_0056_number_of_employees'),
+        ('metadata', '0037_add_service_hierarchy'),
+        ('metadata', '0026_add_index_upper_team_name'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('metadata', '0001_squashed_0011_add_default_id_for_metadata'),
+        ('core', '0003_rename_read_permissions'),
+        ('event', '0008_add_service'),
+        ('metadata', '0023_add_chinese_regions'),
+        ('company', '0060_trading_names_not_null'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='CommunicationChannel',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('name', models.TextField(blank=True)),
+                ('disabled_on', models.DateTimeField(blank=True, null=True)),
+            ],
+            options={
+                'ordering': ('name',),
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='ServiceDeliveryStatus',
+            fields=[
+                ('disabled_on', models.DateTimeField(blank=True, null=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('name', models.TextField(blank=True)),
+                ('order', models.FloatField(default=0.0)),
+            ],
+            options={
+                'ordering': ('order',),
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='PolicyArea',
+            fields=[
+                ('disabled_on', models.DateTimeField(blank=True, null=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('name', models.TextField(blank=True)),
+                ('order', models.FloatField(default=0.0)),
+            ],
+            options={
+                'ordering': ('order',),
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='PolicyIssueType',
+            fields=[
+                ('disabled_on', models.DateTimeField(blank=True, null=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('name', models.TextField(blank=True)),
+                ('order', models.FloatField(default=0.0)),
+            ],
+            options={
+                'ordering': ('order',),
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='Interaction',
+            fields=[
+                ('created_on', models.DateTimeField(auto_now_add=True, db_index=True, null=True)),
+                ('modified_on', models.DateTimeField(auto_now=True, null=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('date', models.DateTimeField()),
+                ('subject', models.TextField()),
+                ('notes', models.TextField(blank=True, max_length=10000)),
+                ('company', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='interactions', to='company.Company')),
+                ('communication_channel', models.ForeignKey(blank=True, help_text='For interactions only.', null=True, on_delete=django.db.models.deletion.SET_NULL, to='interaction.CommunicationChannel')),
+                ('service', mptt.fields.TreeForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, to='metadata.Service')),
+                ('investment_project', models.ForeignKey(blank=True, help_text='For interactions only.', null=True, on_delete=django.db.models.deletion.CASCADE, related_name='interactions', to='investment.InvestmentProject')),
+                ('created_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('modified_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('kind', models.CharField(choices=[('interaction', 'Interaction'), ('service_delivery', 'Service delivery')], max_length=255)),
+                ('event', models.ForeignKey(blank=True, help_text='For service deliveries only.', null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='interactions', to='event.Event')),
+                ('archived_documents_url_path', models.CharField(blank=True, help_text='Legacy field. File browser path to the archived documents for this interaction.', max_length=255)),
+                ('service_delivery_status', models.ForeignKey(blank=True, help_text='For service deliveries only.', null=True, on_delete=django.db.models.deletion.PROTECT, to='interaction.ServiceDeliveryStatus', verbose_name='status')),
+                ('grant_amount_offered', models.DecimalField(blank=True, decimal_places=2, help_text='For service deliveries only.', max_digits=19, null=True)),
+                ('net_company_receipt', models.DecimalField(blank=True, decimal_places=2, help_text='For service deliveries only.', max_digits=19, null=True)),
+                ('policy_areas', models.ManyToManyField(blank=True, related_name='interactions', to='interaction.PolicyArea')),
+                ('policy_issue_types', models.ManyToManyField(blank=True, related_name='interactions', to='interaction.PolicyIssueType')),
+                ('policy_feedback_notes', models.TextField(blank=True, default='')),
+                ('was_policy_feedback_provided', models.BooleanField()),
+                ('contacts', models.ManyToManyField(blank=True, related_name='interactions', to='company.Contact')),
+                ('status', models.CharField(choices=[('draft', 'Draft'), ('complete', 'Complete')], default='complete', max_length=255)),
+                ('archived', models.BooleanField(default=False)),
+                ('archived_by', models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.SET_NULL, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('archived_on', models.DateTimeField(blank=True, null=True)),
+                ('archived_reason', models.TextField(blank=True, null=True)),
+                ('source', django.contrib.postgres.fields.jsonb.JSONField(blank=True, encoder=django.core.serializers.json.DjangoJSONEncoder, null=True)),
+                ('theme', models.CharField(blank=True, choices=[(None, 'Not set'), ('export', 'Export'), ('investment', 'Investment'), ('other', 'Something else')], max_length=255, null=True)),
+                ('service_answers', django.contrib.postgres.fields.jsonb.JSONField(blank=True, encoder=django.core.serializers.json.DjangoJSONEncoder, null=True)),
+            ],
+            options={
+                'abstract': False,
+                'indexes': [
+                    models.Index(fields=['-date', '-created_on'], name='interaction_date_06c266_idx'),
+                    models.Index(fields=['modified_on', 'id'], name='interaction_modifie_d52a56_idx'),
+                    django.contrib.postgres.indexes.GinIndex(fields=['source'], name='interaction_source_cfbd11_gin'),
+                    models.Index(fields=['company', '-date', '-created_on', 'id'], name='interaction_company_236ca9_idx'),
+                ],
+                'default_permissions': ('add_all', 'change_all', 'delete', 'view_all'),
+                'permissions': (('view_associated_investmentproject_interaction', 'Can view interaction for associated investment projects'), ('add_associated_investmentproject_interaction', 'Can add interaction for associated investment projects'), ('change_associated_investmentproject_interaction', 'Can change interaction for associated investment projects'), ('export_interaction', 'Can export interaction')),
+            },
+        ),
+        migrations.CreateModel(
+            name='InteractionDITParticipant',
+            fields=[
+                ('id', models.BigAutoField(primary_key=True, serialize=False)),
+                ('adviser', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='+', to=settings.AUTH_USER_MODEL)),
+                ('interaction', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='dit_participants', to='interaction.Interaction')),
+                ('team', models.ForeignKey(null=True, on_delete=django.db.models.deletion.CASCADE, related_name='+', to='metadata.Team')),
+            ],
+            options={
+                'default_permissions': (),
+                'unique_together': {('interaction', 'adviser')},
+            },
+        ),
+        migrations.CreateModel(
+            name='ServiceQuestion',
+            fields=[
+                ('disabled_on', models.DateTimeField(blank=True, null=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('name', models.TextField(blank=True)),
+                ('order', models.FloatField(default=0.0)),
+                ('service', mptt.fields.TreeForeignKey(on_delete=django.db.models.deletion.PROTECT, related_name='interaction_questions', to='metadata.Service',)),
+            ],
+            options={
+                'ordering': ('order',),
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='ServiceAnswerOption',
+            fields=[
+                ('disabled_on', models.DateTimeField(blank=True, null=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('name', models.TextField(blank=True)),
+                ('order', models.FloatField(default=0.0)),
+                ('question', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='answer_options', to='interaction.ServiceQuestion')),
+            ],
+            options={
+                'ordering': ('order',),
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='ServiceAdditionalQuestion',
+            fields=[
+                ('disabled_on', models.DateTimeField(blank=True, null=True)),
+                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
+                ('name', models.TextField(blank=True)),
+                ('order', models.FloatField(default=0.0)),
+                ('type', models.CharField(choices=[('text', 'Text'), ('money', 'Money')], max_length=255)),
+                ('is_required', models.BooleanField(default=False)),
+                ('answer_option', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='additional_questions', to='interaction.ServiceAnswerOption')),
+            ],
+            options={
+                'ordering': ('order',),
+                'abstract': False,
+            },
+        ),
+        migrations.RunPython(
+            code=load_initial_statuses,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RunPython(
+            code=load_initial_policy_area,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RunPython(
+            code=load_initial_policy_issue_type,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RunPython(
+            code=load_initial_communication_channels,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.RunPython(
+            code=load_service_questions_and_answers,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
### Description of change

This squashes all interaction migrations up to 0068. It includes some manual optimisation, corrections and clean-up of the replacement migration.

Once this has been deployed to all environments, the old migrations can be removed and the squashed migration can be turned into a normal migration.

See https://docs.djangoproject.com/en/2.2/topics/migrations/#squashing-migrations for more information on squashing migrations.

This change also reduces the build time on CircleCI slightly. Locally (which is faster than CircleCI), it reduces the time to set up the test databases from about 61 seconds to 55 seconds; if migrations were squashed for other apps too this time would reduce further.

### To test

#### Check that all changes are included in the migration

If you run `./manage.py makemigrations --name dummy` on this branch then 'No changes detected' should be output.

#### Check that the schema and loaded fixtures are the same as before

One way to do this is:

1. Check out `develop`:
    
    ```
    git checkout develop
    ```

1. Create a fresh test database from develop:

    ```
    pytest --reuse-db --create-db -k TestDisableableModel
    ```

1. Dump the test database (edit the command according to your environment):

    ```
    sudo -upostgres pg_dump test_datahub > before.sql
    ```

1. Check out `feature/squash-interaction-migrations-0068`:

    ```
    git checkout feature/squash-interaction-migrations-0068
    ```

1. Create a fresh test database on this branch:

    ```
    pytest --reuse-db --create-db -k TestDisableableModel
    ```

1. Dump the test database (edit the command according to your environment):

    ```
    sudo -upostgres pg_dump test_datahub > after.sql
    ```

1. Compare `before.sql` and `after.sql` using your preferred tool.

    There should be no significant changes (but there will be some insignificant ones).

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
