### PR TITLE
Deprecate legacy company list endpoints

### DIFF
--- a/changelog/adviser/legacy-company-list.deprecation.md
+++ b/changelog/adviser/legacy-company-list.deprecation.md
@@ -1,0 +1,8 @@
+The following legacy company list endpoints are deprecated and will be removed on or after 6 November 2019:
+
+- `GET /v4/user/company-list`
+- `GET /v4/user/company-list/<company ID>`
+- `PUT /v4/user/company-list/<company ID>`
+- `DELETE /v4/user/company-list/<company ID>`
+
+Please use the new multi-list endpoints starting with `/v4/company-list` instead.


### PR DESCRIPTION
### Description of change

This deprecates the following endpoints:

- `GET /v4/user/company-list`
- `GET /v4/user/company-list/<company ID>`
- `PUT /v4/user/company-list/<company ID>`
- `DELETE /v4/user/company-list/<company ID>`

These were replaced by the multi-list endpoints starting with `/v4/company-list`.

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
