### PR TITLE
Add company filter and sort facility for latest_interaction_date

### DIFF
--- a/changelog/company/latest-interaction-date-filter.api.md
+++ b/changelog/company/latest-interaction-date-filter.api.md
@@ -1,0 +1,1 @@
+`POST /v4/search/company`: A filter was added for the `latest_interaction_date` field, in the form of `latest_interaction_date_before` and `latest_interaction_date_after`. Both the fields are optional. A company will only be returned if its latest interaction date falls between those dates.

--- a/datahub/search/company/apps.py
+++ b/datahub/search/company/apps.py
@@ -1,4 +1,7 @@
+from django.db.models import Max
+
 from datahub.company.models import Company as DBCompany, CompanyPermission
+from datahub.core.query_utils import get_aggregate_subquery
 from datahub.search.apps import SearchApp
 from datahub.search.company.models import Company
 
@@ -29,4 +32,9 @@ class CompanySearchApp(SearchApp):
     ).prefetch_related(
         'export_to_countries',
         'future_interest_countries',
+    ).annotate(
+        latest_interaction_date=get_aggregate_subquery(
+            DBCompany,
+            Max('interactions__date'),
+        ),
     )

--- a/datahub/search/company/models.py
+++ b/datahub/search/company/models.py
@@ -120,6 +120,7 @@ class Company(BaseESModel):
             },
         ],
     )
+    latest_interaction_date = Date()
 
     COMPUTED_MAPPINGS = {
         'suggest': get_suggestions,
@@ -129,6 +130,7 @@ class Company(BaseESModel):
             'get_one_list_group_global_account_manager',
             dict_utils.contact_or_adviser_dict,
         ),
+        'latest_interaction_date': lambda obj: obj.latest_interaction_date,
     }
 
     MAPPINGS = {

--- a/datahub/search/company/serializers.py
+++ b/datahub/search/company/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from datahub.core.serializers import RelaxedDateField
 from datahub.search.serializers import (
     EntitySearchQuerySerializer,
     SingleOrListField,
@@ -27,10 +28,13 @@ class SearchCompanyQuerySerializer(EntitySearchQuerySerializer):
         child=StringUUIDField(),
         required=False,
     )
+    latest_interaction_date_after = RelaxedDateField(required=False)
+    latest_interaction_date_before = RelaxedDateField(required=False)
 
     SORT_BY_FIELDS = (
         'modified_on',
         'name',
+        'latest_interaction_date',
     )
 
 

--- a/datahub/search/company/signals.py
+++ b/datahub/search/company/signals.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from django.db.models.signals import post_save
 
 from datahub.company.models import Company as DBCompany
+from datahub.interaction.models import Interaction as DBInteraction
 from datahub.search.company import CompanySearchApp
 from datahub.search.signals import SignalReceiver
 from datahub.search.sync_object import sync_object_async, sync_related_objects_async
@@ -21,7 +22,15 @@ def company_subsidiaries_sync_es(instance):
     )
 
 
+def sync_related_company_to_es(instance):
+    """Sync related company."""
+    transaction.on_commit(
+        lambda: sync_object_async(CompanySearchApp, instance.company.pk),
+    )
+
+
 receivers = (
     SignalReceiver(post_save, DBCompany, company_sync_es),
     SignalReceiver(post_save, DBCompany, company_subsidiaries_sync_es),
+    SignalReceiver(post_save, DBInteraction, sync_related_company_to_es),
 )

--- a/datahub/search/company/test/test_elasticsearch.py
+++ b/datahub/search/company/test/test_elasticsearch.py
@@ -2,7 +2,6 @@ import pytest
 from elasticsearch_dsl import Mapping
 
 from datahub.company.test.factories import CompanyFactory
-from datahub.search import elasticsearch
 from datahub.search.company import CompanySearchApp
 from datahub.search.company.models import Company as ESCompany
 from datahub.search.query_builder import (
@@ -10,6 +9,7 @@ from datahub.search.query_builder import (
     get_search_by_entity_query,
     limit_search_query,
 )
+from datahub.search.sync_object import sync_object
 
 
 def test_mapping(es):
@@ -297,6 +297,7 @@ def test_mapping(es):
                     'type': 'keyword',
                 },
                 'website': {'type': 'text'},
+                'latest_interaction_date': {'type': 'date'},
             },
         },
     }
@@ -517,9 +518,7 @@ def test_indexed_doc(es):
     company = CompanyFactory(
         trading_names=['a', 'b'],
     )
