### PR TITLE
Fix intermittently failing OMIS notification test

### DIFF
--- a/datahub/omis/notification/test/test_client.py
+++ b/datahub/omis/notification/test/test_client.py
@@ -23,6 +23,7 @@ from datahub.omis.region.models import UKRegionalSettings
 pytestmark = pytest.mark.django_db
 
 
+@pytest.mark.usefixtures('synchronous_thread_pool')
 class TestSendEmail:
     """Tests for errors with the internal send_email function."""
 


### PR DESCRIPTION
### Description of change

The `TestSendEmail` class was missing the `synchronous_thread_pool` fixture which caused some of its tests to fail intermittently.

This adds the fixture in line with the other test classes.

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
