### PR TITLE
Fix intermittently failing event search sorting test

### DIFF
--- a/datahub/search/event/test/test_views.py
+++ b/datahub/search/event/test/test_views.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 from django.utils.timezone import now, utc
+from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.reverse import reverse
 
@@ -410,10 +411,13 @@ class TestSearch(APITestMixin):
     def test_search_event_sortby_modified_on(self, es_with_collector, setup_data):
         """Tests sort by modified_on desc."""
         start_date = datetime.date(2001, 9, 29)
-        event_a = EventFactory(start_date=start_date)
-        event_b = EventFactory(start_date=start_date)
-        event_a.name = 'testing'
-        event_a.save()
+
+        with freeze_time('2018-03-05 16:00:00'):
+            event_a = EventFactory(start_date=start_date)
+
+        with freeze_time('2016-01-02 11:00:00'):
+            event_b = EventFactory(start_date=start_date)
+
         es_with_collector.flush_and_refresh()
 
         url = reverse('api-v3:search:event')


### PR DESCRIPTION
### Description of change

This fixes an intermittently failing test for sorting event search results by `modified_on:desc`.

Locally this was failing about 6% of the time for me. It was intermittently failing because it was relying on the system clock advancing by more than a millisecond (the resolution used by Elasticsearch `Date` fields) between two save operations.

This changes the test to use `freeze_time()` instead of relying on the system clock. (An extra `save()` call was also removed, as it's not relevant for the test.)

### Checklist

* [ ] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