-
-    doc = ESCompany.es_document(company)
-    elasticsearch.bulk(actions=(doc, ), chunk_size=1)
+    sync_object(CompanySearchApp, company.pk)
 
     es.indices.refresh()
 
@@ -561,4 +560,5 @@ def test_indexed_doc(es):
         'vat_number',
         'duns_number',
         'website',
+        'latest_interaction_date',
     }

--- a/datahub/search/company/test/test_models.py
+++ b/datahub/search/company/test/test_models.py
@@ -4,6 +4,7 @@ import pytest
 
 from datahub.company.test.factories import CompanyFactory
 from datahub.core.constants import Country as CountryConstant
+from datahub.search.apps import get_search_app
 from datahub.search.company.models import Company as ESCompany, get_suggestions
 
 pytestmark = pytest.mark.django_db
@@ -15,8 +16,10 @@ class TestCompanyElasticModel:
     def test_company_dbmodel_to_dict(self, es):
         """Tests conversion of db model to dict."""
         company = CompanyFactory()
+        app = get_search_app('company')
+        company_qs = app.queryset.get(pk=company.pk)
 
-        result = ESCompany.db_object_to_dict(company)
+        result = ESCompany.db_object_to_dict(company_qs)
 
         keys = {
             'archived',
@@ -39,6 +42,7 @@ class TestCompanyElasticModel:
             'reference_code',
             'sector',
             'suggest',
+            'latest_interaction_date',
 
             'address',
             'registered_address',
@@ -59,8 +63,10 @@ class TestCompanyElasticModel:
     def test_company_dbmodels_to_es_documents(self, es):
         """Tests conversion of db models to Elasticsearch documents."""
         companies = CompanyFactory.create_batch(2)
+        app = get_search_app('company')
+        companies_qs = app.queryset.all()
 
-        result = ESCompany.db_objects_to_es_documents(companies)
+        result = ESCompany.db_objects_to_es_documents(companies_qs)
 
         assert len(list(result)) == len(companies)
 

--- a/datahub/search/company/test/test_signals.py
+++ b/datahub/search/company/test/test_signals.py
@@ -1,6 +1,8 @@
 import pytest
+from dateutil.parser import parse as dateutil_parse
 
 from datahub.company.test.factories import AdviserFactory, CompanyFactory
+from datahub.interaction.test.factories import CompanyInteractionFactory
 from datahub.search.company.apps import CompanySearchApp
 from datahub.search.company.models import Company
 from datahub.search.query_builder import get_basic_search_query
@@ -87,3 +89,36 @@ def test_company_subsidiaries_auto_update_to_es(es_with_signals):
 
     assert len(new_result['docs']) == 2
     assert new_search_results == new_expected_results
+
+
+def test_adding_interaction_updates_company(es_with_signals):
+    """Test that when an interaction is added, the company is synced to ES."""
+    test_name = 'very_hard_to_find_company'
+    company = CompanyFactory(
+        name=test_name,
+    )
+
+    es_with_signals.indices.refresh()
+
+    doc = es_with_signals.get(
+        index=CompanySearchApp.es_model.get_read_alias(),
+        doc_type=CompanySearchApp.name,
+        id=company.pk,
+    )
+    assert doc['_source']['name'] == test_name
+    assert doc['_source']['latest_interaction_date'] is None
+
+    CompanyInteractionFactory(
+        date=dateutil_parse('2018-04-05T00:00:00Z'),
+        company=company,
+    )
+
+    es_with_signals.indices.refresh()
+
+    updated_doc = es_with_signals.get(
+        index=CompanySearchApp.es_model.get_read_alias(),
+        doc_type=CompanySearchApp.name,
+        id=company.pk,
+    )
+    assert updated_doc['_source']['name'] == test_name
+    assert updated_doc['_source']['latest_interaction_date'] == '2018-04-05T00:00:00+00:00'

--- a/datahub/search/company/views.py
+++ b/datahub/search/company/views.py
@@ -52,6 +52,8 @@ class SearchCompanyAPIViewMixin:
         'export_to_countries',
         'future_interest_countries',
         'one_list_group_global_account_manager',
+        'latest_interaction_date_after',
+        'latest_interaction_date_before',
     )
 
     REMAP_FIELDS = {


### PR DESCRIPTION
### Description of change
Last interaction date filter is added to company search API in the form of two optional parameters: `latest_interaction_date_before` and `latest_interaction_date_after`.


### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
