### PR TITLE
Add one list account manager filter to company search.

### DIFF
--- a/changelog/company/add-one-list-group-account-manager-filter.api.md
+++ b/changelog/company/add-one-list-group-account-manager-filter.api.md
@@ -1,0 +1,1 @@
+`POST /v4/search/company`: new filter `one_list_group_global_account_manager` was added.

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -17,6 +17,7 @@ class CompanySearchApp(SearchApp):
         'export_experience_category',
         'headquarter_type',
         'one_list_account_owner',
+        'global_headquarters__one_list_account_owner',
         'global_headquarters',
         'address_country',
         'registered_address_country',

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -23,6 +23,10 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
     uk_region = SingleOrListField(child=StringUUIDField(), required=False)
     export_to_countries = SingleOrListField(child=StringUUIDField(), required=False)
     future_interest_countries = SingleOrListField(child=StringUUIDField(), required=False)
+    one_list_group_global_account_manager = SingleOrListField(
+        child=StringUUIDField(),
+        required=False,
+    )
 
     SORT_BY_FIELDS = (
         'modified_on',

--- a/datahub/search/company/signals.py
+++ b/datahub/search/company/signals.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_save
 from datahub.company.models import Company as DBCompany
 from datahub.search.company import CompanySearchApp
 from datahub.search.signals import SignalReceiver
-from datahub.search.sync_object import sync_object_async
+from datahub.search.sync_object import sync_object_async, sync_related_objects_async
 
 
 def company_sync_es(instance):
@@ -14,4 +14,14 @@ def company_sync_es(instance):
     )
 
 
-receivers = (SignalReceiver(post_save, DBCompany, company_sync_es),)
+def company_subsidiaries_sync_es(instance):
+    """Sync company subsidiaries to the Elasticsearch."""
+    transaction.on_commit(
+        lambda: sync_related_objects_async(instance, 'subsidiaries'),
+    )
+
+
+receivers = (
+    SignalReceiver(post_save, DBCompany, company_sync_es),
+    SignalReceiver(post_save, DBCompany, company_subsidiaries_sync_es),
+)

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -218,6 +218,26 @@ def test_mapping(es):
                         },
                     },
                 },
