### PR TITLE
Deprecate search/companieshousecompany

### DIFF
--- a/changelog/company/search-ch.deprecation.md
+++ b/changelog/company/search-ch.deprecation.md
@@ -1,0 +1,4 @@
+The following Comapnies House endpoints are deprecated and will be removed on or after 6 November 2019:
+
+- `GET /v3/search/companieshousecompany`
+- `GET /v4/search/companieshousecompany`


### PR DESCRIPTION
### Description of change

The following Comapnies House endpoints are deprecated and will be removed on or after 6 November 2019:

- `GET /v3/search/companieshousecompany`
- `GET /v4/search/companieshousecompany`

### Checklist

* [x] Has a new newsfragment been created? Check [changelog/README.md](https://github.com/uktrade/data-hub-leeloo/blob/master/changelog/README.md) for instructions
* [ ] Do any added or updated endpoints appear in the API documentation? See [docs/Maintaining the API documentation.md](https://github.com/uktrade/data-hub-leeloo/blob/develop/docs/Maintaining&#32;the&#32;API&#32;documentation.md) for more details
* [ ] Have any relevant search models been updated?
* [ ] Have any relevant fixtures (`fixtures/test_data.yaml`) been updated?
* [ ] Have any relevant select-/prefetch-related field lists in the views and search apps been updated?
* [ ] Has the admin site been updated (for new models, fields etc.)?
* [ ] Has the README been updated (if needed)?