+                'one_list_group_global_account_manager': {
+                    'properties': {
+                        'first_name': {
+                            'index': False,
+                            'type': 'text',
+                        },
+                        'id': {
+                            'type': 'keyword',
+                        },
+                        'last_name': {
+                            'index': False,
+                            'type': 'text',
+                        },
+                        'name': {
+                            'index': False,
+                            'type': 'text',
+                        },
+                    },
+                    'type': 'object',
+                },
                 'sector': {
                     'properties': {
                         'ancestors': {
@@ -531,6 +551,7 @@ def test_indexed_doc(es):
         'reference_code',
         'address',
         'registered_address',
+        'one_list_group_global_account_manager',
         'sector',
         'suggest',
         'trading_names',

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -43,6 +43,8 @@ class TestCompanyElasticModel:
             'address',
             'registered_address',
 
+            'one_list_group_global_account_manager',
+
             'trading_names',
             'turnover_range',
             'uk_based',

--- a/datahub/search/company/test/test_signals.py
+++ b/datahub/search/company/test/test_signals.py
@@ -1,8 +1,10 @@
 import pytest
 
-from datahub.company.test.factories import CompanyFactory
+from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.search.company.apps import CompanySearchApp
 from datahub.search.company.models import Company
 from datahub.search.query_builder import get_basic_search_query
+from datahub.search.test.utils import get_documents_by_ids
 
 pytestmark = pytest.mark.django_db
 
@@ -35,3 +37,53 @@ def test_company_auto_updates_to_es(es_with_signals):
 
     assert result.hits.total == 1
     assert result.hits[0].id == str(company.id)
+
+
+def test_company_subsidiaries_auto_update_to_es(es_with_signals):
+    """Tests if company subsidiaries get updated in Elasticsearch."""
+    account_owner = AdviserFactory()
+    global_headquarters = CompanyFactory(one_list_account_owner=account_owner)
+    subsidiaries = CompanyFactory.create_batch(2, global_headquarters=global_headquarters)
+    es_with_signals.indices.refresh()
+
+    subsidiary_ids = [subsidiary.id for subsidiary in subsidiaries]
+
+    result = get_documents_by_ids(
+        es_with_signals,
+        CompanySearchApp,
+        subsidiary_ids,
+    )
+
+    expected_results = {
+        (str(subsidiary_id), str(account_owner.id)) for subsidiary_id in subsidiary_ids
+    }
+    search_results = {
+        (doc['_id'], doc['_source']['one_list_group_global_account_manager']['id'])
+        for doc in result['docs']
+    }
+
+    assert len(result['docs']) == 2
+    assert search_results == expected_results
+
+    new_account_owner = AdviserFactory()
+    global_headquarters.one_list_account_owner = new_account_owner
+    global_headquarters.save()
+
+    es_with_signals.indices.refresh()
+
+    new_result = get_documents_by_ids(
+        es_with_signals,
+        CompanySearchApp,
+        subsidiary_ids,
+    )
+
+    new_expected_results = {
+        (str(subsidiary_id), str(new_account_owner.id)) for subsidiary_id in subsidiary_ids
+    }
+    new_search_results = {
+        (doc['_id'], doc['_source']['one_list_group_global_account_manager']['id'])
+        for doc in new_result['docs']
+    }
+
+    assert len(new_result['docs']) == 2
+    assert new_search_results == new_expected_results

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -51,6 +51,7 @@ class SearchCompanyAPIViewMixin:
         'uk_region',
         'export_to_countries',
         'future_interest_countries',
+        'one_list_group_global_account_manager',
     )
 
     REMAP_FIELDS = {
@@ -58,6 +59,7 @@ class SearchCompanyAPIViewMixin:
         'uk_region': 'uk_region.id',
         'export_to_countries': 'export_to_countries.id',
         'future_interest_countries': 'future_interest_countries.id',
+        'one_list_group_global_account_manager': 'one_list_group_global_account_manager.id',
     }
 
     COMPOSITE_FILTERS = {

--- a/datahub/search/dict_utils.py
+++ b/datahub/search/dict_utils.py
@@ -138,6 +138,20 @@ def _computed_nested_dict(nested_field, dict_func):
     return get_dict
 
 
+def computed_field_function(function_name, dict_func):
+    """Create a dictionary from a result of provided function call."""
+    def get_dict(obj):
+        field = getattr(obj, function_name, None)
+        if field is None:
+            raise ValueError(f'The object function "{function_name}" does not exist.')
+        if not callable(field):
+            raise ValueError(f'"{function_name}" is not callable.')
+
+        return dict_func(field())
+
+    return get_dict
+
+
 def computed_nested_id_name_dict(nested_field):
     """Creates a dictionary with id and name from a nested field."""
     return _computed_nested_dict(nested_field, id_name_dict)

--- a/datahub/search/test/test_dict_utils.py
+++ b/datahub/search/test/test_dict_utils.py
@@ -366,3 +366,31 @@ def test_nested_id_name_dict_raises_exception_on_invalid_argument():
 
     with raises(ValueError):
         dict_utils.computed_nested_id_name_dict('company')(obj)
+
+
+def test_computed_field_function():
+    """Tests if provided function is being called and dictionary created."""
+    obj = construct_mock(
+        get_cats_name=lambda: construct_mock(id='cat-01', name='Mittens'),
+    )
+
+    result = dict_utils.computed_field_function('get_cats_name', dict_utils.id_name_dict)(obj)
+    assert result == {'id': 'cat-01', 'name': 'Mittens'}
+
+
+def test_computed_field_function_missing_function():
+    """Tests when provided function is missing, ValueError is raised."""
+    obj = construct_mock()
+
+    with raises(ValueError):
+        dict_utils.computed_field_function('get_cats_name', dict_utils.id_name_dict)(obj)
+
+
+def test_computed_field_function_not_a_function():
+    """Tests when provided function is missing, ValueError is raised."""
+    obj = construct_mock(
+        get_cats_name='tabby',
+    )
+
+    with raises(ValueError):
+        dict_utils.computed_field_function('get_cats_name', dict_utils.id_name_dict)(obj)

--- a/datahub/search/test/utils.py
+++ b/datahub/search/test/utils.py
@@ -62,3 +62,14 @@ def _create_mock_es_model(
         get_write_alias=Mock(return_value='test-write-alias'),
         get_target_index_name=Mock(return_value=f'test-index-{target_mapping_hash}'),
     )
+
+
+def get_documents_by_ids(es_client, app, ids):
+    """Get given search app documents by supplied ids."""
+    return es_client.mget(
+        index=app.es_model.get_read_alias(),
+        doc_type=app.name,
+        body={
+            'ids': ids,
+        },
+    )


### PR DESCRIPTION
### Description of change

`POST /v3/search/company/`: new filter `one_list_group_global_account_manager` was added.

This enables filtering by computed field `one_list_group_global_account_manager` that contains an id of one list account manager. If company is a subsidiary, this value will be inherited from the parent company.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
